### PR TITLE
[codex] Harden customer execution permissions and audit trail

### DIFF
--- a/frontend/app/(dashboard)/campaigns/[id]/actions.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/actions.ts
@@ -7,6 +7,11 @@
  */
 
 import { createClient } from '@/lib/supabase/server'
+import { insertCampaignAuditEvent } from '@/lib/campaign-audit'
+import {
+  getCustomerActionPermission,
+  getPermissionDeniedMessage,
+} from '@/lib/customer-permissions'
 import { getOrganizationApiKey } from '@/lib/organization-secrets'
 import { getBackendApiUrl } from '@/lib/server-env'
 import { formatBackendDetail } from './reminder-feedback'
@@ -40,15 +45,38 @@ export async function resendPendingAction(campaignId: string): Promise<ResendRes
     return { sent: 0, failed: 0, skipped: 0, error: 'Campaign niet gevonden of niet toegankelijk.' }
   }
 
-  const { data: membership, error: membershipError } = await supabase
-    .from('org_members')
-    .select('role')
-    .eq('org_id', campaign.organization_id)
-    .eq('user_id', user.id)
-    .maybeSingle()
+  const [
+    { data: profile },
+    { data: membership, error: membershipError },
+  ] = await Promise.all([
+    supabase.from('profiles').select('is_verisight_admin').eq('id', user.id).maybeSingle(),
+    supabase
+      .from('org_members')
+      .select('role')
+      .eq('org_id', campaign.organization_id)
+      .eq('user_id', user.id)
+      .maybeSingle(),
+  ])
 
-  if (membershipError || !membership) {
-    return { sent: 0, failed: 0, skipped: 0, error: 'Je hebt geen rechten om herinneringen te versturen.' }
+  const actorRole =
+    profile?.is_verisight_admin === true ? 'verisight_admin' : membership?.role ?? 'unknown'
+  const canSendReminders =
+    profile?.is_verisight_admin === true ||
+    getCustomerActionPermission(membership?.role ?? null, 'send_reminders')
+
+  if (membershipError || (!profile?.is_verisight_admin && !membership) || !canSendReminders) {
+    await insertCampaignAuditEvent({
+      supabase,
+      organizationId: campaign.organization_id,
+      campaignId,
+      actorUserId: user.id,
+      actorRole,
+      action: 'send_reminders',
+      outcome: 'blocked',
+      summary: getPermissionDeniedMessage('send_reminders'),
+    })
+
+    return { sent: 0, failed: 0, skipped: 0, error: getPermissionDeniedMessage('send_reminders') }
   }
 
   let apiKey: string
@@ -92,6 +120,22 @@ export async function resendPendingAction(campaignId: string): Promise<ResendRes
     }
 
     const result = await resp.json()
+    await insertCampaignAuditEvent({
+      supabase,
+      organizationId: campaign.organization_id,
+      campaignId,
+      actorUserId: user.id,
+      actorRole,
+      action: 'send_reminders',
+      outcome: 'completed',
+      summary: `Reminderactie uitgevoerd voor ${result.sent ?? 0} respondent(en).`,
+      metadata: {
+        sent: result.sent ?? 0,
+        failed: result.failed ?? 0,
+        skipped: result.skipped ?? 0,
+      },
+    })
+
     return {
       sent:    result.sent    ?? 0,
       failed:  result.failed  ?? 0,

--- a/frontend/app/(dashboard)/campaigns/[id]/page.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.test.ts
@@ -38,4 +38,22 @@ describe('campaign page render truth', () => {
     expect(source).toContain('Guided self-serve')
     expect(guidedPanelSource).toContain('Start uitnodigingen')
   })
+
+  it('keeps customer execution role-aware and critical actions auditable', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+    const guidedPanelSource = readFileSync(
+      new URL('../../../../components/dashboard/guided-self-serve-panel.tsx', import.meta.url),
+      'utf8',
+    )
+    const preflightSource = readFileSync(
+      new URL('../../../../components/dashboard/preflight-checklist.tsx', import.meta.url),
+      'utf8',
+    )
+
+    expect(source).toContain("getCustomerActionPermission(membership?.role ?? null, 'review_launch')")
+    expect(guidedPanelSource).toContain('Jouw rol en kritieke acties')
+    expect(guidedPanelSource).toContain('Alleen de klant owner kan')
+    expect(preflightSource).toContain('Recente kritieke acties')
+    expect(preflightSource).toContain('Launch-owner')
+  })
 })

--- a/frontend/app/(dashboard)/campaigns/[id]/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.tsx
@@ -56,6 +56,8 @@ import {
 } from './page-helpers'
 import { buildCampaignReadinessState, getDeliveryModeLabel } from '@/lib/implementation-readiness'
 import { getLifecycleDecisionCards } from '@/lib/client-onboarding'
+import { type CampaignAuditEventRecord } from '@/lib/campaign-audit'
+import { getCustomerActionPermission } from '@/lib/customer-permissions'
 import type { CampaignDeliveryCheckpoint, CampaignDeliveryRecord } from '@/lib/ops-delivery'
 import { buildTeamLocalReadState, buildTeamPriorityReadState } from '@/lib/products/team'
 import { getProductModule } from '@/lib/products/shared/registry'
