### PR TITLE
[codex] Harden response ops dashboard activation

### DIFF
--- a/frontend/app/(dashboard)/campaigns/[id]/page-helpers.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page-helpers.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react'
 import { getProductModule } from '@/lib/products/shared/registry'
 import type { SegmentPlaybookEntry, SignalTrendCard } from '@/lib/products/shared/types'
 import { buildFactorPresentation, getManagementBandLabel } from '@/lib/management-language'
+import { FIRST_DASHBOARD_THRESHOLD, FIRST_INSIGHT_THRESHOLD } from '@/lib/response-activation'
 import { getScanDefinition } from '@/lib/scan-definitions'
 import {
   EXIT_REASON_LABELS,
@@ -14,8 +15,8 @@ import { DashboardPanel } from '@/components/dashboard/dashboard-primitives'
 
 const ORG_FACTORS = ['leadership', 'culture', 'growth', 'compensation', 'workload', 'role_clarity']
 
-export const MIN_N_PATTERNS = 10
-export const MIN_N_DISPLAY = 5
+export const MIN_N_PATTERNS = FIRST_INSIGHT_THRESHOLD
+export const MIN_N_DISPLAY = FIRST_DASHBOARD_THRESHOLD
 
 export type RetentionSignalAverages = {
   retentionSignal: number | null

--- a/frontend/app/(dashboard)/campaigns/[id]/page.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.test.ts
@@ -33,8 +33,10 @@ describe('campaign page render truth', () => {
     )
 
     expect(source).toContain('Begeleide uitvoerflow')
-    expect(source).toContain('Dashboard wordt zichtbaar vanaf de eerste veilige responsdrempel')
+    expect(source).toContain('activationState.heroActionLabel')
     expect(source).toContain('showManagementOutput &&')
+    expect(source).toContain('showDeeperInsights')
+    expect(source).toContain('Verdieping nog dicht')
     expect(source).toContain('Guided self-serve')
     expect(guidedPanelSource).toContain('Start uitnodigingen')
   })

--- a/frontend/app/(dashboard)/campaigns/[id]/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.tsx
@@ -59,6 +59,7 @@ import { getLifecycleDecisionCards } from '@/lib/client-onboarding'
 import type { CampaignDeliveryCheckpoint, CampaignDeliveryRecord } from '@/lib/ops-delivery'
 import { buildTeamLocalReadState, buildTeamPriorityReadState } from '@/lib/products/team'
 import { getProductModule } from '@/lib/products/shared/registry'
+import { buildResponseActivationState } from '@/lib/response-activation'
 import { getScanDefinition } from '@/lib/scan-definitions'
 import { FACTOR_LABELS, hasCampaignAddOn } from '@/lib/types'
 import type { CampaignStats, Respondent, SurveyResponse } from '@/lib/types'
@@ -281,8 +282,10 @@ export default async function CampaignPage({ params }: Props) {
     hasMinDisplay,
     hasEnoughData,
   })
+  const activationState = buildResponseActivationState(stats.total_completed)
   const showClientExecutionFlow = !isVerisightAdmin
