### PR TITLE
Guided self-serve dashboard and seeded acceptance flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,10 @@ Thumbs.db
 # Logs
 *.log
 .codex-artifacts/
+.acceptance-runtime/
 .worktrees/
+supabase/.branches/
+supabase/.temp/
 
 # Node (frontend heeft eigen .gitignore)
 frontend/node_modules/

--- a/backend/email.py
+++ b/backend/email.py
@@ -97,6 +97,10 @@ def _sanitize_error_reason(reason: str, *, max_length: int = 240) -> str:
     return normalized[: max_length - 3] + "..."
 
 
+def _acceptance_email_stub_enabled() -> bool:
+    return os.getenv("VERISIGHT_ACCEPTANCE_FAKE_EMAIL", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
 def _send_result(
     *,
     to: str,
@@ -114,6 +118,9 @@ def _send_result(
     if not _CONTACT_EMAIL.strip() and subject.startswith("Kennismakingsaanvraag"):
         logger.warning("E-mail niet verzonden naar %s: CONTACT_EMAIL ontbreekt.", safe_to)
         return EmailSendResult(ok=False, reason="missing_contact_email")
+    if _acceptance_email_stub_enabled():
+        logger.info("Acceptance-stub: e-mail als verzonden gemarkeerd voor %s.", safe_to)
+        return EmailSendResult(ok=True, reason="acceptance_stub")
     if _resend is None:
         logger.warning("E-mail niet verzonden naar %s: resend package ontbreekt.", safe_to)
         return EmailSendResult(ok=False, reason="resend_import_missing")

--- a/demo_environment.py
+++ b/demo_environment.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Literal
 
+from sqlalchemy import inspect, text
 from sqlalchemy.orm import Session
 
 from backend.models import Campaign, Organization, OrganizationSecret, Respondent, SurveyResponse
@@ -31,6 +32,11 @@ INTERNAL_SALES_DEMO_CONTACT_EMAIL = "sales-demo@verisight.nl"
 
 QA_EXIT_ORG_NAME = "Verisight ExitScan Live Test"
 QA_EXIT_ORG_SLUG = "exitscan-live-test"
+GUIDED_SELF_SERVE_ACCEPTANCE_ORG_NAME = "Verisight Guided Self-Serve Acceptance"
+GUIDED_SELF_SERVE_ACCEPTANCE_ORG_SLUG = "guided-self-serve-acceptance"
+GUIDED_SELF_SERVE_ACCEPTANCE_CONTACT_EMAIL = "guided-acceptance@verisight.nl"
+GUIDED_SELF_SERVE_SETUP_CAMPAIGN_NAME = "Guided Self-Serve - Setup Journey"
+GUIDED_SELF_SERVE_THRESHOLD_CAMPAIGN_NAME = "Guided Self-Serve - Threshold Journey"
 QA_RETENTION_ORG_SLUG = "bakker-partners-demo"
 
 VALIDATION_RETENTION_DEFAULT_DB = "data/retention_pilot_dummy.db"
@@ -39,6 +45,7 @@ VALIDATION_RETENTION_DEFAULT_OUTDIR = "data/retention_pilot_dummy_run"
 RANDOM_SEEDS = {
     "sales_demo_exit": 20260415,
     "sales_demo_retention": 20260416,
+    "qa_guided_self_serve_acceptance": 20260423,
 }
 
 RESPONSE_THRESHOLDS = {
@@ -46,11 +53,22 @@ RESPONSE_THRESHOLDS = {
     "pattern": 10,
 }
 
+
+def _is_uuid_like(value: str | None) -> bool:
+    if not value:
+        return False
+    try:
+        uuid.UUID(str(value))
+    except (ValueError, TypeError, AttributeError):
+        return False
+    return True
+
 DemoLayerKey = Literal["buyer_facing_showcase", "internal_sales_demo", "qa_live_fixture", "validation_sandbox"]
 DemoScenarioKey = Literal[
     "sales_demo_exit",
     "sales_demo_retention",
     "qa_exit_live_test",
+    "qa_guided_self_serve_acceptance",
     "qa_retention_demo",
     "validation_retention_pilot",
 ]
@@ -199,6 +217,21 @@ DEMO_SCENARIOS: dict[DemoScenarioKey, DemoScenarioDefinition] = {
         data_policy="Fictive org, safe demo mailboxes, and token/test-only behavior.",
         expected_campaign_states=("empty", "early_signal", "indicative", "decision_ready", "closed_archive", "action_safe"),
         entrypoint="manage_demo_environment.py run qa_exit_live_test",
+    ),
+    "qa_guided_self_serve_acceptance": DemoScenarioDefinition(
+        key="qa_guided_self_serve_acceptance",
+        label="Guided self-serve acceptance fixture",
+        layer="qa_live_fixture",
+        audience="operators and engineers validating the customer execution flow",
+        scenario_type="qa_live_fixture",
+        org_name=GUIDED_SELF_SERVE_ACCEPTANCE_ORG_NAME,
+        org_slug=GUIDED_SELF_SERVE_ACCEPTANCE_ORG_SLUG,
+        purpose="Deterministic customer-journey fixture for setup, import recovery, launch gating, dashboard activation and first next-step checks.",
+        claim_boundary="Use only for QA acceptance and seeded browser walkthroughs, never as a sales default.",
+        reset_strategy="Reseeds the dedicated guided self-serve acceptance org and advances only the threshold journey on request.",
+        data_policy="Fictive org, safe demo mailboxes and one linked viewer account for customer-rights validation.",
+        expected_campaign_states=("setup_journey", "threshold_journey"),
+        entrypoint="manage_demo_environment.py run qa_guided_self_serve_acceptance",
     ),
     "qa_retention_demo": DemoScenarioDefinition(
         key="qa_retention_demo",
@@ -359,9 +392,20 @@ def _get_or_create_org(
     slug: str,
     name: str,
     contact_email: str,
+    acting_user_id: str | None = None,
 ) -> Organization:
     org = db.query(Organization).filter(Organization.slug == slug).one_or_none()
     if org is None:
+        bind = db.get_bind()
+        if (
+            bind is not None
+            and bind.dialect.name != "sqlite"
+            and _is_uuid_like(acting_user_id)
+        ):
+            db.execute(
+                text("select set_config('request.jwt.claim.sub', :user_id, true)"),
+                {"user_id": str(acting_user_id)},
+            )
         org = Organization(
             id=str(uuid.uuid4()),
             name=name,
@@ -384,6 +428,55 @@ def _ensure_org_secret(db: Session, org: Organization) -> None:
     if existing is None:
         db.add(OrganizationSecret(org_id=org.id))
         db.flush()
+
+
+def _has_table(db: Session, table_name: str) -> bool:
+    return inspect(db.bind).has_table(table_name)
+
+
+def _ensure_role_memberships(
+    db: Session,
+    *,
+    org: Organization,
+    admin_user_id: str | None = None,
+    member_user_ids: list[str] | None = None,
+    viewer_user_ids: list[str] | None = None,
+) -> None:
+    member_user_ids = member_user_ids or []
+    viewer_user_ids = viewer_user_ids or []
+
+    if not (_has_table(db, "profiles") and _has_table(db, "org_members")):
+        return
+
+    assignments: list[tuple[str, str, bool]] = []
+    if admin_user_id:
+        assignments.append((admin_user_id, "owner", True))
+    assignments.extend((user_id, "member", False) for user_id in member_user_ids)
+    assignments.extend((user_id, "viewer", False) for user_id in viewer_user_ids)
+
+    for user_id, role, is_admin in assignments:
+        db.execute(
+            text(
+                """
+                insert into public.profiles (id, is_verisight_admin)
+                values (:user_id, :is_admin)
+                on conflict (id) do update
+                set is_verisight_admin = excluded.is_verisight_admin
+                """
+            ),
+            {"user_id": user_id, "is_admin": is_admin},
+        )
+        db.execute(
+            text(
+                """
+                insert into public.org_members (org_id, user_id, role)
+                values (:org_id, :user_id, :role)
+                on conflict (org_id, user_id) do update
+                set role = excluded.role
+                """
+            ),
+            {"org_id": org.id, "user_id": user_id, "role": role},
+        )
 
 
 def _purge_campaign(db: Session, campaign: Campaign) -> None:
@@ -613,6 +706,131 @@ def _create_retention_completed_respondent(
     return respondent
 
 
+def _create_guided_self_serve_fixture_campaign(
+    db: Session,
+    *,
+    org: Organization,
+    name: str,
+    created_days_ago: int,
+    enabled_modules: list[str] | None = None,
+) -> Campaign:
+    created_at = datetime.now(timezone.utc) - timedelta(days=created_days_ago)
+    campaign = Campaign(
+        id=str(uuid.uuid4()),
+        organization_id=org.id,
+        name=name,
+        scan_type="exit",
+        delivery_mode="baseline",
+        is_active=True,
+        enabled_modules=enabled_modules,
+        created_at=created_at,
+        closed_at=None,
+    )
+    db.add(campaign)
+    db.flush()
+    return campaign
+
+
+def _safe_guided_acceptance_email(campaign_key: str, status: str, index: int) -> str:
+    return _safe_demo_email("guided-self-serve", campaign_key, status, index)
+
+
+def _get_guided_self_serve_org(db: Session, org_slug: str) -> Organization:
+    org = db.query(Organization).filter(Organization.slug == org_slug).one_or_none()
+    if org is None:
+        raise RuntimeError(f"Organisatie met slug '{org_slug}' niet gevonden voor guided self-serve acceptance.")
+    return org
+
+
+def _get_guided_self_serve_threshold_campaign(db: Session, org: Organization) -> Campaign:
+    campaign = (
+        db.query(Campaign)
+        .filter(
+            Campaign.organization_id == org.id,
+            Campaign.name == GUIDED_SELF_SERVE_THRESHOLD_CAMPAIGN_NAME,
+        )
+        .one_or_none()
+    )
+    if campaign is None:
+        raise RuntimeError("Threshold journey ontbreekt in guided self-serve acceptance fixture.")
+    return campaign
+
+
+def _completed_count(campaign: Campaign) -> int:
+    return sum(1 for respondent in campaign.respondents if respondent.completed)
+
+
+def _ensure_completed_responses(db: Session, *, campaign: Campaign, target_total_completed: int) -> int:
+    current_completed = _completed_count(campaign)
+    if current_completed >= target_total_completed:
+        return current_completed
+
+    pending_rows = [
+        respondent
+        for respondent in sorted(
+            campaign.respondents,
+            key=lambda respondent: (respondent.sent_at or campaign.created_at, respondent.email or respondent.id),
+        )
+        if not respondent.completed
+    ]
+
+    while current_completed < target_total_completed and pending_rows:
+        respondent = pending_rows.pop(0)
+        completed_at = datetime.now(timezone.utc) - timedelta(minutes=(target_total_completed - current_completed) * 9)
+        respondent.completed = True
+        respondent.completed_at = completed_at
+        respondent.opened_at = respondent.opened_at or completed_at - timedelta(hours=6)
+        if respondent.sent_at is None:
+            respondent.sent_at = completed_at - timedelta(days=2)
+        respondent.token_expires_at = completed_at + timedelta(days=30)
+        db.add(respondent)
+        db.flush()
+
+        profile = _pick_exit_profile()
+        response_payload = _build_exit_response(profile, respondent.annual_salary_eur or float(random.choice(SALARIES)), respondent.role_level or random.choice(ROLE_LEVELS))
+        db.add(
+            SurveyResponse(
+                id=str(uuid.uuid4()),
+                respondent_id=respondent.id,
+                tenure_years=response_payload["tenure_years"],
+                exit_reason_category=response_payload["exit_reason_category"],
+                exit_reason_code=response_payload["exit_reason_code"],
+                stay_intent_score=response_payload["stay_intent_score"],
+                sdt_raw=response_payload["sdt_raw"],
+                sdt_scores=response_payload["sdt_scores"],
+                org_raw=response_payload["org_raw"],
+                org_scores=response_payload["org_scores"],
+                pull_factors_raw=response_payload["pull_factors_raw"],
+                open_text_raw=response_payload["open_text_raw"],
+                uwes_raw=response_payload["uwes_raw"],
+                uwes_score=response_payload["uwes_score"],
+                turnover_intention_raw=response_payload["turnover_intention_raw"],
+                turnover_intention_score=response_payload["turnover_intention_score"],
+                risk_score=response_payload["risk_score"],
+                risk_band=response_payload["risk_band"],
+                preventability=response_payload["preventability"],
+                replacement_cost_eur=response_payload["replacement_cost_eur"],
+                full_result=response_payload["full_result"],
+                submitted_at=completed_at,
+                scoring_version="v1.1",
+            )
+        )
+        db.flush()
+        current_completed += 1
+
+    while current_completed < target_total_completed:
+        completed_at = datetime.now(timezone.utc) - timedelta(minutes=(target_total_completed - current_completed) * 7)
+        _create_exit_completed_respondent(
+            db,
+            campaign=campaign,
+            email=_safe_guided_acceptance_email("threshold", "completed", current_completed + 1),
+            completed_at=completed_at,
+        )
+        current_completed += 1
+
+    return current_completed
+
+
 def seed_sales_demo_exit(
     db: Session,
     *,
@@ -700,6 +918,106 @@ def seed_sales_demo_retention(
     return {
         "org_slug": org.slug,
         "campaign_count": len(RETENTION_SALES_FIXTURES),
+        "detail_threshold": RESPONSE_THRESHOLDS["detail"],
+        "pattern_threshold": RESPONSE_THRESHOLDS["pattern"],
+    }
+
+
+def seed_guided_self_serve_acceptance(
+    db: Session,
+    *,
+    org_slug: str = GUIDED_SELF_SERVE_ACCEPTANCE_ORG_SLUG,
+    org_name: str = GUIDED_SELF_SERVE_ACCEPTANCE_ORG_NAME,
+    contact_email: str = GUIDED_SELF_SERVE_ACCEPTANCE_CONTACT_EMAIL,
+    viewer_user_id: str | None = None,
+) -> dict[str, str | int | None]:
+    random.seed(RANDOM_SEEDS["qa_guided_self_serve_acceptance"])
+    resolved_org_slug = org_slug
+
+    org = _get_or_create_org(
+        db,
+        slug=org_slug,
+        name=org_name,
+        contact_email=contact_email,
+        acting_user_id=viewer_user_id if _is_uuid_like(viewer_user_id) else None,
+    )
+    _ensure_org_secret(db, org)
+    if _is_uuid_like(viewer_user_id):
+        _ensure_role_memberships(db, org=org, viewer_user_ids=[viewer_user_id])
+    _purge_named_campaigns(
+        db,
+        org,
+        [GUIDED_SELF_SERVE_SETUP_CAMPAIGN_NAME, GUIDED_SELF_SERVE_THRESHOLD_CAMPAIGN_NAME],
+    )
+
+    _create_guided_self_serve_fixture_campaign(
+        db,
+        org=org,
+        name=GUIDED_SELF_SERVE_SETUP_CAMPAIGN_NAME,
+        created_days_ago=1,
+    )
+    threshold_campaign = _create_guided_self_serve_fixture_campaign(
+        db,
+        org=org,
+        name=GUIDED_SELF_SERVE_THRESHOLD_CAMPAIGN_NAME,
+        created_days_ago=3,
+    )
+
+    for index in range(4):
+        completed_at = threshold_campaign.created_at + timedelta(days=1, minutes=index * 13)
+        _create_exit_completed_respondent(
+            db,
+            campaign=threshold_campaign,
+            email=_safe_guided_acceptance_email("threshold", "completed", index + 1),
+            completed_at=completed_at,
+        )
+
+    for index in range(4):
+        _create_pending_respondent(
+            db,
+            campaign=threshold_campaign,
+            email=_safe_guided_acceptance_email("threshold", "pending", index + 1),
+            sent_at=threshold_campaign.created_at + timedelta(days=1),
+            opened=index % 2 == 0,
+            exit_month="2026-03",
+        )
+
+    db.commit()
+    return {
+        "org_slug": resolved_org_slug,
+        "campaign_count": 2,
+        "detail_threshold": RESPONSE_THRESHOLDS["detail"],
+        "pattern_threshold": RESPONSE_THRESHOLDS["pattern"],
+        "viewer_user_id": viewer_user_id,
+    }
+
+
+def advance_guided_self_serve_acceptance(
+    db: Session,
+    *,
+    phase: Literal["min_display", "patterns"],
+    org_slug: str = GUIDED_SELF_SERVE_ACCEPTANCE_ORG_SLUG,
+) -> dict[str, str | int]:
+    target_total_completed = (
+        RESPONSE_THRESHOLDS["detail"]
+        if phase == "min_display"
+        else RESPONSE_THRESHOLDS["pattern"]
+    )
+    resolved_org_slug = org_slug
+    org = _get_guided_self_serve_org(db, org_slug)
+    threshold_campaign = _get_guided_self_serve_threshold_campaign(db, org)
+    campaign_name = threshold_campaign.name
+    total_completed = _ensure_completed_responses(
+        db,
+        campaign=threshold_campaign,
+        target_total_completed=target_total_completed,
+    )
+    db.commit()
+    return {
+        "org_slug": resolved_org_slug,
+        "campaign_name": campaign_name,
+        "phase": phase,
+        "total_completed": total_completed,
         "detail_threshold": RESPONSE_THRESHOLDS["detail"],
         "pattern_threshold": RESPONSE_THRESHOLDS["pattern"],
     }

--- a/frontend/app/(auth)/complete-account/page.tsx
+++ b/frontend/app/(auth)/complete-account/page.tsx
@@ -8,7 +8,6 @@ import { createClient } from '@/lib/supabase/client'
 
 export default function CompleteAccountPage() {
   const router = useRouter()
-  const supabase = createClient()
   const [password, setPassword] = useState('')
   const [password2, setPassword2] = useState('')
   const [loading, setLoading] = useState(false)
@@ -21,6 +20,7 @@ export default function CompleteAccountPage() {
     let mounted = true
 
     async function loadSession() {
+      const supabase = createClient()
       const { data } = await supabase.auth.getUser()
 
       if (!mounted) {
@@ -41,7 +41,7 @@ export default function CompleteAccountPage() {
     return () => {
       mounted = false
     }
-  }, [router, supabase])
+  }, [router])
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -58,6 +58,7 @@ export default function CompleteAccountPage() {
     }
 
     setLoading(true)
+    const supabase = createClient()
     const { error: updateError } = await supabase.auth.updateUser({ password })
     setLoading(false)
 

--- a/frontend/app/(auth)/forgot-password/page.tsx
+++ b/frontend/app/(auth)/forgot-password/page.tsx
@@ -9,13 +9,13 @@ export default function ForgotPasswordPage() {
   const [submitted, setSubmitted] = useState(false)
   const [error,     setError]     = useState<string | null>(null)
   const [loading,   setLoading]   = useState(false)
-  const supabase = createClient()
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     setLoading(true)
     setError(null)
 
+    const supabase = createClient()
     const { error } = await supabase.auth.resetPasswordForEmail(email, {
       redirectTo: `${window.location.origin}/reset-password`,
     })

--- a/frontend/app/(auth)/login/page.tsx
+++ b/frontend/app/(auth)/login/page.tsx
@@ -11,13 +11,13 @@ export default function LoginPage() {
   const [error,    setError]    = useState<string | null>(null)
   const [loading,  setLoading]  = useState(false)
   const router = useRouter()
-  const supabase = createClient()
 
   async function handleLogin(e: React.FormEvent) {
     e.preventDefault()
     setLoading(true)
     setError(null)
 
+    const supabase = createClient()
     const { error } = await supabase.auth.signInWithPassword({ email, password })
 
     if (error) {
@@ -45,6 +45,14 @@ export default function LoginPage() {
         {/* Card */}
         <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-8">
           <h1 className="text-xl font-semibold text-gray-900 mb-6">Inloggen</h1>
+
+          <div className="mb-5 rounded-lg border border-blue-100 bg-blue-50 px-4 py-3 text-sm text-blue-900">
+            <p className="font-semibold">Begeleide klantuitvoering</p>
+            <p className="mt-1 leading-6 text-blue-800">
+              Verisight heeft account, campaign en productgrenzen al voorbereid. Na login zie je direct wat nu ontbreekt,
+              wanneer deelnemers kunnen worden aangeleverd, wanneer uitnodigingen veilig live mogen en wanneer het dashboard echt actief wordt.
+            </p>
+          </div>
 
           <form onSubmit={handleLogin} className="space-y-4">
             <div>

--- a/frontend/app/(auth)/reset-password/page.tsx
+++ b/frontend/app/(auth)/reset-password/page.tsx
@@ -13,14 +13,17 @@ export default function ResetPasswordPage() {
   const [done,      setDone]      = useState(false)
   const [ready,     setReady]     = useState(false)
   const router  = useRouter()
-  const supabase = createClient()
 
   // Supabase verwerkt de reset-token via de URL-hash zodra de client laadt
   useEffect(() => {
-    supabase.auth.onAuthStateChange((event) => {
+    const supabase = createClient()
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((event) => {
       if (event === 'PASSWORD_RECOVERY') setReady(true)
     })
-  }, [supabase])
+    return () => subscription.unsubscribe()
+  }, [])
 
   async function handleReset(e: React.FormEvent) {
     e.preventDefault()
@@ -36,6 +39,7 @@ export default function ResetPasswordPage() {
     }
 
     setLoading(true)
+    const supabase = createClient()
     const { error } = await supabase.auth.updateUser({ password })
 
     if (error) {

--- a/frontend/app/(auth)/signup/page.tsx
+++ b/frontend/app/(auth)/signup/page.tsx
@@ -11,7 +11,6 @@ export default function SignupPage() {
   const [error,     setError]     = useState<string | null>(null)
   const [success,   setSuccess]   = useState(false)
   const [loading,   setLoading]   = useState(false)
-  const supabase = createClient()
 
   async function handleSignup(e: React.FormEvent) {
     e.preventDefault()
@@ -28,6 +27,7 @@ export default function SignupPage() {
 
     setLoading(true)
 
+    const supabase = createClient()
     const { error } = await supabase.auth.signUp({
       email,
       password,

--- a/frontend/app/(dashboard)/campaigns/[id]/actions.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/actions.ts
@@ -45,7 +45,6 @@ export async function resendPendingAction(campaignId: string): Promise<ResendRes
     .select('role')
     .eq('org_id', campaign.organization_id)
     .eq('user_id', user.id)
-    .in('role', ['owner', 'member'])
     .maybeSingle()
 
   if (membershipError || !membership) {

--- a/frontend/app/(dashboard)/campaigns/[id]/campaign-actions.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/campaign-actions.tsx
@@ -9,10 +9,17 @@ interface CampaignActionsProps {
   campaignId: string
   isActive: boolean
   pendingCount: number
-  canManageCampaign: boolean
+  canResendInvites: boolean
+  canArchiveCampaign: boolean
 }
 
-export function CampaignActions({ campaignId, isActive, pendingCount, canManageCampaign }: CampaignActionsProps) {
+export function CampaignActions({
+  campaignId,
+  isActive,
+  pendingCount,
+  canResendInvites,
+  canArchiveCampaign,
+}: CampaignActionsProps) {
   const [loading, setLoading] = useState<'archive' | 'resend' | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [toast, setToast] = useState<string | null>(null)
@@ -71,12 +78,12 @@ export function CampaignActions({ campaignId, isActive, pendingCount, canManageC
     }
   }
 
-  if (!isActive || !canManageCampaign) return null
+  if (!isActive || (!canResendInvites && !canArchiveCampaign)) return null
 
   return (
     <div className="flex flex-col items-start gap-2 sm:items-end">
       <div className="flex flex-wrap gap-2">
-        {pendingCount > 0 ? (
+        {canResendInvites && pendingCount > 0 ? (
           <button
             onClick={handleResend}
             disabled={loading !== null}
@@ -86,13 +93,15 @@ export function CampaignActions({ campaignId, isActive, pendingCount, canManageC
             {loading === 'resend' ? 'Versturen...' : `Herinnering (${pendingCount})`}
           </button>
         ) : null}
-        <button
-          onClick={handleArchive}
-          disabled={loading !== null}
-          className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 transition-colors hover:border-amber-200 hover:bg-amber-50 hover:text-amber-700 disabled:opacity-50"
-        >
-          {loading === 'archive' ? 'Archiveren...' : 'Archiveer campaign'}
-        </button>
+        {canArchiveCampaign ? (
+          <button
+            onClick={handleArchive}
+            disabled={loading !== null}
+            className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-600 transition-colors hover:border-amber-200 hover:bg-amber-50 hover:text-amber-700 disabled:opacity-50"
+          >
+            {loading === 'archive' ? 'Archiveren...' : 'Archiveer campaign'}
+          </button>
+        ) : null}
       </div>
 
       {toast ? (

--- a/frontend/app/(dashboard)/campaigns/[id]/page.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.test.ts
@@ -24,4 +24,18 @@ describe('campaign page render truth', () => {
     expect(source).not.toContain("signalTabLabel: 'Vertrekbeeld'")
     expect(source).not.toContain('stay-intent')
   })
+
+  it('keeps the client shell guided until the dashboard is actually activated', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+    const guidedPanelSource = readFileSync(
+      new URL('../../../../components/dashboard/guided-self-serve-panel.tsx', import.meta.url),
+      'utf8',
+    )
+
+    expect(source).toContain('Begeleide uitvoerflow')
+    expect(source).toContain('Dashboard wordt zichtbaar vanaf de eerste veilige responsdrempel')
+    expect(source).toContain('showManagementOutput &&')
+    expect(source).toContain('Guided self-serve')
+    expect(guidedPanelSource).toContain('Start uitnodigingen')
+  })
 })

--- a/frontend/app/(dashboard)/campaigns/[id]/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.tsx
@@ -15,12 +15,14 @@ import {
 } from '@/components/dashboard/dashboard-primitives'
 import { DashboardTabs } from '@/components/dashboard/dashboard-tabs'
 import { FactorTable } from '@/components/dashboard/factor-table'
+import { GuidedSelfServePanel } from '@/components/dashboard/guided-self-serve-panel'
 import { ManagementReadGuide } from '@/components/dashboard/onboarding-panels'
 import { OnboardingAdvancer, OnboardingBalloon } from '@/components/dashboard/onboarding-balloon'
 import { PreflightChecklist } from '@/components/dashboard/preflight-checklist'
 import { RespondentTable } from '@/components/dashboard/respondent-table'
 import { RiskCharts } from '@/components/dashboard/risk-charts'
 import { getContactRequestsForAdmin } from '@/lib/contact-requests'
+import { buildGuidedSelfServeState } from '@/lib/guided-self-serve'
 import {
   ActionPlaybookList,
   buildDecisionPanels,
@@ -127,6 +129,7 @@ export default async function CampaignPage({ params }: Props) {
     membership?.role === 'owner' ||
     membership?.role === 'member'
   const isVerisightAdmin = profile?.is_verisight_admin === true
+  const canExecuteCampaign = isVerisightAdmin || Boolean(membership?.role)
   const hasSegmentDeepDive = hasCampaignAddOn(campaignMeta, 'segment_deep_dive')
   const { data: deliveryRecordRaw } = await supabase
     .from('campaign_delivery_records')
@@ -187,6 +190,10 @@ export default async function CampaignPage({ params }: Props) {
     .eq('campaign_id', id)
     .order('completed_at', { ascending: false, nullsFirst: false })
   const respondents = (allRespondents ?? []) as Respondent[]
+  const unsentRespondents = respondents
+    .filter((respondent) => !respondent.sent_at && !respondent.completed)
+    .map((respondent) => ({ token: respondent.token, email: respondent.email ?? null }))
+  const remindableCount = respondents.filter((respondent) => Boolean(respondent.sent_at) && !respondent.completed).length
 
   const factorData = computeFactorAverages(responses)
   const averageRiskScore = computeAverageSignalScore(responses)
@@ -266,6 +273,17 @@ export default async function CampaignPage({ params }: Props) {
     activeClientAccessCount: activeClientAccessCount ?? 0,
     pendingClientInviteCount: pendingClientInviteCount ?? 0,
   })
+  const guidedSelfServeState = buildGuidedSelfServeState({
+    isActive: stats.is_active,
+    totalInvited: stats.total_invited,
+    totalCompleted: stats.total_completed,
+    invitesNotSent,
+    hasMinDisplay,
+    hasEnoughData,
+  })
+  const showClientExecutionFlow = !isVerisightAdmin
+  const showManagementOutput = isVerisightAdmin || guidedSelfServeState.dashboardVisible
+  const utilitySectionVisible = canExecuteCampaign || respondents.length > 0 || isVerisightAdmin
   const riskDistribution = {
     HOOG: stats.band_high,
     MIDDEN: stats.band_medium,
@@ -695,34 +713,39 @@ export default async function CampaignPage({ params }: Props) {
   ]
   const sectionAnchors = [
     { id: 'samenvatting', label: 'Samenvatting' },
-    {
-      id: 'handoff',
-      label: stats.scan_type === 'retention' ? 'Handoff' : stats.scan_type === 'team' ? 'Lokale read' : 'Handoff',
-    },
-    {
-      id: 'drivers',
-      label: stats.scan_type === 'retention' ? 'Signalen' : stats.scan_type === 'team' ? 'Lokaal' : 'Drivers',
-    },
-    {
-      id: 'acties',
-      label: stats.scan_type === 'retention' ? 'Behoudsacties' : stats.scan_type === 'team' ? 'Lokale acties' : 'Acties',
-    },
-    {
-      id: 'route',
-      label:
-        stats.scan_type === 'retention' || stats.scan_type === 'exit'
-          ? 'Kernroute'
-          : stats.scan_type === 'team' ||
-              stats.scan_type === 'pulse' ||
-              stats.scan_type === 'onboarding' ||
-              stats.scan_type === 'leadership'
-            ? 'Vervolgroute'
-            : 'Route',
-    },
+    ...(showManagementOutput
+      ? [
+          {
+            id: 'handoff',
+            label: stats.scan_type === 'retention' ? 'Handoff' : stats.scan_type === 'team' ? 'Lokale read' : 'Handoff',
+          },
+          {
+            id: 'drivers',
+            label: stats.scan_type === 'retention' ? 'Signalen' : stats.scan_type === 'team' ? 'Lokaal' : 'Drivers',
+          },
+          {
+            id: 'acties',
+            label: stats.scan_type === 'retention' ? 'Behoudsacties' : stats.scan_type === 'team' ? 'Lokale acties' : 'Acties',
+          },
+          {
+            id: 'route',
+            label:
+              stats.scan_type === 'retention' || stats.scan_type === 'exit'
+                ? 'Kernroute'
+                : stats.scan_type === 'team' ||
+                    stats.scan_type === 'pulse' ||
+                    stats.scan_type === 'onboarding' ||
+                    stats.scan_type === 'leadership'
+                  ? 'Vervolgroute'
+                  : 'Route',
+          },
+        ]
+      : []),
     { id: 'methodiek', label: 'Methodiek' },
-    { id: 'operatie', label: 'Operatie' },
+    ...(utilitySectionVisible
+      ? [{ id: showClientExecutionFlow ? 'uitvoering' : 'operatie', label: showClientExecutionFlow ? 'Uitvoering' : 'Operatie' }]
+      : []),
   ]
-  const utilitySectionVisible = canManageCampaign || respondents.length > 0 || isVerisightAdmin
   const promotedSummaryCards =
     productExperience.promotedSummaryCards > 0
       ? dashboardViewModel.topSummaryCards.slice(0, productExperience.promotedSummaryCards)
@@ -977,7 +1000,11 @@ export default async function CampaignPage({ params }: Props) {
             </>
           }
           actions={
-            stats.scan_type === 'pulse' || stats.scan_type === 'team' || stats.scan_type === 'onboarding' || stats.scan_type === 'leadership' ? (
+            !showManagementOutput ? (
+              <div className="rounded-full border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-900">
+                Dashboard wordt zichtbaar vanaf de eerste veilige responsdrempel
+              </div>
+            ) : stats.scan_type === 'pulse' || stats.scan_type === 'team' || stats.scan_type === 'onboarding' || stats.scan_type === 'leadership' ? (
               <>
                 {!profile?.is_verisight_admin ? <OnboardingAdvancer fromStep={1} /> : null}
                 <div className="rounded-full border border-[#d6e4e8] bg-[#f3f8f8] px-4 py-2 text-sm font-semibold text-[#234B57]">
@@ -1057,7 +1084,11 @@ export default async function CampaignPage({ params }: Props) {
         items={summaryItems}
         anchors={sectionAnchors}
         actions={
-          stats.scan_type === 'pulse' || stats.scan_type === 'team' || stats.scan_type === 'onboarding' || stats.scan_type === 'leadership' ? (
+          !showManagementOutput ? (
+            <div className="rounded-full border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-900">
+              Eerst uitvoerflow afronden
+            </div>
+          ) : stats.scan_type === 'pulse' || stats.scan_type === 'team' || stats.scan_type === 'onboarding' || stats.scan_type === 'leadership' ? (
             <div className="rounded-full border border-[#d6e4e8] bg-[#f3f8f8] px-4 py-2 text-sm font-semibold text-[#234B57]">
               {stats.scan_type === 'pulse'
                 ? 'Pulse: management handoff live'
@@ -1073,7 +1104,33 @@ export default async function CampaignPage({ params }: Props) {
         }
       />
 
-      {promotedSummaryCards.length > 0 ? (
+      {showClientExecutionFlow ? (
+        <DashboardSection
+          id="uitvoering"
+          eyebrow="Guided self-serve"
+          title="Begeleide uitvoerflow"
+          description="Verisight heeft de campaign ingericht. Vanaf hier lever jij deelnemers aan, start je de inviteflow veilig en volg je respons op zonder buiten de productgrenzen te hoeven treden."
+          aside={<DashboardChip label="Klantuitvoering" tone="emerald" />}
+        >
+          <GuidedSelfServePanel
+            campaignId={id}
+            scanType={stats.scan_type}
+            isActive={stats.is_active}
+            deliveryMode={campaignMeta?.delivery_mode ?? null}
+            hasSegmentDeepDive={hasSegmentDeepDive}
+            totalInvited={stats.total_invited}
+            totalCompleted={stats.total_completed}
+            invitesNotSent={invitesNotSent}
+              hasMinDisplay={hasMinDisplay}
+              hasEnoughData={hasEnoughData}
+              pendingCount={pendingCount}
+              remindableCount={remindableCount}
+              unsentRespondents={unsentRespondents}
+            />
+          </DashboardSection>
+        ) : null}
+
+      {showManagementOutput && promotedSummaryCards.length > 0 ? (
         <div className="rounded-[24px] border border-[color:var(--border)] bg-[color:var(--bg)] p-4 shadow-[0_12px_30px_rgba(19,32,51,0.05)] sm:p-5">
           <div className="flex flex-col gap-3 border-b border-[color:var(--border)]/80 pb-4 lg:flex-row lg:items-start lg:justify-between">
             <div>
@@ -1104,6 +1161,7 @@ export default async function CampaignPage({ params }: Props) {
         </div>
       ) : null}
 
+      {showManagementOutput ? (
       <DashboardSection
         id="handoff"
         eyebrow="Bestuurlijke handoff"
@@ -1266,7 +1324,9 @@ export default async function CampaignPage({ params }: Props) {
           ) : null}
         </div>
       </DashboardSection>
+      ) : null}
 
+      {showManagementOutput ? (
       <DashboardSection
         id="drivers"
         eyebrow="Wat drijft dit beeld?"
@@ -1285,9 +1345,11 @@ export default async function CampaignPage({ params }: Props) {
           <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-4 text-sm leading-6 text-slate-600">
             Verdiepende analyse wordt zichtbaar vanaf {MIN_N_PATTERNS} ingevulde responses. Tot die tijd blijft het dashboard bewust compact en voorzichtig.
           </div>
-        )}
-      </DashboardSection>
+          )}
+        </DashboardSection>
+      ) : null}
 
+      {showManagementOutput ? (
       <DashboardSection
         id="acties"
         eyebrow="Waar eerst op handelen"
@@ -1413,9 +1475,11 @@ export default async function CampaignPage({ params }: Props) {
           <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-4 text-sm leading-6 text-slate-600">
             Focusvragen en route-uitvoer worden betekenisvoller zodra het dashboard minstens {MIN_N_PATTERNS} responses heeft.
           </div>
-        )}
-      </DashboardSection>
+          )}
+        </DashboardSection>
+      ) : null}
 
+      {showManagementOutput ? (
       <DashboardSection
         id="route"
         eyebrow="30–90 dagenroute"
@@ -1497,6 +1561,7 @@ export default async function CampaignPage({ params }: Props) {
           </div>
         </div>
       </DashboardSection>
+      ) : null}
 
       <div id="methodiek" className="scroll-mt-36">
         <DashboardDisclosure
@@ -1517,10 +1582,14 @@ export default async function CampaignPage({ params }: Props) {
       {utilitySectionVisible ? (
         <DashboardSection
           id="operatie"
-          eyebrow="Utilitylaag"
-          title="Operatie, respondenten en delivery"
-          description="Alles onder deze lijn ondersteunt uitvoering en beheer. De managementhoofdlijn blijft hierboven compact en bestuurlijk."
-          aside={<DashboardChip label="Admin en operations" tone="slate" />}
+          eyebrow={showClientExecutionFlow ? 'Uitvoering' : 'Utilitylaag'}
+          title={showClientExecutionFlow ? 'Responsmonitoring en begrensde uitvoerlaag' : 'Operatie, respondenten en delivery'}
+          description={
+            showClientExecutionFlow
+              ? 'Gebruik deze laag om deelnemers, uitnodigingen en respons netjes te volgen. Productsetup, campaignarchitectuur en deliveryrecords blijven bewust bij Verisight.'
+              : 'Alles onder deze lijn ondersteunt uitvoering en beheer. De managementhoofdlijn blijft hierboven compact en bestuurlijk.'
+          }
+          aside={<DashboardChip label={showClientExecutionFlow ? 'Guided self-serve' : 'Admin en operations'} tone="slate" />}
         >
           <div className="space-y-4">
             {canManageCampaign ? (
@@ -1535,7 +1604,8 @@ export default async function CampaignPage({ params }: Props) {
                     campaignId={id}
                     isActive={stats.is_active}
                     pendingCount={pendingCount}
-                    canManageCampaign={canManageCampaign}
+                    canResendInvites={canExecuteCampaign}
+                    canArchiveCampaign={canManageCampaign}
                   />
                   <CampaignHealthIndicator
                     totalInvited={stats.total_invited}
@@ -1604,9 +1674,11 @@ export default async function CampaignPage({ params }: Props) {
                 <div className="rounded-[22px] border border-dashed border-slate-200 bg-slate-50 px-4 py-8 text-center">
                   <p className="text-base font-semibold text-slate-900">Nog geen respondenten toegevoegd</p>
                   <p className="mt-2 text-sm leading-6 text-slate-600">
-                    Voeg eerst respondenten toe via de setupflow. Daarna komen uitnodigingen, responsmonitoring en deze tabel automatisch beschikbaar.
+                    {showClientExecutionFlow
+                      ? 'Gebruik de begeleide uitvoerflow hierboven om eerst het deelnemersbestand aan te leveren. Daarna verschijnen uitnodigingen, responsmonitoring en deze tabel automatisch.'
+                      : 'Voeg eerst respondenten toe via de setupflow. Daarna komen uitnodigingen, responsmonitoring en deze tabel automatisch beschikbaar.'}
                   </p>
-                  {canManageCampaign ? (
+                  {!showClientExecutionFlow && canManageCampaign ? (
                     <Link
                       href="/beheer"
                       className="mt-4 inline-flex rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700"

--- a/frontend/app/(dashboard)/dashboard/page.test.ts
+++ b/frontend/app/(dashboard)/dashboard/page.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('dashboard home guided execution shell', () => {
+  it('keeps the customer landing focused on guided execution before dashboard activation', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+
+    expect(source).toContain('Jouw uitvoerstatus')
+    expect(source).toContain('Open uitvoerflow')
+    expect(source).toContain('Open deze campaign voor deelnemersimport, inviteflow, responsmonitoring')
+    expect(source).toContain('Dashboard actief')
+  })
+})

--- a/frontend/app/(dashboard)/dashboard/page.test.ts
+++ b/frontend/app/(dashboard)/dashboard/page.test.ts
@@ -9,5 +9,8 @@ describe('dashboard home guided execution shell', () => {
     expect(source).toContain('Open uitvoerflow')
     expect(source).toContain('Open deze campaign voor deelnemersimport, inviteflow, responsmonitoring')
     expect(source).toContain('Dashboard actief')
+    expect(source).toContain("if (campaign.total_completed < 5) return 'building'")
+    expect(source).toContain('primaryGuideInvitesNotSent')
+    expect(source).toContain('getPrimaryGuideCampaign')
   })
 })

--- a/frontend/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/page.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/dashboard/dashboard-primitives'
 import { ManagementReadGuide } from '@/components/dashboard/onboarding-panels'
 import { PdfDownloadButton } from '@/app/(dashboard)/campaigns/[id]/pdf-download-button'
+import { buildGuidedSelfServeState } from '@/lib/guided-self-serve'
 import { getScanDefinition } from '@/lib/scan-definitions'
 import type { CampaignStats } from '@/lib/types'
 
@@ -62,6 +63,16 @@ export default async function DashboardHomePage() {
   const buildingCount = campaigns.filter((campaign) => getCampaignBucket(campaign) === 'building').length
   const setupCount = campaigns.filter((campaign) => getCampaignBucket(campaign) === 'setup').length
   const closedCount = campaigns.filter((campaign) => getCampaignBucket(campaign) === 'closed').length
+  const primaryExecutionState = primaryGuideCampaign
+    ? buildGuidedSelfServeState({
+        isActive: primaryGuideCampaign.is_active,
+        totalInvited: primaryGuideCampaign.total_invited,
+        totalCompleted: primaryGuideCampaign.total_completed,
+        invitesNotSent: Math.max(primaryGuideCampaign.total_invited - primaryGuideCampaign.total_completed, 0),
+        hasMinDisplay: primaryGuideCampaign.total_completed >= 5,
+        hasEnoughData: primaryGuideCampaign.total_completed >= 10,
+      })
+    : null
 
   return (
     <div className="space-y-6">
@@ -122,6 +133,57 @@ export default async function DashboardHomePage() {
           />
         </div>
       </DashboardSection>
+
+      {!isAdmin ? (
+        primaryGuideCampaign && primaryExecutionState ? (
+          <DashboardSection
+            eyebrow="Jouw uitvoerstatus"
+            title={primaryExecutionState.headline}
+            description={primaryExecutionState.detail}
+            aside={<DashboardChip label={primaryExecutionState.dashboardVisible ? 'Dashboard actief' : 'Uitvoer loopt'} tone={primaryExecutionState.dashboardVisible ? 'emerald' : 'amber'} />}
+          >
+            <div className="grid gap-4 xl:grid-cols-[minmax(0,1.4fr),minmax(320px,0.6fr)]">
+              <div className="rounded-[22px] border border-[color:var(--border)] bg-white p-4 shadow-[0_10px_30px_rgba(19,32,51,0.05)]">
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
+                  Eerstvolgende stap
+                </p>
+                <p className="mt-2 text-lg font-semibold text-[color:var(--ink)]">
+                  {primaryExecutionState.nextAction.title}
+                </p>
+                <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">
+                  {primaryExecutionState.nextAction.body}
+                </p>
+                <div className="mt-4 flex flex-wrap gap-2">
+                  {primaryExecutionState.statusBlocks.map((item) => (
+                    <DashboardChip
+                      key={item.key}
+                      label={item.label}
+                      tone={item.status === 'done' ? 'emerald' : item.status === 'current' ? 'blue' : 'slate'}
+                    />
+                  ))}
+                </div>
+              </div>
+              <div className="rounded-[22px] border border-[color:var(--border)] bg-[color:var(--bg)] p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
+                  Jouw campagne nu
+                </p>
+                <p className="mt-2 text-base font-semibold text-[color:var(--ink)]">
+                  {primaryGuideCampaign.campaign_name}
+                </p>
+                <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">
+                  Open deze campaign voor deelnemersimport, inviteflow, responsmonitoring en pas daarna dashboardgebruik.
+                </p>
+                <Link
+                  href={`/campaigns/${primaryGuideCampaign.campaign_id}`}
+                  className="mt-4 inline-flex rounded-full border border-[#d6e4e8] bg-[#f3f8f8] px-4 py-2 text-sm font-semibold text-[#234B57] transition-colors hover:border-[#bfd3d8] hover:bg-[#e9f2f3]"
+                >
+                  {primaryExecutionState.dashboardVisible ? 'Open campaign en dashboard' : 'Open uitvoerflow'}
+                </Link>
+              </div>
+            </div>
+          </DashboardSection>
+        ) : null
+      ) : null}
 
       {!isAdmin ? (
         <DashboardSection
@@ -303,10 +365,12 @@ function CampaignRow({
               href={`/campaigns/${campaign.campaign_id}`}
               className="inline-flex rounded-full border border-[#d6e4e8] bg-[#f3f8f8] px-4 py-2 text-sm font-semibold text-[#234B57] transition-colors hover:border-[#bfd3d8] hover:bg-[#e9f2f3]"
             >
-              Open dashboard
+              {!isAdmin && getCampaignBucket(campaign) !== 'ready' ? 'Open uitvoerflow' : 'Open dashboard'}
             </Link>
           </div>
-          <PdfDownloadButton campaignId={campaign.campaign_id} campaignName={campaign.campaign_name} />
+          {isAdmin || getCampaignBucket(campaign) === 'ready' || getCampaignBucket(campaign) === 'closed' ? (
+            <PdfDownloadButton campaignId={campaign.campaign_id} campaignName={campaign.campaign_name} />
+          ) : null}
         </div>
       </div>
     </div>

--- a/frontend/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/page.tsx
@@ -46,7 +46,20 @@ export default async function DashboardHomePage() {
   const campaigns = (stats ?? []) as CampaignStats[]
   const groups = groupCampaigns(campaigns)
   const activeCampaigns = campaigns.filter((campaign) => campaign.is_active)
-  const primaryGuideCampaign = activeCampaigns[0] ?? campaigns[0] ?? null
+  const primaryGuideCampaign = getPrimaryGuideCampaign(activeCampaigns, campaigns)
+  const { data: primaryGuideRespondentsRaw } = primaryGuideCampaign
+    ? await supabase
+        .from('respondents')
+        .select('sent_at, completed')
+        .eq('campaign_id', primaryGuideCampaign.campaign_id)
+    : { data: [] }
+  const primaryGuideRespondents = (primaryGuideRespondentsRaw ?? []) as Array<{
+    sent_at: string | null
+    completed: boolean
+  }>
+  const primaryGuideInvitesNotSent = primaryGuideRespondents.filter(
+    (respondent) => !respondent.sent_at && !respondent.completed,
+  ).length
   const avgResponse =
     campaigns.length > 0
       ? Math.round(campaigns.reduce((sum, campaign) => sum + (campaign.completion_rate_pct ?? 0), 0) / campaigns.length)
@@ -68,7 +81,14 @@ export default async function DashboardHomePage() {
         isActive: primaryGuideCampaign.is_active,
         totalInvited: primaryGuideCampaign.total_invited,
         totalCompleted: primaryGuideCampaign.total_completed,
-        invitesNotSent: Math.max(primaryGuideCampaign.total_invited - primaryGuideCampaign.total_completed, 0),
+        invitesNotSent:
+          primaryGuideRespondents.length > 0
+            ? primaryGuideInvitesNotSent
+            : primaryGuideCampaign.total_invited === 0
+              ? 0
+              : primaryGuideCampaign.total_completed >= 5
+                ? 0
+                : 1,
         hasMinDisplay: primaryGuideCampaign.total_completed >= 5,
         hasEnoughData: primaryGuideCampaign.total_completed >= 10,
       })
@@ -466,8 +486,30 @@ function getNextAction(campaign: CampaignStats) {
 function getCampaignBucket(campaign: CampaignStats): CampaignBucket {
   if (!campaign.is_active) return 'closed'
   if (campaign.total_invited === 0) return 'setup'
-  if (campaign.total_completed < 10) return 'building'
+  if (campaign.total_completed < 5) return 'building'
   return 'ready'
+}
+
+function getPrimaryGuideCampaign(
+  activeCampaigns: CampaignStats[],
+  allCampaigns: CampaignStats[],
+): CampaignStats | null {
+  const candidatePool = activeCampaigns.length > 0 ? activeCampaigns : allCampaigns
+  if (candidatePool.length === 0) return null
+
+  const priority = (campaign: CampaignStats) => {
+    const bucket = getCampaignBucket(campaign)
+    if (bucket === 'setup') return 0
+    if (bucket === 'building') return 1
+    if (bucket === 'ready') return 2
+    return 3
+  }
+
+  return [...candidatePool].sort((left, right) => {
+    const priorityDelta = priority(left) - priority(right)
+    if (priorityDelta !== 0) return priorityDelta
+    return new Date(right.created_at).getTime() - new Date(left.created_at).getTime()
+  })[0] ?? null
 }
 
 function getCampaignReadiness(campaign: CampaignStats) {

--- a/frontend/app/api/campaigns/[id]/respondents/import/route.ts
+++ b/frontend/app/api/campaigns/[id]/respondents/import/route.ts
@@ -18,16 +18,6 @@ export async function POST(request: Request, { params }: Context) {
     return NextResponse.json({ detail: 'Niet ingelogd.' }, { status: 401 })
   }
 
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('is_verisight_admin')
-    .eq('id', user.id)
-    .single()
-
-  if (profile?.is_verisight_admin !== true) {
-    return NextResponse.json({ detail: 'Alleen Verisight-beheerders kunnen respondentimport uitvoeren.' }, { status: 403 })
-  }
-
   const { data: campaign, error: campaignError } = await supabase
     .from('campaigns')
     .select('organization_id')
@@ -36,6 +26,31 @@ export async function POST(request: Request, { params }: Context) {
 
   if (campaignError || !campaign) {
     return NextResponse.json({ detail: 'Campaign niet gevonden of niet toegankelijk.' }, { status: 404 })
+  }
+
+  const [
+    { data: profile },
+    { data: membership },
+  ] = await Promise.all([
+    supabase
+      .from('profiles')
+      .select('is_verisight_admin')
+      .eq('id', user.id)
+      .maybeSingle(),
+    supabase
+      .from('org_members')
+      .select('role')
+      .eq('org_id', campaign.organization_id)
+      .eq('user_id', user.id)
+      .maybeSingle(),
+  ])
+
+  const canExecuteCampaign = profile?.is_verisight_admin === true || Boolean(membership)
+  if (!canExecuteCampaign) {
+    return NextResponse.json(
+      { detail: 'Je hebt geen rechten om deelnemers voor deze campaign aan te leveren.' },
+      { status: 403 },
+    )
   }
 
   let apiKey: string

--- a/frontend/app/api/campaigns/[id]/respondents/send-invites/route.ts
+++ b/frontend/app/api/campaigns/[id]/respondents/send-invites/route.ts
@@ -16,16 +16,6 @@ export async function POST(request: Request, { params }: Context) {
     return NextResponse.json({ detail: 'Niet ingelogd.' }, { status: 401 })
   }
 
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('is_verisight_admin')
-    .eq('id', user.id)
-    .single()
-
-  if (profile?.is_verisight_admin !== true) {
-    return NextResponse.json({ detail: 'Alleen Verisight-beheerders kunnen uitnodigingen versturen.' }, { status: 403 })
-  }
-
   const { data: campaign, error: campaignError } = await supabase
     .from('campaigns')
     .select('organization_id')
@@ -34,6 +24,31 @@ export async function POST(request: Request, { params }: Context) {
 
   if (campaignError || !campaign) {
     return NextResponse.json({ detail: 'Campaign niet gevonden of niet toegankelijk.' }, { status: 404 })
+  }
+
+  const [
+    { data: profile },
+    { data: membership },
+  ] = await Promise.all([
+    supabase
+      .from('profiles')
+      .select('is_verisight_admin')
+      .eq('id', user.id)
+      .maybeSingle(),
+    supabase
+      .from('org_members')
+      .select('role')
+      .eq('org_id', campaign.organization_id)
+      .eq('user_id', user.id)
+      .maybeSingle(),
+  ])
+
+  const canExecuteCampaign = profile?.is_verisight_admin === true || Boolean(membership)
+  if (!canExecuteCampaign) {
+    return NextResponse.json(
+      { detail: 'Je hebt geen rechten om uitnodigingen voor deze campaign te versturen.' },
+      { status: 403 },
+    )
   }
 
   let apiKey: string

--- a/frontend/components/dashboard/guided-self-serve-panel.tsx
+++ b/frontend/components/dashboard/guided-self-serve-panel.tsx
@@ -1,0 +1,539 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { resendPendingAction } from '@/app/(dashboard)/campaigns/[id]/actions'
+import { buildResendResultMessage } from '@/app/(dashboard)/campaigns/[id]/reminder-feedback'
+import {
+  DashboardChip,
+  DashboardPanel,
+} from '@/components/dashboard/dashboard-primitives'
+import { CLIENT_FILE_SPEC } from '@/lib/client-onboarding'
+import { buildGuidedSelfServeState } from '@/lib/guided-self-serve'
+import {
+  getDeliveryModeDescription,
+  getInviteDefaultForDeliveryMode,
+  getDeliveryModeLabel,
+} from '@/lib/implementation-readiness'
+import {
+  type DeliveryMode,
+  REPORT_ADD_ON_LABELS,
+  SCAN_TYPE_LABELS,
+  type ScanType,
+} from '@/lib/types'
+
+interface Props {
+  campaignId: string
+  scanType: ScanType
+  isActive: boolean
+  deliveryMode: DeliveryMode | null
+  hasSegmentDeepDive: boolean
+  totalInvited: number
+  totalCompleted: number
+  invitesNotSent: number
+  hasMinDisplay: boolean
+  hasEnoughData: boolean
+  pendingCount: number
+  remindableCount: number
+  unsentRespondents: Array<{ token: string; email: string | null }>
+}
+
+interface ImportIssue {
+  row_number: number
+  field: string
+  message: string
+}
+
+interface ImportPreviewRow {
+  row_number: number
+  email: string
+  department: string | null
+  role_level: string | null
+  exit_month: string | null
+}
+
+interface ImportResponse {
+  dry_run: boolean
+  total_rows: number
+  valid_rows: number
+  invalid_rows: number
+  duplicate_existing: number
+  preview_rows: ImportPreviewRow[]
+  errors: ImportIssue[]
+  imported: number
+  emails_sent: number
+}
+
+function getStatusTone(status: 'done' | 'current' | 'blocked') {
+  if (status === 'done') return 'emerald' as const
+  if (status === 'current') return 'blue' as const
+  return 'slate' as const
+}
+
+export function GuidedSelfServePanel({
+  campaignId,
+  scanType,
+  isActive,
+  deliveryMode,
+  hasSegmentDeepDive,
+  totalInvited,
+  totalCompleted,
+  invitesNotSent,
+  hasMinDisplay,
+  hasEnoughData,
+  pendingCount,
+  remindableCount,
+  unsentRespondents,
+}: Props) {
+  const router = useRouter()
+  const guidedState = useMemo(
+    () =>
+      buildGuidedSelfServeState({
+        isActive,
+        totalInvited,
+        totalCompleted,
+        invitesNotSent,
+        hasMinDisplay,
+        hasEnoughData,
+      }),
+    [hasEnoughData, hasMinDisplay, invitesNotSent, isActive, totalCompleted, totalInvited],
+  )
+  const [uploadFile, setUploadFile] = useState<File | null>(null)
+  const [uploadSendInvites, setUploadSendInvites] = useState(true)
+  const [previewResult, setPreviewResult] = useState<ImportResponse | null>(null)
+  const [importSuccess, setImportSuccess] = useState<ImportResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState<'preview' | 'import' | 'launch' | 'remind' | null>(null)
+  const [toast, setToast] = useState<string | null>(null)
+
+  useEffect(() => {
+    setUploadSendInvites(getInviteDefaultForDeliveryMode(deliveryMode))
+  }, [campaignId, deliveryMode])
+
+  async function requestImport(dryRun: boolean) {
+    setError(null)
+    setImportSuccess(null)
+
+    if (!uploadFile) {
+      setError('Kies eerst een CSV- of Excel-bestand met deelnemers.')
+      return
+    }
+
+    setLoading(dryRun ? 'preview' : 'import')
+    const body = new FormData()
+    body.append('file', uploadFile)
+    body.append('dry_run', String(dryRun))
+    body.append('send_invites', String(uploadSendInvites))
+
+    try {
+      const response = await fetch(`/api/campaigns/${campaignId}/respondents/import`, {
+        method: 'POST',
+        body,
+      })
+      const payload = (await response.json().catch(() => ({}))) as Partial<ImportResponse> & {
+        detail?: string
+      }
+
+      if (!response.ok) {
+        setError(payload.detail ?? 'Import kon niet worden verwerkt.')
+        setLoading(null)
+        return
+      }
+
+      const typedPayload = payload as ImportResponse
+      if (dryRun) {
+        setPreviewResult(typedPayload)
+      } else {
+        setImportSuccess(typedPayload)
+        setPreviewResult(null)
+        router.refresh()
+      }
+    } catch {
+      setError('Verbindingsfout tijdens import.')
+    } finally {
+      setLoading(null)
+    }
+  }
+
+  async function resendPendingInvites() {
+    setError(null)
+    setLoading('remind')
+    const result = await resendPendingAction(campaignId)
+    setLoading(null)
+
+    if (result.error) {
+      setError(result.error)
+      return
+    }
+
+    setToast(buildResendResultMessage(result))
+    setTimeout(() => setToast(null), 4000)
+    router.refresh()
+  }
+
+  async function startInvites() {
+    setError(null)
+    setLoading('launch')
+
+    try {
+      const response = await fetch(`/api/campaigns/${campaignId}/respondents/send-invites`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(
+          unsentRespondents
+            .filter((respondent) => respondent.email)
+            .map((respondent) => ({
+              token: respondent.token,
+              email: respondent.email,
+            })),
+        ),
+      })
+
+      const payload = (await response.json().catch(() => ({}))) as {
+        detail?: string
+        sent?: number
+        failed?: number
+        skipped?: number
+      }
+
+      if (!response.ok) {
+        setError(payload.detail ?? 'Uitnodigingen konden niet worden gestart.')
+        setLoading(null)
+        return
+      }
+
+      const sent = payload.sent ?? 0
+      const failed = payload.failed ?? 0
+      const skipped = payload.skipped ?? 0
+      setToast(
+        sent > 0
+          ? `${sent} uitnodiging(en) gestart.${failed > 0 || skipped > 0 ? ` ${failed} mislukt, ${skipped} overgeslagen.` : ''}`
+          : 'Er zijn geen nieuwe uitnodigingen gestart.',
+      )
+      setTimeout(() => setToast(null), 4000)
+      router.refresh()
+    } catch {
+      setError('Verbindingsfout tijdens het starten van uitnodigingen.')
+    } finally {
+      setLoading(null)
+    }
+  }
+
+  const hasPreviewErrors = (previewResult?.errors.length ?? 0) > 0
+  const canImportPreview = Boolean(previewResult) && !hasPreviewErrors && (previewResult?.valid_rows ?? 0) > 0
+  const previewMissingDepartmentCount =
+    previewResult?.preview_rows.filter((row) => !row.department?.trim()).length ?? 0
+  const previewMissingRoleLevelCount =
+    previewResult?.preview_rows.filter((row) => !row.role_level?.trim()).length ?? 0
+  const localValidationState =
+    previewResult && hasPreviewErrors
+      ? 'Import validatie vereist'
+      : previewResult && canImportPreview
+        ? 'Klaar om uit te nodigen'
+        : null
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-[24px] border border-[#d6e4e8] bg-[#f6fafb] p-4 sm:p-5">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+          <div className="max-w-3xl">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+              Begeleide uitvoering
+            </p>
+            <h2 className="mt-2 text-xl font-semibold text-slate-950">{guidedState.headline}</h2>
+            <p className="mt-2 text-sm leading-6 text-slate-700">{guidedState.detail}</p>
+            <p className="mt-3 text-sm font-medium text-slate-900">
+              Volgende stap: {guidedState.nextAction.title}
+            </p>
+            <p className="mt-1 text-sm leading-6 text-slate-700">{guidedState.nextAction.body}</p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <DashboardChip
+              label={guidedState.dashboardVisible ? 'Dashboard vrijgegeven' : 'Dashboard nog niet actief'}
+              tone={guidedState.dashboardVisible ? 'emerald' : 'amber'}
+            />
+            {localValidationState ? (
+              <DashboardChip
+                label={localValidationState}
+                tone={hasPreviewErrors ? 'amber' : 'blue'}
+              />
+            ) : null}
+          </div>
+        </div>
+
+        <div className="mt-4 flex flex-wrap gap-2">
+          {guidedState.statusBlocks.map((item) => (
+            <DashboardChip
+              key={item.key}
+              label={item.label}
+              tone={getStatusTone(item.status)}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-3">
+        <DashboardPanel
+          eyebrow="Verisight doet"
+          title="Provisioning en campaigngrenzen"
+          body="Account, campaign, productkaders en de begrensde outputroute staan al klaar. Je hoeft geen surveytool of setuparchitectuur te beheren."
+          tone="blue"
+        />
+        <DashboardPanel
+          eyebrow="Jij doet nu"
+          title={
+            totalInvited === 0
+              ? 'Lever deelnemers aan'
+              : invitesNotSent > 0
+                ? 'Start de inviteflow'
+                : pendingCount > 0
+                  ? 'Volg respons en reminders'
+                  : guidedState.deeperInsightsVisible
+                    ? 'Maak de eerste stap expliciet'
+                    : 'Lees eerst de compacte output'
+          }
+          body={guidedState.nextAction.body}
+          tone="emerald"
+        />
+        <DashboardPanel
+          eyebrow="Dashboardactivatie"
+          title="5 responses voor eerste read, 10 voor verdieping"
+          body="Het dashboard gaat pas zichtbaar open zodra de eerste veilige responsdrempel is gehaald. Verdiepende patronen en scherpere prioritering volgen bewust pas vanaf 10 responses."
+          tone={guidedState.deeperInsightsVisible ? 'emerald' : 'amber'}
+        />
+      </div>
+
+      {isActive ? (
+        <div className="rounded-[24px] border border-slate-200 bg-white p-4 shadow-[0_10px_30px_rgba(19,32,51,0.05)] sm:p-5">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+            <div className="max-w-3xl">
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                Deelnemers importeren
+              </p>
+              <h3 className="mt-2 text-lg font-semibold text-slate-950">
+                Upload het deelnemersbestand in dezelfde begrensde flow
+              </h3>
+              <p className="mt-2 text-sm leading-6 text-slate-700">
+                Gebruik bij voorkeur een eenvoudig Excel- of CSV-bestand met minimaal{' '}
+                <code className="font-mono">email</code>. Aanbevolen: {CLIENT_FILE_SPEC.recommended.join(', ')}
+                . {scanType === 'exit' ? `Exit-specifiek optioneel: ${CLIENT_FILE_SPEC.exitOptional.join(', ')}.` : ''}
+              </p>
+              <p className="mt-2 text-sm leading-6 text-slate-700">
+                Route: {SCAN_TYPE_LABELS[scanType]} {getDeliveryModeLabel(deliveryMode, scanType)}.{' '}
+                {getDeliveryModeDescription(deliveryMode, scanType)}
+              </p>
+              {hasSegmentDeepDive ? (
+                <p className="mt-2 text-sm leading-6 text-slate-700">
+                  Voor {REPORT_ADD_ON_LABELS.segment_deep_dive.toLowerCase()} zijn{' '}
+                  <code className="font-mono">department</code> en{' '}
+                  <code className="font-mono">role_level</code> sterk aanbevolen.
+                </p>
+              ) : null}
+            </div>
+            <a
+              href="/templates/verisight-respondenten-template.xlsx"
+              download
+              className="inline-flex rounded-full border border-[#d6e4e8] bg-[#f3f8f8] px-4 py-2 text-sm font-semibold text-[#234B57] transition-colors hover:border-[#bfd3d8] hover:bg-[#e9f2f3]"
+            >
+              Download template
+            </a>
+          </div>
+
+          <div className="mt-5 space-y-4">
+            <input
+              type="file"
+              accept=".csv,.xlsx"
+              onChange={(event) => {
+                setUploadFile(event.target.files?.[0] ?? null)
+                setError(null)
+                setPreviewResult(null)
+                setImportSuccess(null)
+              }}
+              className="block w-full text-sm text-slate-600 file:mr-3 file:rounded-lg file:border-0 file:bg-blue-50 file:px-3 file:py-2 file:text-sm file:font-medium file:text-blue-700 hover:file:bg-blue-100"
+            />
+
+            <label className="flex items-start gap-2 text-sm text-slate-700">
+              <input
+                type="checkbox"
+                checked={uploadSendInvites}
+                onChange={(event) => setUploadSendInvites(event.target.checked)}
+                className="mt-0.5 rounded"
+              />
+              <span>
+                Verstuur direct uitnodigingen na een geslaagde import
+                <span className="block text-xs leading-5 text-slate-500">
+                  Zet dit uit als je eerst alleen de import wilt valideren en de launch later bewust wilt starten.
+                </span>
+              </span>
+            </label>
+
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={() => void requestImport(true)}
+                disabled={loading !== null || !uploadFile}
+                className="rounded-full border border-[#d6e4e8] bg-[#f3f8f8] px-4 py-2 text-sm font-semibold text-[#234B57] transition-colors hover:border-[#bfd3d8] hover:bg-[#e9f2f3] disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {loading === 'preview' ? 'Bestand controleren...' : 'Bestand controleren'}
+              </button>
+              {canImportPreview ? (
+                <button
+                  type="button"
+                  onClick={() => void requestImport(false)}
+                  disabled={loading !== null}
+                  className="rounded-full bg-[#234B57] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#1B2E45] disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {loading === 'import'
+                    ? 'Importeren...'
+                    : uploadSendInvites
+                      ? `Importeer en nodig ${previewResult?.valid_rows ?? 0} deelnemers uit`
+                      : `Importeer ${previewResult?.valid_rows ?? 0} deelnemers`}
+                </button>
+              ) : null}
+              {invitesNotSent > 0 && unsentRespondents.length > 0 ? (
+                <button
+                  type="button"
+                  onClick={() => void startInvites()}
+                  disabled={loading !== null}
+                  className="rounded-full bg-[#234B57] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#1B2E45] disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {loading === 'launch'
+                    ? 'Uitnodigingen starten...'
+                    : `Start uitnodigingen (${unsentRespondents.length})`}
+                </button>
+              ) : null}
+              {remindableCount > 0 ? (
+                <button
+                  type="button"
+                  onClick={() => void resendPendingInvites()}
+                  disabled={loading !== null}
+                  className="rounded-full border border-blue-200 bg-blue-50 px-4 py-2 text-sm font-semibold text-blue-700 transition-colors hover:border-blue-300 hover:bg-blue-100 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {loading === 'remind' ? 'Herinneringen versturen...' : `Stuur reminder naar ${remindableCount}`}
+                </button>
+              ) : null}
+            </div>
+
+            {error ? (
+              <div className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+                {error}
+              </div>
+            ) : null}
+
+            {toast ? (
+              <div className="rounded-2xl border border-slate-200 bg-slate-900 px-4 py-3 text-sm text-white">
+                {toast}
+              </div>
+            ) : null}
+
+            {importSuccess ? (
+              <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-900">
+                <p className="font-semibold">
+                  {importSuccess.imported} deelnemer(s) toegevoegd
+                </p>
+                <p className="mt-1 leading-6">
+                  {importSuccess.emails_sent > 0
+                    ? `${importSuccess.emails_sent} uitnodiging(en) zijn direct verstuurd.`
+                    : 'De deelnemers zijn toegevoegd. Start de inviteflow zodra timing en communicatie kloppen.'}
+                </p>
+              </div>
+            ) : null}
+
+            {previewResult ? (
+              <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+                <div className="grid gap-3 sm:grid-cols-4">
+                  <DashboardPanel eyebrow="Preview" title={`${previewResult.total_rows}`} body="Rijen aangeleverd" tone="slate" />
+                  <DashboardPanel eyebrow="Geldig" title={`${previewResult.valid_rows}`} body="Rijen zonder fouten" tone="emerald" />
+                  <DashboardPanel eyebrow="Fouten" title={`${previewResult.invalid_rows}`} body="Rijen die eerst gecorrigeerd moeten worden" tone={previewResult.invalid_rows > 0 ? 'amber' : 'slate'} />
+                  <DashboardPanel eyebrow="Bestaat al" title={`${previewResult.duplicate_existing}`} body="Dubbele adressen in deze campagne" tone={previewResult.duplicate_existing > 0 ? 'amber' : 'slate'} />
+                </div>
+
+                {(previewMissingDepartmentCount > 0 || previewMissingRoleLevelCount > 0) ? (
+                  <div className="mt-4 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+                    <p className="font-semibold">Metadata verdient nog controle</p>
+                    <p className="mt-1 leading-6">
+                      {previewMissingDepartmentCount > 0
+                        ? `${previewMissingDepartmentCount} rij(en) missen afdeling. `
+                        : ''}
+                      {previewMissingRoleLevelCount > 0
+                        ? `${previewMissingRoleLevelCount} rij(en) missen functieniveau. `
+                        : ''}
+                      Zonder nette metadata blijft segmentatie en vervolguitleg beperkter.
+                    </p>
+                  </div>
+                ) : null}
+
+                {previewResult.errors.length > 0 ? (
+                  <div className="mt-4 space-y-3">
+                    <div>
+                      <p className="text-sm font-semibold text-slate-950">Import validatie vereist</p>
+                      <p className="mt-1 text-sm leading-6 text-slate-600">
+                        Corrigeer eerst deze rijen en controleer daarna opnieuw. Pas zonder fouten wordt uitnodigen vrijgegeven.
+                      </p>
+                    </div>
+                    <div className="overflow-x-auto rounded-2xl border border-slate-200 bg-white">
+                      <table className="min-w-full text-sm">
+                        <thead className="bg-slate-50 text-slate-500">
+                          <tr>
+                            <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-[0.18em]">Rij</th>
+                            <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-[0.18em]">Veld</th>
+                            <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-[0.18em]">Uitleg</th>
+                          </tr>
+                        </thead>
+                        <tbody className="divide-y divide-slate-100">
+                          {previewResult.errors.slice(0, 8).map((issue) => (
+                            <tr key={`${issue.row_number}-${issue.field}-${issue.message}`}>
+                              <td className="px-3 py-2 text-slate-700">{issue.row_number}</td>
+                              <td className="px-3 py-2 font-mono text-xs text-slate-600">{issue.field}</td>
+                              <td className="px-3 py-2 text-slate-700">{issue.message}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                ) : null}
+
+                {previewResult.preview_rows.length > 0 ? (
+                  <div className="mt-4">
+                    <p className="text-sm font-semibold text-slate-950">Preview van geldige rijen</p>
+                    <div className="mt-2 overflow-x-auto rounded-2xl border border-slate-200 bg-white">
+                      <table className="min-w-full text-sm">
+                        <thead className="bg-slate-50 text-slate-500">
+                          <tr>
+                            <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-[0.18em]">Rij</th>
+                            <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-[0.18em]">E-mail</th>
+                            <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-[0.18em]">Afdeling</th>
+                            <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-[0.18em]">Niveau</th>
+                            {scanType === 'exit' ? (
+                              <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-[0.18em]">Exitmaand</th>
+                            ) : null}
+                          </tr>
+                        </thead>
+                        <tbody className="divide-y divide-slate-100">
+                          {previewResult.preview_rows.slice(0, 8).map((row) => (
+                            <tr key={`${row.row_number}-${row.email}`}>
+                              <td className="px-3 py-2 text-slate-700">{row.row_number}</td>
+                              <td className="px-3 py-2 font-mono text-xs text-slate-600">{row.email}</td>
+                              <td className="px-3 py-2 text-slate-700">{row.department || '-'}</td>
+                              <td className="px-3 py-2 text-slate-700">{row.role_level || '-'}</td>
+                              {scanType === 'exit' ? (
+                                <td className="px-3 py-2 text-slate-700">{row.exit_month || '-'}</td>
+                              ) : null}
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/lib/guided-self-serve.test.ts
+++ b/frontend/lib/guided-self-serve.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import { buildGuidedSelfServeState } from '@/lib/guided-self-serve'
+
+describe('guided self-serve execution state', () => {
+  it('keeps the customer in data-required mode until a validated participant file exists', () => {
+    const state = buildGuidedSelfServeState({
+      isActive: true,
+      totalInvited: 0,
+      totalCompleted: 0,
+      invitesNotSent: 0,
+      hasMinDisplay: false,
+      hasEnoughData: false,
+    })
+
+    expect(state.phase).toBe('data_required')
+    expect(state.dashboardVisible).toBe(false)
+    expect(state.deeperInsightsVisible).toBe(false)
+    expect(state.nextAction.title.toLowerCase()).toContain('deelnemersbestand')
+    expect(state.statusBlocks.find((item) => item.key === 'setup_incomplete')?.status).toBe('current')
+    expect(state.statusBlocks.find((item) => item.key === 'data_required')?.status).toBe('current')
+  })
+
+  it('moves to invite-ready when participants exist but launch has not been sent yet', () => {
+    const state = buildGuidedSelfServeState({
+      isActive: true,
+      totalInvited: 18,
+      totalCompleted: 0,
+      invitesNotSent: 18,
+      hasMinDisplay: false,
+      hasEnoughData: false,
+    })
+
+    expect(state.phase).toBe('ready_to_invite')
+    expect(state.nextAction.title.toLowerCase()).toContain('uitnodigingen')
+    expect(state.statusBlocks.find((item) => item.key === 'ready_to_invite')?.status).toBe('current')
+    expect(state.statusBlocks.find((item) => item.key === 'responses_incoming')?.status).toBe('blocked')
+  })
+
+  it('keeps dashboard access locked while responses are still below the first safe threshold', () => {
+    const state = buildGuidedSelfServeState({
+      isActive: true,
+      totalInvited: 24,
+      totalCompleted: 3,
+      invitesNotSent: 0,
+      hasMinDisplay: false,
+      hasEnoughData: false,
+    })
+
+    expect(state.phase).toBe('responses_incoming')
+    expect(state.dashboardVisible).toBe(false)
+    expect(state.detail.toLowerCase()).toContain('vanaf 5')
+    expect(state.nextAction.body.toLowerCase()).toContain('responses')
+  })
+
+  it('activates the dashboard at first-value threshold but keeps deeper insights behind the pattern threshold', () => {
+    const state = buildGuidedSelfServeState({
+      isActive: true,
+      totalInvited: 24,
+      totalCompleted: 6,
+      invitesNotSent: 0,
+      hasMinDisplay: true,
+      hasEnoughData: false,
+    })
+
+    expect(state.phase).toBe('dashboard_active')
+    expect(state.dashboardVisible).toBe(true)
+    expect(state.deeperInsightsVisible).toBe(false)
+    expect(state.nextAction.title.toLowerCase()).toContain('compacte dashboardread')
+    expect(state.statusBlocks.find((item) => item.key === 'dashboard_active')?.status).toBe('current')
+  })
+
+  it('switches to first-next-step once readiness and pattern threshold are both reached', () => {
+    const state = buildGuidedSelfServeState({
+      isActive: true,
+      totalInvited: 24,
+      totalCompleted: 11,
+      invitesNotSent: 0,
+      hasMinDisplay: true,
+      hasEnoughData: true,
+    })
+
+    expect(state.phase).toBe('first_next_step_available')
+    expect(state.dashboardVisible).toBe(true)
+    expect(state.deeperInsightsVisible).toBe(true)
+    expect(state.nextAction.title.toLowerCase()).toContain('eerste vervolgstap')
+    expect(state.statusBlocks.find((item) => item.key === 'first_next_step_available')?.status).toBe('current')
+  })
+
+  it('keeps a closed campaign out of self-serve execution mode', () => {
+    const state = buildGuidedSelfServeState({
+      isActive: false,
+      totalInvited: 24,
+      totalCompleted: 11,
+      invitesNotSent: 0,
+      hasMinDisplay: true,
+      hasEnoughData: true,
+    })
+
+    expect(state.phase).toBe('closed')
+    expect(state.nextAction.title.toLowerCase()).toContain('vervolggesprek')
+    expect(state.statusBlocks.find((item) => item.key === 'dashboard_active')?.status).toBe('done')
+  })
+})

--- a/frontend/lib/guided-self-serve.ts
+++ b/frontend/lib/guided-self-serve.ts
@@ -1,0 +1,167 @@
+type GuidedSelfServePhase =
+  | 'closed'
+  | 'data_required'
+  | 'ready_to_invite'
+  | 'responses_incoming'
+  | 'dashboard_active'
+  | 'first_next_step_available'
+
+type GuidedStatusKey =
+  | 'setup_incomplete'
+  | 'data_required'
+  | 'ready_to_invite'
+  | 'responses_incoming'
+  | 'dashboard_active'
+  | 'first_next_step_available'
+
+type GuidedStatusState = 'done' | 'current' | 'blocked'
+
+export interface GuidedStatusBlock {
+  key: GuidedStatusKey
+  label: string
+  status: GuidedStatusState
+}
+
+export interface GuidedNextAction {
+  title: string
+  body: string
+}
+
+export interface GuidedSelfServeState {
+  phase: GuidedSelfServePhase
+  headline: string
+  detail: string
+  nextAction: GuidedNextAction
+  dashboardVisible: boolean
+  deeperInsightsVisible: boolean
+  statusBlocks: GuidedStatusBlock[]
+}
+
+interface GuidedSelfServeArgs {
+  isActive: boolean
+  totalInvited: number
+  totalCompleted: number
+  invitesNotSent: number
+  hasMinDisplay: boolean
+  hasEnoughData: boolean
+}
+
+const STATUS_FLOW: GuidedStatusKey[] = [
+  'setup_incomplete',
+  'data_required',
+  'ready_to_invite',
+  'responses_incoming',
+  'dashboard_active',
+  'first_next_step_available',
+]
+
+const STATUS_LABELS: Record<GuidedStatusKey, string> = {
+  setup_incomplete: 'Setup incompleet',
+  data_required: 'Data vereist',
+  ready_to_invite: 'Klaar om uit te nodigen',
+  responses_incoming: 'Responses binnen',
+  dashboard_active: 'Dashboard actief',
+  first_next_step_available: 'Eerste vervolgstap beschikbaar',
+}
+
+function buildStatusBlocks(current: GuidedStatusKey): GuidedStatusBlock[] {
+  const currentIndex = STATUS_FLOW.indexOf(current)
+
+  return STATUS_FLOW.map((key, index) => ({
+    key,
+    label: STATUS_LABELS[key],
+    status: index < currentIndex ? 'done' : index === currentIndex ? 'current' : current === 'setup_incomplete' ? 'blocked' : 'blocked',
+  }))
+}
+
+export function buildGuidedSelfServeState(args: GuidedSelfServeArgs): GuidedSelfServeState {
+  if (!args.isActive) {
+    return {
+      phase: 'closed',
+      headline: 'Campagne gesloten',
+      detail: 'De uitvoerfase is afgerond. Gebruik dashboard, rapport en terugblik nu voor het vervolggesprek en de gekozen opvolgroute.',
+      nextAction: {
+        title: 'Plan het vervolggesprek',
+        body: 'Gebruik de uitkomst nu om eerste besluiten, eigenaar en vervolgroute expliciet te maken.',
+      },
+      dashboardVisible: true,
+      deeperInsightsVisible: true,
+      statusBlocks: buildStatusBlocks('first_next_step_available'),
+    }
+  }
+
+  if (args.totalInvited === 0) {
+    return {
+      phase: 'data_required',
+      headline: 'Deelnemersbestand ontbreekt nog',
+      detail: 'Verisight heeft account en campagne klaargezet. Lever nu eerst het deelnemersbestand aan en controleer daarna de importpreview voordat iemand wordt uitgenodigd.',
+      nextAction: {
+        title: 'Lever het deelnemersbestand aan',
+        body: 'Upload een CSV- of Excel-bestand, controleer de validatie en ga pas daarna door naar uitnodigen.',
+      },
+      dashboardVisible: false,
+      deeperInsightsVisible: false,
+      statusBlocks: buildStatusBlocks('setup_incomplete').map((item) =>
+        item.key === 'data_required' ? { ...item, status: 'current' } : item,
+      ),
+    }
+  }
+
+  if (args.invitesNotSent > 0) {
+    return {
+      phase: 'ready_to_invite',
+      headline: 'De setup staat klaar voor launch',
+      detail: `${args.totalInvited} deelnemer(s) staan klaar, maar ${args.invitesNotSent} uitnodiging(en) zijn nog niet verstuurd. Controleer de aanlevering en start daarna pas de inviteflow.`,
+      nextAction: {
+        title: 'Verstuur de uitnodigingen',
+        body: 'Zodra het bestand klopt kun je de inviteflow veilig starten. Tot die tijd blijft het dashboard bewust gesloten.',
+      },
+      dashboardVisible: false,
+      deeperInsightsVisible: false,
+      statusBlocks: buildStatusBlocks('ready_to_invite'),
+    }
+  }
+
+  if (!args.hasMinDisplay) {
+    return {
+      phase: 'responses_incoming',
+      headline: 'Responses lopen binnen',
+      detail: `Er zijn ${args.totalCompleted} responses binnen. Vanaf 5 responses wordt de eerste dashboardread veilig genoeg om zichtbaar te maken.`,
+      nextAction: {
+        title: 'Volg respons en stuur zo nodig een reminder',
+        body: 'Laat de inviteflow eerst verder lopen en bouw meer responses op. Het dashboard gaat pas open zodra de eerste veilige responsegrens is gehaald.',
+      },
+      dashboardVisible: false,
+      deeperInsightsVisible: false,
+      statusBlocks: buildStatusBlocks('responses_incoming'),
+    }
+  }
+
+  if (!args.hasEnoughData) {
+    return {
+      phase: 'dashboard_active',
+      headline: 'Dashboard actief, nog bewust compact',
+      detail: `De eerste veilige drempel is gehaald. Vanaf ${args.totalCompleted} responses is de dashboardread bruikbaar, maar verdiepende patroonduiding blijft bewust dicht tot minstens 10 responses.`,
+      nextAction: {
+        title: 'Gebruik nu de compacte dashboardread',
+        body: 'Lees wat al zichtbaar is, houd conclusies voorlopig indicatief en blijf tegelijk respons opbouwen richting patroonniveau.',
+      },
+      dashboardVisible: true,
+      deeperInsightsVisible: false,
+      statusBlocks: buildStatusBlocks('dashboard_active'),
+    }
+  }
+
+  return {
+    phase: 'first_next_step_available',
+    headline: 'Eerste vervolgstap beschikbaar',
+    detail: 'De campagne heeft nu genoeg respons voor veilige dashboardactivatie en eerste patroonduiding. Vanaf hier hoort de flow door te schuiven naar de eerste managementstap, niet terug naar setup.',
+    nextAction: {
+      title: 'Maak de eerste vervolgstap expliciet',
+      body: 'Gebruik dashboard en rapport nu om eerste eigenaar, eerste managementactie en reviewmoment vast te leggen.',
+    },
+    dashboardVisible: true,
+    deeperInsightsVisible: true,
+    statusBlocks: buildStatusBlocks('first_next_step_available'),
+  }
+}

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -7,7 +7,7 @@ export type DeliveryMode = 'baseline' | 'live'
 // Access roles only. These are not billable seats or plan licenses.
 // owner  = Verisight-beheerder (volledige toegang)
 // member = intern Verisight (zelfde rechten als owner)
-// viewer = HR-klant (alleen lezen: dashboard + PDF)
+// viewer = HR-klant in guided self-serve uitvoering (deelnemers aanleveren, uitnodigingen volgen, dashboard lezen)
 export type MemberRole = 'owner' | 'member' | 'viewer'
 export type Preventability = 'STERK_WERKSIGNAAL' | 'GEMENGD_WERKSIGNAAL' | 'BEPERKT_WERKSIGNAAL'
 export const SCAN_TYPE_LABELS: Record<ScanType, string> = {
@@ -65,6 +65,7 @@ export interface Respondent {
   id: string
   campaign_id: string
   token: string
+  email: string | null
   department: string | null
   role_level: string | null
   exit_month: string | null

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -75,6 +75,21 @@ export async function middleware(request: NextRequest) {
   }
 
   let supabaseResponse = NextResponse.next({ request })
+  const isPublicRoute = isPublicRoutePath(pathname)
+  const isPublicApiRoute = isPublicApiRoutePath(pathname)
+  const hasSupabaseEnv = Boolean(
+    process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+  )
+
+  if (!hasSupabaseEnv) {
+    if (isPublicRoute || isPublicApiRoute) {
+      return supabaseResponse
+    }
+
+    const url = request.nextUrl.clone()
+    url.pathname = '/login'
+    return NextResponse.redirect(url)
+  }
 
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -101,9 +116,6 @@ export async function middleware(request: NextRequest) {
   const {
     data: { user },
   } = await supabase.auth.getUser()
-
-  const isPublicRoute = isPublicRoutePath(pathname)
-  const isPublicApiRoute = isPublicApiRoutePath(pathname)
 
   // Niet ingelogd + beveiligde route -> login
   if (!user && !isPublicRoute && !isPublicApiRoute) {

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -9,6 +9,26 @@ const distDir =
       ? configuredDistDir
       : undefined
 
+const connectSrc = [
+  "'self'",
+  'https://*.supabase.co',
+  'wss://*.supabase.co',
+  'https://verisight-production.up.railway.app',
+]
+const scriptSrc = ["'self'", "'unsafe-inline'"]
+const isLocalAcceptanceDev = process.env.VERISIGHT_ACCEPTANCE_FRONTEND_RUNTIME === 'dev'
+const isDevelopment = process.env.NODE_ENV !== 'production'
+if (isLocalAcceptanceDev || isDevelopment) {
+  scriptSrc.push("'unsafe-eval'")
+}
+
+const localSupabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL?.trim()
+if (localSupabaseUrl?.startsWith('http://127.0.0.1') || localSupabaseUrl?.startsWith('http://localhost')) {
+  const localSupabaseOrigin = new URL(localSupabaseUrl).origin
+  connectSrc.push(localSupabaseOrigin)
+  connectSrc.push(localSupabaseOrigin.replace(/^http/, 'ws'))
+}
+
 const securityHeaders = [
   {
     key: 'X-Content-Type-Options',
@@ -35,9 +55,9 @@ const securityHeaders = [
     value: [
       "default-src 'self'",
       // Supabase API + auth
-      "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://verisight-production.up.railway.app",
+      `connect-src ${connectSrc.join(' ')}`,
       // Next.js inline scripts + Google Fonts
-      "script-src 'self' 'unsafe-inline'",
+      `script-src ${scriptSrc.join(' ')}`,
       "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
       "font-src 'self' https://fonts.gstatic.com",
       "img-src 'self' data: blob:",
@@ -50,6 +70,7 @@ const securityHeaders = [
 
 const nextConfig: NextConfig = {
   ...(distDir ? { distDir } : {}),
+  allowedDevOrigins: ['127.0.0.1', 'localhost'],
   turbopack: {
     // Silences the "multiple lockfiles" workspace root warning
     root: path.resolve(__dirname),

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint",
     "test": "vitest run",
     "test:e2e": "playwright test",
+    "test:e2e:guided-self-serve": "python ../manage_acceptance_environment.py run-guided-self-serve",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:ui": "playwright test --ui"
   },

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -3,6 +3,16 @@ import { defineConfig, devices } from '@playwright/test'
 const port = process.env.PLAYWRIGHT_PORT ?? '3002'
 const baseURL = `http://127.0.0.1:${port}`
 const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+const acceptanceMode = process.env.VERISIGHT_ACCEPTANCE_MODE
+const frontendRuntime = process.env.VERISIGHT_ACCEPTANCE_FRONTEND_RUNTIME === 'dev' ? 'dev' : 'start'
+const webServerCommand =
+  frontendRuntime === 'dev'
+    ? `${npmCommand} run dev -- --port ${port}`
+    : `${npmCommand} run build && ${npmCommand} run start -- --port ${port}`
+const reuseExistingServer =
+  acceptanceMode === 'local'
+    ? false
+    : !process.env.CI
 
 export default defineConfig({
   testDir: './tests/e2e',
@@ -16,10 +26,10 @@ export default defineConfig({
     trace: 'on-first-retry',
   },
   webServer: {
-    command: `${npmCommand} run build && ${npmCommand} run start -- --port ${port}`,
+    command: webServerCommand,
     url: baseURL,
-    reuseExistingServer: !process.env.CI,
-    timeout: 120 * 1000,
+    reuseExistingServer,
+    timeout: frontendRuntime === 'dev' ? 180 * 1000 : 120 * 1000,
   },
   projects: [
     {

--- a/frontend/scripts/bootstrap-guided-self-serve-acceptance.mjs
+++ b/frontend/scripts/bootstrap-guided-self-serve-acceptance.mjs
@@ -1,0 +1,167 @@
+import { execFile } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+import { createClient } from '@supabase/supabase-js'
+
+const execFileAsync = promisify(execFile)
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url))
+const frontendRoot = path.resolve(currentDir, '..')
+const repoRoot = path.resolve(frontendRoot, '..')
+const defaultPythonExecutable = path.join(repoRoot, '.venv', 'Scripts', 'python.exe')
+
+const acceptanceEnv = {
+  email: process.env.PLAYWRIGHT_GUIDED_SELF_SERVE_EMAIL ?? 'guided-self-serve.acceptance@demo.verisight.local',
+  orgSlug: process.env.PLAYWRIGHT_GUIDED_SELF_SERVE_ORG_SLUG ?? 'guided-self-serve-acceptance',
+  password: process.env.PLAYWRIGHT_GUIDED_SELF_SERVE_PASSWORD ?? 'Verisight!Acceptance123',
+  serviceRoleKey: process.env.SUPABASE_SERVICE_ROLE_KEY ?? '',
+  supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL ?? '',
+}
+
+function getPythonExecutable() {
+  if (process.env.PLAYWRIGHT_PYTHON_EXECUTABLE) {
+    return process.env.PLAYWRIGHT_PYTHON_EXECUTABLE
+  }
+  if (existsSync(defaultPythonExecutable)) {
+    return defaultPythonExecutable
+  }
+  return 'python'
+}
+
+function createAdminSupabase() {
+  if (!acceptanceEnv.supabaseUrl || !acceptanceEnv.serviceRoleKey) {
+    throw new Error('Supabase service-role env ontbreekt voor acceptance-bootstrap.')
+  }
+
+  return createClient(acceptanceEnv.supabaseUrl, acceptanceEnv.serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  })
+}
+
+async function runManageDemo(args) {
+  const { stdout, stderr } = await execFileAsync(
+    getPythonExecutable(),
+    ['manage_demo_environment.py', ...args],
+    {
+      cwd: repoRoot,
+      env: process.env,
+    },
+  )
+
+  const output = stdout.trim() || stderr.trim()
+  if (!output) {
+    throw new Error(`manage_demo_environment.py gaf geen output voor args: ${args.join(' ')}`)
+  }
+
+  return JSON.parse(output)
+}
+
+async function upsertAcceptanceUser() {
+  const admin = createAdminSupabase()
+  let page = 1
+  let existingUserId = null
+
+  while (!existingUserId) {
+    const { data, error } = await admin.auth.admin.listUsers({ page, perPage: 200 })
+    if (error) {
+      throw error
+    }
+
+    existingUserId =
+      data.users.find((user) => user.email?.toLowerCase() === acceptanceEnv.email.toLowerCase())?.id ?? null
+
+    if (existingUserId || data.users.length < 200) {
+      break
+    }
+    page += 1
+  }
+
+  if (existingUserId) {
+    const { error } = await admin.auth.admin.updateUserById(existingUserId, {
+      email_confirm: true,
+      password: acceptanceEnv.password,
+    })
+    if (error) {
+      throw error
+    }
+    return existingUserId
+  }
+
+  const { data, error } = await admin.auth.admin.createUser({
+    email: acceptanceEnv.email,
+    email_confirm: true,
+    password: acceptanceEnv.password,
+  })
+  if (error || !data.user) {
+    throw error ?? new Error('Acceptance test user kon niet worden aangemaakt.')
+  }
+  return data.user.id
+}
+
+async function fetchCampaignIds() {
+  const admin = createAdminSupabase()
+  const { data: org, error: orgError } = await admin
+    .from('organizations')
+    .select('id')
+    .eq('slug', acceptanceEnv.orgSlug)
+    .single()
+
+  if (orgError || !org) {
+    throw orgError ?? new Error('Acceptance org niet gevonden na seeden.')
+  }
+
+  const { data: campaigns, error: campaignError } = await admin
+    .from('campaigns')
+    .select('id,name')
+    .eq('organization_id', org.id)
+    .in('name', ['Guided Self-Serve - Setup Journey', 'Guided Self-Serve - Threshold Journey'])
+
+  if (campaignError || !campaigns) {
+    throw campaignError ?? new Error('Acceptance campaigns niet gevonden na seeden.')
+  }
+
+  const setupCampaign = campaigns.find((campaign) => campaign.name === 'Guided Self-Serve - Setup Journey')
+  const thresholdCampaign = campaigns.find((campaign) => campaign.name === 'Guided Self-Serve - Threshold Journey')
+
+  if (!setupCampaign || !thresholdCampaign) {
+    throw new Error('Niet alle acceptance campaigns zijn aanwezig na seeden.')
+  }
+
+  return {
+    setupCampaignId: setupCampaign.id,
+    thresholdCampaignId: thresholdCampaign.id,
+  }
+}
+
+async function main() {
+  const userId = await upsertAcceptanceUser()
+  await runManageDemo([
+    'run',
+    'qa_guided_self_serve_acceptance',
+    '--org-slug',
+    acceptanceEnv.orgSlug,
+    '--viewer-user-id',
+    userId,
+  ])
+  const campaigns = await fetchCampaignIds()
+
+  process.stdout.write(
+    JSON.stringify({
+      email: acceptanceEnv.email,
+      password: acceptanceEnv.password,
+      setupCampaignId: campaigns.setupCampaignId,
+      thresholdCampaignId: campaigns.thresholdCampaignId,
+      userId,
+    }),
+  )
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exit(1)
+})

--- a/frontend/tests/e2e/guided-self-serve-acceptance.helpers.ts
+++ b/frontend/tests/e2e/guided-self-serve-acceptance.helpers.ts
@@ -1,0 +1,81 @@
+import { execFile } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import * as path from 'node:path'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+const frontendRoot = process.cwd()
+const repoRoot = path.resolve(frontendRoot, '..')
+const defaultPythonExecutable = path.join(repoRoot, '.venv', 'Scripts', 'python.exe')
+const runtimePath = path.join(repoRoot, '.acceptance-runtime', 'guided-self-serve.json')
+
+interface GuidedSelfServeAcceptanceRuntime {
+  mode: 'local' | 'remote'
+  profile: string
+  frontend_port: number
+  backend_port: number
+  env: Record<string, string>
+  fixture: GuidedSelfServeAcceptanceFixture
+}
+
+export interface GuidedSelfServeAcceptanceFixture {
+  email: string
+  password: string
+  setup_campaign_id: string
+  threshold_campaign_id: string
+  user_id: string
+}
+
+function getPythonExecutable() {
+  if (process.env.PLAYWRIGHT_PYTHON_EXECUTABLE) {
+    return process.env.PLAYWRIGHT_PYTHON_EXECUTABLE
+  }
+  if (existsSync(defaultPythonExecutable)) {
+    return defaultPythonExecutable
+  }
+  return 'python'
+}
+
+async function runAcceptanceManager(args: string[]) {
+  const { stdout, stderr } = await execFileAsync(
+    getPythonExecutable(),
+    ['manage_acceptance_environment.py', ...args],
+    {
+      cwd: repoRoot,
+      env: process.env,
+    },
+  )
+
+  const output = stdout.trim() || stderr.trim()
+  if (!output) {
+    throw new Error(`manage_acceptance_environment.py gaf geen output voor args: ${args.join(' ')}`)
+  }
+
+  return JSON.parse(output)
+}
+
+export async function loadGuidedSelfServeAcceptanceRuntime(): Promise<GuidedSelfServeAcceptanceRuntime> {
+  try {
+    const raw = await readFile(runtimePath, 'utf-8')
+    return JSON.parse(raw) as GuidedSelfServeAcceptanceRuntime
+  } catch {
+    throw new Error(
+      'Guided self-serve acceptance-runtime ontbreekt. Gebruik `npm run test:e2e:guided-self-serve` of bootstrap de runtime eerst via `python manage_acceptance_environment.py bootstrap`.',
+    )
+  }
+}
+
+export async function loadGuidedSelfServeAcceptanceFixture(): Promise<GuidedSelfServeAcceptanceFixture> {
+  const runtime = await loadGuidedSelfServeAcceptanceRuntime()
+  return runtime.fixture
+}
+
+export async function advanceGuidedSelfServeAcceptanceFixture(phase: 'min_display' | 'patterns') {
+  return runAcceptanceManager([
+    'advance',
+    '--phase',
+    phase,
+  ])
+}

--- a/frontend/tests/e2e/guided-self-serve-acceptance.spec.ts
+++ b/frontend/tests/e2e/guided-self-serve-acceptance.spec.ts
@@ -1,0 +1,102 @@
+import * as path from 'node:path'
+import { expect, test } from '@playwright/test'
+import {
+  advanceGuidedSelfServeAcceptanceFixture,
+  loadGuidedSelfServeAcceptanceFixture,
+  type GuidedSelfServeAcceptanceFixture,
+} from './guided-self-serve-acceptance.helpers'
+
+const fixturesDir = path.resolve(process.cwd(), 'tests', 'fixtures', 'guided-self-serve')
+const invalidImportPath = path.join(fixturesDir, 'invalid-import.csv')
+const validImportPath = path.join(fixturesDir, 'valid-import.csv')
+
+async function loginAsAcceptanceUser(page: any, fixture: GuidedSelfServeAcceptanceFixture) {
+  await page.goto('/login')
+  await page.getByLabel(/e-mailadres/i).fill(fixture.email)
+  await page.getByLabel(/wachtwoord/i).fill(fixture.password)
+  await page.getByRole('button', { name: /^inloggen$/i }).click()
+  await page.waitForURL('**/dashboard')
+}
+
+test.describe.serial('guided self-serve acceptance', () => {
+  let fixture: GuidedSelfServeAcceptanceFixture | null = null
+
+  test.beforeAll(async () => {
+    fixture = await loadGuidedSelfServeAcceptanceFixture()
+  })
+
+  test('setup journey guides import recovery and explicit invite launch', async ({ page }) => {
+    if (!fixture) {
+      throw new Error('Acceptance fixture ontbreekt.')
+    }
+
+    await loginAsAcceptanceUser(page, fixture)
+
+    await expect(page.getByText(/jouw uitvoerstatus/i).first()).toBeVisible()
+    await expect(page.getByText(/deelnemersbestand ontbreekt nog/i).first()).toBeVisible()
+    await expect(page.getByRole('link', { name: /open uitvoerflow/i }).first()).toBeVisible()
+
+    await page.goto(`/campaigns/${fixture.setup_campaign_id}`)
+
+    await expect(page.getByRole('heading', { name: /begeleide uitvoerflow/i })).toBeVisible()
+    await expect(page.getByText(/deelnemersbestand ontbreekt nog/i).first()).toBeVisible()
+    await expect(page.getByText(/dashboard nog niet actief/i).first()).toBeVisible()
+    await expect(page.getByRole('button', { name: /pdf-rapport/i })).toHaveCount(0)
+
+    await page.locator('input[type="file"]').setInputFiles(invalidImportPath)
+    await page.getByRole('button', { name: /^bestand controleren$/i }).click()
+
+    await expect(page.getByText(/import validatie vereist/i).first()).toBeVisible()
+    await expect(page.getByText(/dit e-mailadres staat dubbel in het bestand/i)).toBeVisible()
+    await expect(page.getByText(/valid email address/i)).toBeVisible()
+
+    await page.locator('input[type="file"]').setInputFiles(validImportPath)
+    await page.getByLabel(/verstuur direct uitnodigingen na een geslaagde import/i).uncheck()
+    await page.getByRole('button', { name: /^bestand controleren$/i }).click()
+
+    await expect(page.getByText(/preview van geldige rijen/i).first()).toBeVisible()
+    await expect(page.getByText(/klaar om uit te nodigen/i).first()).toBeVisible()
+
+    await page.getByRole('button', { name: /importeer 2 deelnemers/i }).click()
+
+    await expect(page.getByText(/2 deelnemer\(s\) toegevoegd/i)).toBeVisible()
+    await expect(page.getByRole('button', { name: /start uitnodigingen \(2\)/i })).toBeVisible()
+
+    await page.getByRole('button', { name: /start uitnodigingen \(2\)/i }).click()
+
+    await expect(page.getByText(/2 uitnodiging\(en\) gestart/i)).toBeVisible()
+    await expect(page.getByText(/responses lopen binnen/i).first()).toBeVisible()
+    await expect(page.getByRole('button', { name: /pdf-rapport/i })).toHaveCount(0)
+    await expect(page.getByText(/dashboard nog niet actief/i).first()).toBeVisible()
+  })
+
+  test('threshold journey unlocks dashboard first and deeper guidance only at pattern readiness', async ({ page }) => {
+    if (!fixture) {
+      throw new Error('Acceptance fixture ontbreekt.')
+    }
+
+    await loginAsAcceptanceUser(page, fixture)
+    await page.goto(`/campaigns/${fixture.threshold_campaign_id}`)
+
+    await expect(page.getByText(/responses lopen binnen/i).first()).toBeVisible()
+    await expect(page.getByText(/dashboard nog niet actief/i).first()).toBeVisible()
+    await expect(page.getByRole('button', { name: /pdf-rapport/i })).toHaveCount(0)
+
+    await advanceGuidedSelfServeAcceptanceFixture('min_display')
+    await page.reload()
+
+    await expect(page.getByText(/dashboard actief, nog bewust compact/i).first()).toBeVisible()
+    await expect(page.getByRole('button', { name: /pdf-rapport/i }).first()).toBeVisible()
+    await expect(page.getByText(/vertrekduiding en managementgesprek/i)).toBeVisible()
+    await expect(page.getByText(/verdiepende analyse wordt zichtbaar vanaf 10 ingevulde responses/i)).toBeVisible()
+
+    await advanceGuidedSelfServeAcceptanceFixture('patterns')
+    await page.reload()
+
+    await expect(page.getByText(/eerste vervolgstap beschikbaar/i).first()).toBeVisible()
+    await expect(page.getByText(/verdiepende analyse wordt zichtbaar vanaf 10 ingevulde responses/i)).toHaveCount(0)
+    await expect(page.getByText(/focusvragen en route-uitvoer worden betekenisvoller zodra het dashboard minstens 10 responses heeft/i)).toHaveCount(0)
+    await expect(page.getByText(/van vertrekduiding naar managementroute/i)).toBeVisible()
+    await expect(page.getByRole('button', { name: /pdf-rapport/i }).first()).toBeVisible()
+  })
+})

--- a/frontend/tests/e2e/login-guided-flow.spec.ts
+++ b/frontend/tests/e2e/login-guided-flow.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from '@playwright/test'
+
+test('login page explains the guided customer execution flow', async ({ page }) => {
+  await page.goto('/login')
+
+  await expect(page.getByRole('heading', { name: /inloggen/i })).toBeVisible()
+  await expect(page.getByText(/begeleide klantuitvoering/i)).toBeVisible()
+  await expect(
+    page.getByText(/na login zie je direct wat nu ontbreekt, wanneer deelnemers kunnen worden aangeleverd/i),
+  ).toBeVisible()
+  await expect(page.getByLabel(/e-mailadres/i)).toBeVisible()
+  await expect(page.getByLabel(/wachtwoord/i)).toBeVisible()
+})

--- a/frontend/tests/fixtures/guided-self-serve/invalid-import.csv
+++ b/frontend/tests/fixtures/guided-self-serve/invalid-import.csv
@@ -1,0 +1,4 @@
+email,department,role_level,exit_month,annual_salary_eur
+bad-email,Operations,specialist,2026-03,55000
+dup@example.com,People,manager,2026-04,64000
+dup@example.com,People,manager,2026-04,64000

--- a/frontend/tests/fixtures/guided-self-serve/valid-import.csv
+++ b/frontend/tests/fixtures/guided-self-serve/valid-import.csv
@@ -1,0 +1,3 @@
+email,department,role_level,exit_month,annual_salary_eur
+anne@example.com,Operations,specialist,2026-03,55000
+bart@example.com,People,manager,2026-04,64000

--- a/manage_acceptance_environment.py
+++ b/manage_acceptance_environment.py
@@ -1,0 +1,472 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import time
+import urllib.request
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import psycopg2
+
+
+ROOT = Path(__file__).resolve().parent
+FRONTEND_DIR = ROOT / "frontend"
+SUPABASE_SCHEMA_PATH = ROOT / "supabase" / "schema.sql"
+ACCEPTANCE_RUNTIME_DIR = ROOT / ".acceptance-runtime"
+GUIDED_SELF_SERVE_RUNTIME_PATH = ACCEPTANCE_RUNTIME_DIR / "guided-self-serve.json"
+GUIDED_SELF_SERVE_BOOTSTRAP_SCRIPT = FRONTEND_DIR / "scripts" / "bootstrap-guided-self-serve-acceptance.mjs"
+
+DEFAULT_FRONTEND_PORT = 3002
+DEFAULT_BACKEND_PORT = 8000
+GUIDED_SELF_SERVE_ORG_SLUG = "guided-self-serve-acceptance"
+GUIDED_SELF_SERVE_EMAIL = "guided-self-serve.acceptance@demo.verisight.local"
+GUIDED_SELF_SERVE_PASSWORD = "Verisight!Acceptance123"
+LOCAL_FRONTEND_RUNTIME = "dev"
+DEFAULT_FRONTEND_RUNTIME = "start"
+
+
+class AcceptanceEnvironmentError(RuntimeError):
+    pass
+
+
+@dataclass(slots=True)
+class GuidedSelfServeFixture:
+    email: str
+    password: str
+    setup_campaign_id: str
+    threshold_campaign_id: str
+    user_id: str
+
+
+@dataclass(slots=True)
+class GuidedSelfServeAcceptanceRuntime:
+    mode: str
+    profile: str
+    frontend_port: int
+    backend_port: int
+    env: dict[str, str]
+    fixture: GuidedSelfServeFixture
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Autonome acceptance-runner voor guided self-serve.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    bootstrap_parser = subparsers.add_parser("bootstrap", help="Bootstrap guided self-serve acceptance lokaal of remote.")
+    bootstrap_parser.add_argument("--profile", choices=["guided_self_serve"], default="guided_self_serve")
+    bootstrap_parser.add_argument("--mode", choices=["local", "remote"], default=os.getenv("VERISIGHT_ACCEPTANCE_MODE", "local"))
+    bootstrap_parser.add_argument("--frontend-port", type=int, default=DEFAULT_FRONTEND_PORT)
+    bootstrap_parser.add_argument("--backend-port", type=int, default=DEFAULT_BACKEND_PORT)
+
+    run_parser = subparsers.add_parser("run-guided-self-serve", help="Bootstrap, start backend en draai de Playwright acceptance-flow.")
+    run_parser.add_argument("--mode", choices=["local", "remote"], default=os.getenv("VERISIGHT_ACCEPTANCE_MODE", "local"))
+    run_parser.add_argument("--teardown", action="store_true")
+
+    advance_parser = subparsers.add_parser("advance", help="Schuif de guided self-serve threshold-journey door.")
+    advance_parser.add_argument("--mode", choices=["local", "remote"], default=os.getenv("VERISIGHT_ACCEPTANCE_MODE", "local"))
+    advance_parser.add_argument("--phase", choices=["min_display", "patterns"], required=True)
+
+    teardown_parser = subparsers.add_parser("teardown", help="Stop lokale acceptance-infra en verwijder runtime-contracten.")
+    teardown_parser.add_argument("--mode", choices=["local", "remote"], default=os.getenv("VERISIGHT_ACCEPTANCE_MODE", "local"))
+    teardown_parser.add_argument("--reset-data", action="store_true")
+
+    return parser.parse_args()
+
+
+def _command_path(name: str) -> str | None:
+    return shutil.which(name)
+
+
+def _get_supabase_cli_command() -> list[str]:
+    configured = os.getenv("SUPABASE_CLI_BIN")
+    if configured:
+        return shlex.split(configured, posix=os.name != "nt")
+
+    supabase_bin = _command_path("supabase")
+    if supabase_bin:
+        return [supabase_bin]
+
+    npx_cmd = _command_path("npx.cmd" if os.name == "nt" else "npx")
+    if npx_cmd:
+        return [npx_cmd, "supabase"]
+
+    raise AcceptanceEnvironmentError(
+        "Supabase CLI ontbreekt. Installeer de CLI of zet SUPABASE_CLI_BIN expliciet voor acceptance-bootstrap."
+    )
+
+
+def _get_npm_command() -> str:
+    npm_cmd = _command_path("npm.cmd" if os.name == "nt" else "npm")
+    if not npm_cmd:
+        raise AcceptanceEnvironmentError("npm ontbreekt. Frontend acceptance kan niet worden gestart.")
+    return npm_cmd
+
+
+def _get_node_command() -> str:
+    node_cmd = _command_path("node.exe" if os.name == "nt" else "node")
+    if not node_cmd:
+        raise AcceptanceEnvironmentError("Node.js ontbreekt. De acceptance-bootstrap kan de Supabase helper niet starten.")
+    return node_cmd
+
+
+def _get_python_command() -> str:
+    configured = os.getenv("PLAYWRIGHT_PYTHON_EXECUTABLE")
+    if configured:
+        return configured
+
+    venv_python = ROOT / ".venv" / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+    if venv_python.exists():
+        return str(venv_python)
+
+    return sys.executable
+
+
+def get_acceptance_frontend_runtime(mode: str) -> str:
+    configured = os.getenv("VERISIGHT_ACCEPTANCE_FRONTEND_RUNTIME", "").strip().lower()
+    if configured in {"dev", "start"}:
+        return configured
+    if mode == "local":
+        return LOCAL_FRONTEND_RUNTIME
+    return DEFAULT_FRONTEND_RUNTIME
+
+
+def _run_command(
+    args: list[str],
+    *,
+    cwd: Path = ROOT,
+    env: dict[str, str] | None = None,
+    capture_output: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            args,
+            cwd=str(cwd),
+            env=env,
+            check=True,
+            capture_output=capture_output,
+            text=True,
+            errors="replace",
+        )
+    except subprocess.CalledProcessError as exc:
+        output = (exc.stdout or "").strip()
+        error = (exc.stderr or "").strip()
+        detail = "\n".join(part for part in (output, error) if part)
+        message = f"Commando mislukt: {' '.join(args)}"
+        if detail:
+            message += f"\n{detail}"
+        raise AcceptanceEnvironmentError(message) from exc
+
+
+def _ensure_local_prerequisites() -> None:
+    docker_cmd = _command_path("docker.exe" if os.name == "nt" else "docker")
+    if not docker_cmd:
+        raise AcceptanceEnvironmentError(
+            "Docker ontbreekt. Installeer Docker Desktop en probeer daarna opnieuw."
+        )
+    _run_command([docker_cmd, "--version"])
+    _run_command([*_get_supabase_cli_command(), "--version"])
+
+
+def _start_local_supabase() -> None:
+    _run_command([*_get_supabase_cli_command(), "start"], capture_output=True)
+
+
+def _read_local_supabase_status_env() -> dict[str, str]:
+    completed = _run_command([*_get_supabase_cli_command(), "status", "-o", "env"])
+    env_map: dict[str, str] = {}
+    for raw_line in completed.stdout.splitlines():
+        line = raw_line.strip()
+        if not line or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        cleaned = value.strip()
+        if len(cleaned) >= 2 and cleaned[0] == cleaned[-1] and cleaned[0] in {'"', "'"}:
+            cleaned = cleaned[1:-1]
+        env_map[key.strip()] = cleaned
+    return env_map
+
+
+def _build_local_acceptance_env(*, frontend_port: int, backend_port: int) -> dict[str, str]:
+    _ensure_local_prerequisites()
+    _start_local_supabase()
+    status_env = _read_local_supabase_status_env()
+    required = ["API_URL", "ANON_KEY", "SERVICE_ROLE_KEY", "DB_URL"]
+    missing = [key for key in required if not status_env.get(key)]
+    if missing:
+        raise AcceptanceEnvironmentError(
+            "Lokale Supabase-stack levert onvolledige status terug. Ontbreekt: " + ", ".join(missing)
+        )
+
+    return {
+        **os.environ,
+        "DATABASE_URL": status_env["DB_URL"],
+        "FRONTEND_URL": f"http://127.0.0.1:{frontend_port}",
+        "NEXT_PUBLIC_API_URL": f"http://127.0.0.1:{backend_port}",
+        "NEXT_PUBLIC_SUPABASE_ANON_KEY": status_env["ANON_KEY"],
+        "NEXT_PUBLIC_SUPABASE_URL": status_env["API_URL"],
+        "PLAYWRIGHT_GUIDED_SELF_SERVE_EMAIL": os.getenv("PLAYWRIGHT_GUIDED_SELF_SERVE_EMAIL", GUIDED_SELF_SERVE_EMAIL),
+        "PLAYWRIGHT_GUIDED_SELF_SERVE_ORG_SLUG": os.getenv("PLAYWRIGHT_GUIDED_SELF_SERVE_ORG_SLUG", GUIDED_SELF_SERVE_ORG_SLUG),
+        "PLAYWRIGHT_GUIDED_SELF_SERVE_PASSWORD": os.getenv("PLAYWRIGHT_GUIDED_SELF_SERVE_PASSWORD", GUIDED_SELF_SERVE_PASSWORD),
+        "PLAYWRIGHT_PORT": str(frontend_port),
+        "SUPABASE_SERVICE_ROLE_KEY": status_env["SERVICE_ROLE_KEY"],
+        "SUPABASE_URL": status_env["API_URL"],
+        "VERISIGHT_ACCEPTANCE_FAKE_EMAIL": "1",
+        "VERISIGHT_ACCEPTANCE_FRONTEND_RUNTIME": get_acceptance_frontend_runtime("local"),
+        "VERISIGHT_ACCEPTANCE_MODE": "local",
+        "VERISIGHT_ACCEPTANCE_PROFILE": "guided_self_serve",
+    }
+
+
+def _build_remote_acceptance_env(*, frontend_port: int, backend_port: int) -> dict[str, str]:
+    env = {
+        **os.environ,
+        "FRONTEND_URL": os.getenv("FRONTEND_URL", f"http://127.0.0.1:{frontend_port}"),
+        "NEXT_PUBLIC_API_URL": os.getenv("NEXT_PUBLIC_API_URL", f"http://127.0.0.1:{backend_port}"),
+        "PLAYWRIGHT_GUIDED_SELF_SERVE_EMAIL": os.getenv("PLAYWRIGHT_GUIDED_SELF_SERVE_EMAIL", GUIDED_SELF_SERVE_EMAIL),
+        "PLAYWRIGHT_GUIDED_SELF_SERVE_ORG_SLUG": os.getenv("PLAYWRIGHT_GUIDED_SELF_SERVE_ORG_SLUG", GUIDED_SELF_SERVE_ORG_SLUG),
+        "PLAYWRIGHT_GUIDED_SELF_SERVE_PASSWORD": os.getenv("PLAYWRIGHT_GUIDED_SELF_SERVE_PASSWORD", GUIDED_SELF_SERVE_PASSWORD),
+        "PLAYWRIGHT_PORT": str(frontend_port),
+        "SUPABASE_URL": os.getenv("SUPABASE_URL", os.getenv("NEXT_PUBLIC_SUPABASE_URL", "")),
+        "VERISIGHT_ACCEPTANCE_FRONTEND_RUNTIME": get_acceptance_frontend_runtime("remote"),
+        "VERISIGHT_ACCEPTANCE_MODE": "remote",
+        "VERISIGHT_ACCEPTANCE_PROFILE": "guided_self_serve",
+    }
+    required = [
+        "NEXT_PUBLIC_SUPABASE_URL",
+        "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+        "SUPABASE_SERVICE_ROLE_KEY",
+        "DATABASE_URL",
+    ]
+    missing = [key for key in required if not env.get(key)]
+    if missing:
+        raise AcceptanceEnvironmentError(
+            "Remote acceptance-env mist verplichte variabelen: " + ", ".join(missing)
+        )
+    return env
+
+
+def build_acceptance_env(
+    mode: str,
+    *,
+    frontend_port: int = DEFAULT_FRONTEND_PORT,
+    backend_port: int = DEFAULT_BACKEND_PORT,
+) -> dict[str, str]:
+    if mode == "remote":
+        return _build_remote_acceptance_env(frontend_port=frontend_port, backend_port=backend_port)
+    return _build_local_acceptance_env(frontend_port=frontend_port, backend_port=backend_port)
+
+
+def _load_schema_sql() -> str:
+    return SUPABASE_SCHEMA_PATH.read_text(encoding="utf-8").lstrip("\ufeff")
+
+
+def _apply_schema(database_url: str) -> None:
+    schema_sql = _load_schema_sql()
+    connection = psycopg2.connect(database_url)
+    try:
+        connection.autocommit = True
+        with connection.cursor() as cursor:
+            cursor.execute(schema_sql)
+    finally:
+        connection.close()
+
+
+def _bootstrap_guided_self_serve_fixture(env: dict[str, str]) -> GuidedSelfServeFixture:
+    completed = _run_command(
+        [_get_node_command(), str(GUIDED_SELF_SERVE_BOOTSTRAP_SCRIPT)],
+        cwd=FRONTEND_DIR,
+        env=env,
+    )
+    payload = json.loads(completed.stdout)
+    return GuidedSelfServeFixture(
+        email=payload["email"],
+        password=payload["password"],
+        setup_campaign_id=payload["setupCampaignId"],
+        threshold_campaign_id=payload["thresholdCampaignId"],
+        user_id=payload["userId"],
+    )
+
+
+def _write_runtime_contract(runtime: GuidedSelfServeAcceptanceRuntime) -> None:
+    ACCEPTANCE_RUNTIME_DIR.mkdir(parents=True, exist_ok=True)
+    GUIDED_SELF_SERVE_RUNTIME_PATH.write_text(
+        json.dumps(asdict(runtime), ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+def bootstrap_guided_self_serve_acceptance(
+    *,
+    mode: str = "local",
+    frontend_port: int = DEFAULT_FRONTEND_PORT,
+    backend_port: int = DEFAULT_BACKEND_PORT,
+) -> GuidedSelfServeAcceptanceRuntime:
+    env = build_acceptance_env(mode, frontend_port=frontend_port, backend_port=backend_port)
+    if mode == "local":
+        _apply_schema(env["DATABASE_URL"])
+    fixture = _bootstrap_guided_self_serve_fixture(env)
+    runtime = GuidedSelfServeAcceptanceRuntime(
+        mode=mode,
+        profile="guided_self_serve",
+        frontend_port=frontend_port,
+        backend_port=backend_port,
+        env=env,
+        fixture=fixture,
+    )
+    _write_runtime_contract(runtime)
+    return runtime
+
+
+def _run_manage_demo(args: list[str], env: dict[str, str]) -> dict[str, object]:
+    completed = _run_command(
+        [_get_python_command(), "manage_demo_environment.py", *args],
+        cwd=ROOT,
+        env=env,
+    )
+    output = completed.stdout.strip() or completed.stderr.strip()
+    if not output:
+        raise AcceptanceEnvironmentError("manage_demo_environment.py gaf geen output terug.")
+    return json.loads(output)
+
+
+def advance_guided_self_serve_acceptance(phase: str, *, mode: str = "local") -> dict[str, object]:
+    env = build_acceptance_env(mode)
+    return _run_manage_demo(
+        [
+            "advance",
+            "qa_guided_self_serve_acceptance",
+            "--org-slug",
+            GUIDED_SELF_SERVE_ORG_SLUG,
+            "--phase",
+            phase,
+        ],
+        env,
+    )
+
+
+def _wait_for_health(url: str, *, timeout_seconds: float = 45.0, label: str = "service") -> None:
+    deadline = time.time() + timeout_seconds
+    last_error: str | None = None
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=5) as response:
+                if 200 <= response.status < 500:
+                    return
+        except Exception as exc:  # pragma: no cover - network timing path
+            last_error = str(exc)
+            time.sleep(1.0)
+    raise AcceptanceEnvironmentError(
+        f"{label} werd niet gezond binnen {timeout_seconds:.0f}s."
+        + (f" Laatste fout: {last_error}" if last_error else "")
+    )
+
+
+def _start_backend_process(env: dict[str, str], *, backend_port: int = DEFAULT_BACKEND_PORT) -> subprocess.Popen[str]:
+    return subprocess.Popen(
+        [
+            _get_python_command(),
+            "-m",
+            "uvicorn",
+            "backend.main:app",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(backend_port),
+        ],
+        cwd=str(ROOT),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+
+def _stop_backend_process(process: subprocess.Popen[str]) -> None:
+    process.terminate()
+    try:
+        process.wait(timeout=10)
+    except subprocess.TimeoutExpired:  # pragma: no cover - defensive path
+        process.kill()
+        process.wait(timeout=5)
+
+
+def _run_playwright_guided_self_serve(env: dict[str, str]) -> None:
+    _run_command(
+        [_get_npm_command(), "run", "test:e2e", "--", "tests/e2e/guided-self-serve-acceptance.spec.ts"],
+        cwd=FRONTEND_DIR,
+        env=env,
+        capture_output=False,
+    )
+
+
+def _run_frontend_build_check(env: dict[str, str]) -> None:
+    _run_command(
+        [_get_npm_command(), "run", "build"],
+        cwd=FRONTEND_DIR,
+        env=env,
+        capture_output=False,
+    )
+
+
+def teardown_acceptance_environment(*, mode: str = "local", reset_data: bool = False) -> None:
+    if GUIDED_SELF_SERVE_RUNTIME_PATH.exists():
+        GUIDED_SELF_SERVE_RUNTIME_PATH.unlink()
+
+    if mode == "local":
+        command = [*_get_supabase_cli_command(), "stop"]
+        if reset_data:
+            command.append("--no-backup")
+        _run_command(command, capture_output=True)
+
+
+def run_guided_self_serve_acceptance(*, mode: str = "local", teardown: bool = False) -> GuidedSelfServeAcceptanceRuntime:
+    runtime = bootstrap_guided_self_serve_acceptance(mode=mode)
+    _run_frontend_build_check(runtime.env)
+    backend_process = _start_backend_process(runtime.env, backend_port=runtime.backend_port)
+    try:
+        _wait_for_health(f"http://127.0.0.1:{runtime.backend_port}/api/health", label="backend")
+        _run_playwright_guided_self_serve(runtime.env)
+        return runtime
+    finally:
+        _stop_backend_process(backend_process)
+        if teardown:
+            teardown_acceptance_environment(mode=mode)
+
+
+def main() -> None:
+    args = _parse_args()
+
+    try:
+        if args.command == "bootstrap":
+            runtime = bootstrap_guided_self_serve_acceptance(
+                mode=args.mode,
+                frontend_port=args.frontend_port,
+                backend_port=args.backend_port,
+            )
+            print(json.dumps(asdict(runtime), ensure_ascii=False, indent=2))
+            return
+
+        if args.command == "run-guided-self-serve":
+            runtime = run_guided_self_serve_acceptance(mode=args.mode, teardown=args.teardown)
+            print(json.dumps(asdict(runtime), ensure_ascii=False, indent=2))
+            return
+
+        if args.command == "advance":
+            print(json.dumps(advance_guided_self_serve_acceptance(args.phase, mode=args.mode), ensure_ascii=False, indent=2))
+            return
+
+        teardown_acceptance_environment(mode=args.mode, reset_data=args.reset_data)
+        print(json.dumps({"status": "stopped", "mode": args.mode, "reset_data": args.reset_data}, ensure_ascii=False, indent=2))
+    except AcceptanceEnvironmentError as exc:
+        print(str(exc), file=sys.stderr)
+        raise SystemExit(1) from exc
+
+
+if __name__ == "__main__":
+    main()

--- a/manage_demo_environment.py
+++ b/manage_demo_environment.py
@@ -9,6 +9,9 @@ from pathlib import Path
 from backend.database import SessionLocal, init_db
 from demo_environment import (
     DEMO_SCENARIOS,
+    GUIDED_SELF_SERVE_ACCEPTANCE_CONTACT_EMAIL,
+    GUIDED_SELF_SERVE_ACCEPTANCE_ORG_NAME,
+    GUIDED_SELF_SERVE_ACCEPTANCE_ORG_SLUG,
     INTERNAL_SALES_DEMO_CONTACT_EMAIL,
     INTERNAL_SALES_DEMO_ORG_NAME,
     INTERNAL_SALES_DEMO_ORG_SLUG,
@@ -17,8 +20,10 @@ from demo_environment import (
     QA_RETENTION_ORG_SLUG,
     VALIDATION_RETENTION_DEFAULT_DB,
     VALIDATION_RETENTION_DEFAULT_OUTDIR,
+    advance_guided_self_serve_acceptance,
     get_demo_layer_contracts,
     get_demo_scenarios,
+    seed_guided_self_serve_acceptance,
     seed_sales_demo_exit,
     seed_sales_demo_retention,
 )
@@ -47,6 +52,11 @@ def _parse_args() -> argparse.Namespace:
     run_parser.add_argument("--db-path", default=VALIDATION_RETENTION_DEFAULT_DB)
     run_parser.add_argument("--outdir", default=VALIDATION_RETENTION_DEFAULT_OUTDIR)
     run_parser.add_argument("--responses", type=int, default=72)
+
+    advance_parser = subparsers.add_parser("advance", help="Schuif een deterministic QA-scenario door naar de volgende fase.")
+    advance_parser.add_argument("scenario", choices=["qa_guided_self_serve_acceptance"])
+    advance_parser.add_argument("--phase", choices=["min_display", "patterns"], required=True)
+    advance_parser.add_argument("--org-slug", default=None)
     return parser.parse_args()
 
 
@@ -146,6 +156,40 @@ def _run_qa_retention_demo(args: argparse.Namespace) -> int:
     return _run_subprocess(command)
 
 
+def _run_qa_guided_self_serve_acceptance(args: argparse.Namespace) -> int:
+    init_db()
+    db = SessionLocal()
+    try:
+        result = seed_guided_self_serve_acceptance(
+            db,
+            org_slug=args.org_slug or GUIDED_SELF_SERVE_ACCEPTANCE_ORG_SLUG,
+            org_name=args.org_name or GUIDED_SELF_SERVE_ACCEPTANCE_ORG_NAME,
+            contact_email=args.contact_email or GUIDED_SELF_SERVE_ACCEPTANCE_CONTACT_EMAIL,
+            viewer_user_id=(args.viewer_user_id[0] if args.viewer_user_id else None),
+        )
+    finally:
+        db.close()
+
+    print(json.dumps({"scenario": "qa_guided_self_serve_acceptance", **result}, ensure_ascii=False, indent=2))
+    return 0
+
+
+def _advance_qa_guided_self_serve_acceptance(args: argparse.Namespace) -> int:
+    init_db()
+    db = SessionLocal()
+    try:
+        result = advance_guided_self_serve_acceptance(
+            db,
+            phase=args.phase,
+            org_slug=args.org_slug or GUIDED_SELF_SERVE_ACCEPTANCE_ORG_SLUG,
+        )
+    finally:
+        db.close()
+
+    print(json.dumps({"scenario": "qa_guided_self_serve_acceptance", **result}, ensure_ascii=False, indent=2))
+    return 0
+
+
 def _run_validation_retention_pilot(args: argparse.Namespace) -> int:
     command = [
         args.python_executable,
@@ -167,10 +211,17 @@ def main() -> None:
         print(_render_json() if args.format == "json" else _render_table())
         return
 
+    if args.command == "advance":
+        runners = {
+            "qa_guided_self_serve_acceptance": _advance_qa_guided_self_serve_acceptance,
+        }
+        raise SystemExit(runners[args.scenario](args))
+
     runners = {
         "sales_demo_exit": _run_sales_demo_exit,
         "sales_demo_retention": _run_sales_demo_retention,
         "qa_exit_live_test": _run_qa_exit_live_test,
+        "qa_guided_self_serve_acceptance": _run_qa_guided_self_serve_acceptance,
         "qa_retention_demo": _run_qa_retention_demo,
         "validation_retention_pilot": _run_validation_retention_pilot,
     }

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,38 @@
+project_id = "verisight-guided-self-serve"
+
+[api]
+enabled = true
+port = 54321
+schemas = ["public", "storage", "graphql_public"]
+extra_search_path = ["public", "extensions"]
+max_rows = 1000
+
+[db]
+port = 54322
+shadow_port = 54320
+major_version = 15
+
+[studio]
+enabled = true
+port = 54323
+
+[inbucket]
+enabled = true
+port = 54324
+
+[auth]
+enabled = true
+site_url = "http://127.0.0.1:3002"
+additional_redirect_urls = [
+  "http://127.0.0.1:3002",
+  "http://localhost:3002",
+  "http://127.0.0.1:3000",
+  "http://localhost:3000",
+]
+jwt_expiry = 3600
+enable_signup = true
+
+[auth.email]
+enable_signup = true
+double_confirm_changes = false
+enable_confirmations = false

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -178,7 +178,10 @@ end $$;
 
 -- Voeg scoring_version toe aan bestaande survey_responses indien nog niet aanwezig
 do $$ begin
-  if not exists (
+  if exists (
+    select 1 from information_schema.tables
+    where table_schema = 'public' and table_name = 'survey_responses'
+  ) and not exists (
     select 1 from information_schema.columns
     where table_name = 'survey_responses' and column_name = 'scoring_version'
   ) then
@@ -666,6 +669,13 @@ as $$
       and org_members.role in ('owner', 'member')
   );
 $$;
+
+-- Zorg dat profiles beschikbaar is voordat adminfuncties en policies ernaar verwijzen.
+create table if not exists public.profiles (
+  id                 uuid primary key references auth.users(id) on delete cascade,
+  is_verisight_admin boolean not null default false,
+  created_at         timestamptz default now()
+);
 
 create or replace function public.is_verisight_admin_user()
 returns boolean

--- a/tests/test_acceptance_environment.py
+++ b/tests/test_acceptance_environment.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+import manage_acceptance_environment as acceptance
+
+
+def test_bootstrap_guided_self_serve_acceptance_local_writes_runtime_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime_dir = Path(acceptance.ROOT) / ".codex-artifacts" / "pytest-acceptance-runtime"
+    shutil.rmtree(runtime_dir, ignore_errors=True)
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    runtime_file = runtime_dir / "guided-self-serve.json"
+
+    monkeypatch.setattr(acceptance, "ACCEPTANCE_RUNTIME_DIR", runtime_dir)
+    monkeypatch.setattr(acceptance, "GUIDED_SELF_SERVE_RUNTIME_PATH", runtime_file)
+    monkeypatch.setattr(acceptance, "_ensure_local_prerequisites", lambda: None)
+    monkeypatch.setattr(acceptance, "_start_local_supabase", lambda: None)
+    monkeypatch.setattr(
+        acceptance,
+        "_read_local_supabase_status_env",
+        lambda: {
+            "API_URL": "http://127.0.0.1:54321",
+            "ANON_KEY": "anon-key",
+            "SERVICE_ROLE_KEY": "service-role-key",
+            "DB_URL": "postgresql://postgres:postgres@127.0.0.1:54322/postgres",
+        },
+    )
+    applied = []
+    monkeypatch.setattr(acceptance, "_apply_schema", lambda database_url: applied.append(database_url))
+    monkeypatch.setattr(
+        acceptance,
+        "_bootstrap_guided_self_serve_fixture",
+        lambda env: acceptance.GuidedSelfServeFixture(
+            email="guided-self-serve.acceptance@demo.verisight.local",
+            password="Verisight!Acceptance123",
+            setup_campaign_id="setup-campaign",
+            threshold_campaign_id="threshold-campaign",
+            user_id="user-1",
+        ),
+    )
+
+    runtime = acceptance.bootstrap_guided_self_serve_acceptance(mode="local")
+
+    assert runtime.mode == "local"
+    assert runtime.fixture.setup_campaign_id == "setup-campaign"
+    assert runtime.env["NEXT_PUBLIC_SUPABASE_URL"] == "http://127.0.0.1:54321"
+    assert runtime.env["NEXT_PUBLIC_API_URL"] == "http://127.0.0.1:8000"
+    assert runtime.env["DATABASE_URL"] == "postgresql://postgres:postgres@127.0.0.1:54322/postgres"
+    assert runtime.env["VERISIGHT_ACCEPTANCE_FAKE_EMAIL"] == "1"
+    assert applied == ["postgresql://postgres:postgres@127.0.0.1:54322/postgres"]
+
+    stored = json.loads(runtime_file.read_text(encoding="utf-8"))
+    assert stored["fixture"]["threshold_campaign_id"] == "threshold-campaign"
+    assert stored["mode"] == "local"
+    shutil.rmtree(runtime_dir, ignore_errors=True)
+
+
+def test_read_local_supabase_status_env_strips_wrapping_quotes(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        acceptance,
+        "_run_command",
+        lambda *args, **kwargs: type(
+            "Completed",
+            (),
+            {
+                "stdout": 'API_URL="http://127.0.0.1:54321"\nANON_KEY="anon-key"\nSERVICE_ROLE_KEY="service-role-key"\nDB_URL="postgresql://postgres:postgres@127.0.0.1:54322/postgres"\n',
+            },
+        )(),
+    )
+
+    status_env = acceptance._read_local_supabase_status_env()
+
+    assert status_env["API_URL"] == "http://127.0.0.1:54321"
+    assert status_env["DB_URL"] == "postgresql://postgres:postgres@127.0.0.1:54322/postgres"
+
+
+def test_load_schema_sql_strips_utf8_bom(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakePath:
+        def read_text(self, encoding: str = "utf-8") -> str:
+            return "\ufeffcreate table demo ();"
+
+    monkeypatch.setattr(acceptance, "SUPABASE_SCHEMA_PATH", FakePath())
+
+    assert acceptance._load_schema_sql() == "create table demo ();"
+
+
+def test_build_acceptance_env_remote_requires_all_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in (
+        "NEXT_PUBLIC_SUPABASE_URL",
+        "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+        "SUPABASE_SERVICE_ROLE_KEY",
+        "DATABASE_URL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    with pytest.raises(acceptance.AcceptanceEnvironmentError) as excinfo:
+        acceptance.build_acceptance_env(mode="remote")
+
+    assert "NEXT_PUBLIC_SUPABASE_URL" in str(excinfo.value)
+    assert "DATABASE_URL" in str(excinfo.value)
+
+
+def test_get_acceptance_frontend_runtime_prefers_explicit_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VERISIGHT_ACCEPTANCE_FRONTEND_RUNTIME", "start")
+
+    assert acceptance.get_acceptance_frontend_runtime("local") == "start"
+
+
+def test_get_acceptance_frontend_runtime_defaults_to_local_dev(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("VERISIGHT_ACCEPTANCE_FRONTEND_RUNTIME", raising=False)
+
+    assert acceptance.get_acceptance_frontend_runtime("local") == "dev"
+    assert acceptance.get_acceptance_frontend_runtime("remote") == "start"
+
+
+def test_advance_guided_self_serve_acceptance_uses_runtime_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        acceptance,
+        "build_acceptance_env",
+        lambda mode, frontend_port=3002, backend_port=8000: {"DATABASE_URL": "postgresql://db", "MODE": mode},
+    )
+
+    def fake_run_manage_demo(args: list[str], env: dict[str, str]) -> dict[str, object]:
+        captured["args"] = args
+        captured["env"] = env
+        return {"phase": "patterns", "total_completed": 10}
+
+    monkeypatch.setattr(acceptance, "_run_manage_demo", fake_run_manage_demo)
+
+    result = acceptance.advance_guided_self_serve_acceptance("patterns", mode="local")
+
+    assert result["phase"] == "patterns"
+    assert captured["args"] == [
+        "advance",
+        "qa_guided_self_serve_acceptance",
+        "--org-slug",
+        acceptance.GUIDED_SELF_SERVE_ORG_SLUG,
+        "--phase",
+        "patterns",
+    ]
+    assert captured["env"] == {"DATABASE_URL": "postgresql://db", "MODE": "local"}
+
+
+def test_run_guided_self_serve_acceptance_starts_backend_runs_playwright_and_cleans_up(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = acceptance.GuidedSelfServeAcceptanceRuntime(
+        mode="local",
+        profile="guided_self_serve",
+        frontend_port=3002,
+        backend_port=8000,
+        env={"NEXT_PUBLIC_API_URL": "http://127.0.0.1:8000"},
+        fixture=acceptance.GuidedSelfServeFixture(
+            email="guided-self-serve.acceptance@demo.verisight.local",
+            password="Verisight!Acceptance123",
+            setup_campaign_id="setup-campaign",
+            threshold_campaign_id="threshold-campaign",
+            user_id="user-1",
+        ),
+    )
+    events: list[str] = []
+
+    class FakeProcess:
+        def terminate(self) -> None:
+            events.append("terminate")
+
+        def wait(self, timeout: float | None = None) -> None:
+            events.append("wait")
+
+        def kill(self) -> None:
+            events.append("kill")
+
+    monkeypatch.setattr(acceptance, "bootstrap_guided_self_serve_acceptance", lambda mode="local": runtime)
+    monkeypatch.setattr(
+        acceptance,
+        "_run_frontend_build_check",
+        lambda env: events.append("build-frontend"),
+    )
+    monkeypatch.setattr(
+        acceptance,
+        "_start_backend_process",
+        lambda env, backend_port=8000: events.append("start-backend") or FakeProcess(),
+    )
+    monkeypatch.setattr(
+        acceptance,
+        "_wait_for_health",
+        lambda url, timeout_seconds=45.0, label="service": events.append(f"health:{label}:{url}"),
+    )
+    monkeypatch.setattr(
+        acceptance,
+        "_run_playwright_guided_self_serve",
+        lambda env: events.append("run-playwright"),
+    )
+    monkeypatch.setattr(
+        acceptance,
+        "teardown_acceptance_environment",
+        lambda mode="local", reset_data=False: events.append(f"teardown:{mode}:{reset_data}"),
+    )
+
+    acceptance.run_guided_self_serve_acceptance(mode="local", teardown=True)
+
+    assert events == [
+        "build-frontend",
+        "start-backend",
+        "health:backend:http://127.0.0.1:8000/api/health",
+        "run-playwright",
+        "terminate",
+        "wait",
+        "teardown:local:False",
+    ]

--- a/tests/test_demo_environment_system.py
+++ b/tests/test_demo_environment_system.py
@@ -5,9 +5,14 @@ from demo_environment import (
     BUYER_FACING_SAMPLE_ORG_SLUG,
     DEMO_LAYER_CONTRACTS,
     DEMO_SCENARIOS,
+    GUIDED_SELF_SERVE_ACCEPTANCE_ORG_SLUG,
+    GUIDED_SELF_SERVE_SETUP_CAMPAIGN_NAME,
+    GUIDED_SELF_SERVE_THRESHOLD_CAMPAIGN_NAME,
     INTERNAL_SALES_DEMO_ORG_SLUG,
     RESPONSE_THRESHOLDS,
     SAFE_DEMO_EMAIL_DOMAIN,
+    advance_guided_self_serve_acceptance,
+    seed_guided_self_serve_acceptance,
     seed_sales_demo_exit,
     seed_sales_demo_retention,
 )
@@ -24,6 +29,7 @@ def test_demo_scenario_registry_covers_expected_layers_and_scenarios():
         "sales_demo_exit",
         "sales_demo_retention",
         "qa_exit_live_test",
+        "qa_guided_self_serve_acceptance",
         "qa_retention_demo",
         "validation_retention_pilot",
     }
@@ -31,6 +37,7 @@ def test_demo_scenario_registry_covers_expected_layers_and_scenarios():
     assert DEMO_SCENARIOS["sales_demo_exit"].layer == "internal_sales_demo"
     assert DEMO_SCENARIOS["sales_demo_retention"].layer == "internal_sales_demo"
     assert DEMO_SCENARIOS["qa_exit_live_test"].layer == "qa_live_fixture"
+    assert DEMO_SCENARIOS["qa_guided_self_serve_acceptance"].layer == "qa_live_fixture"
     assert DEMO_SCENARIOS["validation_retention_pilot"].layer == "validation_sandbox"
 
 
@@ -109,3 +116,64 @@ def test_seed_sales_demo_retention_creates_trend_pair_and_threshold_states(db_se
 
     all_emails = [respondent.email for campaign in campaigns for respondent in campaign.respondents if respondent.email]
     assert all(email.endswith(f"@{SAFE_DEMO_EMAIL_DOMAIN}") for email in all_emails)
+
+
+def test_seed_guided_self_serve_acceptance_creates_setup_and_threshold_journeys(db_session):
+    result = seed_guided_self_serve_acceptance(db_session, viewer_user_id="viewer-guided-self-serve")
+
+    assert result["org_slug"] == GUIDED_SELF_SERVE_ACCEPTANCE_ORG_SLUG
+    assert result["campaign_count"] == 2
+    assert result["detail_threshold"] == RESPONSE_THRESHOLDS["detail"]
+    assert result["pattern_threshold"] == RESPONSE_THRESHOLDS["pattern"]
+    assert result["viewer_user_id"] == "viewer-guided-self-serve"
+
+    org = db_session.query(Organization).filter(Organization.slug == GUIDED_SELF_SERVE_ACCEPTANCE_ORG_SLUG).one()
+    campaigns = (
+        db_session.query(Campaign)
+        .filter(Campaign.organization_id == org.id, Campaign.scan_type == "exit")
+        .order_by(Campaign.name.asc())
+        .all()
+    )
+
+    assert [campaign.name for campaign in campaigns] == [
+        GUIDED_SELF_SERVE_SETUP_CAMPAIGN_NAME,
+        GUIDED_SELF_SERVE_THRESHOLD_CAMPAIGN_NAME,
+    ]
+
+    setup_campaign = next(campaign for campaign in campaigns if campaign.name == GUIDED_SELF_SERVE_SETUP_CAMPAIGN_NAME)
+    threshold_campaign = next(campaign for campaign in campaigns if campaign.name == GUIDED_SELF_SERVE_THRESHOLD_CAMPAIGN_NAME)
+
+    assert setup_campaign.is_active is True
+    assert len(setup_campaign.respondents) == 0
+    assert threshold_campaign.is_active is True
+    assert len(threshold_campaign.respondents) == 8
+    assert sum(1 for respondent in threshold_campaign.respondents if respondent.completed) == 4
+    assert all(
+        respondent.email is None or respondent.email.endswith(f"@{SAFE_DEMO_EMAIL_DOMAIN}")
+        for respondent in threshold_campaign.respondents
+    )
+
+
+def test_advance_guided_self_serve_acceptance_progresses_threshold_journey(db_session):
+    seed_guided_self_serve_acceptance(db_session)
+
+    min_display = advance_guided_self_serve_acceptance(db_session, phase="min_display")
+    patterns = advance_guided_self_serve_acceptance(db_session, phase="patterns")
+
+    assert min_display["phase"] == "min_display"
+    assert min_display["total_completed"] == RESPONSE_THRESHOLDS["detail"]
+    assert patterns["phase"] == "patterns"
+    assert patterns["total_completed"] == RESPONSE_THRESHOLDS["pattern"]
+
+    org = db_session.query(Organization).filter(Organization.slug == GUIDED_SELF_SERVE_ACCEPTANCE_ORG_SLUG).one()
+    threshold_campaign = (
+        db_session.query(Campaign)
+        .filter(
+            Campaign.organization_id == org.id,
+            Campaign.name == GUIDED_SELF_SERVE_THRESHOLD_CAMPAIGN_NAME,
+        )
+        .one()
+    )
+
+    assert len(threshold_campaign.respondents) == RESPONSE_THRESHOLDS["pattern"]
+    assert sum(1 for respondent in threshold_campaign.respondents if respondent.completed) == RESPONSE_THRESHOLDS["pattern"]

--- a/tests/test_email_acceptance_stub.py
+++ b/tests/test_email_acceptance_stub.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import pytest
+
+from backend import email as email_module
+
+
+def test_acceptance_email_stub_marks_invite_as_sent(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VERISIGHT_ACCEPTANCE_FAKE_EMAIL", "1")
+    monkeypatch.setattr(email_module, "_EMAIL_FROM", "Verisight <noreply@verisight.nl>")
+
+    assert email_module.send_survey_invite(
+        to_email="guided-self-serve.acceptance@demo.verisight.local",
+        campaign_name="Guided Self-Serve - Setup Journey",
+        token="demo-token",
+        scan_type="exit",
+    )


### PR DESCRIPTION
## Samenvatting
Deze PR richt Verisight concreet in als `assisted provisioning + guided self-serve execution` in plaats van een te vroege self-serve dashboardervaring. De klant landt nu in een begrensde uitvoerflow met duidelijke next steps, importvalidatie, invite-gating, response-status en dashboardactivatie op echte readiness.

Daar bovenop voegt deze PR een deterministische lokale acceptance-run toe waarmee dezelfde klantflow seeded en browsermatig bewezen kan worden via lokale Supabase, echte login en twee representatieve journeys.

## Wat nu end-to-end bewezen is
- Een fictieve klant kan lokaal echt inloggen met Supabase-auth en landt in de guided execution flow in plaats van een lege analyseomgeving.
- De setup journey is browsermatig bewezen: checklist/status zichtbaar, fout CSV wordt afgewezen met herstelbare feedback, gecorrigeerde import werkt, en uitnodigingen kunnen pas daarna expliciet worden gestart.
- De threshold journey is browsermatig bewezen: vóór readiness blijft dashboardoutput begrensd, bij `5` responses komt de compacte dashboardread vrij, en bij `10` responses verschijnt pas de eerste vervolgstap en verdiepende route.
- De seeded acceptance-run bootstrapt lokaal zelf Supabase, schema, acceptance-user, fixturedata, backend en Playwright-run zonder vooraf ingerichte remote acceptance-omgeving.
- Kritieke flowlogica is aanvullend afgedekt met frontend-tests, backend-regressietests en acceptance-runner-tests.

## Wat nog assisted blijft
- Account-, workspace- en campagneprovisioning blijven bij Verisight.
- Productgrenzen, readinessdrempels, outputgating en operationele inrichting blijven door Verisight bewaakt.
- De klant voert nu veilig uit binnen de al voorbereide campagne, maar opent geen nieuwe productscope, campaignarchitectuur of suite-configuratie.
- De lokale acceptance-run gebruikt bewust een acceptance-mailstub; die is alleen bedoeld om QA-flow en gating browsermatig te bewijzen zonder externe mailprovider.

## Wat nog geen productie-self-serve is
- Dit opent geen self-service signup of billingflow.
- Dit maakt Verisight niet tot een vrije SaaS-suite waarin klanten zelf provisioning, productactivatie of commerciële setup beheren.
- De acceptance-mailstub is geen productiepad; productie-uitnodigingen blijven afhangen van de bestaande mailinrichting.
- De lokale `next dev` runtime in acceptance is een QA-uitvoerruntime voor betrouwbare browserverificatie op Windows, niet de productie-serveermodus.

## Verificatie
- `python manage_acceptance_environment.py run-guided-self-serve --mode local`
- `npm.cmd test`
- `python -m pytest tests/test_demo_environment_system.py tests/test_acceptance_environment.py tests/test_email_acceptance_stub.py -q`
- `python -m pytest tests/test_api_flows.py -k "implementation_smoke_flow_imports_sends_invites_and_generates_output or respondent_import" -q`

## Reviewfocus
- Klopt de begrenzing tussen assisted provisioning en klantuitvoering productmatig nog steeds met de suite-canon?
- Is de dashboard-/report-gating op `5` en `10` responses op de juiste plekken zichtbaar en afgedwongen?
- Is de lokale acceptance-run precies strak genoeg voor QA, zonder productiegedrag open te zetten?