@@ -126,10 +128,13 @@ export default async function CampaignPage({ params }: Props) {
 
   const canManageCampaign =
     profile?.is_verisight_admin === true ||
-    membership?.role === 'owner' ||
-    membership?.role === 'member'
+    getCustomerActionPermission(membership?.role ?? null, 'review_launch')
   const isVerisightAdmin = profile?.is_verisight_admin === true
-  const canExecuteCampaign = isVerisightAdmin || Boolean(membership?.role)
+  const canExecuteCampaign =
+    isVerisightAdmin ||
+    getCustomerActionPermission(membership?.role ?? null, 'import_respondents') ||
+    getCustomerActionPermission(membership?.role ?? null, 'launch_invites') ||
+    getCustomerActionPermission(membership?.role ?? null, 'send_reminders')
   const hasSegmentDeepDive = hasCampaignAddOn(campaignMeta, 'segment_deep_dive')
   const { data: deliveryRecordRaw } = await supabase
     .from('campaign_delivery_records')
@@ -145,6 +150,16 @@ export default async function CampaignPage({ params }: Props) {
         .order('created_at', { ascending: true })
     : { data: [] }
   const deliveryCheckpoints = (deliveryCheckpointsRaw ?? []) as CampaignDeliveryCheckpoint[]
+  const { data: auditEventsRaw } =
+    isVerisightAdmin || Boolean(membership?.role)
+      ? await supabase
+          .from('campaign_action_audit_events')
+          .select('id, action_key, outcome, action_label, owner_label, actor_role, actor_label, summary, metadata, created_at')
+          .eq('campaign_id', id)
+          .order('created_at', { ascending: false })
+          .limit(8)
+      : { data: [] }
+  const auditEvents = (auditEventsRaw ?? []) as CampaignAuditEventRecord[]
   const {
     rows: deliveryLeadOptions,
     configError: deliveryLeadConfigError,
@@ -1112,9 +1127,9 @@ export default async function CampaignPage({ params }: Props) {
           description="Verisight heeft de campaign ingericht. Vanaf hier lever jij deelnemers aan, start je de inviteflow veilig en volg je respons op zonder buiten de productgrenzen te hoeven treden."
           aside={<DashboardChip label="Klantuitvoering" tone="emerald" />}
         >
-          <GuidedSelfServePanel
-            campaignId={id}
-            scanType={stats.scan_type}
+                    <GuidedSelfServePanel
+                      campaignId={id}
+                      scanType={stats.scan_type}
             isActive={stats.is_active}
             deliveryMode={campaignMeta?.delivery_mode ?? null}
             hasSegmentDeepDive={hasSegmentDeepDive}
@@ -1123,10 +1138,11 @@ export default async function CampaignPage({ params }: Props) {
             invitesNotSent={invitesNotSent}
               hasMinDisplay={hasMinDisplay}
               hasEnoughData={hasEnoughData}
-              pendingCount={pendingCount}
-              remindableCount={remindableCount}
-              unsentRespondents={unsentRespondents}
-            />
+                      pendingCount={pendingCount}
+                      remindableCount={remindableCount}
+                      unsentRespondents={unsentRespondents}
+                      memberRole={membership?.role ?? null}
+                    />
           </DashboardSection>
         ) : null}
 
@@ -1654,6 +1670,7 @@ export default async function CampaignPage({ params }: Props) {
                       linkedLearningDossierCount={learningDossiers.length}
                       learningCloseoutEvidenceCount={learningCloseoutEvidenceCount}
                       editable={isVerisightAdmin}
+                      auditEvents={auditEvents}
                     />
                   ) : (
                     <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm leading-6 text-slate-700">

--- a/frontend/app/api/campaign-delivery-checkpoints/[id]/route.ts
+++ b/frontend/app/api/campaign-delivery-checkpoints/[id]/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import { insertCampaignAuditEvent } from '@/lib/campaign-audit'
 import { createClient } from '@/lib/supabase/server'
 import {
   DELIVERY_CHECKPOINT_DEFINITIONS,
@@ -88,7 +89,7 @@ export async function PATCH(request: Request, context: Context) {
 
   const { data: checkpoint } = await admin.supabase
     .from('campaign_delivery_checkpoints')
-    .select('id, checkpoint_key')
+    .select('id, checkpoint_key, delivery_record_id')
     .eq('id', id)
     .maybeSingle()
 
@@ -139,6 +140,30 @@ export async function PATCH(request: Request, context: Context) {
 
   if (error) {
     return NextResponse.json({ detail: error.message }, { status: 500 })
+  }
+
+  const { data: deliveryRecord } = await admin.supabase
+    .from('campaign_delivery_records')
+    .select('organization_id, campaign_id')
+    .eq('id', checkpoint.delivery_record_id)
+    .maybeSingle()
+
+  if (deliveryRecord?.campaign_id && deliveryRecord.organization_id) {
+    await insertCampaignAuditEvent({
+      supabase: admin.supabase,
+      organizationId: deliveryRecord.organization_id,
+      campaignId: deliveryRecord.campaign_id,
+      actorUserId: admin.user.id,
+      actorRole: 'verisight_admin',
+      action: 'delivery_checkpoint_confirmed',
+      outcome: 'completed',
+      summary: `Checkpoint ${checkpoint.checkpoint_key} bijgewerkt naar ${body.manual_state ?? 'pending'}.`,
+      metadata: {
+        checkpoint_key: checkpoint.checkpoint_key,
+        manual_state: body.manual_state ?? null,
+        exception_status: body.exception_status ?? null,
+      },
+    })
   }
 
   return NextResponse.json({ message: 'Deliverycheckpoint bijgewerkt.' })

--- a/frontend/app/api/campaign-delivery/[id]/route.ts
+++ b/frontend/app/api/campaign-delivery/[id]/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import { insertCampaignAuditEvent } from '@/lib/campaign-audit'
 import { createClient } from '@/lib/supabase/server'
 import {
   buildDeliveryCheckpointMap,
@@ -86,7 +87,7 @@ export async function PATCH(request: Request, context: Context) {
 
   const { data: record } = await admin.supabase
     .from('campaign_delivery_records')
-    .select('id, campaign_id, contact_request_id, lifecycle_stage, exception_status, first_management_use_confirmed_at, follow_up_decided_at, learning_closed_at')
+    .select('id, organization_id, campaign_id, contact_request_id, lifecycle_stage, exception_status, first_management_use_confirmed_at, follow_up_decided_at, learning_closed_at')
     .eq('campaign_id', id)
     .maybeSingle()
 
@@ -218,6 +219,23 @@ export async function PATCH(request: Request, context: Context) {
 
   if (error) {
     return NextResponse.json({ detail: error.message }, { status: 500 })
+  }
+
+  if ('lifecycle_stage' in body && body.lifecycle_stage && body.lifecycle_stage !== record.lifecycle_stage) {
+    await insertCampaignAuditEvent({
+      supabase: admin.supabase,
+      organizationId: record.organization_id,
+      campaignId: id,
+      actorUserId: admin.user.id,
+      actorRole: 'verisight_admin',
+      action: 'delivery_lifecycle_changed',
+      outcome: 'completed',
+      summary: `Lifecycle verschoven van ${record.lifecycle_stage} naar ${body.lifecycle_stage}.`,
+      metadata: {
+        from: record.lifecycle_stage,
+        to: body.lifecycle_stage,
+      },
+    })
   }
 
   return NextResponse.json({ message: 'Deliveryrecord bijgewerkt.' })

--- a/frontend/app/api/campaigns/[id]/respondents/import/route.ts
+++ b/frontend/app/api/campaigns/[id]/respondents/import/route.ts
@@ -1,4 +1,9 @@
 import { NextResponse } from 'next/server'
+import { insertCampaignAuditEvent } from '@/lib/campaign-audit'
+import {
+  getCustomerActionPermission,
+  getPermissionDeniedMessage,
+} from '@/lib/customer-permissions'
 import { createClient } from '@/lib/supabase/server'
 import { getOrganizationApiKey } from '@/lib/organization-secrets'
 import { getBackendApiUrl } from '@/lib/server-env'
@@ -45,10 +50,25 @@ export async function POST(request: Request, { params }: Context) {
       .maybeSingle(),
   ])
 
-  const canExecuteCampaign = profile?.is_verisight_admin === true || Boolean(membership)
-  if (!canExecuteCampaign) {
+  const actorRole =
+    profile?.is_verisight_admin === true ? 'verisight_admin' : membership?.role ?? 'unknown'
+  const canImportRespondents =
+    profile?.is_verisight_admin === true ||
+    getCustomerActionPermission(membership?.role ?? null, 'import_respondents')
+  if (!canImportRespondents) {
+    await insertCampaignAuditEvent({
+      supabase,
+      organizationId: campaign.organization_id,
+      campaignId: id,
+      actorUserId: user.id,
+      actorRole,
+      action: 'import_respondents',
+      outcome: 'blocked',
+      summary: getPermissionDeniedMessage('import_respondents'),
+    })
+
     return NextResponse.json(
-      { detail: 'Je hebt geen rechten om deelnemers voor deze campaign aan te leveren.' },
+      { detail: getPermissionDeniedMessage('import_respondents') },
       { status: 403 },
     )
   }
@@ -83,10 +103,44 @@ export async function POST(request: Request, { params }: Context) {
   const contentType = backendResponse.headers.get('content-type') ?? ''
   if (contentType.includes('application/json')) {
     const payload = await backendResponse.json()
+    await insertCampaignAuditEvent({
+      supabase,
+      organizationId: campaign.organization_id,
+      campaignId: id,
+      actorUserId: user.id,
+      actorRole,
+      action: 'import_respondents',
+      outcome: backendResponse.ok ? 'completed' : 'blocked',
+      summary:
+        backendResponse.ok
+          ? `Deelnemersimport verwerkt voor ${payload.valid_rows ?? payload.imported ?? 0} rij(en).`
+          : typeof payload?.detail === 'string'
+            ? payload.detail
+            : 'Deelnemersimport kon niet worden verwerkt.',
+      metadata: {
+        dry_run: String(incoming.get('dry_run') ?? 'true') === 'true',
+        valid_rows: payload.valid_rows ?? null,
+        imported: payload.imported ?? null,
+      },
+    })
     return NextResponse.json(payload, { status: backendResponse.status })
   }
 
   const detail = await backendResponse.text()
+  await insertCampaignAuditEvent({
+    supabase,
+    organizationId: campaign.organization_id,
+    campaignId: id,
+    actorUserId: user.id,
+    actorRole,
+    action: 'import_respondents',
+    outcome: backendResponse.ok ? 'completed' : 'blocked',
+    summary: detail || 'Import kon niet worden verwerkt.',
+    metadata: {
+      dry_run: String(incoming.get('dry_run') ?? 'true') === 'true',
+    },
+  })
+
   return NextResponse.json(
     { detail: detail || 'Import kon niet worden verwerkt.' },
     { status: backendResponse.status || 500 },

--- a/frontend/app/api/campaigns/[id]/respondents/send-invites/route.ts
+++ b/frontend/app/api/campaigns/[id]/respondents/send-invites/route.ts
@@ -1,4 +1,9 @@
 import { NextResponse } from 'next/server'
+import { insertCampaignAuditEvent } from '@/lib/campaign-audit'
+import {
+  getCustomerActionPermission,
+  getPermissionDeniedMessage,
+} from '@/lib/customer-permissions'
 import { createClient } from '@/lib/supabase/server'
 import { getOrganizationApiKey } from '@/lib/organization-secrets'
 import { getBackendApiUrl } from '@/lib/server-env'
@@ -43,10 +48,25 @@ export async function POST(request: Request, { params }: Context) {
       .maybeSingle(),
   ])
 
-  const canExecuteCampaign = profile?.is_verisight_admin === true || Boolean(membership)
-  if (!canExecuteCampaign) {
+  const actorRole =
+    profile?.is_verisight_admin === true ? 'verisight_admin' : membership?.role ?? 'unknown'
+  const canLaunchInvites =
+    profile?.is_verisight_admin === true ||
+    getCustomerActionPermission(membership?.role ?? null, 'launch_invites')
+  if (!canLaunchInvites) {
+    await insertCampaignAuditEvent({
+      supabase,
+      organizationId: campaign.organization_id,
+      campaignId: id,
+      actorUserId: user.id,
+      actorRole,
+      action: 'launch_invites',
+      outcome: 'blocked',
+      summary: getPermissionDeniedMessage('launch_invites'),
+    })
+
     return NextResponse.json(
-      { detail: 'Je hebt geen rechten om uitnodigingen voor deze campaign te versturen.' },
+      { detail: getPermissionDeniedMessage('launch_invites') },
       { status: 403 },
     )
   }
@@ -70,5 +90,25 @@ export async function POST(request: Request, { params }: Context) {
   })
 
   const payload = await backendResponse.json().catch(() => ({}))
+  await insertCampaignAuditEvent({
+    supabase,
+    organizationId: campaign.organization_id,
+    campaignId: id,
+    actorUserId: user.id,
+    actorRole,
+    action: 'launch_invites',
+    outcome: backendResponse.ok ? 'completed' : 'blocked',
+    summary:
+      backendResponse.ok
+        ? `Inviteflow gestart voor ${payload.sent ?? 0} respondent(en).`
+        : typeof payload?.detail === 'string'
+          ? payload.detail
+          : 'Inviteflow kon niet worden gestart.',
+    metadata: {
+      sent: payload.sent ?? null,
+      failed: payload.failed ?? null,
+      skipped: payload.skipped ?? null,
+    },
+  })
   return NextResponse.json(payload, { status: backendResponse.status })
 }

--- a/frontend/app/api/org-invites/invite-helpers.ts
+++ b/frontend/app/api/org-invites/invite-helpers.ts
@@ -8,7 +8,7 @@ export interface InviteBody {
   orgId?: string
   email?: string
   fullName?: string
-  role?: 'viewer' | 'member'
+  role?: 'owner' | 'viewer' | 'member'
 }
 
 export const RESEND_COOLDOWN_MINUTES = 10

--- a/frontend/app/api/org-invites/route.ts
+++ b/frontend/app/api/org-invites/route.ts
@@ -21,7 +21,7 @@ export async function POST(request: Request) {
     const orgId = body.orgId?.trim()
     const email = body.email?.trim().toLowerCase()
     const fullName = body.fullName?.trim() || null
-    const role = body.role === 'member' ? 'member' : 'viewer'
+    const role = body.role === 'owner' ? 'owner' : body.role === 'member' ? 'member' : 'viewer'
 
     if (!orgId || !email) {
       return NextResponse.json({ detail: 'Organisatie en e-mailadres zijn verplicht.' }, { status: 400 })

--- a/frontend/components/dashboard/client-access-list.tsx
+++ b/frontend/components/dashboard/client-access-list.tsx
@@ -91,7 +91,7 @@ export function ClientAccessList({ invites }: Props) {
                       {statusLabel}
                     </span>
                     <span className="rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700">
-                      {invite.role === 'member' ? 'Member' : 'Viewer'}
+                      {invite.role === 'owner' ? 'Klant owner' : invite.role === 'member' ? 'Member' : 'Viewer'}
                     </span>
                   </div>
                   <p className="mt-1 text-sm text-gray-500">{invite.email}</p>

--- a/frontend/components/dashboard/guided-self-serve-panel.tsx
+++ b/frontend/components/dashboard/guided-self-serve-panel.tsx
@@ -9,6 +9,10 @@ import {
   DashboardPanel,
 } from '@/components/dashboard/dashboard-primitives'
 import { CLIENT_FILE_SPEC } from '@/lib/client-onboarding'
+import {
+  getCustomerActionPermission,
+  getCustomerRoleSummary,
+} from '@/lib/customer-permissions'
 import { buildGuidedSelfServeState } from '@/lib/guided-self-serve'
 import {
   getDeliveryModeDescription,
@@ -17,6 +21,7 @@ import {
 } from '@/lib/implementation-readiness'
 import {
   type DeliveryMode,
+  type MemberRole,
   REPORT_ADD_ON_LABELS,
   SCAN_TYPE_LABELS,
   type ScanType,
@@ -36,6 +41,7 @@ interface Props {
   pendingCount: number
   remindableCount: number
   unsentRespondents: Array<{ token: string; email: string | null }>
+  memberRole: MemberRole | null
 }
 
 interface ImportIssue {
@@ -84,8 +90,13 @@ export function GuidedSelfServePanel({
   pendingCount,
   remindableCount,
   unsentRespondents,
+  memberRole,
 }: Props) {
   const router = useRouter()
+  const roleSummary = getCustomerRoleSummary(memberRole)
+  const canImportRespondents = getCustomerActionPermission(memberRole, 'import_respondents')
+  const canLaunchInvites = getCustomerActionPermission(memberRole, 'launch_invites')
+  const canSendReminders = getCustomerActionPermission(memberRole, 'send_reminders')
   const guidedState = useMemo(
     () =>
       buildGuidedSelfServeState({
@@ -305,6 +316,47 @@ export function GuidedSelfServePanel({
         />
       </div>
 
+      <div className="rounded-[24px] border border-slate-200 bg-white p-4 shadow-[0_10px_30px_rgba(19,32,51,0.05)] sm:p-5">
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,0.8fr),minmax(0,1.2fr)]">
+          <div className="rounded-2xl border border-slate-100 bg-slate-50 px-4 py-4">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+              Jouw rol en kritieke acties
+            </p>
+            <p className="mt-2 text-lg font-semibold text-slate-950">{roleSummary.label}</p>
+            <p className="mt-2 text-sm leading-6 text-slate-700">{roleSummary.description}</p>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="rounded-2xl border border-slate-100 bg-slate-50 px-4 py-4">
+              <p className="text-sm font-semibold text-slate-950">Mag nu wel</p>
+              <ul className="mt-3 space-y-2">
+                {roleSummary.allowedActions.map((item) => (
+                  <li key={item} className="text-sm leading-6 text-slate-700">
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="rounded-2xl border border-slate-100 bg-slate-50 px-4 py-4">
+              <p className="text-sm font-semibold text-slate-950">Blijft begrensd</p>
+              <ul className="mt-3 space-y-2">
+                {roleSummary.restrictedActions.map((item) => (
+                  <li key={item} className="text-sm leading-6 text-slate-700">
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        {!canImportRespondents || !canLaunchInvites || !canSendReminders ? (
+          <div className="mt-4 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm leading-6 text-amber-900">
+            Alleen de klant owner kan deelnemers aanleveren, de inviteflow starten en reminders versturen.
+            Gebruik deze rol daarom vooral voor dashboardlezing en rapportduiding.
+          </div>
+        ) : null}
+      </div>
+
       {isActive ? (
         <div className="rounded-[24px] border border-slate-200 bg-white p-4 shadow-[0_10px_30px_rgba(19,32,51,0.05)] sm:p-5">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
@@ -373,7 +425,7 @@ export function GuidedSelfServePanel({
               <button
                 type="button"
                 onClick={() => void requestImport(true)}
-                disabled={loading !== null || !uploadFile}
+                disabled={loading !== null || !uploadFile || !canImportRespondents}
                 className="rounded-full border border-[#d6e4e8] bg-[#f3f8f8] px-4 py-2 text-sm font-semibold text-[#234B57] transition-colors hover:border-[#bfd3d8] hover:bg-[#e9f2f3] disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {loading === 'preview' ? 'Bestand controleren...' : 'Bestand controleren'}
@@ -382,7 +434,7 @@ export function GuidedSelfServePanel({
                 <button
                   type="button"
                   onClick={() => void requestImport(false)}
-                  disabled={loading !== null}
+                  disabled={loading !== null || !canImportRespondents}
                   className="rounded-full bg-[#234B57] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#1B2E45] disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {loading === 'import'
@@ -396,7 +448,7 @@ export function GuidedSelfServePanel({
                 <button
                   type="button"
                   onClick={() => void startInvites()}
-                  disabled={loading !== null}
+                  disabled={loading !== null || !canLaunchInvites}
                   className="rounded-full bg-[#234B57] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#1B2E45] disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {loading === 'launch'
@@ -408,7 +460,7 @@ export function GuidedSelfServePanel({
                 <button
                   type="button"
                   onClick={() => void resendPendingInvites()}
-                  disabled={loading !== null}
+                  disabled={loading !== null || !canSendReminders}
                   className="rounded-full border border-blue-200 bg-blue-50 px-4 py-2 text-sm font-semibold text-blue-700 transition-colors hover:border-blue-300 hover:bg-blue-100 disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {loading === 'remind' ? 'Herinneringen versturen...' : `Stuur reminder naar ${remindableCount}`}

--- a/frontend/components/dashboard/invite-client-user-form.tsx
+++ b/frontend/components/dashboard/invite-client-user-form.tsx
@@ -13,7 +13,7 @@ export function InviteClientUserForm({ orgs }: Props) {
   const [orgId, setOrgId] = useState(orgs[0]?.id ?? '')
   const [fullName, setFullName] = useState('')
   const [email, setEmail] = useState('')
-  const [role, setRole] = useState<'viewer' | 'member'>('viewer')
+  const [role, setRole] = useState<'viewer' | 'owner'>('viewer')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState<string | null>(null)
@@ -103,14 +103,14 @@ export function InviteClientUserForm({ orgs }: Props) {
 
       <div>
         <label className="block text-sm font-medium text-gray-700 mb-1">Rol</label>
-        <select value={role} onChange={e => setRole(e.target.value as 'viewer' | 'member')} className={selectCls}>
+        <select value={role} onChange={e => setRole(e.target.value as 'viewer' | 'owner')} className={selectCls}>
           <option value="viewer">Viewer - alleen dashboard en rapport</option>
-          <option value="member">Member - uitgebreidere interne rol</option>
+          <option value="owner">Klant owner - kritieke launchacties</option>
         </select>
         <p className="mt-1 text-xs text-gray-400">
           Gebruik standaard <span className="font-medium text-gray-500">Viewer</span>. Kies alleen{' '}
-          <span className="font-medium text-gray-500">Member</span> als iemand later ook schrijfrechten binnen de
-          organisatie moet krijgen.
+          <span className="font-medium text-gray-500">Klant owner</span> als iemand deelnemers mag aanleveren,
+          uitnodigingen mag starten en reminders mag bewaken.
         </p>
       </div>
 

--- a/frontend/components/dashboard/preflight-checklist.tsx
+++ b/frontend/components/dashboard/preflight-checklist.tsx
@@ -3,6 +3,10 @@
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useMemo, useState } from 'react'
+import {
+  formatCampaignAuditHeadline,
+  type CampaignAuditEventRecord,
+} from '@/lib/campaign-audit'
 import { getContactDesiredTimingLabel, getContactRouteLabel } from '@/lib/contact-funnel'
 import { getDeliveryModeLabel, normalizeDeliveryMode } from '@/lib/implementation-readiness'
 import {
@@ -45,6 +49,7 @@ interface Props {
   linkedLearningDossierCount?: number
   learningCloseoutEvidenceCount?: number
   editable?: boolean
+  auditEvents?: CampaignAuditEventRecord[]
 }
 
 type RecordDraft = {
@@ -99,6 +104,7 @@ export function PreflightChecklist({
   linkedLearningDossierCount = 0,
   learningCloseoutEvidenceCount = 0,
   editable = false,
+  auditEvents = [],
 }: Props) {
   const router = useRouter()
   const resolvedMode = normalizeDeliveryMode(deliveryMode)
@@ -584,6 +590,13 @@ export function PreflightChecklist({
                 <div className="rounded-2xl border border-white bg-white px-4 py-4">
                   <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Operatorrollen</p>
                   <div className="mt-3 space-y-3">
+                    <div className="rounded-2xl border border-slate-100 bg-slate-50 px-3 py-3">
+                      <p className="text-sm font-semibold text-slate-950">Launch-owner</p>
+                      <p className="mt-1 text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">Klant owner</p>
+                      <p className="mt-2 text-sm leading-6 text-slate-700">
+                        Draagt deelnemersimport, invitevrijgave, reminderbesluit en de eerste expliciete vervolgstap aan klantzijde.
+                      </p>
+                    </div>
                     {operatingGuide.roles.map((role) => (
                       <div key={role.title} className="rounded-2xl border border-slate-100 bg-slate-50 px-3 py-3">
                         <p className="text-sm font-semibold text-slate-950">{role.title}</p>
@@ -644,6 +657,37 @@ export function PreflightChecklist({
                   </div>
                 </div>
               </div>
+            </div>
+
+            <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4">
+              <p className="text-sm font-semibold text-slate-950">Recente kritieke acties</p>
+              <p className="mt-2 text-sm leading-6 text-slate-600">
+                Deze auditlaag laat zien wie een launchkritieke stap heeft uitgevoerd of geblokkeerd zag, en welke owner daarbij hoort.
+              </p>
+              {auditEvents.length === 0 ? (
+                <div className="mt-4 rounded-2xl border border-white bg-white px-4 py-3 text-sm leading-6 text-slate-600">
+                  Nog geen vastgelegde kritieke acties voor deze campaign.
+                </div>
+              ) : (
+                <div className="mt-4 space-y-3">
+                  {auditEvents.map((event) => (
+                    <div key={`${event.id ?? event.created_at ?? event.summary}-${event.action_key}`} className="rounded-2xl border border-white bg-white px-4 py-3">
+                      <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                        <div>
+                          <p className="text-sm font-semibold text-slate-950">
+                            {formatCampaignAuditHeadline(event)}
+                          </p>
+                          <p className="mt-1 text-sm leading-6 text-slate-700">{event.summary}</p>
+                        </div>
+                        <div className="text-xs leading-5 text-slate-500">
+                          <p>{event.owner_label}</p>
+                          <p>{event.actor_label ?? 'Onbekende actor'}</p>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
 
             <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4 text-sm leading-6 text-slate-700">

--- a/frontend/lib/campaign-audit.test.ts
+++ b/frontend/lib/campaign-audit.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  CAMPAIGN_AUDIT_ACTIONS,
+  buildCampaignAuditEvent,
+  formatCampaignAuditHeadline,
+} from './campaign-audit'
+
+describe('campaign audit events', () => {
+  it('keeps critical launch actions auditable with owner-safe labels', () => {
+    expect(CAMPAIGN_AUDIT_ACTIONS.launch_invites.ownerLabel).toBe('Klant owner')
+    expect(CAMPAIGN_AUDIT_ACTIONS.import_respondents.actionLabel).toBe('Deelnemersimport')
+    expect(CAMPAIGN_AUDIT_ACTIONS.delivery_lifecycle_changed.actionLabel).toBe('Launchstatus bijgewerkt')
+  })
+
+  it('builds a blocked audit event with clear customer-safe language', () => {
+    const event = buildCampaignAuditEvent({
+      action: 'launch_invites',
+      outcome: 'blocked',
+      actorRole: 'viewer',
+      actorLabel: 'Viewer',
+      summary: 'Inviteflow geblokkeerd omdat de rol geen launchrecht heeft.',
+    })
+
+    expect(event.owner_label).toBe('Klant owner')
+    expect(event.summary).toContain('launchrecht')
+    expect(formatCampaignAuditHeadline(event)).toBe('Geblokkeerd - Inviteflow gestart')
+  })
+})

--- a/frontend/lib/campaign-audit.ts
+++ b/frontend/lib/campaign-audit.ts
@@ -1,0 +1,128 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { MemberRole } from '@/lib/types'
+
+export type CampaignAuditActionKey =
+  | 'import_respondents'
+  | 'launch_invites'
+  | 'send_reminders'
+  | 'grant_client_access'
+  | 'delivery_lifecycle_changed'
+  | 'delivery_checkpoint_confirmed'
+
+export type CampaignAuditOutcome = 'completed' | 'blocked'
+export type CampaignAuditActorRole = MemberRole | 'verisight_admin' | 'unknown'
+
+export const CAMPAIGN_AUDIT_ACTIONS: Record<
+  CampaignAuditActionKey,
+  { actionLabel: string; ownerLabel: string }
+> = {
+  import_respondents: {
+    actionLabel: 'Deelnemersimport',
+    ownerLabel: 'Klant owner',
+  },
+  launch_invites: {
+    actionLabel: 'Inviteflow gestart',
+    ownerLabel: 'Klant owner',
+  },
+  send_reminders: {
+    actionLabel: 'Reminder verstuurd',
+    ownerLabel: 'Klant owner',
+  },
+  grant_client_access: {
+    actionLabel: 'Klanttoegang bijgewerkt',
+    ownerLabel: 'Verisight',
+  },
+  delivery_lifecycle_changed: {
+    actionLabel: 'Launchstatus bijgewerkt',
+    ownerLabel: 'Launch-owner',
+  },
+  delivery_checkpoint_confirmed: {
+    actionLabel: 'Launchcheck bevestigd',
+    ownerLabel: 'Launch-owner',
+  },
+}
+
+export interface CampaignAuditEventRecord {
+  id?: string
+  action_key: CampaignAuditActionKey
+  outcome: CampaignAuditOutcome
+  action_label: string
+  owner_label: string
+  actor_role: string | null
+  actor_label: string | null
+  summary: string
+  metadata: Record<string, unknown>
+  created_at?: string
+}
+
+function getDefaultActorLabel(role: CampaignAuditActorRole | null | undefined) {
+  switch (role) {
+    case 'owner':
+      return 'Klant owner'
+    case 'viewer':
+      return 'Viewer'
+    case 'member':
+      return 'Member'
+    case 'verisight_admin':
+      return 'Verisight beheer'
+    default:
+      return 'Onbekende actor'
+  }
+}
+
+export function buildCampaignAuditEvent(args: {
+  action: CampaignAuditActionKey
+  outcome: CampaignAuditOutcome
+  actorRole: CampaignAuditActorRole | null | undefined
+  actorLabel?: string | null
+  summary: string
+  metadata?: Record<string, unknown>
+}) {
+  const action = CAMPAIGN_AUDIT_ACTIONS[args.action]
+
+  return {
+    action_key: args.action,
+    outcome: args.outcome,
+    action_label: action.actionLabel,
+    owner_label: action.ownerLabel,
+    actor_role: args.actorRole ?? null,
+    actor_label: args.actorLabel?.trim() || getDefaultActorLabel(args.actorRole),
+    summary: args.summary,
+    metadata: args.metadata ?? {},
+  } satisfies CampaignAuditEventRecord
+}
+
+export function formatCampaignAuditHeadline(event: Pick<CampaignAuditEventRecord, 'action_label' | 'outcome'>) {
+  return `${event.outcome === 'blocked' ? 'Geblokkeerd' : 'Uitgevoerd'} - ${event.action_label}`
+}
+
+export async function insertCampaignAuditEvent(args: {
+  supabase: Pick<SupabaseClient, 'from'>
+  organizationId: string
+  campaignId: string
+  actorUserId?: string | null
+  action: CampaignAuditActionKey
+  outcome: CampaignAuditOutcome
+  actorRole: CampaignAuditActorRole | null | undefined
+  actorLabel?: string | null
+  summary: string
+  metadata?: Record<string, unknown>
+}) {
+  const payload = buildCampaignAuditEvent({
+    action: args.action,
+    outcome: args.outcome,
+    actorRole: args.actorRole,
+    actorLabel: args.actorLabel,
+    summary: args.summary,
+    metadata: args.metadata,
+  })
+
+  const { error } = await args.supabase.from('campaign_action_audit_events').insert({
+    organization_id: args.organizationId,
+    campaign_id: args.campaignId,
+    actor_user_id: args.actorUserId ?? null,
+    ...payload,
+  })
+
+  return { error }
+}

--- a/frontend/lib/customer-permissions.test.ts
+++ b/frontend/lib/customer-permissions.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getCustomerActionPermission,
+  getCustomerRoleSummary,
+  getPermissionDeniedMessage,
+} from './customer-permissions'
+
+describe('customer execution permissions', () => {
+  it('keeps viewers read-first and outside launch-critical execution', () => {
+    expect(getCustomerActionPermission('viewer', 'view_dashboard')).toBe(true)
+    expect(getCustomerActionPermission('viewer', 'view_report')).toBe(true)
+    expect(getCustomerActionPermission('viewer', 'import_respondents')).toBe(false)
+    expect(getCustomerActionPermission('viewer', 'launch_invites')).toBe(false)
+    expect(getCustomerActionPermission('viewer', 'send_reminders')).toBe(false)
+    expect(getPermissionDeniedMessage('launch_invites')).toContain('klant owner')
+  })
+
+  it('keeps member access outside customer launch execution', () => {
+    expect(getCustomerActionPermission('member', 'view_dashboard')).toBe(true)
+    expect(getCustomerActionPermission('member', 'import_respondents')).toBe(false)
+    expect(getCustomerActionPermission('member', 'launch_invites')).toBe(false)
+    expect(getCustomerActionPermission('member', 'send_reminders')).toBe(false)
+  })
+
+  it('lets the owner carry critical customer execution safely', () => {
+    expect(getCustomerActionPermission('owner', 'import_respondents')).toBe(true)
+    expect(getCustomerActionPermission('owner', 'launch_invites')).toBe(true)
+    expect(getCustomerActionPermission('owner', 'send_reminders')).toBe(true)
+
+    const summary = getCustomerRoleSummary('owner')
+    expect(summary.label).toBe('Klant owner')
+    expect(summary.allowedActions.join(' ').toLowerCase()).toContain('deelnemers')
+    expect(summary.allowedActions.join(' ').toLowerCase()).toContain('inviteflow')
+  })
+})

--- a/frontend/lib/customer-permissions.ts
+++ b/frontend/lib/customer-permissions.ts
@@ -1,0 +1,119 @@
+import type { MemberRole } from '@/lib/types'
+
+export type CustomerCampaignAction =
+  | 'view_dashboard'
+  | 'view_report'
+  | 'import_respondents'
+  | 'launch_invites'
+  | 'send_reminders'
+  | 'review_launch'
+
+const OWNER_ONLY_ACTIONS = new Set<CustomerCampaignAction>([
+  'import_respondents',
+  'launch_invites',
+  'send_reminders',
+  'review_launch',
+])
+
+const SHARED_READ_ACTIONS = new Set<CustomerCampaignAction>(['view_dashboard', 'view_report'])
+
+const ACTION_LABELS: Record<CustomerCampaignAction, string> = {
+  view_dashboard: 'Dashboard lezen',
+  view_report: 'Rapport gebruiken',
+  import_respondents: 'Deelnemers aanleveren',
+  launch_invites: 'Inviteflow starten',
+  send_reminders: 'Reminders versturen',
+  review_launch: 'Launchstatus en vervolgstap bevestigen',
+}
+
+export function getCustomerActionPermission(
+  role: MemberRole | null | undefined,
+  action: CustomerCampaignAction,
+) {
+  if (!role) {
+    return false
+  }
+
+  if (SHARED_READ_ACTIONS.has(action)) {
+    return true
+  }
+
+  if (OWNER_ONLY_ACTIONS.has(action)) {
+    return role === 'owner'
+  }
+
+  return false
+}
+
+export function getPermissionDeniedMessage(action: Exclude<CustomerCampaignAction, 'view_dashboard' | 'view_report'>) {
+  switch (action) {
+    case 'import_respondents':
+      return 'Alleen de klant owner kan deelnemers aanleveren. Stem deze stap af met de aangewezen owner of laat Verisight begeleiden.'
+    case 'launch_invites':
+      return 'Alleen de klant owner kan de inviteflow starten. Controleer eerst wie deze campaign draagt voordat je verdergaat.'
+    case 'send_reminders':
+      return 'Alleen de klant owner kan reminders versturen. Houd ownership en timing eerst expliciet.'
+    case 'review_launch':
+    default:
+      return 'Alleen de klant owner kan launchstatus en vervolgstap bevestigen.'
+  }
+}
+
+export function getCustomerRoleSummary(role: MemberRole | null | undefined) {
+  if (role === 'owner') {
+    return {
+      label: 'Klant owner',
+      description:
+        'Draagt de klantuitvoering op launchkritieke stappen en houdt ownership, timing en vervolgstap expliciet.',
+      allowedActions: [
+        ACTION_LABELS.import_respondents,
+        ACTION_LABELS.launch_invites,
+        ACTION_LABELS.send_reminders,
+        ACTION_LABELS.review_launch,
+      ],
+      restrictedActions: [] as string[],
+    }
+  }
+
+  if (role === 'member') {
+    return {
+      label: 'Member',
+      description:
+        'Heeft ondersteunende toegang binnen begeleide uitvoering, maar launchkritieke klantacties blijven bewust bij de klant owner.',
+      allowedActions: [ACTION_LABELS.view_dashboard, ACTION_LABELS.view_report],
+      restrictedActions: [
+        ACTION_LABELS.import_respondents,
+        ACTION_LABELS.launch_invites,
+        ACTION_LABELS.send_reminders,
+        ACTION_LABELS.review_launch,
+      ],
+    }
+  }
+
+  if (role === 'viewer') {
+    return {
+      label: 'Viewer',
+      description:
+        'Blijft read-first: gebruikt dashboard en rapport, maar neemt geen launchkritieke acties.',
+      allowedActions: [ACTION_LABELS.view_dashboard, ACTION_LABELS.view_report],
+      restrictedActions: [
+        ACTION_LABELS.import_respondents,
+        ACTION_LABELS.launch_invites,
+        ACTION_LABELS.send_reminders,
+        ACTION_LABELS.review_launch,
+      ],
+    }
+  }
+
+  return {
+    label: 'Geen rol',
+    description: 'Deze gebruiker heeft nog geen expliciete klantrol voor deze campaign.',
+    allowedActions: [] as string[],
+    restrictedActions: [
+      ACTION_LABELS.import_respondents,
+      ACTION_LABELS.launch_invites,
+      ACTION_LABELS.send_reminders,
+      ACTION_LABELS.review_launch,
+    ],
+  }
+}

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -5,9 +5,9 @@ export type RiskBand = 'HOOG' | 'MIDDEN' | 'LAAG'
 export type CampaignAddOn = 'segment_deep_dive'
 export type DeliveryMode = 'baseline' | 'live'
 // Access roles only. These are not billable seats or plan licenses.
-// owner  = Verisight-beheerder (volledige toegang)
-// member = intern Verisight (zelfde rechten als owner)
-// viewer = HR-klant in guided self-serve uitvoering (deelnemers aanleveren, uitnodigingen volgen, dashboard lezen)
+// owner  = klant owner voor launchkritieke klantuitvoering
+// member = interne / ondersteunende rol binnen assisted uitvoering
+// viewer = read-first klantrol voor dashboard en rapport
 export type MemberRole = 'owner' | 'member' | 'viewer'
 export type Preventability = 'STERK_WERKSIGNAAL' | 'GEMENGD_WERKSIGNAAL' | 'BEPERKT_WERKSIGNAAL'
 export const SCAN_TYPE_LABELS: Record<ScanType, string> = {
@@ -109,7 +109,7 @@ export interface OrgInvite {
   org_id: string
   email: string
   full_name: string | null
-  role: 'viewer' | 'member'
+  role: MemberRole
   invited_by: string | null
   invited_at: string
   accepted_at: string | null

--- a/migrations/2026_04_23_add_campaign_action_audit_events.sql
+++ b/migrations/2026_04_23_add_campaign_action_audit_events.sql
@@ -1,0 +1,44 @@
+alter table public.org_invites
+drop constraint if exists org_invites_role_check;
+
+alter table public.org_invites
+add constraint org_invites_role_check
+check (role in ('owner', 'member', 'viewer'));
+
+create table if not exists public.campaign_action_audit_events (
+  id                uuid primary key default gen_random_uuid(),
+  organization_id   uuid references public.organizations(id) on delete cascade not null,
+  campaign_id       uuid references public.campaigns(id) on delete cascade not null,
+  actor_user_id     uuid references auth.users(id) on delete set null,
+  action_key        text not null check (action_key in ('import_respondents', 'launch_invites', 'send_reminders', 'grant_client_access', 'delivery_lifecycle_changed', 'delivery_checkpoint_confirmed')),
+  outcome           text not null check (outcome in ('completed', 'blocked')),
+  action_label      text not null,
+  owner_label       text not null,
+  actor_role        text,
+  actor_label       text,
+  summary           text not null,
+  metadata          jsonb not null default '{}'::jsonb,
+  created_at        timestamptz default now()
+);
+
+create index if not exists idx_campaign_action_audit_campaign
+  on public.campaign_action_audit_events(campaign_id, created_at desc);
+
+create index if not exists idx_campaign_action_audit_org
+  on public.campaign_action_audit_events(organization_id, created_at desc);
+
+alter table public.campaign_action_audit_events enable row level security;
+
+drop policy if exists "org_members_can_select_campaign_action_audit_events"
+  on public.campaign_action_audit_events;
+
+drop policy if exists "org_members_can_insert_campaign_action_audit_events"
+  on public.campaign_action_audit_events;
+
+create policy "org_members_can_select_campaign_action_audit_events"
+  on public.campaign_action_audit_events for select
+  using (public.is_verisight_admin_user() or public.is_org_member(organization_id));
+
+create policy "org_members_can_insert_campaign_action_audit_events"
+  on public.campaign_action_audit_events for insert
+  with check (public.is_verisight_admin_user() or public.is_org_member(organization_id));

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -43,7 +43,7 @@ create table if not exists public.org_invites (
   org_id      uuid references public.organizations(id) on delete cascade not null,
   email       text not null,
   full_name   text,
-  role        text not null default 'viewer' check (role in ('member', 'viewer')),
+  role        text not null default 'viewer' check (role in ('owner', 'member', 'viewer')),
   invited_by  uuid references auth.users(id) on delete set null,
   invited_at  timestamptz default now(),
   accepted_at timestamptz,
@@ -438,6 +438,22 @@ create table if not exists public.campaign_delivery_checkpoints (
   unique (delivery_record_id, checkpoint_key)
 );
 
+create table if not exists public.campaign_action_audit_events (
+  id                uuid primary key default gen_random_uuid(),
+  organization_id   uuid references public.organizations(id) on delete cascade not null,
+  campaign_id       uuid references public.campaigns(id) on delete cascade not null,
+  actor_user_id     uuid references auth.users(id) on delete set null,
+  action_key        text not null check (action_key in ('import_respondents', 'launch_invites', 'send_reminders', 'grant_client_access', 'delivery_lifecycle_changed', 'delivery_checkpoint_confirmed')),
+  outcome           text not null check (outcome in ('completed', 'blocked')),
+  action_label      text not null,
+  owner_label       text not null,
+  actor_role        text,
+  actor_label       text,
+  summary           text not null,
+  metadata          jsonb not null default '{}'::jsonb,
+  created_at        timestamptz default now()
+);
+
 create table if not exists public.pilot_learning_dossiers (
   id                      uuid primary key default gen_random_uuid(),
   organization_id         uuid references public.organizations(id) on delete cascade,
@@ -620,6 +636,8 @@ create index if not exists idx_delivery_records_contact_request on public.campai
 create index if not exists idx_delivery_records_lifecycle on public.campaign_delivery_records(lifecycle_stage);
 create index if not exists idx_delivery_records_exception on public.campaign_delivery_records(exception_status);
 create index if not exists idx_delivery_checkpoints_record on public.campaign_delivery_checkpoints(delivery_record_id);
+create index if not exists idx_campaign_action_audit_campaign on public.campaign_action_audit_events(campaign_id, created_at desc);
+create index if not exists idx_campaign_action_audit_org on public.campaign_action_audit_events(organization_id, created_at desc);
 
 -- ============================================================
 -- ROW LEVEL SECURITY
@@ -634,6 +652,7 @@ alter table public.respondents      enable row level security;
 alter table public.survey_responses enable row level security;
 alter table public.campaign_delivery_records enable row level security;
 alter table public.campaign_delivery_checkpoints enable row level security;
+alter table public.campaign_action_audit_events enable row level security;
 alter table public.pilot_learning_dossiers enable row level security;
 alter table public.pilot_learning_checkpoints enable row level security;
 
@@ -949,6 +968,17 @@ create policy "org_managers_can_update_delivery_checkpoints"
         and public.is_org_manager(d.organization_id)
     )
   );
+
+drop policy if exists "org_members_can_select_campaign_action_audit_events" on public.campaign_action_audit_events;
+drop policy if exists "org_members_can_insert_campaign_action_audit_events" on public.campaign_action_audit_events;
+
+create policy "org_members_can_select_campaign_action_audit_events"
+  on public.campaign_action_audit_events for select
+  using (public.is_verisight_admin_user() or public.is_org_member(organization_id));
+
+create policy "org_members_can_insert_campaign_action_audit_events"
+  on public.campaign_action_audit_events for insert
+  with check (public.is_verisight_admin_user() or public.is_org_member(organization_id));
 
 -- Pilot learning dossiers
 drop policy if exists "verisight_admins_can_select_learning_dossiers" on public.pilot_learning_dossiers;


### PR DESCRIPTION
## What changed
- added explicit customer execution permissions for critical campaign actions
- limited respondent import, invite launch, reminder sending, and launch review to the customer owner role or Verisight admin
- added campaign action audit events for blocked and completed critical actions
- surfaced role clarity, launch ownership, and recent critical actions in the guided self-serve and preflight UI
- expanded invite role handling so customer owner can be assigned explicitly in client access flows
- added schema and migration support for campaign action audit events

## Why it changed
Wrong users could still reach launch-critical actions through broad membership checks. This hardens the customer execution flow so ownership, permission boundaries, and auditability are explicit before critical survey and launch steps are taken.

## User and delivery impact
- viewers and members remain read-first for dashboard and report use
- customer owners carry the bounded execution path for launch-critical steps
- blocked actions now return clear, customer-safe permission feedback
- launch-critical actions are now visible in an audit trail on the campaign page

## Validation
- `npm test -- customer-permissions.test.ts campaign-audit.test.ts "app/(dashboard)/campaigns/[id]/page.test.ts" "app/(dashboard)/campaigns/[id]/actions.test.ts" guided-self-serve.test.ts ops-delivery.test.ts client-onboarding.test.ts types.test.ts`
- `npm run build`

## Still open
- `grant_client_access` exists as an audit action key but is not yet emitted from the org invite route, because the current audit table is campaign-scoped and the invite flow is org-scoped
- backend compatibility for `member` remains in place intentionally, while the UI now narrows assignment to `viewer` and `owner` for safer customer execution