-  const showManagementOutput = isVerisightAdmin || guidedSelfServeState.dashboardVisible
+  const showManagementOutput = guidedSelfServeState.dashboardVisible
+  const showDeeperInsights = guidedSelfServeState.deeperInsightsVisible
   const utilitySectionVisible = canExecuteCampaign || respondents.length > 0 || isVerisightAdmin
   const riskDistribution = {
     HOOG: stats.band_high,
@@ -385,11 +388,7 @@ export default async function CampaignPage({ params }: Props) {
             : stats.scan_type === 'leadership'
               ? 'Deze laag vertaalt Leadership Scan naar een bestuurlijk leesbare managementread: welke context valt op, wat moet je eerst toetsen en welke begrensde managementstap hoort hier direct achteraan.'
         : 'Deze laag opent met de Frictiescore als bestuurlijk leesbare managementsamenvatting: wat keert terug, waar lijkt werkfrictie beinvloedbaar en waar moet management eerst doorvragen.'
-  const readinessLabel = hasEnoughData
-    ? 'Beslisniveau bereikt'
-    : hasMinDisplay
-      ? 'Indicatief beeld'
-      : 'Nog in opbouw'
+  const readinessLabel = activationState.readinessLabel
   const focusBadgeLabel =
     stats.scan_type === 'pulse'
       ? 'Signaal -> bijsturen -> opnieuw meten'
@@ -701,8 +700,14 @@ export default async function CampaignPage({ params }: Props) {
     },
     {
       label: productExperience.summarySignalLabel,
-      value: averageRiskScore !== null ? `${averageRiskScore.toFixed(1)}/10` : 'Nog geen veilig beeld',
-      tone: averageRiskScore !== null ? (stats.scan_type === 'retention' ? 'emerald' : 'blue') : 'amber',
+      value:
+        showManagementOutput && averageRiskScore !== null
+          ? `${averageRiskScore.toFixed(1)}/10`
+          : 'Nog in opbouw',
+      tone:
+        showManagementOutput && averageRiskScore !== null
+          ? (stats.scan_type === 'retention' ? 'emerald' : 'blue')
+          : 'amber',
     },
     {
       label: 'Responsstatus',
@@ -719,26 +724,30 @@ export default async function CampaignPage({ params }: Props) {
             id: 'handoff',
             label: stats.scan_type === 'retention' ? 'Handoff' : stats.scan_type === 'team' ? 'Lokale read' : 'Handoff',
           },
-          {
-            id: 'drivers',
-            label: stats.scan_type === 'retention' ? 'Signalen' : stats.scan_type === 'team' ? 'Lokaal' : 'Drivers',
-          },
-          {
-            id: 'acties',
-            label: stats.scan_type === 'retention' ? 'Behoudsacties' : stats.scan_type === 'team' ? 'Lokale acties' : 'Acties',
-          },
-          {
-            id: 'route',
-            label:
-              stats.scan_type === 'retention' || stats.scan_type === 'exit'
-                ? 'Kernroute'
-                : stats.scan_type === 'team' ||
-                    stats.scan_type === 'pulse' ||
-                    stats.scan_type === 'onboarding' ||
-                    stats.scan_type === 'leadership'
-                  ? 'Vervolgroute'
-                  : 'Route',
-          },
+          ...(showDeeperInsights
+            ? [
+                {
+                  id: 'drivers',
+                  label: stats.scan_type === 'retention' ? 'Signalen' : stats.scan_type === 'team' ? 'Lokaal' : 'Drivers',
+                },
+                {
+                  id: 'acties',
+                  label: stats.scan_type === 'retention' ? 'Behoudsacties' : stats.scan_type === 'team' ? 'Lokale acties' : 'Acties',
+                },
+                {
+                  id: 'route',
+                  label:
+                    stats.scan_type === 'retention' || stats.scan_type === 'exit'
+                      ? 'Kernroute'
+                      : stats.scan_type === 'team' ||
+                          stats.scan_type === 'pulse' ||
+                          stats.scan_type === 'onboarding' ||
+                          stats.scan_type === 'leadership'
+                        ? 'Vervolgroute'
+                        : 'Route',
+                },
+              ]
+            : []),
         ]
       : []),
     { id: 'methodiek', label: 'Methodiek' },
@@ -984,13 +993,7 @@ export default async function CampaignPage({ params }: Props) {
               />
               <DashboardChip label={`${stats.completion_rate_pct ?? 0}% respons`} tone="slate" />
               <DashboardChip
-                label={
-                  hasEnoughData
-                    ? 'Beslisniveau bereikt'
-                    : hasMinDisplay
-                      ? 'Indicatief beeld'
-                      : 'Nog onvoldoende responses'
-                }
+                label={readinessLabel}
                 tone={hasEnoughData ? 'blue' : 'amber'}
               />
               <DashboardChip
@@ -1002,7 +1005,7 @@ export default async function CampaignPage({ params }: Props) {
           actions={
             !showManagementOutput ? (
               <div className="rounded-full border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-900">
-                Dashboard wordt zichtbaar vanaf de eerste veilige responsdrempel
+                {activationState.heroActionLabel}
               </div>
             ) : stats.scan_type === 'pulse' || stats.scan_type === 'team' || stats.scan_type === 'onboarding' || stats.scan_type === 'leadership' ? (
               <>
@@ -1037,8 +1040,10 @@ export default async function CampaignPage({ params }: Props) {
                 <DashboardKeyValue label="Ingevuld" value={`${stats.total_completed}`} />
                 <DashboardKeyValue
                   label={`Gem. ${scanDefinition.signalLabelLower}`}
-                  value={averageRiskScore !== null ? `${averageRiskScore.toFixed(1)}/10` : '-'}
-                  accent={averageRiskScore !== null ? 'text-blue-700' : undefined}
+                  value={
+                    showManagementOutput && averageRiskScore !== null ? `${averageRiskScore.toFixed(1)}/10` : 'Nog niet actief'
+                  }
+                  accent={showManagementOutput && averageRiskScore !== null ? 'text-blue-700' : undefined}
                   helpText={scanDefinition.signalHelp}
                 />
               </div>
@@ -1053,6 +1058,7 @@ export default async function CampaignPage({ params }: Props) {
                 <p className="mt-2 text-xs leading-5 text-slate-500">
                   Route: {getDeliveryModeLabel(campaignMeta?.delivery_mode ?? null, stats.scan_type)}.
                 </p>
+                <p className="mt-2 text-xs leading-5 text-slate-500">{activationState.statusDetail}</p>
               </div>
             </div>
           }
@@ -1086,7 +1092,7 @@ export default async function CampaignPage({ params }: Props) {
         actions={
           !showManagementOutput ? (
             <div className="rounded-full border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-900">
-              Eerst uitvoerflow afronden
+              {activationState.heroActionLabel}
             </div>
           ) : stats.scan_type === 'pulse' || stats.scan_type === 'team' || stats.scan_type === 'onboarding' || stats.scan_type === 'leadership' ? (
             <div className="rounded-full border border-[#d6e4e8] bg-[#f3f8f8] px-4 py-2 text-sm font-semibold text-[#234B57]">
@@ -1130,7 +1136,7 @@ export default async function CampaignPage({ params }: Props) {
           </DashboardSection>
         ) : null}
 
-      {showManagementOutput && promotedSummaryCards.length > 0 ? (
+      {showDeeperInsights && promotedSummaryCards.length > 0 ? (
         <div className="rounded-[24px] border border-[color:var(--border)] bg-[color:var(--bg)] p-4 shadow-[0_12px_30px_rgba(19,32,51,0.05)] sm:p-5">
           <div className="flex flex-col gap-3 border-b border-[color:var(--border)]/80 pb-4 lg:flex-row lg:items-start lg:justify-between">
             <div>
@@ -1326,7 +1332,17 @@ export default async function CampaignPage({ params }: Props) {
       </DashboardSection>
       ) : null}
 
-      {showManagementOutput ? (
+      {showManagementOutput && !showDeeperInsights ? (
+      <div className="rounded-[24px] border border-amber-200 bg-amber-50 px-5 py-4 text-sm leading-6 text-amber-950">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-amber-800">Verdieping nog dicht</p>
+        <p className="mt-2 font-semibold">Het dashboard is al bruikbaar, maar blijft nog bewust compact.</p>
+        <p className="mt-2">
+          {activationState.statusDetail} Verdiepende drivers, focusvragen en route-uitvoer verschijnen pas zodra de survey ook methodologisch klaar is voor eerste patroonduiding.
+        </p>
+      </div>
+      ) : null}
+
+      {showDeeperInsights ? (
       <DashboardSection
         id="drivers"
         eyebrow="Wat drijft dit beeld?"
@@ -1346,10 +1362,10 @@ export default async function CampaignPage({ params }: Props) {
             Verdiepende analyse wordt zichtbaar vanaf {MIN_N_PATTERNS} ingevulde responses. Tot die tijd blijft het dashboard bewust compact en voorzichtig.
           </div>
           )}
-        </DashboardSection>
+      </DashboardSection>
       ) : null}
 
-      {showManagementOutput ? (
+      {showDeeperInsights ? (
       <DashboardSection
         id="acties"
         eyebrow="Waar eerst op handelen"
@@ -1476,10 +1492,10 @@ export default async function CampaignPage({ params }: Props) {
             Focusvragen en route-uitvoer worden betekenisvoller zodra het dashboard minstens {MIN_N_PATTERNS} responses heeft.
           </div>
           )}
-        </DashboardSection>
+      </DashboardSection>
       ) : null}
 
-      {showManagementOutput ? (
+      {showDeeperInsights ? (
       <DashboardSection
         id="route"
         eyebrow="30–90 dagenroute"

--- a/frontend/app/api/campaigns/[id]/report/route.test.ts
+++ b/frontend/app/api/campaigns/[id]/report/route.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  createClientMock: vi.fn(),
+  getOrganizationApiKeyMock: vi.fn(),
+  getBackendApiUrlMock: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: mocks.createClientMock,
+}))
+
+vi.mock('@/lib/organization-secrets', () => ({
+  getOrganizationApiKey: mocks.getOrganizationApiKeyMock,
+}))
+
+vi.mock('@/lib/server-env', () => ({
+  getBackendApiUrl: mocks.getBackendApiUrlMock,
+}))
+
+import { GET } from './route'
+
+function buildSupabaseClient(totalCompleted: number) {
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: {
+          user: { id: 'user-1' },
+        },
+      }),
+    },
+    from: (table: string) => {
+      if (table === 'campaigns') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: vi.fn().mockResolvedValue({
+                data: { organization_id: 'org-1', name: 'Activation Campaign' },
+                error: null,
+              }),
+            }),
+          }),
+        }
+      }
+
+      if (table === 'campaign_stats') {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: { total_completed: totalCompleted },
+                error: null,
+              }),
+            }),
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    },
+  }
+}
+
+describe('campaign report route activation gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.createClientMock.mockResolvedValue(buildSupabaseClient(4))
+    mocks.getOrganizationApiKeyMock.mockResolvedValue('api-key')
+    mocks.getBackendApiUrlMock.mockReturnValue('https://backend.example.com')
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  it('blocks report download before the first safe dashboard threshold', async () => {
+    const response = await GET(new Request('http://localhost/api/campaigns/camp-1/report'), {
+      params: Promise.resolve({ id: 'camp-1' }),
+    })
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({
+      detail: expect.stringContaining('vanaf 5 responses'),
+    })
+    expect(fetch).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/app/api/campaigns/[id]/report/route.ts
+++ b/frontend/app/api/campaigns/[id]/report/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import { getOrganizationApiKey } from '@/lib/organization-secrets'
+import { FIRST_DASHBOARD_THRESHOLD, buildResponseActivationState } from '@/lib/response-activation'
 import { getBackendApiUrl } from '@/lib/server-env'
 
 interface Context {
@@ -24,6 +25,22 @@ export async function GET(_request: Request, { params }: Context) {
 
   if (campaignError || !campaign) {
     return NextResponse.json({ detail: 'Campaign niet gevonden of niet toegankelijk.' }, { status: 404 })
+  }
+
+  const { data: stats } = await supabase
+    .from('campaign_stats')
+    .select('total_completed')
+    .eq('campaign_id', id)
+    .maybeSingle()
+  const activationState = buildResponseActivationState(stats?.total_completed ?? 0)
+
+  if (!activationState.reportVisible) {
+    return NextResponse.json(
+      {
+        detail: `Rapport wordt pas vrijgegeven vanaf ${FIRST_DASHBOARD_THRESHOLD} responses. ${activationState.statusDetail}`,
+      },
+      { status: 409 },
+    )
   }
 
   const backendBaseUrl = getBackendApiUrl()

--- a/frontend/components/dashboard/guided-self-serve-panel.tsx
+++ b/frontend/components/dashboard/guided-self-serve-panel.tsx
@@ -15,6 +15,7 @@ import {
   getInviteDefaultForDeliveryMode,
   getDeliveryModeLabel,
 } from '@/lib/implementation-readiness'
+import { buildResponseActivationState } from '@/lib/response-activation'
 import {
   type DeliveryMode,
   REPORT_ADD_ON_LABELS,
@@ -98,6 +99,7 @@ export function GuidedSelfServePanel({
       }),
     [hasEnoughData, hasMinDisplay, invitesNotSent, isActive, totalCompleted, totalInvited],
   )
+  const activationState = useMemo(() => buildResponseActivationState(totalCompleted), [totalCompleted])
   const [uploadFile, setUploadFile] = useState<File | null>(null)
   const [uploadSendInvites, setUploadSendInvites] = useState(true)
   const [previewResult, setPreviewResult] = useState<ImportResponse | null>(null)
@@ -299,8 +301,8 @@ export function GuidedSelfServePanel({
         />
         <DashboardPanel
           eyebrow="Dashboardactivatie"
-          title="5 responses voor eerste read, 10 voor verdieping"
-          body="Het dashboard gaat pas zichtbaar open zodra de eerste veilige responsdrempel is gehaald. Verdiepende patronen en scherpere prioritering volgen bewust pas vanaf 10 responses."
+          title={activationState.deeperInsightsVisible ? 'Eerste inzichten actief' : activationState.heroActionLabel}
+          body={activationState.statusDetail}
           tone={guidedState.deeperInsightsVisible ? 'emerald' : 'amber'}
         />
       </div>

--- a/frontend/lib/guided-self-serve.test.ts
+++ b/frontend/lib/guided-self-serve.test.ts
@@ -48,7 +48,7 @@ describe('guided self-serve execution state', () => {
 
     expect(state.phase).toBe('responses_incoming')
     expect(state.dashboardVisible).toBe(false)
-    expect(state.detail.toLowerCase()).toContain('vanaf 5')
+    expect(state.detail.toLowerCase()).toContain('nog 2 responses')
     expect(state.nextAction.body.toLowerCase()).toContain('responses')
   })
 
@@ -99,5 +99,21 @@ describe('guided self-serve execution state', () => {
     expect(state.phase).toBe('closed')
     expect(state.nextAction.title.toLowerCase()).toContain('vervolggesprek')
     expect(state.statusBlocks.find((item) => item.key === 'dashboard_active')?.status).toBe('done')
+  })
+
+  it('does not unlock dashboard or report copy for a closed campaign that never reached the first safe threshold', () => {
+    const state = buildGuidedSelfServeState({
+      isActive: false,
+      totalInvited: 24,
+      totalCompleted: 3,
+      invitesNotSent: 0,
+      hasMinDisplay: false,
+      hasEnoughData: false,
+    })
+
+    expect(state.phase).toBe('closed')
+    expect(state.dashboardVisible).toBe(false)
+    expect(state.deeperInsightsVisible).toBe(false)
+    expect(state.detail).toContain('blijven dashboard en rapport nog gesloten')
   })
 })

--- a/frontend/lib/guided-self-serve.ts
+++ b/frontend/lib/guided-self-serve.ts
@@ -1,3 +1,9 @@
+import {
+  FIRST_DASHBOARD_THRESHOLD,
+  FIRST_INSIGHT_THRESHOLD,
+  buildResponseActivationState,
+} from '@/lib/response-activation'
+
 type GuidedSelfServePhase =
   | 'closed'
   | 'data_required'
@@ -75,18 +81,30 @@ function buildStatusBlocks(current: GuidedStatusKey): GuidedStatusBlock[] {
 }
 
 export function buildGuidedSelfServeState(args: GuidedSelfServeArgs): GuidedSelfServeState {
+  const activationState = buildResponseActivationState(args.totalCompleted)
+
   if (!args.isActive) {
     return {
       phase: 'closed',
       headline: 'Campagne gesloten',
-      detail: 'De uitvoerfase is afgerond. Gebruik dashboard, rapport en terugblik nu voor het vervolggesprek en de gekozen opvolgroute.',
+      detail: activationState.dashboardVisible
+        ? 'De uitvoerfase is afgerond. Gebruik dashboard, rapport en terugblik nu voor het vervolggesprek en de gekozen opvolgroute.'
+        : `De uitvoerfase is afgerond voordat de eerste veilige dashboarddrempel is gehaald. Tot er minstens ${FIRST_DASHBOARD_THRESHOLD} responses zijn, blijven dashboard en rapport nog gesloten.`,
       nextAction: {
-        title: 'Plan het vervolggesprek',
-        body: 'Gebruik de uitkomst nu om eerste besluiten, eigenaar en vervolgroute expliciet te maken.',
+        title: activationState.dashboardVisible ? 'Plan het vervolggesprek' : 'Beslis of een heropening nodig is',
+        body: activationState.dashboardVisible
+          ? 'Gebruik de uitkomst nu om eerste besluiten, eigenaar en vervolgroute expliciet te maken.'
+          : 'Zonder eerste dashboardread blijft deze wave onder de veilige leesdrempel. Heropen alleen als extra respons nog logisch en methodologisch eerlijk is.',
       },
-      dashboardVisible: true,
-      deeperInsightsVisible: true,
-      statusBlocks: buildStatusBlocks('first_next_step_available'),
+      dashboardVisible: activationState.dashboardVisible,
+      deeperInsightsVisible: activationState.deeperInsightsVisible,
+      statusBlocks: buildStatusBlocks(
+        activationState.deeperInsightsVisible
+          ? 'first_next_step_available'
+          : activationState.dashboardVisible
+            ? 'dashboard_active'
+            : 'responses_incoming',
+      ),
     }
   }
 
@@ -126,10 +144,10 @@ export function buildGuidedSelfServeState(args: GuidedSelfServeArgs): GuidedSelf
     return {
       phase: 'responses_incoming',
       headline: 'Responses lopen binnen',
-      detail: `Er zijn ${args.totalCompleted} responses binnen. Vanaf 5 responses wordt de eerste dashboardread veilig genoeg om zichtbaar te maken.`,
+      detail: activationState.statusDetail,
       nextAction: {
         title: 'Volg respons en stuur zo nodig een reminder',
-        body: 'Laat de inviteflow eerst verder lopen en bouw meer responses op. Het dashboard gaat pas open zodra de eerste veilige responsegrens is gehaald.',
+        body: 'Laat de inviteflow eerst verder lopen en bouw meer responses op. Dashboard en rapport gaan pas open zodra de eerste veilige responsegrens is gehaald.',
       },
       dashboardVisible: false,
       deeperInsightsVisible: false,
@@ -141,7 +159,7 @@ export function buildGuidedSelfServeState(args: GuidedSelfServeArgs): GuidedSelf
     return {
       phase: 'dashboard_active',
       headline: 'Dashboard actief, nog bewust compact',
-      detail: `De eerste veilige drempel is gehaald. Vanaf ${args.totalCompleted} responses is de dashboardread bruikbaar, maar verdiepende patroonduiding blijft bewust dicht tot minstens 10 responses.`,
+      detail: activationState.statusDetail,
       nextAction: {
         title: 'Gebruik nu de compacte dashboardread',
         body: 'Lees wat al zichtbaar is, houd conclusies voorlopig indicatief en blijf tegelijk respons opbouwen richting patroonniveau.',
@@ -155,7 +173,7 @@ export function buildGuidedSelfServeState(args: GuidedSelfServeArgs): GuidedSelf
   return {
     phase: 'first_next_step_available',
     headline: 'Eerste vervolgstap beschikbaar',
-    detail: 'De campagne heeft nu genoeg respons voor veilige dashboardactivatie en eerste patroonduiding. Vanaf hier hoort de flow door te schuiven naar de eerste managementstap, niet terug naar setup.',
+    detail: `De campagne heeft nu genoeg respons voor veilige dashboardactivatie en eerste patroonduiding. Vanaf ${FIRST_INSIGHT_THRESHOLD} responses hoort de flow door te schuiven naar de eerste managementstap, niet terug naar setup.`,
     nextAction: {
       title: 'Maak de eerste vervolgstap expliciet',
       body: 'Gebruik dashboard en rapport nu om eerste eigenaar, eerste managementactie en reviewmoment vast te leggen.',

--- a/frontend/lib/implementation-readiness.test.ts
+++ b/frontend/lib/implementation-readiness.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { buildCampaignReadinessState } from '@/lib/implementation-readiness'
+
+describe('campaign implementation readiness', () => {
+  it('keeps first-read readiness explicit while the campaign is still one response short of dashboard activation', () => {
+    const state = buildCampaignReadinessState({
+      totalInvited: 12,
+      totalCompleted: 4,
+      invitesNotSent: 0,
+      incompleteScores: 0,
+      hasMinDisplay: false,
+      hasEnoughData: false,
+      activeClientAccessCount: 0,
+      pendingClientInviteCount: 0,
+    })
+
+    expect(state.headline).toBe('Eerste output nog in opbouw')
+    expect(state.detail).toContain('Nog 1 response tot de eerste dashboardread')
+    expect(state.nextStep).toContain('Bouw eerst 1 extra response op')
+  })
+
+  it('keeps launch messaging compact after dashboard activation until the first pattern threshold is reached', () => {
+    const state = buildCampaignReadinessState({
+      totalInvited: 20,
+      totalCompleted: 6,
+      invitesNotSent: 0,
+      incompleteScores: 0,
+      hasMinDisplay: true,
+      hasEnoughData: false,
+      activeClientAccessCount: 1,
+      pendingClientInviteCount: 0,
+    })
+
+    expect(state.headline).toBe('Dashboard actief, inzichten nog in opbouw')
+    expect(state.detail).toContain('Nog 4 responses tot eerste patroonduiding')
+    expect(state.nextStep).toContain('compacte dashboardread')
+  })
+})

--- a/frontend/lib/implementation-readiness.ts
+++ b/frontend/lib/implementation-readiness.ts
@@ -1,4 +1,5 @@
 import type { DeliveryMode, ScanType } from '@/lib/types'
+import { buildResponseActivationState } from '@/lib/response-activation'
 
 export function normalizeDeliveryMode(mode: DeliveryMode | null | undefined): DeliveryMode {
   return mode === 'live' ? 'live' : 'baseline'
@@ -69,6 +70,7 @@ export function buildCampaignReadinessState({
   activeClientAccessCount: number
   pendingClientInviteCount: number
 }): CampaignReadinessState {
+  const activationState = buildResponseActivationState(totalCompleted)
   const setupComplete = totalInvited > 0
   const invitesLive = setupComplete && invitesNotSent === 0
   const outputReady = hasMinDisplay && incompleteScores === 0
@@ -119,8 +121,12 @@ export function buildCampaignReadinessState({
       headline: 'Eerste output nog in opbouw',
       detail: incompleteScores > 0
         ? `${incompleteScores} response(s) bevatten nog onvolledige scoredata.`
-        : `Er zijn ${totalCompleted} responses binnen; vanaf 5 wordt eerste detailweergave veilig genoeg voor klantuitleg en acceptatie.`,
-      nextStep: 'Wacht op voldoende responses of herstel eerst de incomplete scoredata voordat je output als eerste managementread positioneert.',
+        : activationState.statusDetail,
+      nextStep: incompleteScores > 0
+        ? 'Herstel eerst de incomplete scoredata voordat je output als eerste managementread positioneert.'
+        : activationState.remainingToDashboard === 1
+          ? 'Bouw eerst 1 extra response op of stuur gericht een reminder voordat dashboard en rapport worden vrijgegeven.'
+          : `Bouw eerst ${activationState.remainingToDashboard} extra responses op of stuur gericht reminders voordat dashboard en rapport worden vrijgegeven.`,
     }
   }
 
@@ -162,12 +168,12 @@ export function buildCampaignReadinessState({
     clientAccessActivated,
     clientActivationPending,
     launchReady,
-    headline: analysisReady ? 'Launch readiness op orde' : 'Eerste klantread mogelijk',
+    headline: analysisReady ? 'Launch readiness op orde' : 'Dashboard actief, inzichten nog in opbouw',
     detail: analysisReady
       ? 'Setup, inviteflow, eerste output en klanttoegang zijn op orde. Deze campagne is operationeel sterk genoeg voor eerste managementduiding.'
-      : 'De klant kan veilig live, maar het inhoudelijke beeld blijft nog indicatief totdat er minstens 10 responses zijn.',
+      : activationState.statusDetail,
     nextStep: analysisReady
       ? 'Gebruik nu dashboard en rapport samen voor het eerste managementgesprek en leg de eerste eigenaar of vervolgstap vast.'
-      : 'Gebruik deze campagne nu voor eerste klantread en responsopbouw, niet voor te scherpe patroonclaims.',
+      : 'Gebruik nu de compacte dashboardread, houd de duiding indicatief en bouw tegelijk respons op richting eerste patroonduiding.',
   }
 }

--- a/frontend/lib/response-activation.test.ts
+++ b/frontend/lib/response-activation.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import {
+  FIRST_DASHBOARD_THRESHOLD,
+  FIRST_INSIGHT_THRESHOLD,
+  buildResponseActivationState,
+} from '@/lib/response-activation'
+
+describe('response activation thresholds', () => {
+  it('keeps dashboard and report locked before the first safe response threshold', () => {
+    const state = buildResponseActivationState(0)
+
+    expect(state.stage).toBe('collecting_responses')
+    expect(state.readinessLabel).toBe('Nog in opbouw')
+    expect(state.dashboardVisible).toBe(false)
+    expect(state.reportVisible).toBe(false)
+    expect(state.deeperInsightsVisible).toBe(false)
+    expect(state.remainingToDashboard).toBe(FIRST_DASHBOARD_THRESHOLD)
+    expect(state.statusDetail).toContain(`${FIRST_DASHBOARD_THRESHOLD} responses`)
+  })
+
+  it('turns almost-ready messaging concrete right before dashboard activation', () => {
+    const state = buildResponseActivationState(FIRST_DASHBOARD_THRESHOLD - 1)
+
+    expect(state.stage).toBe('collecting_responses')
+    expect(state.heroActionLabel).toBe('Nog 1 response tot dashboardread')
+    expect(state.statusDetail).toContain('Nog 1 response')
+  })
+
+  it('activates dashboard and report first, but keeps deeper insights closed until pattern readiness', () => {
+    const state = buildResponseActivationState(FIRST_DASHBOARD_THRESHOLD + 1)
+
+    expect(state.stage).toBe('dashboard_active')
+    expect(state.readinessLabel).toBe('Indicatief beeld')
+    expect(state.dashboardVisible).toBe(true)
+    expect(state.reportVisible).toBe(true)
+    expect(state.deeperInsightsVisible).toBe(false)
+    expect(state.remainingToInsights).toBe(FIRST_INSIGHT_THRESHOLD - (FIRST_DASHBOARD_THRESHOLD + 1))
+    expect(state.statusDetail).toContain('Nog 4 responses')
+  })
+
+  it('switches to active insights once the pattern threshold is reached', () => {
+    const state = buildResponseActivationState(FIRST_INSIGHT_THRESHOLD)
+
+    expect(state.stage).toBe('insights_active')
+    expect(state.readinessLabel).toBe('Beslisniveau bereikt')
+    expect(state.dashboardVisible).toBe(true)
+    expect(state.reportVisible).toBe(true)
+    expect(state.deeperInsightsVisible).toBe(true)
+    expect(state.heroActionLabel).toBe('Eerste inzichten actief')
+  })
+})

--- a/frontend/lib/response-activation.ts
+++ b/frontend/lib/response-activation.ts
@@ -1,0 +1,82 @@
+export const FIRST_DASHBOARD_THRESHOLD = 5
+export const FIRST_INSIGHT_THRESHOLD = 10
+
+export type ResponseActivationStage =
+  | 'collecting_responses'
+  | 'dashboard_active'
+  | 'insights_active'
+
+export interface ResponseActivationState {
+  stage: ResponseActivationStage
+  readinessLabel: string
+  dashboardVisible: boolean
+  reportVisible: boolean
+  deeperInsightsVisible: boolean
+  remainingToDashboard: number
+  remainingToInsights: number
+  statusDetail: string
+  heroActionLabel: string
+}
+
+function formatResponseCount(count: number) {
+  return `${count} response${count === 1 ? '' : 's'}`
+}
+
+export function buildResponseActivationState(totalCompleted: number): ResponseActivationState {
+  const completed = Number.isFinite(totalCompleted) ? Math.max(0, Math.floor(totalCompleted)) : 0
+  const remainingToDashboard = Math.max(0, FIRST_DASHBOARD_THRESHOLD - completed)
+  const remainingToInsights = Math.max(0, FIRST_INSIGHT_THRESHOLD - completed)
+
+  if (completed < FIRST_DASHBOARD_THRESHOLD) {
+    return {
+      stage: 'collecting_responses',
+      readinessLabel: 'Nog in opbouw',
+      dashboardVisible: false,
+      reportVisible: false,
+      deeperInsightsVisible: false,
+      remainingToDashboard,
+      remainingToInsights,
+      statusDetail:
+        remainingToDashboard === 1
+          ? 'Nog 1 response tot de eerste dashboardread. Tot die drempel is gehaald blijven dashboard en rapport bewust gesloten.'
+          : `Nog ${formatResponseCount(remainingToDashboard)} tot de eerste dashboardread. Tot die drempel is gehaald blijven dashboard en rapport bewust gesloten.`,
+      heroActionLabel:
+        remainingToDashboard === 1
+          ? 'Nog 1 response tot dashboardread'
+          : `Nog ${formatResponseCount(remainingToDashboard)} tot dashboardread`,
+    }
+  }
+
+  if (completed < FIRST_INSIGHT_THRESHOLD) {
+    return {
+      stage: 'dashboard_active',
+      readinessLabel: 'Indicatief beeld',
+      dashboardVisible: true,
+      reportVisible: true,
+      deeperInsightsVisible: false,
+      remainingToDashboard,
+      remainingToInsights,
+      statusDetail:
+        remainingToInsights === 1
+          ? 'Dashboard en rapport zijn nu zichtbaar. Nog 1 response tot eerste patroonduiding; tot die tijd blijft de read bewust compact.'
+          : `Dashboard en rapport zijn nu zichtbaar. Nog ${formatResponseCount(remainingToInsights)} tot eerste patroonduiding; tot die tijd blijft de read bewust compact.`,
+      heroActionLabel:
+        remainingToInsights === 1
+          ? 'Nog 1 response tot eerste inzichten'
+          : `Nog ${formatResponseCount(remainingToInsights)} tot eerste inzichten`,
+    }
+  }
+
+  return {
+    stage: 'insights_active',
+    readinessLabel: 'Beslisniveau bereikt',
+    dashboardVisible: true,
+    reportVisible: true,
+    deeperInsightsVisible: true,
+    remainingToDashboard,
+    remainingToInsights,
+    statusDetail:
+      'De campagne heeft nu genoeg respons voor veilige dashboardactivatie, rapportvrijgave en eerste patroonduiding.',
+    heroActionLabel: 'Eerste inzichten actief',
+  }
+}

--- a/frontend/tests/e2e/guided-self-serve-acceptance.spec.ts
+++ b/frontend/tests/e2e/guided-self-serve-acceptance.spec.ts
@@ -88,13 +88,14 @@ test.describe.serial('guided self-serve acceptance', () => {
     await expect(page.getByText(/dashboard actief, nog bewust compact/i).first()).toBeVisible()
     await expect(page.getByRole('button', { name: /pdf-rapport/i }).first()).toBeVisible()
     await expect(page.getByText(/vertrekduiding en managementgesprek/i)).toBeVisible()
-    await expect(page.getByText(/verdiepende analyse wordt zichtbaar vanaf 10 ingevulde responses/i)).toBeVisible()
+    await expect(page.getByText(/verdieping nog dicht/i)).toBeVisible()
+    await expect(page.getByText(/nog \d+ responses tot eerste patroonduiding/i).first()).toBeVisible()
 
     await advanceGuidedSelfServeAcceptanceFixture('patterns')
     await page.reload()
 
     await expect(page.getByText(/eerste vervolgstap beschikbaar/i).first()).toBeVisible()
-    await expect(page.getByText(/verdiepende analyse wordt zichtbaar vanaf 10 ingevulde responses/i)).toHaveCount(0)
+    await expect(page.getByText(/verdieping nog dicht/i)).toHaveCount(0)
     await expect(page.getByText(/focusvragen en route-uitvoer worden betekenisvoller zodra het dashboard minstens 10 responses heeft/i)).toHaveCount(0)
     await expect(page.getByText(/van vertrekduiding naar managementroute/i)).toBeVisible()
     await expect(page.getByRole('button', { name: /pdf-rapport/i }).first()).toBeVisible()


### PR DESCRIPTION
## Summary
- centralize response activation thresholds so dashboard, report access, and readiness labels follow one shared truth
- keep the customer flow compact between first dashboard activation and first pattern readiness, without showing premature insights
- hard-gate report download server-side and extend unit plus guided self-serve acceptance coverage for the activation flow

## Why
Customers need response status and dashboard activation to be clear without implying insights before the survey is methodologically ready. This change removes the split between response monitoring, dashboard visibility, and report availability.

## Impact
- dashboard and report stay closed before the first safe response threshold
- the first visible dashboard state is intentionally compact and explicit about what is still not ready
- deeper drivers, focus, and route output only unlock once pattern readiness is reached

## Test Plan
- `npm test`
- `npm run build`
- `npm run test:e2e:guided-self-serve`