### PR TITLE
Harden delivery operating discipline

### DIFF
--- a/frontend/components/dashboard/preflight-checklist.tsx
+++ b/frontend/components/dashboard/preflight-checklist.tsx
@@ -7,11 +7,13 @@ import { getContactDesiredTimingLabel, getContactRouteLabel } from '@/lib/contac
 import { getDeliveryModeLabel, normalizeDeliveryMode } from '@/lib/implementation-readiness'
 import {
   buildDeliveryAutoSignals,
+  buildDeliveryDisciplineWarnings,
   buildDeliveryOpsSummary,
   DELIVERY_CHECKPOINT_DEFINITIONS,
   DELIVERY_EXCEPTION_OPTIONS,
   DELIVERY_LIFECYCLE_OPTIONS,
   DELIVERY_MANUAL_STATE_OPTIONS,
+  getDeliveryOperatingGuide,
   getDeliveryAutoStateLabel,
   getDeliveryExceptionLabel,
   getDeliveryLifecycleLabel,
@@ -76,30 +78,6 @@ function formatAmsterdamDate(value: string | null | undefined) {
 
 function buildLeadLabel(lead: ContactRequestRecord) {
   return `${lead.name} — ${lead.organization} — ${getContactRouteLabel(lead.route_interest)} — ${getContactDesiredTimingLabel(lead.desired_timing)}`
-}
-
-function buildOpsWarnings(args: {
-  record: CampaignDeliveryRecord | null
-  linkedLead: ContactRequestRecord | null
-  invitesNotSent: number
-  pendingClientInviteCount: number
-  incompleteScores: number
-  activeClientAccessCount: number
-  totalCompleted: number
-  hasEnoughData: boolean
-  governanceBlockers: string[]
-}) {
-  const items: string[] = []
-
-  if (!args.linkedLead) items.push('De sales-to-delivery handoff is nog niet expliciet gekoppeld aan deze campaign.')
-  if (args.invitesNotSent > 0) items.push(`${args.invitesNotSent} respondent(en) hebben nog geen invite ontvangen of verzendbevestiging.`)
-  if (args.pendingClientInviteCount > 0 && args.activeClientAccessCount === 0) items.push(`${args.pendingClientInviteCount} klantinvite(s) wachten nog op activatie.`)
-  if (args.incompleteScores > 0) items.push(`${args.incompleteScores} opgeslagen responses hebben nog incomplete scoredata.`)
-  if (args.totalCompleted >= 5 && !args.hasEnoughData) items.push('De campaign heeft een indicatief first-value beeld, maar nog geen stevig patroonniveau.')
-  if (args.record?.exception_status && args.record.exception_status !== 'none') items.push(`Open exception: ${getDeliveryExceptionLabel(args.record.exception_status)}.`)
-  items.push(...args.governanceBlockers)
-
-  return Array.from(new Set(items))
 }
 
 export function PreflightChecklist({
@@ -167,6 +145,7 @@ export function PreflightChecklist({
     () => leadOptions.find((lead) => lead.id === record?.contact_request_id) ?? null,
     [leadOptions, record?.contact_request_id],
   )
+  const operatingGuide = useMemo(() => getDeliveryOperatingGuide(scanType), [scanType])
   const [recordDraft, setRecordDraft] = useState<RecordDraft>({
     contact_request_id: record?.contact_request_id ?? '',
     lifecycle_stage: record?.lifecycle_stage ?? 'setup_in_progress',
@@ -193,9 +172,9 @@ export function PreflightChecklist({
   const [message, setMessage] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
 
-  const opsWarnings = buildOpsWarnings({
+  const opsWarnings = buildDeliveryDisciplineWarnings({
     record,
-    linkedLead,
+    linkedLeadPresent: Boolean(linkedLead),
     invitesNotSent,
     pendingClientInviteCount,
     incompleteScores,
@@ -203,6 +182,8 @@ export function PreflightChecklist({
     totalCompleted,
     hasEnoughData,
     governanceBlockers: governance.globalBlockers,
+    linkedLearningDossierCount,
+    learningCloseoutEvidenceCount,
   })
 
   function updateRecordDraft<K extends keyof RecordDraft>(key: K, value: RecordDraft[K]) {
@@ -591,6 +572,77 @@ export function PreflightChecklist({
                         : []),
                   ]}
                 />
+              </div>
+            </div>
+
+            <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4">
+              <p className="text-sm font-semibold text-slate-950">Operating discipline</p>
+              <p className="mt-2 text-sm leading-6 text-slate-600">
+                Deze laag maakt de delivery-control overdraagbaar: wie bewaakt de route, wat telt als management use en welke bounded vervolguitkomsten canoniek zijn.
+              </p>
+              <div className="mt-4 grid gap-4 xl:grid-cols-2">
+                <div className="rounded-2xl border border-white bg-white px-4 py-4">
+                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Operatorrollen</p>
+                  <div className="mt-3 space-y-3">
+                    {operatingGuide.roles.map((role) => (
+                      <div key={role.title} className="rounded-2xl border border-slate-100 bg-slate-50 px-3 py-3">
+                        <p className="text-sm font-semibold text-slate-950">{role.title}</p>
+                        <p className="mt-1 text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">{role.owner}</p>
+                        <p className="mt-2 text-sm leading-6 text-slate-700">{role.responsibility}</p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="rounded-2xl border border-white bg-white px-4 py-4">
+                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Management use contract</p>
+                  <div className="mt-3 space-y-3">
+                    {operatingGuide.managementUseSteps.map((step) => (
+                      <div key={step.title} className="rounded-2xl border border-slate-100 bg-slate-50 px-3 py-3">
+                        <p className="text-sm font-semibold text-slate-950">{step.title}</p>
+                        <p className="mt-2 text-sm leading-6 text-slate-700">{step.detail}</p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="rounded-2xl border border-white bg-white px-4 py-4">
+                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Follow-up uitkomsten</p>
+                  <div className="mt-3 space-y-3">
+                    {operatingGuide.followUpOutcomes.map((outcome) => (
+                      <div key={outcome.title} className="rounded-2xl border border-slate-100 bg-slate-50 px-3 py-3">
+                        <p className="text-sm font-semibold text-slate-950">{outcome.title}</p>
+                        <p className="mt-1 text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">{outcome.fit}</p>
+                        <p className="mt-2 text-sm leading-6 text-slate-700">{outcome.detail}</p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="rounded-2xl border border-white bg-white px-4 py-4">
+                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Exceptions en weekreview</p>
+                  <div className="mt-3 space-y-3">
+                    {operatingGuide.exceptionRules.map((rule) => (
+                      <div key={rule.status} className="rounded-2xl border border-slate-100 bg-slate-50 px-3 py-3">
+                        <p className="text-sm font-semibold text-slate-950">{rule.title}</p>
+                        <p className="mt-1 text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                          {rule.owner} · {rule.responseWindow}
+                        </p>
+                        <p className="mt-2 text-sm leading-6 text-slate-700">{rule.escalationRule}</p>
+                      </div>
+                    ))}
+                    <div className="rounded-2xl border border-slate-100 bg-slate-50 px-3 py-3">
+                      <p className="text-sm font-semibold text-slate-950">Weekly delivery review</p>
+                      <ul className="mt-2 space-y-2">
+                        {operatingGuide.weeklyReviewRules.map((rule) => (
+                          <li key={rule.title} className="text-sm leading-6 text-slate-700">
+                            <span className="font-semibold text-slate-900">{rule.title}:</span> {rule.detail}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
 

--- a/frontend/lib/ops-delivery.test.ts
+++ b/frontend/lib/ops-delivery.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildDeliveryAutoSignals,
+  buildDeliveryDisciplineWarnings,
   buildDeliveryGovernanceSnapshot,
   buildDeliveryOpsSummary,
+  getDeliveryOperatingGuide,
   validateDeliveryCheckpointUpdate,
   validateDeliveryLifecycleTransition,
   type CampaignDeliveryCheckpoint,
@@ -227,5 +229,41 @@ describe('delivery ops governance helpers', () => {
     expect(transition.allowed).toBe(false)
     expect(transition.blockers.join(' ')).toContain('Follow-up')
     expect(transition.blockers.join(' ')).toContain('Learning closure')
+  })
+
+  it('flags missing operator discipline when lifecycle advances without owner, handoff or dated follow-up', () => {
+    const warnings = buildDeliveryDisciplineWarnings({
+      record: createRecord({
+        lifecycle_stage: 'follow_up_decided',
+        operator_owner: '',
+        next_step: '',
+        customer_handoff_note: '',
+        follow_up_decided_at: null,
+      }),
+      linkedLeadPresent: false,
+      invitesNotSent: 0,
+      pendingClientInviteCount: 0,
+      incompleteScores: 0,
+      activeClientAccessCount: 1,
+      totalCompleted: 8,
+      hasEnoughData: false,
+      governanceBlockers: [],
+      linkedLearningDossierCount: 1,
+      learningCloseoutEvidenceCount: 0,
+    })
+
+    expect(warnings.join(' ')).toContain('sales-to-delivery handoff')
+    expect(warnings.join(' ')).toContain('delivery-owner')
+    expect(warnings.join(' ')).toContain('klant-handoff')
+    expect(warnings.join(' ')).toContain('follow-upbeslissing')
+  })
+
+  it('returns bounded operating guidance for non-core routes', () => {
+    const onboardingGuide = getDeliveryOperatingGuide('onboarding')
+    const leadershipGuide = getDeliveryOperatingGuide('leadership')
+
+    expect(onboardingGuide.followUpOutcomes.map((item) => item.detail).join(' ')).toContain('geen journey-suite')
+    expect(leadershipGuide.followUpOutcomes.map((item) => item.detail).join(' ')).toContain('named-leader')
+    expect(leadershipGuide.weeklyReviewRules).toHaveLength(3)
   })
 })

--- a/frontend/lib/ops-delivery.ts
+++ b/frontend/lib/ops-delivery.ts
@@ -97,6 +97,44 @@ export type DeliveryGovernanceSnapshot = {
   learningCloseoutReady: boolean
 }
 
+export type DeliveryOperatingRole = {
+  title: string
+  owner: string
+  responsibility: string
+}
+
+export type DeliveryManagementUseStep = {
+  title: string
+  detail: string
+}
+
+export type DeliveryFollowUpOutcome = {
+  title: string
+  fit: string
+  detail: string
+}
+
+export type DeliveryExceptionRule = {
+  status: Exclude<DeliveryExceptionStatus, 'none'>
+  title: string
+  owner: string
+  responseWindow: string
+  escalationRule: string
+}
+
+export type DeliveryWeeklyReviewRule = {
+  title: string
+  detail: string
+}
+
+export type DeliveryOperatingGuide = {
+  roles: DeliveryOperatingRole[]
+  managementUseSteps: DeliveryManagementUseStep[]
+  followUpOutcomes: DeliveryFollowUpOutcome[]
+  exceptionRules: DeliveryExceptionRule[]
+  weeklyReviewRules: DeliveryWeeklyReviewRule[]
+}
+
 type DeliveryAutoSignalArgs = {
   scanType: ScanType
   linkedLeadPresent: boolean
@@ -178,6 +216,18 @@ export const DELIVERY_CHECKPOINT_DEFINITIONS: Array<{
   },
 ] as const
 
+const DELIVERY_LIFECYCLE_ORDER: DeliveryLifecycleStage[] = [
+  'setup_in_progress',
+  'import_cleared',
+  'invites_live',
+  'client_activation_pending',
+  'client_activation_confirmed',
+  'first_value_reached',
+  'first_management_use',
+  'follow_up_decided',
+  'learning_closed',
+]
+
 export function getDeliveryLifecycleLabel(value: DeliveryLifecycleStage | null | undefined) {
   return DELIVERY_LIFECYCLE_OPTIONS.find((option) => option.value === value)?.label ?? 'Setup in uitvoering'
 }
@@ -208,10 +258,192 @@ export function getDeliveryAutoStateLabel(value: DeliveryAutoState) {
   }
 }
 
+export function isDeliveryLifecycleAtLeast(
+  current: DeliveryLifecycleStage | null | undefined,
+  target: DeliveryLifecycleStage,
+) {
+  if (!current) return false
+  return DELIVERY_LIFECYCLE_ORDER.indexOf(current) >= DELIVERY_LIFECYCLE_ORDER.indexOf(target)
+}
+
 export function buildDeliveryCheckpointMap(checkpoints: CampaignDeliveryCheckpoint[]) {
   return Object.fromEntries(
     checkpoints.map((checkpoint) => [checkpoint.checkpoint_key, checkpoint]),
   ) as Partial<Record<DeliveryCheckpointKey, CampaignDeliveryCheckpoint>>
+}
+
+export function getDeliveryOperatingGuide(scanType: ScanType): DeliveryOperatingGuide {
+  const sharedRoles: DeliveryOperatingRole[] = [
+    {
+      title: 'Delivery-owner',
+      owner: 'Verisight delivery',
+      responsibility: 'Bewaakt launch discipline, deliverystart, open blockers en de eerstvolgende stap.',
+    },
+    {
+      title: 'Management-use confirmer',
+      owner:
+        scanType === 'exit' || scanType === 'retention'
+          ? 'Klant sponsor of HR-owner'
+          : 'Klant owner van de bounded route',
+      responsibility: 'Bevestigt dat output echt in een eerste managementgesprek is gebruikt en dat eigenaar, eerste stap en reviewdatum expliciet zijn.',
+    },
+    {
+      title: 'Follow-up beslisser',
+      owner: 'Verisight + klant owner',
+      responsibility: 'Kiest bewust of de route doorgaat, bounded vervolgt, verdiept, pauzeert of stopt.',
+    },
+  ]
+
+  const managementUseSteps: DeliveryManagementUseStep[] = [
+    {
+      title: 'Leg de eerste managementvraag vast',
+      detail:
+        scanType === 'onboarding'
+          ? 'Maak expliciet waar de vroege landing nu stokt en welk checkpointspoor eerst aandacht vraagt.'
+          : scanType === 'leadership'
+            ? 'Maak expliciet welke managementcontext nu eerst een begrensde check of correctie vraagt.'
+            : scanType === 'pulse'
+              ? 'Maak expliciet welke review- of herijkingsvraag nu eerst aandacht vraagt.'
+              : scanType === 'retention'
+                ? 'Maak expliciet waar behoud nu onder druk staat en welk verificatiespoor eerst telt.'
+                : 'Maak expliciet welk vertrek- of verbeterpatroon nu als eerste managementvraag telt.',
+    },
+    {
+      title: 'Bevestig eigenaar en eerste stap',
+      detail: 'Leg vast wie de eigenaar is, welke kleine toetsbare stap nu start en wat nog niet besloten is.',
+    },
+    {
+      title: 'Zet reviewdatum en terugkoppeling',
+      detail: 'Management use telt pas echt als een reviewmoment en verwachte terugkoppeling expliciet zijn vastgelegd.',
+    },
+  ]
+
+  const followUpOutcomes: DeliveryFollowUpOutcome[] =
+    scanType === 'onboarding'
+      ? [
+          {
+            title: 'Doorgaan op hetzelfde checkpointspoor',
+            fit: 'Alleen na expliciete eerste borg- of correctiestap',
+            detail: 'Gebruik dit pas als eigenaar, eerste stap en vervolgmoment al vaststaan. Onboarding blijft hierbij een bounded checkpoint-route, geen journey-suite.',
+          },
+          {
+            title: 'Bounded vervolg',
+            fit: 'Alleen bij logische volgende checkpointread',
+            detail: 'Kies dit alleen wanneer dezelfde instroomvraag later opnieuw getoetst moet worden zonder bredere lifecycle-uitbouw.',
+          },
+          {
+            title: 'Stop of ga naar andere route',
+            fit: 'Bij andere managementvraag',
+            detail: 'Schakel pas door als de vraag inmiddels eerder over behoud, retrospectieve duiding of lokale lokalisatie gaat dan over vroege landing.',
+          },
+        ]
+      : scanType === 'leadership'
+        ? [
+            {
+              title: 'Doorgaan met bounded verificatie',
+              fit: 'Alleen na expliciete eerste correctie',
+              detail: 'Gebruik dit wanneer dezelfde managementcontext later opnieuw begrensd getoetst moet worden.',
+            },
+            {
+              title: 'Verdiepen zonder named leaders',
+              fit: 'Alleen bij scherpere groepsvraag',
+              detail: 'Verdiep alleen zolang de route group-level blijft en niet afglijdt naar 360-, named-leader- of performance-logica.',
+            },
+            {
+              title: 'Stop of ga terug naar bredere duiding',
+              fit: 'Bij andere managementvraag',
+              detail: 'Gebruik dit wanneer de contextvraag eigenlijk een bredere people-route of een andere productscope vraagt.',
+            },
+          ]
+        : scanType === 'pulse'
+          ? [
+              {
+                title: 'Doorgaan met bounded hercheck',
+                fit: 'Alleen na zichtbare kleine correctie',
+                detail: 'Gebruik dit wanneer de eerste review al heeft geleid tot een eigenaar, kleine bijsturing en afgesproken hercheck.',
+              },
+              {
+                title: 'Verdiepen naar bredere duiding',
+                fit: 'Alleen als reviewvraag te groot wordt',
+                detail: 'Gebruik dit wanneer dezelfde signalen niet meer als compacte reviewvraag leesbaar blijven.',
+              },
+              {
+                title: 'Pauzeren of stoppen',
+                fit: 'Bij voldoende stabilisatie of te smalle basis',
+                detail: 'Houd Pulse compact en kies bewust voor stop of later opnieuw openen in plaats van automatische ritme-uitbreiding.',
+              },
+            ]
+          : [
+              {
+                title: 'Doorgaan op dezelfde route',
+                fit: 'Standaard na eerste managementuse',
+                detail: 'Gebruik dit als dezelfde managementvraag een logische vervolgmeting of verdere uitvoering vraagt.',
+              },
+              {
+                title: 'Bounded vervolg of verdieping',
+                fit: 'Alleen bij expliciete aanvullende vraag',
+                detail: 'Kies dit wanneer dezelfde route blijft, maar een extra verdiepingslaag of bounded vervolg bewust is gekozen.',
+              },
+              {
+                title: 'Pauzeren of stoppen',
+                fit: 'Bij afgeronde eerste actie of andere routevraag',
+                detail: 'Gebruik dit wanneer de eerste managementactie staat en een volgende stap pas later of via een ander product logisch wordt.',
+              },
+            ]
+
+  const exceptionRules: DeliveryExceptionRule[] = [
+    {
+      status: 'blocked',
+      title: 'Geblokkeerd',
+      owner: 'Delivery-owner',
+      responseWindow: 'Zelfde werkdag triage',
+      escalationRule: 'Escaleer bestuurlijk zodra de blokkade launch, first value of management use direct tegenhoudt.',
+    },
+    {
+      status: 'needs_operator_recovery',
+      title: 'Operator recovery nodig',
+      owner: 'Verisight delivery',
+      responseWindow: 'Binnen 1 werkdag herstelpad',
+      escalationRule: 'Escaleer als herstel niet binnen het afgesproken reviewmoment of de eerstvolgende deliverystap kan landen.',
+    },
+    {
+      status: 'awaiting_client_input',
+      title: 'Wacht op klantinput',
+      owner: 'Klant owner + delivery-owner',
+      responseWindow: 'Binnen 2 werkdagen opvolgen',
+      escalationRule: 'Escaleer als ontbrekende input first value, report delivery of follow-upbesluit blijft blokkeren.',
+    },
+    {
+      status: 'awaiting_external_delivery',
+      title: 'Wacht op externe delivery',
+      owner: 'Delivery-owner',
+      responseWindow: 'Binnen 1 werkdag statusupdate',
+      escalationRule: 'Escaleer zodra externe afhankelijkheid het afgesproken launch- of reviewmoment in gevaar brengt.',
+    },
+  ]
+
+  const weeklyReviewRules: DeliveryWeeklyReviewRule[] = [
+    {
+      title: 'Open launch- en activationblockers',
+      detail: 'Bekijk wekelijks alle dossiers met open intake-, import-, invite- of activatieblokkades en leg de eerstvolgende stap opnieuw vast.',
+    },
+    {
+      title: 'Management use zonder follow-up',
+      detail: 'Bekijk wekelijks alle dossiers waar first management use al bevestigd is, maar follow-up nog niet expliciet is besloten.',
+    },
+    {
+      title: 'Verouderde bounded routes',
+      detail: 'Heropen dossiers waarvan reviewdatum, volgende stap of owner ontbreekt, zodat bounded routes niet stilzwijgend als gezond blijven ogen.',
+    },
+  ]
+
+  return {
+    roles: sharedRoles,
+    managementUseSteps,
+    followUpOutcomes,
+    exceptionRules,
+    weeklyReviewRules,
+  }
 }
 
 export function buildDeliveryAutoSignals({
@@ -511,17 +743,82 @@ export function buildDeliveryGovernanceSnapshot(args: {
   } satisfies DeliveryGovernanceSnapshot
 }
 
-const DELIVERY_LIFECYCLE_ORDER: DeliveryLifecycleStage[] = [
-  'setup_in_progress',
-  'import_cleared',
-  'invites_live',
-  'client_activation_pending',
-  'client_activation_confirmed',
-  'first_value_reached',
-  'first_management_use',
-  'follow_up_decided',
-  'learning_closed',
-]
+export function buildDeliveryDisciplineWarnings(args: {
+  record: CampaignDeliveryRecord | null
+  linkedLeadPresent: boolean
+  invitesNotSent: number
+  pendingClientInviteCount: number
+  incompleteScores: number
+  activeClientAccessCount: number
+  totalCompleted: number
+  hasEnoughData: boolean
+  governanceBlockers: string[]
+  linkedLearningDossierCount?: number
+  learningCloseoutEvidenceCount?: number
+}) {
+  const items: string[] = []
+
+  if (!args.linkedLeadPresent) {
+    items.push('De sales-to-delivery handoff is nog niet expliciet gekoppeld aan deze campaign.')
+  }
+  if (!args.record?.operator_owner?.trim()) {
+    items.push('Er is nog geen expliciete delivery-owner vastgelegd voor deze campaign.')
+  }
+  if (args.invitesNotSent > 0) {
+    items.push(`${args.invitesNotSent} respondent(en) hebben nog geen invite ontvangen of verzendbevestiging.`)
+  }
+  if (args.pendingClientInviteCount > 0 && args.activeClientAccessCount === 0) {
+    items.push(`${args.pendingClientInviteCount} klantinvite(s) wachten nog op activatie.`)
+  }
+  if (args.incompleteScores > 0) {
+    items.push(`${args.incompleteScores} opgeslagen responses hebben nog incomplete scoredata.`)
+  }
+  if (args.totalCompleted >= 5 && !args.hasEnoughData) {
+    items.push('De campaign heeft een indicatief first-value beeld, maar nog geen stevig patroonniveau.')
+  }
+  if (args.record?.exception_status && args.record.exception_status !== 'none') {
+    items.push(`Open exception: ${getDeliveryExceptionLabel(args.record.exception_status)}.`)
+  }
+  if (
+    args.record &&
+    isDeliveryLifecycleAtLeast(args.record.lifecycle_stage, 'client_activation_confirmed') &&
+    !args.record.next_step?.trim()
+  ) {
+    items.push('Na klantactivatie ontbreekt nog een expliciete volgende stap voor delivery.')
+  }
+  if (
+    args.record &&
+    isDeliveryLifecycleAtLeast(args.record.lifecycle_stage, 'first_value_reached') &&
+    !args.record.customer_handoff_note?.trim()
+  ) {
+    items.push('First value staat verder dan setup, maar de klant-handoff naar management use is nog niet expliciet vastgelegd.')
+  }
+  if (
+    args.record &&
+    isDeliveryLifecycleAtLeast(args.record.lifecycle_stage, 'first_management_use') &&
+    !args.record.first_management_use_confirmed_at
+  ) {
+    items.push('Lifecycle staat al op of voorbij eerste management use, maar de bevestigingsdatum ontbreekt nog.')
+  }
+  if (
+    args.record &&
+    isDeliveryLifecycleAtLeast(args.record.lifecycle_stage, 'follow_up_decided') &&
+    !args.record.follow_up_decided_at
+  ) {
+    items.push('Follow-up staat bestuurlijk verder, maar er is nog geen expliciete follow-upbeslissing gedateerd vastgelegd.')
+  }
+  if (
+    args.record?.lifecycle_stage === 'learning_closed' &&
+    (args.linkedLearningDossierCount ?? 0) > 0 &&
+    (args.learningCloseoutEvidenceCount ?? 0) === 0
+  ) {
+    items.push('Learning staat op gesloten, maar expliciete review-, vervolg- of stopevidence ontbreekt nog.')
+  }
+
+  items.push(...args.governanceBlockers)
+
+  return dedupeMessages(items)
+}
 
 export function validateDeliveryLifecycleTransition(args: {
   scanType: ScanType


### PR DESCRIPTION
## Samenvatting
- hardent de delivery-control met expliciete operating discipline in de preflight-checklist
- voegt routebewuste management-use, follow-up en exception guidance toe aan de ops helperlaag
- breidt delivery tests uit voor disciplinewarnings en bounded follow-up guidance

## Verificatie
- `vitest run --run lib/ops-delivery.test.ts`
- `next build` met frontend `.env.local` en `NEXT_DIST_DIR=.next-preview`
