### PR TITLE
[codex] Harden participant data import safety

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -47,6 +47,8 @@ from fastapi import BackgroundTasks, Depends, FastAPI, File, Form, Header, HTTPE
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, JSONResponse, Response
 from fastapi.templating import Jinja2Templates
+from pydantic import TypeAdapter
+from pydantic.networks import EmailStr
 from sqlalchemy import text
 from sqlalchemy.exc import OperationalError, SQLAlchemyError
 from sqlalchemy.orm import Session, selectinload
@@ -231,10 +233,8 @@ RESPONDENT_IMPORT_COLUMN_ALIASES = {
     "email": "email",
     "e-mail": "email",
     "e-mailadres": "email",
-    "mailadres": "email",
     "department": "department",
     "afdeling": "department",
-    "team": "department",
     "role_level": "role_level",
     "role level": "role_level",
     "functieniveau": "role_level",
@@ -286,6 +286,20 @@ QUALIFICATION_CONFIRMABLE_ROUTE_INTERESTS = {
     "onboarding",
     "leadership",
 }
+MINIMUM_IMPORT_PARTICIPANTS = 5
+IMPORT_CORE_PLACEHOLDERS = {
+    "-",
+    "--",
+    "n.v.t.",
+    "nvt",
+    "na",
+    "n/a",
+    "geen",
+    "onbekend",
+    "unknown",
+    "null",
+}
+EMAIL_TYPE_ADAPTER = TypeAdapter(EmailStr)
 
 
 def _get_client_ip(request: Request) -> str:
@@ -340,6 +354,55 @@ def _normalize_import_header(value: Any) -> str | None:
         return None
     raw = raw.replace("-", "_")
     return RESPONDENT_IMPORT_COLUMN_ALIASES.get(raw, RESPONDENT_IMPORT_COLUMN_ALIASES.get(raw.replace("_", " ")))
+
+
+def _is_placeholder_import_value(value: Any) -> bool:
+    if value is None:
+        return True
+    normalized = str(value).strip().lower()
+    return not normalized or normalized in IMPORT_CORE_PLACEHOLDERS
+
+
+def _normalize_import_headers(raw_rows: list[tuple[int, dict[str, Any]]]) -> tuple[list[str], list[str], list[RespondentImportIssue]]:
+    if not raw_rows:
+        return [], [], []
+
+    raw_headers = [str(key).strip() for key in raw_rows[0][1].keys()]
+    recognized_columns: list[str] = []
+    ignored_columns: list[str] = []
+    seen_columns: set[str] = set()
+
+    for raw_header in raw_headers:
+        canonical = _normalize_import_header(raw_header)
+        if canonical:
+            if canonical not in seen_columns:
+                recognized_columns.append(canonical)
+                seen_columns.add(canonical)
+        elif raw_header:
+            ignored_columns.append(raw_header)
+
+    issues: list[RespondentImportIssue] = []
+    if "email" not in seen_columns:
+        detail = "Gebruik minimaal de kolom email."
+        if ignored_columns:
+            detail = f"{detail} Niet bruikbaar: {', '.join(ignored_columns)}."
+        issues.append(
+            RespondentImportIssue(
+                row_number=1,
+                field="columns",
+                message=detail,
+            )
+        )
+
+    return recognized_columns, ignored_columns, issues
+
+
+def _validate_email_address(value: str) -> bool:
+    try:
+        EMAIL_TYPE_ADAPTER.validate_python(value)
+    except Exception:
+        return False
+    return True
 
 
 def _normalize_role_level(value: Any) -> str | None:
@@ -409,12 +472,33 @@ def _build_import_preview(
     *,
     raw_rows: list[tuple[int, dict[str, Any]]],
     existing_emails: set[str],
-) -> tuple[list[RespondentCreate], list[RespondentImportIssue], list[RespondentImportPreviewRow], int]:
+) -> tuple[
+    list[RespondentCreate],
+    list[RespondentImportIssue],
+    list[RespondentImportPreviewRow],
+    int,
+    list[str],
+    list[str],
+    list[str],
+]:
     issues: list[RespondentImportIssue] = []
     preview_rows: list[RespondentImportPreviewRow] = []
     normalized_rows: list[RespondentCreate] = []
     seen_emails: set[str] = set()
     duplicate_existing = 0
+    recognized_columns, ignored_columns, header_issues = _normalize_import_headers(raw_rows)
+    issues.extend(header_issues)
+    provided_columns = set(recognized_columns)
+
+    if header_issues:
+        blocking_messages = [
+            "Gebruik het deelnemersbestand met minimaal de kolom email en controleer daarna opnieuw.",
+        ]
+        if len(raw_rows) < MINIMUM_IMPORT_PARTICIPANTS:
+            blocking_messages.append(
+                f"Minimaal {MINIMUM_IMPORT_PARTICIPANTS} deelnemers zijn nodig om deze route veilig te starten."
+            )
+        return normalized_rows, issues, preview_rows, duplicate_existing, recognized_columns, ignored_columns, blocking_messages
 
     for row_number, row in raw_rows:
         normalized = {
@@ -431,31 +515,55 @@ def _build_import_preview(
         if not email:
             issues.append(RespondentImportIssue(row_number=row_number, field="email", message="E-mailadres ontbreekt."))
             continue
+        if not _validate_email_address(email):
+            issues.append(
+                RespondentImportIssue(
+                    row_number=row_number,
+                    field="email",
+                    message="E-mailadres is ongeldig.",
+                )
+            )
+            continue
 
         department_raw = normalized["department"]
         department = str(department_raw).strip() if department_raw not in (None, "") else None
+        row_issues: list[RespondentImportIssue] = []
+        if "department" in provided_columns and _is_placeholder_import_value(department_raw):
+            row_issues.append(
+                RespondentImportIssue(
+                    row_number=row_number,
+                    field="department",
+                    message="Afdeling ontbreekt of is niet bruikbaar. Vul een herkenbare afdelingsnaam in of laat de kolom weg.",
+                )
+            )
 
         role_level = _normalize_role_level(normalized["role_level"])
-        if normalized["role_level"] not in (None, "") and not role_level:
-            issues.append(
+        if "role_level" in provided_columns and _is_placeholder_import_value(normalized["role_level"]):
+            row_issues.append(
+                RespondentImportIssue(
+                    row_number=row_number,
+                    field="role_level",
+                    message="Functieniveau ontbreekt. Gebruik uitvoerend, specialist, senior, manager, director of c_level.",
+                )
+            )
+        elif normalized["role_level"] not in (None, "") and not role_level:
+            row_issues.append(
                 RespondentImportIssue(
                     row_number=row_number,
                     field="role_level",
                     message="Functieniveau niet herkend. Gebruik uitvoerend, specialist, senior, manager, director of c_level.",
                 )
             )
-            continue
 
         exit_month = _normalize_exit_month(normalized["exit_month"])
         if normalized["exit_month"] not in (None, "") and not exit_month:
-            issues.append(
+            row_issues.append(
                 RespondentImportIssue(
                     row_number=row_number,
                     field="exit_month",
                     message="Gebruik voor exitmaand het formaat JJJJ-MM, bijvoorbeeld 2026-03.",
                 )
             )
-            continue
 
         salary_value = normalized["annual_salary_eur"]
         annual_salary_eur: float | None = None
@@ -463,14 +571,17 @@ def _build_import_preview(
             try:
                 annual_salary_eur = float(str(salary_value).replace(",", "."))
             except ValueError:
-                issues.append(
+                row_issues.append(
                     RespondentImportIssue(
                         row_number=row_number,
                         field="annual_salary_eur",
                         message="Jaarsalaris moet numeriek zijn.",
                     )
                 )
-                continue
+
+        if row_issues:
+            issues.extend(row_issues)
+            continue
 
         if email in seen_emails:
             issues.append(
@@ -525,7 +636,24 @@ def _build_import_preview(
                 )
             )
 
-    return normalized_rows, issues, preview_rows, duplicate_existing
+    blocking_messages: list[str] = []
+    if len(normalized_rows) < MINIMUM_IMPORT_PARTICIPANTS:
+        blocking_messages.append(
+            f"Minimaal {MINIMUM_IMPORT_PARTICIPANTS} deelnemers zijn nodig om deze route veilig te starten."
+        )
+
+    if issues:
+        blocking_messages.append("Herstel eerst de gemelde rijen voordat je verdergaat met deze dataset.")
+
+    return (
+        normalized_rows,
+        issues,
+        preview_rows,
+        duplicate_existing,
+        recognized_columns,
+        ignored_columns,
+        blocking_messages,
+    )
 
 
 def _render_survey_status(
@@ -1381,10 +1509,11 @@ async def import_respondents(
         .all()
         if email
     }
-    normalized_rows, issues, preview_rows, duplicate_existing = _build_import_preview(
+    normalized_rows, issues, preview_rows, duplicate_existing, recognized_columns, ignored_columns, blocking_messages = _build_import_preview(
         raw_rows=raw_rows,
         existing_emails=existing_emails,
     )
+    launch_blocked = len(issues) > 0 or len(blocking_messages) > 0
 
     response = RespondentImportResponse(
         dry_run=dry_run,
@@ -1392,13 +1521,23 @@ async def import_respondents(
         valid_rows=len(normalized_rows),
         invalid_rows=len(issues),
         duplicate_existing=duplicate_existing,
+        recognized_columns=recognized_columns,
+        ignored_columns=ignored_columns,
+        blocking_messages=blocking_messages,
         preview_rows=preview_rows,
         errors=issues,
         imported=0,
         emails_sent=0,
+        launch_blocked=launch_blocked,
+        readiness_label="Import vrijgegeven" if not launch_blocked else "Importcontrole vereist",
+        recovery_hint=(
+            "De dataset is klaar voor import en launch."
+            if not launch_blocked
+            else "Werk het deelnemersbestand bij en controleer daarna opnieuw."
+        ),
     )
 
-    if dry_run or issues:
+    if dry_run or launch_blocked:
         return response
 
     respondents, emails_sent = _create_campaign_respondents(

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -147,10 +147,16 @@ class RespondentImportResponse(BaseModel):
     valid_rows: int
     invalid_rows: int
     duplicate_existing: int = 0
+    recognized_columns: list[str] = Field(default_factory=list)
+    ignored_columns: list[str] = Field(default_factory=list)
+    blocking_messages: list[str] = Field(default_factory=list)
     preview_rows: list[RespondentImportPreviewRow] = Field(default_factory=list)
     errors: list[RespondentImportIssue] = Field(default_factory=list)
     imported: int = 0
     emails_sent: int = 0
+    launch_blocked: bool = True
+    readiness_label: str = "Importcontrole vereist"
+    recovery_hint: str = "Werk het deelnemersbestand bij en controleer daarna opnieuw."
 
 
 class InviteSendResult(BaseModel):

--- a/demo_environment.py
+++ b/demo_environment.py
@@ -498,6 +498,30 @@ def _purge_named_campaigns(db: Session, org: Organization, names: list[str]) -> 
         _purge_campaign(db, campaign)
 
 
+def _mark_import_qa_ready(db: Session, *, campaign: Campaign) -> None:
+    respondent_count = len(campaign.respondents)
+    summary = (
+        "Het deelnemersbestand is gecontroleerd en 1 deelnemer staat vrijgegeven voor launch."
+        if respondent_count == 1
+        else f"Het deelnemersbestand is gecontroleerd en {respondent_count} deelnemers staan vrijgegeven voor launch."
+    )
+    db.execute(
+        text(
+            """
+            update public.campaign_delivery_checkpoints checkpoint
+            set auto_state = 'ready',
+                last_auto_summary = :summary
+            from public.campaign_delivery_records record
+            where record.id = checkpoint.delivery_record_id
+              and record.campaign_id = :campaign_id
+              and checkpoint.checkpoint_key = 'import_qa'
+            """
+        ),
+        {"campaign_id": campaign.id, "summary": summary},
+    )
+    db.flush()
+
+
 def _pick_exit_profile() -> dict[str, float | str]:
     profile = _pick_profile(EXIT_PROFILES)
     return {
@@ -982,10 +1006,21 @@ def seed_guided_self_serve_acceptance(
             exit_month="2026-03",
         )
 
+    _mark_import_qa_ready(db, campaign=threshold_campaign)
+
     db.commit()
     return {
         "org_slug": resolved_org_slug,
         "campaign_count": 2,
+        "setup_campaign_id": str(
+            db.query(Campaign.id)
+            .filter(
+                Campaign.organization_id == org.id,
+                Campaign.name == GUIDED_SELF_SERVE_SETUP_CAMPAIGN_NAME,
+            )
+            .scalar()
+        ),
+        "threshold_campaign_id": str(threshold_campaign.id),
         "detail_threshold": RESPONSE_THRESHOLDS["detail"],
         "pattern_threshold": RESPONSE_THRESHOLDS["pattern"],
         "viewer_user_id": viewer_user_id,

--- a/frontend/app/(dashboard)/campaigns/[id]/page.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.test.ts
@@ -36,6 +36,8 @@ describe('campaign page render truth', () => {
     expect(source).toContain('Dashboard wordt zichtbaar vanaf de eerste veilige responsdrempel')
     expect(source).toContain('showManagementOutput &&')
     expect(source).toContain('Guided self-serve')
+    expect(source).toContain("createAdminClient()")
+    expect(source).toContain(".eq('checkpoint_key', 'import_qa')")
     expect(guidedPanelSource).toContain('Start uitnodigingen')
   })
 })

--- a/frontend/app/(dashboard)/campaigns/[id]/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.tsx
@@ -1,5 +1,6 @@
 ﻿import Link from 'next/link'
 import { notFound } from 'next/navigation'
+import { createAdminClient } from '@/lib/supabase/admin'
 import { createClient } from '@/lib/supabase/server'
 import { CampaignActions } from './campaign-actions'
 import { PdfDownloadButton } from './pdf-download-button'
@@ -131,6 +132,24 @@ export default async function CampaignPage({ params }: Props) {
   const isVerisightAdmin = profile?.is_verisight_admin === true
   const canExecuteCampaign = isVerisightAdmin || Boolean(membership?.role)
   const hasSegmentDeepDive = hasCampaignAddOn(campaignMeta, 'segment_deep_dive')
+  const deliveryAdminClient = canExecuteCampaign ? createAdminClient() : null
+  const { data: deliveryVisibilityRecord } = deliveryAdminClient
+    ? await deliveryAdminClient
+        .from('campaign_delivery_records')
+        .select('id')
+        .eq('campaign_id', id)
+        .maybeSingle()
+    : { data: null }
+  const { data: importQaCheckpointRaw } =
+    deliveryAdminClient && deliveryVisibilityRecord?.id
+      ? await deliveryAdminClient
+          .from('campaign_delivery_checkpoints')
+          .select('auto_state')
+          .eq('delivery_record_id', deliveryVisibilityRecord.id)
+          .eq('checkpoint_key', 'import_qa')
+          .maybeSingle()
+      : { data: null }
+  const importReady = importQaCheckpointRaw?.auto_state === 'ready'
   const { data: deliveryRecordRaw } = await supabase
     .from('campaign_delivery_records')
     .select('*')
@@ -272,6 +291,7 @@ export default async function CampaignPage({ params }: Props) {
     hasEnoughData,
     activeClientAccessCount: activeClientAccessCount ?? 0,
     pendingClientInviteCount: pendingClientInviteCount ?? 0,
+    importReady,
   })
   const guidedSelfServeState = buildGuidedSelfServeState({
     isActive: stats.is_active,
@@ -280,6 +300,7 @@ export default async function CampaignPage({ params }: Props) {
     invitesNotSent,
     hasMinDisplay,
     hasEnoughData,
+    importReady,
   })
   const showClientExecutionFlow = !isVerisightAdmin
   const showManagementOutput = isVerisightAdmin || guidedSelfServeState.dashboardVisible
@@ -1117,6 +1138,7 @@ export default async function CampaignPage({ params }: Props) {
             scanType={stats.scan_type}
             isActive={stats.is_active}
             deliveryMode={campaignMeta?.delivery_mode ?? null}
+            importReady={importReady}
             hasSegmentDeepDive={hasSegmentDeepDive}
             totalInvited={stats.total_invited}
             totalCompleted={stats.total_completed}
@@ -1642,6 +1664,7 @@ export default async function CampaignPage({ params }: Props) {
                       totalInvited={stats.total_invited}
                       totalCompleted={stats.total_completed}
                       invitesNotSent={invitesNotSent}
+                      importReady={importReady}
                       incompleteScores={incompleteScores}
                       hasMinDisplay={hasMinDisplay}
                       hasEnoughData={hasEnoughData}

--- a/frontend/app/api/campaigns/[id]/respondents/import/route.ts
+++ b/frontend/app/api/campaigns/[id]/respondents/import/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import { createAdminClient } from '@/lib/supabase/admin'
 import { createClient } from '@/lib/supabase/server'
 import { getOrganizationApiKey } from '@/lib/organization-secrets'
 import { getBackendApiUrl } from '@/lib/server-env'
@@ -7,13 +8,64 @@ interface Context {
   params: Promise<{ id: string }>
 }
 
+interface ImportIssuePayload {
+  message?: string
+}
+
+interface ImportResponsePayload {
+  dry_run?: boolean
+  valid_rows?: number
+  imported?: number
+  errors?: ImportIssuePayload[]
+  blocking_messages?: string[]
+  launch_blocked?: boolean
+}
+
 export const runtime = 'nodejs'
+
+async function syncImportQaCheckpoint(campaignId: string, launchBlocked: boolean, summary: string) {
+  try {
+    const supabase = createAdminClient()
+    const { data: deliveryRecord } = await supabase
+      .from('campaign_delivery_records')
+      .select('id')
+      .eq('campaign_id', campaignId)
+      .maybeSingle()
+
+    if (!deliveryRecord?.id) return
+
+    await supabase
+      .from('campaign_delivery_checkpoints')
+      .update({
+        auto_state: launchBlocked ? 'not_ready' : 'ready',
+        last_auto_summary: summary,
+      })
+      .eq('delivery_record_id', deliveryRecord.id)
+      .eq('checkpoint_key', 'import_qa')
+  } catch {
+    // Launch-gating is enforced separately; checkpoint sync is best-effort.
+  }
+}
 
 export async function POST(request: Request, { params }: Context) {
   const { id } = await params
+  const contentType = request.headers.get('content-type') ?? ''
+  if (!contentType.toLowerCase().includes('multipart/form-data')) {
+    return NextResponse.json({ detail: 'Upload een .csv of .xlsx bestand.' }, { status: 400 })
+  }
+
+  let incoming: FormData
+  try {
+    incoming = await request.formData()
+  } catch {
+    return NextResponse.json({ detail: 'Upload een geldig .csv of .xlsx bestand.' }, { status: 400 })
+  }
+
   const supabase = await createClient()
 
-  const { data: { user } } = await supabase.auth.getUser()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
   if (!user) {
     return NextResponse.json({ detail: 'Niet ingelogd.' }, { status: 401 })
   }
@@ -28,15 +80,8 @@ export async function POST(request: Request, { params }: Context) {
     return NextResponse.json({ detail: 'Campaign niet gevonden of niet toegankelijk.' }, { status: 404 })
   }
 
-  const [
-    { data: profile },
-    { data: membership },
-  ] = await Promise.all([
-    supabase
-      .from('profiles')
-      .select('is_verisight_admin')
-      .eq('id', user.id)
-      .maybeSingle(),
+  const [{ data: profile }, { data: membership }] = await Promise.all([
+    supabase.from('profiles').select('is_verisight_admin').eq('id', user.id).maybeSingle(),
     supabase
       .from('org_members')
       .select('role')
@@ -60,7 +105,6 @@ export async function POST(request: Request, { params }: Context) {
     return NextResponse.json({ detail: 'Autorisatie voor import ontbreekt.' }, { status: 403 })
   }
 
-  const incoming = await request.formData()
   const file = incoming.get('file')
   if (!(file instanceof File)) {
     return NextResponse.json({ detail: 'Upload een .csv of .xlsx bestand.' }, { status: 400 })
@@ -80,9 +124,23 @@ export async function POST(request: Request, { params }: Context) {
     cache: 'no-store',
   })
 
-  const contentType = backendResponse.headers.get('content-type') ?? ''
-  if (contentType.includes('application/json')) {
-    const payload = await backendResponse.json()
+  const backendContentType = backendResponse.headers.get('content-type') ?? ''
+  if (backendContentType.includes('application/json')) {
+    const payload = (await backendResponse.json()) as ImportResponsePayload
+    const summary =
+      payload.blocking_messages?.[0] ??
+      payload.errors?.[0]?.message ??
+      (payload.imported && payload.imported > 0
+        ? `${payload.imported} deelnemer(s) gecontroleerd en vrijgegeven voor launch.`
+        : null)
+
+    if (
+      summary &&
+      (payload.launch_blocked === true || (payload.dry_run === false && (payload.imported ?? 0) > 0))
+    ) {
+      await syncImportQaCheckpoint(id, payload.launch_blocked === true, summary)
+    }
+
     return NextResponse.json(payload, { status: backendResponse.status })
   }
 

--- a/frontend/app/api/campaigns/[id]/respondents/send-invites/route.ts
+++ b/frontend/app/api/campaigns/[id]/respondents/send-invites/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import { createAdminClient } from '@/lib/supabase/admin'
 import { createClient } from '@/lib/supabase/server'
 import { getOrganizationApiKey } from '@/lib/organization-secrets'
 import { getBackendApiUrl } from '@/lib/server-env'
@@ -11,7 +12,9 @@ export async function POST(request: Request, { params }: Context) {
   const { id } = await params
   const supabase = await createClient()
 
-  const { data: { user } } = await supabase.auth.getUser()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
   if (!user) {
     return NextResponse.json({ detail: 'Niet ingelogd.' }, { status: 401 })
   }
@@ -26,15 +29,8 @@ export async function POST(request: Request, { params }: Context) {
     return NextResponse.json({ detail: 'Campaign niet gevonden of niet toegankelijk.' }, { status: 404 })
   }
 
-  const [
-    { data: profile },
-    { data: membership },
-  ] = await Promise.all([
-    supabase
-      .from('profiles')
-      .select('is_verisight_admin')
-      .eq('id', user.id)
-      .maybeSingle(),
+  const [{ data: profile }, { data: membership }] = await Promise.all([
+    supabase.from('profiles').select('is_verisight_admin').eq('id', user.id).maybeSingle(),
     supabase
       .from('org_members')
       .select('role')
@@ -48,6 +44,40 @@ export async function POST(request: Request, { params }: Context) {
     return NextResponse.json(
       { detail: 'Je hebt geen rechten om uitnodigingen voor deze campaign te versturen.' },
       { status: 403 },
+    )
+  }
+
+  try {
+    const admin = createAdminClient()
+    const { data: deliveryRecord } = await admin
+      .from('campaign_delivery_records')
+      .select('id')
+      .eq('campaign_id', id)
+      .maybeSingle()
+
+    const { data: checkpoint } = deliveryRecord?.id
+      ? await admin
+          .from('campaign_delivery_checkpoints')
+          .select('auto_state, last_auto_summary')
+          .eq('delivery_record_id', deliveryRecord.id)
+          .eq('checkpoint_key', 'import_qa')
+          .maybeSingle()
+      : { data: null }
+
+    if (!checkpoint || checkpoint.auto_state !== 'ready') {
+      return NextResponse.json(
+        {
+          detail:
+            checkpoint?.last_auto_summary ??
+            'Het deelnemersbestand is nog niet vrijgegeven voor launch. Controleer eerst de import.',
+        },
+        { status: 400 },
+      )
+    }
+  } catch {
+    return NextResponse.json(
+      { detail: 'Importcontrole voor launch kon niet worden bevestigd.' },
+      { status: 400 },
     )
   }
 

--- a/frontend/components/dashboard/add-respondents-form.shared.ts
+++ b/frontend/components/dashboard/add-respondents-form.shared.ts
@@ -33,10 +33,16 @@ export interface ImportResponse {
   valid_rows: number
   invalid_rows: number
   duplicate_existing: number
+  recognized_columns: string[]
+  ignored_columns: string[]
+  blocking_messages: string[]
   preview_rows: ImportPreviewRow[]
   errors: ImportIssue[]
   imported: number
   emails_sent: number
+  launch_blocked: boolean
+  readiness_label: string
+  recovery_hint: string
 }
 
 export function parseEmails(raw: string): string[] {

--- a/frontend/components/dashboard/add-respondents-form.tsx
+++ b/frontend/components/dashboard/add-respondents-form.tsx
@@ -55,10 +55,16 @@ interface ImportResponse {
   valid_rows: number
   invalid_rows: number
   duplicate_existing: number
+  recognized_columns: string[]
+  ignored_columns: string[]
+  blocking_messages: string[]
   preview_rows: ImportPreviewRow[]
   errors: ImportIssue[]
   imported: number
   emails_sent: number
+  launch_blocked: boolean
+  readiness_label: string
+  recovery_hint: string
 }
 
 export function AddRespondentsForm({ campaigns, organizations }: Props) {
@@ -237,7 +243,11 @@ export function AddRespondentsForm({ campaigns, organizations }: Props) {
   }
 
   const hasPreviewErrors = (previewResult?.errors.length ?? 0) > 0
-  const canImportPreview = !!previewResult && !hasPreviewErrors && previewResult.valid_rows > 0
+  const canImportPreview =
+    !!previewResult &&
+    !hasPreviewErrors &&
+    previewResult.valid_rows > 0 &&
+    previewResult.launch_blocked !== true
   const previewMissingDepartmentCount = previewResult?.preview_rows.filter(row => !row.department?.trim()).length ?? 0
   const previewMissingRoleLevelCount = previewResult?.preview_rows.filter(row => !row.role_level?.trim()).length ?? 0
 
@@ -464,6 +474,9 @@ export function AddRespondentsForm({ campaigns, organizations }: Props) {
               {isExitCampaign ? <>, <code className="font-mono">exit_month</code></> : null} en <code className="font-mono">annual_salary_eur</code> meesturen. Upload een <code className="font-mono">.csv</code>
               {' '}of <code className="font-mono">.xlsx</code> bestand.
             </p>
+            <p className="mt-2 text-xs text-gray-500 leading-relaxed">
+              Lever minimaal {CLIENT_FILE_SPEC.minimumParticipants} deelnemers aan en gebruik alleen herkenbare standaardkolommen.
+            </p>
             {selectedCampaign?.scan_type === 'retention' && (
               <p className="mt-2 text-xs leading-relaxed text-emerald-800">
                 Voor RetentieScan v1.1-validatie zijn <code className="font-mono">department</code> en <code className="font-mono">role_level</code> de aanbevolen standaard. Daarmee kunnen we later betrouwbaarheid, segmentverschillen en pragmatische follow-up veel netter toetsen.
@@ -476,13 +489,22 @@ export function AddRespondentsForm({ campaigns, organizations }: Props) {
                 Gebruik bij voorkeur exact deze kolommen: <code className="font-mono">email</code>, <code className="font-mono">department</code>, <code className="font-mono">role_level</code>, <code className="font-mono">exit_month</code>, <code className="font-mono">annual_salary_eur</code>.
               </p>
             )}
-            <a
-              href="/templates/verisight-respondenten-template.xlsx"
-              download
-              className="inline-flex mt-3 text-xs font-medium text-blue-600 hover:underline"
-            >
-              Download Excel-template
-            </a>
+            <div className="mt-3 flex flex-wrap gap-3 text-xs font-medium">
+              <a
+                href="/templates/verisight-respondenten-template.xlsx"
+                download
+                className="inline-flex text-blue-600 hover:underline"
+              >
+                Download Excel-template
+              </a>
+              <a
+                href="/templates/verisight-respondenten-template.csv"
+                download
+                className="inline-flex text-blue-600 hover:underline"
+              >
+                Download CSV-template
+              </a>
+            </div>
             {selectedCampaign?.scan_type === 'retention' && (
               <p className="mt-2 text-xs text-gray-500">
                 Voor follow-up uitkomsten gebruik je daarna het CSV-template <code className="font-mono">retentionscan_followup_outcomes_template.csv</code> uit de repo.
@@ -548,6 +570,33 @@ export function AddRespondentsForm({ campaigns, organizations }: Props) {
                 <ImportMetric label="Fouten" value={previewResult.invalid_rows} />
                 <ImportMetric label="Bestaat al" value={previewResult.duplicate_existing} />
               </div>
+
+              <div
+                className={`rounded-lg border px-4 py-3 text-sm ${
+                  previewResult.launch_blocked
+                    ? 'border-amber-200 bg-amber-50 text-amber-950'
+                    : 'border-emerald-200 bg-emerald-50 text-emerald-900'
+                }`}
+              >
+                <p className="font-semibold">{previewResult.readiness_label}</p>
+                <p className="mt-1 leading-6">{previewResult.recovery_hint}</p>
+                {previewResult.ignored_columns.length > 0 ? (
+                  <p className="mt-2 text-xs leading-5">
+                    Niet herkend: {previewResult.ignored_columns.join(', ')}.
+                  </p>
+                ) : null}
+              </div>
+
+              {previewResult.blocking_messages.length > 0 ? (
+                <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950">
+                  <p className="font-semibold">Je kunt nog niet verder</p>
+                  <ul className="mt-2 space-y-1 text-xs leading-5">
+                    {previewResult.blocking_messages.map((message) => (
+                      <li key={message}>{message}</li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
 
               {previewResult.preview_rows.length > 0 && (
                 <div>

--- a/frontend/components/dashboard/guided-self-serve-panel.tsx
+++ b/frontend/components/dashboard/guided-self-serve-panel.tsx
@@ -27,6 +27,7 @@ interface Props {
   scanType: ScanType
   isActive: boolean
   deliveryMode: DeliveryMode | null
+  importReady: boolean
   hasSegmentDeepDive: boolean
   totalInvited: number
   totalCompleted: number
@@ -58,10 +59,16 @@ interface ImportResponse {
   valid_rows: number
   invalid_rows: number
   duplicate_existing: number
+  recognized_columns: string[]
+  ignored_columns: string[]
+  blocking_messages: string[]
   preview_rows: ImportPreviewRow[]
   errors: ImportIssue[]
   imported: number
   emails_sent: number
+  launch_blocked: boolean
+  readiness_label: string
+  recovery_hint: string
 }
 
 function getStatusTone(status: 'done' | 'current' | 'blocked') {
@@ -75,6 +82,7 @@ export function GuidedSelfServePanel({
   scanType,
   isActive,
   deliveryMode,
+  importReady,
   hasSegmentDeepDive,
   totalInvited,
   totalCompleted,
@@ -95,8 +103,9 @@ export function GuidedSelfServePanel({
         invitesNotSent,
         hasMinDisplay,
         hasEnoughData,
+        importReady,
       }),
-    [hasEnoughData, hasMinDisplay, invitesNotSent, isActive, totalCompleted, totalInvited],
+    [hasEnoughData, hasMinDisplay, importReady, invitesNotSent, isActive, totalCompleted, totalInvited],
   )
   const [uploadFile, setUploadFile] = useState<File | null>(null)
   const [uploadSendInvites, setUploadSendInvites] = useState(true)
@@ -222,7 +231,11 @@ export function GuidedSelfServePanel({
   }
 
   const hasPreviewErrors = (previewResult?.errors.length ?? 0) > 0
-  const canImportPreview = Boolean(previewResult) && !hasPreviewErrors && (previewResult?.valid_rows ?? 0) > 0
+  const canImportPreview =
+    Boolean(previewResult) &&
+    !hasPreviewErrors &&
+    (previewResult?.valid_rows ?? 0) > 0 &&
+    previewResult?.launch_blocked !== true
   const previewMissingDepartmentCount =
     previewResult?.preview_rows.filter((row) => !row.department?.trim()).length ?? 0
   const previewMissingRoleLevelCount =
@@ -231,7 +244,7 @@ export function GuidedSelfServePanel({
     previewResult && hasPreviewErrors
       ? 'Import validatie vereist'
       : previewResult && canImportPreview
-        ? 'Klaar om uit te nodigen'
+        ? 'Import klaar voor launch'
         : null
 
   return (
@@ -321,6 +334,9 @@ export function GuidedSelfServePanel({
                 . {scanType === 'exit' ? `Exit-specifiek optioneel: ${CLIENT_FILE_SPEC.exitOptional.join(', ')}.` : ''}
               </p>
               <p className="mt-2 text-sm leading-6 text-slate-700">
+                Lever minimaal {CLIENT_FILE_SPEC.minimumParticipants} deelnemers aan voordat launch kan worden vrijgegeven.
+              </p>
+              <p className="mt-2 text-sm leading-6 text-slate-700">
                 Route: {SCAN_TYPE_LABELS[scanType]} {getDeliveryModeLabel(deliveryMode, scanType)}.{' '}
                 {getDeliveryModeDescription(deliveryMode, scanType)}
               </p>
@@ -332,13 +348,22 @@ export function GuidedSelfServePanel({
                 </p>
               ) : null}
             </div>
-            <a
-              href="/templates/verisight-respondenten-template.xlsx"
-              download
-              className="inline-flex rounded-full border border-[#d6e4e8] bg-[#f3f8f8] px-4 py-2 text-sm font-semibold text-[#234B57] transition-colors hover:border-[#bfd3d8] hover:bg-[#e9f2f3]"
-            >
-              Download template
-            </a>
+            <div className="flex flex-wrap gap-2">
+              <a
+                href="/templates/verisight-respondenten-template.xlsx"
+                download
+                className="inline-flex rounded-full border border-[#d6e4e8] bg-[#f3f8f8] px-4 py-2 text-sm font-semibold text-[#234B57] transition-colors hover:border-[#bfd3d8] hover:bg-[#e9f2f3]"
+              >
+                Download Excel-template
+              </a>
+              <a
+                href="/templates/verisight-respondenten-template.csv"
+                download
+                className="inline-flex rounded-full border border-[#d6e4e8] bg-[#f3f8f8] px-4 py-2 text-sm font-semibold text-[#234B57] transition-colors hover:border-[#bfd3d8] hover:bg-[#e9f2f3]"
+              >
+                Download CSV-template
+              </a>
+            </div>
           </div>
 
           <div className="mt-5 space-y-4">
@@ -392,7 +417,7 @@ export function GuidedSelfServePanel({
                       : `Importeer ${previewResult?.valid_rows ?? 0} deelnemers`}
                 </button>
               ) : null}
-              {invitesNotSent > 0 && unsentRespondents.length > 0 ? (
+              {importReady && invitesNotSent > 0 && unsentRespondents.length > 0 ? (
                 <button
                   type="button"
                   onClick={() => void startInvites()}
@@ -449,6 +474,33 @@ export function GuidedSelfServePanel({
                   <DashboardPanel eyebrow="Fouten" title={`${previewResult.invalid_rows}`} body="Rijen die eerst gecorrigeerd moeten worden" tone={previewResult.invalid_rows > 0 ? 'amber' : 'slate'} />
                   <DashboardPanel eyebrow="Bestaat al" title={`${previewResult.duplicate_existing}`} body="Dubbele adressen in deze campagne" tone={previewResult.duplicate_existing > 0 ? 'amber' : 'slate'} />
                 </div>
+
+                <div
+                  className={`mt-4 rounded-2xl border px-4 py-3 text-sm ${
+                    previewResult.launch_blocked
+                      ? 'border-amber-200 bg-amber-50 text-amber-950'
+                      : 'border-emerald-200 bg-emerald-50 text-emerald-900'
+                  }`}
+                >
+                  <p className="font-semibold">{previewResult.readiness_label}</p>
+                  <p className="mt-1 leading-6">{previewResult.recovery_hint}</p>
+                  {previewResult.ignored_columns.length > 0 ? (
+                    <p className="mt-2 text-xs leading-5">
+                      Niet herkend: {previewResult.ignored_columns.join(', ')}.
+                    </p>
+                  ) : null}
+                </div>
+
+                {previewResult.blocking_messages.length > 0 ? (
+                  <div className="mt-4 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950">
+                    <p className="font-semibold">Je kunt nog niet verder</p>
+                    <ul className="mt-2 space-y-1 text-xs leading-5">
+                      {previewResult.blocking_messages.map((message) => (
+                        <li key={message}>{message}</li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
 
                 {(previewMissingDepartmentCount > 0 || previewMissingRoleLevelCount > 0) ? (
                   <div className="mt-4 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">

--- a/frontend/components/dashboard/preflight-checklist.tsx
+++ b/frontend/components/dashboard/preflight-checklist.tsx
@@ -33,6 +33,7 @@ interface Props {
   totalInvited: number
   totalCompleted: number
   invitesNotSent: number
+  importReady: boolean
   incompleteScores: number
   hasMinDisplay: boolean
   hasEnoughData: boolean
@@ -87,6 +88,7 @@ export function PreflightChecklist({
   totalInvited,
   totalCompleted,
   invitesNotSent,
+  importReady,
   incompleteScores,
   hasMinDisplay,
   hasEnoughData,
@@ -115,12 +117,14 @@ export function PreflightChecklist({
         hasEnoughData,
         activeClientAccessCount,
         pendingClientInviteCount,
+        importReady,
       }),
     [
       activeClientAccessCount,
       hasEnoughData,
       hasMinDisplay,
       incompleteScores,
+      importReady,
       invitesNotSent,
       pendingClientInviteCount,
       record?.contact_request_id,

--- a/frontend/lib/client-onboarding.test.ts
+++ b/frontend/lib/client-onboarding.test.ts
@@ -49,6 +49,7 @@ describe('client onboarding defaults', () => {
     expect(CLIENT_FILE_SPEC.required).toEqual(['email'])
     expect(CLIENT_FILE_SPEC.recommended).toEqual(['department', 'role_level'])
     expect(CLIENT_FILE_SPEC.exitOptional).toContain('exit_month')
+    expect(CLIENT_FILE_SPEC.minimumParticipants).toBe(5)
   })
 
   it('keeps ExitScan first and follow-on variants explicit', () => {

--- a/frontend/lib/client-onboarding.ts
+++ b/frontend/lib/client-onboarding.ts
@@ -109,6 +109,7 @@ export const CLIENT_FILE_SPEC = {
   recommended: ['department', 'role_level'],
   exitOptional: ['exit_month', 'annual_salary_eur'],
   retentionOptional: ['annual_salary_eur'],
+  minimumParticipants: 5,
   segmentDeepDiveNote:
     'Bij segment deep dive zijn nette metadata extra belangrijk. Zonder afdeling en functieniveau verliest de verdieping snel waarde.',
 } as const

--- a/frontend/lib/guided-self-serve.test.ts
+++ b/frontend/lib/guided-self-serve.test.ts
@@ -28,6 +28,7 @@ describe('guided self-serve execution state', () => {
       invitesNotSent: 18,
       hasMinDisplay: false,
       hasEnoughData: false,
+      importReady: true,
     })
 
     expect(state.phase).toBe('ready_to_invite')
@@ -44,6 +45,7 @@ describe('guided self-serve execution state', () => {
       invitesNotSent: 0,
       hasMinDisplay: false,
       hasEnoughData: false,
+      importReady: true,
     })
 
     expect(state.phase).toBe('responses_incoming')
@@ -60,6 +62,7 @@ describe('guided self-serve execution state', () => {
       invitesNotSent: 0,
       hasMinDisplay: true,
       hasEnoughData: false,
+      importReady: true,
     })
 
     expect(state.phase).toBe('dashboard_active')
@@ -77,6 +80,7 @@ describe('guided self-serve execution state', () => {
       invitesNotSent: 0,
       hasMinDisplay: true,
       hasEnoughData: true,
+      importReady: true,
     })
 
     expect(state.phase).toBe('first_next_step_available')
@@ -94,10 +98,28 @@ describe('guided self-serve execution state', () => {
       invitesNotSent: 0,
       hasMinDisplay: true,
       hasEnoughData: true,
+      importReady: true,
     })
 
     expect(state.phase).toBe('closed')
     expect(state.nextAction.title.toLowerCase()).toContain('vervolggesprek')
     expect(state.statusBlocks.find((item) => item.key === 'dashboard_active')?.status).toBe('done')
+  })
+
+  it('keeps the customer on import recovery until the dataset is really cleared for launch', () => {
+    const state = buildGuidedSelfServeState({
+      isActive: true,
+      totalInvited: 8,
+      totalCompleted: 0,
+      invitesNotSent: 8,
+      hasMinDisplay: false,
+      hasEnoughData: false,
+      importReady: false,
+    })
+
+    expect(state.phase).toBe('data_required')
+    expect(state.dashboardVisible).toBe(false)
+    expect(state.nextAction.title.toLowerCase()).toContain('deelnemersbestand')
+    expect(state.detail.toLowerCase()).toContain('controle')
   })
 })

--- a/frontend/lib/guided-self-serve.ts
+++ b/frontend/lib/guided-self-serve.ts
@@ -44,6 +44,7 @@ interface GuidedSelfServeArgs {
   invitesNotSent: number
   hasMinDisplay: boolean
   hasEnoughData: boolean
+  importReady?: boolean
 }
 
 const STATUS_FLOW: GuidedStatusKey[] = [
@@ -104,6 +105,21 @@ export function buildGuidedSelfServeState(args: GuidedSelfServeArgs): GuidedSelf
       statusBlocks: buildStatusBlocks('setup_incomplete').map((item) =>
         item.key === 'data_required' ? { ...item, status: 'current' } : item,
       ),
+    }
+  }
+
+  if (args.importReady === false) {
+    return {
+      phase: 'data_required',
+      headline: 'Deelnemersbestand vraagt nog controle',
+      detail: 'Het deelnemersbestand is nog niet vrijgegeven voor launch. Controleer de preview, herstel de gemelde rijen of kolommen en ga pas daarna verder.',
+      nextAction: {
+        title: 'Controleer het deelnemersbestand',
+        body: 'Werk de gemelde rijen of kolommen bij en controleer daarna opnieuw totdat de import vrijgegeven is.',
+      },
+      dashboardVisible: false,
+      deeperInsightsVisible: false,
+      statusBlocks: buildStatusBlocks('data_required'),
     }
   }
 

--- a/frontend/lib/implementation-readiness.test.ts
+++ b/frontend/lib/implementation-readiness.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { buildCampaignReadinessState } from '@/lib/implementation-readiness'
+
+describe('campaign readiness import gate', () => {
+  it('blocks launch until the imported dataset is cleared for launch', () => {
+    const state = buildCampaignReadinessState({
+      totalInvited: 8,
+      totalCompleted: 0,
+      invitesNotSent: 8,
+      incompleteScores: 0,
+      hasMinDisplay: false,
+      hasEnoughData: false,
+      activeClientAccessCount: 0,
+      pendingClientInviteCount: 0,
+      importReady: false,
+    })
+
+    expect(state.launchReady).toBe(false)
+    expect(state.headline.toLowerCase()).toContain('import')
+    expect(state.detail.toLowerCase()).toContain('deelnemersbestand')
+    expect(state.nextStep.toLowerCase()).toContain('import')
+  })
+})

--- a/frontend/lib/implementation-readiness.ts
+++ b/frontend/lib/implementation-readiness.ts
@@ -59,6 +59,7 @@ export function buildCampaignReadinessState({
   hasEnoughData,
   activeClientAccessCount,
   pendingClientInviteCount,
+  importReady,
 }: {
   totalInvited: number
   totalCompleted: number
@@ -68,6 +69,7 @@ export function buildCampaignReadinessState({
   hasEnoughData: boolean
   activeClientAccessCount: number
   pendingClientInviteCount: number
+  importReady: boolean
 }): CampaignReadinessState {
   const setupComplete = totalInvited > 0
   const invitesLive = setupComplete && invitesNotSent === 0
@@ -75,7 +77,7 @@ export function buildCampaignReadinessState({
   const analysisReady = hasEnoughData && incompleteScores === 0
   const clientAccessActivated = activeClientAccessCount > 0
   const clientActivationPending = !clientAccessActivated && pendingClientInviteCount > 0
-  const launchReady = invitesLive && outputReady && (clientAccessActivated || clientActivationPending)
+  const launchReady = importReady && invitesLive && outputReady && (clientAccessActivated || clientActivationPending)
 
   if (!setupComplete) {
     return {
@@ -89,6 +91,21 @@ export function buildCampaignReadinessState({
       headline: 'Setup nog niet compleet',
       detail: 'Zonder respondenten is de implementation route nog niet gestart. Gebruik eerst een gecontroleerde import als hard startpunt.',
       nextStep: 'Importeer eerst een gevalideerd respondentbestand en bepaal daarna pas of invites direct uit mogen.',
+    }
+  }
+
+  if (!importReady) {
+    return {
+      setupComplete,
+      invitesLive,
+      outputReady,
+      analysisReady,
+      clientAccessActivated,
+      clientActivationPending,
+      launchReady,
+      headline: 'Import nog niet vrijgegeven',
+      detail: 'Het deelnemersbestand is nog niet vrijgegeven voor launch. Controleer eerst de importpreview, herstel de gemelde rijen of kolommen en bevestig daarna opnieuw.',
+      nextStep: 'Werk eerst het deelnemersbestand bij en rond de importcontrole af voordat je uitnodigingen of klantactivatie verder opent.',
     }
   }
 

--- a/frontend/lib/ops-delivery.test.ts
+++ b/frontend/lib/ops-delivery.test.ts
@@ -65,6 +65,7 @@ describe('delivery ops governance helpers', () => {
       hasEnoughData: false,
       activeClientAccessCount: 0,
       pendingClientInviteCount: 0,
+      importReady: false,
     })
 
     const checkpoints = [
@@ -98,6 +99,7 @@ describe('delivery ops governance helpers', () => {
       hasEnoughData: false,
       activeClientAccessCount: 0,
       pendingClientInviteCount: 0,
+      importReady: false,
     })
 
     const transition = validateDeliveryLifecycleTransition({
@@ -155,6 +157,7 @@ describe('delivery ops governance helpers', () => {
       hasEnoughData: true,
       activeClientAccessCount: 1,
       pendingClientInviteCount: 0,
+      importReady: true,
     })
 
     const checkpoints: CampaignDeliveryCheckpoint[] = [
@@ -201,6 +204,7 @@ describe('delivery ops governance helpers', () => {
       hasEnoughData: true,
       activeClientAccessCount: 1,
       pendingClientInviteCount: 0,
+      importReady: true,
     })
 
     const checkpoints: CampaignDeliveryCheckpoint[] = [
@@ -265,5 +269,38 @@ describe('delivery ops governance helpers', () => {
     expect(onboardingGuide.followUpOutcomes.map((item) => item.detail).join(' ')).toContain('geen journey-suite')
     expect(leadershipGuide.followUpOutcomes.map((item) => item.detail).join(' ')).toContain('named-leader')
     expect(leadershipGuide.weeklyReviewRules).toHaveLength(3)
+  })
+
+  it('keeps import qa hard-blocked until a validated dataset has been imported', () => {
+    const blockedSignals = buildDeliveryAutoSignals({
+      scanType: 'retention',
+      linkedLeadPresent: true,
+      totalInvited: 8,
+      totalCompleted: 0,
+      invitesNotSent: 8,
+      incompleteScores: 0,
+      hasMinDisplay: false,
+      hasEnoughData: false,
+      activeClientAccessCount: 0,
+      pendingClientInviteCount: 0,
+      importReady: false,
+    })
+    const readySignals = buildDeliveryAutoSignals({
+      scanType: 'retention',
+      linkedLeadPresent: true,
+      totalInvited: 8,
+      totalCompleted: 0,
+      invitesNotSent: 8,
+      incompleteScores: 0,
+      hasMinDisplay: false,
+      hasEnoughData: false,
+      activeClientAccessCount: 0,
+      pendingClientInviteCount: 0,
+      importReady: true,
+    })
+
+    expect(blockedSignals.import_qa.autoState).toBe('not_ready')
+    expect(blockedSignals.import_qa.summary.toLowerCase()).toContain('deelnemersbestand')
+    expect(readySignals.import_qa.autoState).toBe('ready')
   })
 })

--- a/frontend/lib/ops-delivery.ts
+++ b/frontend/lib/ops-delivery.ts
@@ -146,6 +146,7 @@ type DeliveryAutoSignalArgs = {
   hasEnoughData: boolean
   activeClientAccessCount: number
   pendingClientInviteCount: number
+  importReady: boolean
 }
 
 export const DELIVERY_LIFECYCLE_OPTIONS: Array<{ value: DeliveryLifecycleStage; label: string }> = [
@@ -457,6 +458,7 @@ export function buildDeliveryAutoSignals({
   hasEnoughData,
   activeClientAccessCount,
   pendingClientInviteCount,
+  importReady,
 }: DeliveryAutoSignalArgs): Record<DeliveryCheckpointKey, DeliveryAutoSignal> {
   return {
     implementation_intake: linkedLeadPresent
@@ -471,17 +473,20 @@ export function buildDeliveryAutoSignals({
             : 'Nog geen gekoppelde lead of intakeharde handoff zichtbaar.',
         },
     import_qa:
-      totalInvited > 0
+      importReady
         ? {
-            autoState: 'warning',
+            autoState: 'ready',
             summary:
               totalInvited === 1
-                ? '1 respondent staat in de campaign. Bevestig handmatig dat preview, metadata en importkeuze zijn gecontroleerd.'
-                : `${totalInvited} respondenten staan in de campaign. Bevestig handmatig dat preview, metadata en importkeuze zijn gecontroleerd.`,
+                ? 'Het deelnemersbestand is gecontroleerd en 1 deelnemer staat vrijgegeven voor launch.'
+                : `Het deelnemersbestand is gecontroleerd en ${totalInvited} deelnemers staan vrijgegeven voor launch.`,
           }
         : {
             autoState: 'not_ready',
-            summary: 'Nog geen respondenten geïmporteerd.',
+            summary:
+              totalInvited > 0
+                ? 'Het deelnemersbestand is nog niet vrijgegeven voor launch.'
+                : 'Nog geen gecontroleerd deelnemersbestand beschikbaar.',
           },
     invite_readiness:
       totalInvited === 0
@@ -626,6 +631,7 @@ export function buildDeliveryGovernanceSnapshot(args: {
     checkpoint: checkpointMap.import_qa,
     autoSignal: args.autoSignals.import_qa,
     pendingMessage: 'Import QA is nog niet expliciet bevestigd.',
+    requireReadyAutoState: true,
   })
   const inviteBlockers = collectCheckpointBlockers({
     checkpoint: checkpointMap.invite_readiness,

--- a/frontend/public/templates/verisight-respondenten-template.csv
+++ b/frontend/public/templates/verisight-respondenten-template.csv
@@ -2,3 +2,5 @@ email,department,role_level,exit_month,annual_salary_eur
 anne@bedrijf.nl,Operations,manager,2026-03,62000
 karim@bedrijf.nl,Customer Service,uitvoerend,2026-02,
 sanne@bedrijf.nl,Logistics,specialist,2026-01,42000
+fatima@bedrijf.nl,People,senior,2026-02,54000
+joris@bedrijf.nl,Finance,director,2026-03,88000

--- a/frontend/scripts/bootstrap-guided-self-serve-acceptance.mjs
+++ b/frontend/scripts/bootstrap-guided-self-serve-acceptance.mjs
@@ -103,44 +103,9 @@ async function upsertAcceptanceUser() {
   return data.user.id
 }
 
-async function fetchCampaignIds() {
-  const admin = createAdminSupabase()
-  const { data: org, error: orgError } = await admin
-    .from('organizations')
-    .select('id')
-    .eq('slug', acceptanceEnv.orgSlug)
-    .single()
-
-  if (orgError || !org) {
-    throw orgError ?? new Error('Acceptance org niet gevonden na seeden.')
-  }
-
-  const { data: campaigns, error: campaignError } = await admin
-    .from('campaigns')
-    .select('id,name')
-    .eq('organization_id', org.id)
-    .in('name', ['Guided Self-Serve - Setup Journey', 'Guided Self-Serve - Threshold Journey'])
-
-  if (campaignError || !campaigns) {
-    throw campaignError ?? new Error('Acceptance campaigns niet gevonden na seeden.')
-  }
-
-  const setupCampaign = campaigns.find((campaign) => campaign.name === 'Guided Self-Serve - Setup Journey')
-  const thresholdCampaign = campaigns.find((campaign) => campaign.name === 'Guided Self-Serve - Threshold Journey')
-
-  if (!setupCampaign || !thresholdCampaign) {
-    throw new Error('Niet alle acceptance campaigns zijn aanwezig na seeden.')
-  }
-
-  return {
-    setupCampaignId: setupCampaign.id,
-    thresholdCampaignId: thresholdCampaign.id,
-  }
-}
-
 async function main() {
   const userId = await upsertAcceptanceUser()
-  await runManageDemo([
+  const seededScenario = await runManageDemo([
     'run',
     'qa_guided_self_serve_acceptance',
     '--org-slug',
@@ -148,14 +113,17 @@ async function main() {
     '--viewer-user-id',
     userId,
   ])
-  const campaigns = await fetchCampaignIds()
+
+  if (!seededScenario.setup_campaign_id || !seededScenario.threshold_campaign_id) {
+    throw new Error('Acceptance bootstrap mist campaign-id output uit de seedstap.')
+  }
 
   process.stdout.write(
     JSON.stringify({
       email: acceptanceEnv.email,
       password: acceptanceEnv.password,
-      setupCampaignId: campaigns.setupCampaignId,
-      thresholdCampaignId: campaigns.thresholdCampaignId,
+      setupCampaignId: seededScenario.setup_campaign_id,
+      thresholdCampaignId: seededScenario.threshold_campaign_id,
       userId,
     }),
   )

--- a/frontend/tests/e2e/guided-self-serve-acceptance.spec.ts
+++ b/frontend/tests/e2e/guided-self-serve-acceptance.spec.ts
@@ -38,7 +38,7 @@ test.describe.serial('guided self-serve acceptance', () => {
 
     await page.goto(`/campaigns/${fixture.setup_campaign_id}`)
 
-    await expect(page.getByRole('heading', { name: /begeleide uitvoerflow/i })).toBeVisible()
+    await expect(page.getByText(/begeleide uitvoerflow/i).first()).toBeVisible()
     await expect(page.getByText(/deelnemersbestand ontbreekt nog/i).first()).toBeVisible()
     await expect(page.getByText(/dashboard nog niet actief/i).first()).toBeVisible()
     await expect(page.getByRole('button', { name: /pdf-rapport/i })).toHaveCount(0)
@@ -48,23 +48,24 @@ test.describe.serial('guided self-serve acceptance', () => {
 
     await expect(page.getByText(/import validatie vereist/i).first()).toBeVisible()
     await expect(page.getByText(/dit e-mailadres staat dubbel in het bestand/i)).toBeVisible()
-    await expect(page.getByText(/valid email address/i)).toBeVisible()
+    await expect(page.getByText(/e-mailadres is ongeldig/i)).toBeVisible()
 
     await page.locator('input[type="file"]').setInputFiles(validImportPath)
     await page.getByLabel(/verstuur direct uitnodigingen na een geslaagde import/i).uncheck()
     await page.getByRole('button', { name: /^bestand controleren$/i }).click()
 
     await expect(page.getByText(/preview van geldige rijen/i).first()).toBeVisible()
-    await expect(page.getByText(/klaar om uit te nodigen/i).first()).toBeVisible()
+    await expect(page.getByText(/import klaar voor launch/i).first()).toBeVisible()
 
-    await page.getByRole('button', { name: /importeer 2 deelnemers/i }).click()
+    await page.getByRole('button', { name: /importeer 5 deelnemers/i }).click()
 
-    await expect(page.getByText(/2 deelnemer\(s\) toegevoegd/i)).toBeVisible()
-    await expect(page.getByRole('button', { name: /start uitnodigingen \(2\)/i })).toBeVisible()
+    await expect(page.getByText(/5 deelnemer\(s\) toegevoegd/i)).toBeVisible()
+    await page.reload()
+    await expect(page.getByRole('button', { name: /start uitnodigingen \(5\)/i })).toBeVisible()
 
-    await page.getByRole('button', { name: /start uitnodigingen \(2\)/i }).click()
+    await page.getByRole('button', { name: /start uitnodigingen \(5\)/i }).click()
 
-    await expect(page.getByText(/2 uitnodiging\(en\) gestart/i)).toBeVisible()
+    await expect(page.getByText(/5 uitnodiging\(en\) gestart/i)).toBeVisible()
     await expect(page.getByText(/responses lopen binnen/i).first()).toBeVisible()
     await expect(page.getByRole('button', { name: /pdf-rapport/i })).toHaveCount(0)
     await expect(page.getByText(/dashboard nog niet actief/i).first()).toBeVisible()

--- a/frontend/tests/fixtures/guided-self-serve/valid-import.csv
+++ b/frontend/tests/fixtures/guided-self-serve/valid-import.csv
@@ -1,3 +1,6 @@
 email,department,role_level,exit_month,annual_salary_eur
 anne@example.com,Operations,specialist,2026-03,55000
 bart@example.com,People,manager,2026-04,64000
+carla@example.com,Finance,senior,2026-04,61000
+daan@example.com,IT,uitvoerend,2026-03,48000
+els@example.com,Sales,director,2026-02,82000

--- a/tests/test_api_flows.py
+++ b/tests/test_api_flows.py
@@ -643,6 +643,9 @@ def test_respondent_import_creates_rows_without_sending_invites(client, db_sessi
         "email,department,role_level,exit_month,annual_salary_eur\n"
         "a@example.com,Operations,specialist,2026-03,55000\n"
         "b@example.com,Sales,manager,2026-02,72000\n"
+        "c@example.com,People,director,2026-02,81000\n"
+        "d@example.com,Finance,senior,2026-01,61000\n"
+        "e@example.com,IT,uitvoerend,2026-01,43000\n"
     )
 
     response = client.post(
@@ -654,13 +657,15 @@ def test_respondent_import_creates_rows_without_sending_invites(client, db_sessi
 
     assert response.status_code == 200
     body = response.json()
-    assert body["imported"] == 2
+    assert body["imported"] == 5
     assert body["emails_sent"] == 0
     assert body["invalid_rows"] == 0
+    assert body["launch_blocked"] is False
+    assert body["readiness_label"] == "Import vrijgegeven"
 
     rows = db_session.query(Respondent).filter(Respondent.campaign_id == campaign.id).all()
-    assert len(rows) == 2
-    assert {row.exit_month for row in rows} == {"2026-03", "2026-02"}
+    assert len(rows) == 5
+    assert {row.exit_month for row in rows} == {"2026-03", "2026-02", "2026-01"}
 
 
 def test_respondent_import_dry_run_reports_duplicate_email_without_persisting(client, db_session: Session):
@@ -685,9 +690,67 @@ def test_respondent_import_dry_run_reports_duplicate_email_without_persisting(cl
     assert body["invalid_rows"] == 1
     assert body["errors"][0]["field"] == "email"
     assert "bestaat al" in body["errors"][0]["message"].lower()
+    assert body["launch_blocked"] is True
 
     rows = db_session.query(Respondent).filter(Respondent.campaign_id == campaign.id).all()
     assert len(rows) == 1
+
+
+def test_respondent_import_dry_run_blocks_missing_required_columns_and_small_dataset(client, db_session: Session):
+    org = _create_org(db_session, api_key="header-key")
+    campaign = _create_campaign(db_session, org, name="Header guard")
+    csv_content = (
+        "mailadres,team\n"
+        "anne@example.com,Operations\n"
+        "bas@example.com,Sales\n"
+    )
+
+    response = client.post(
+        f"/api/campaigns/{campaign.id}/respondents/import",
+        headers={"x-api-key": "header-key"},
+        data={"dry_run": "true", "send_invites": "false"},
+        files={"upload": ("respondents.csv", io.BytesIO(csv_content.encode("utf-8")), "text/csv")},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["imported"] == 0
+    assert body["launch_blocked"] is True
+    assert "email" in body["blocking_messages"][0].lower()
+    assert "minimaal 5" in " ".join(body["blocking_messages"]).lower()
+    assert body["ignored_columns"] == ["mailadres", "team"]
+    assert any(error["field"] == "columns" for error in body["errors"])
+
+
+def test_respondent_import_dry_run_reports_invalid_email_duplicates_and_empty_core_values(client, db_session: Session):
+    org = _create_org(db_session, api_key="quality-key")
+    campaign = _create_campaign(db_session, org, name="Quality guard")
+    csv_content = (
+        "email,department,role_level\n"
+        "anne@example.com,Operations,manager\n"
+        "anne@example.com,Operations,manager\n"
+        "geen-email,Sales,specialist\n"
+        "bas@example.com,,nvt\n"
+        "carla@example.com,Finance,senior\n"
+        "daan@example.com,People,director\n"
+        "els@example.com,IT,uitvoerend\n"
+    )
+
+    response = client.post(
+        f"/api/campaigns/{campaign.id}/respondents/import",
+        headers={"x-api-key": "quality-key"},
+        data={"dry_run": "true", "send_invites": "false"},
+        files={"upload": ("respondents.csv", io.BytesIO(csv_content.encode("utf-8")), "text/csv")},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["launch_blocked"] is True
+    assert body["valid_rows"] == 4
+    assert any("dubbel" in error["message"].lower() for error in body["errors"])
+    assert any(error["field"] == "email" and "ongeldig" in error["message"].lower() for error in body["errors"])
+    assert any(error["field"] == "department" and "afdeling" in error["message"].lower() for error in body["errors"])
+    assert any(error["field"] == "role_level" and "functieniveau" in error["message"].lower() for error in body["errors"])
 
 
 def test_implementation_smoke_flow_imports_sends_invites_and_generates_output(


### PR DESCRIPTION
## What changed
- hardened participant import validation around required fields, invalid emails, duplicates, small datasets, empty core values, and unusable columns
- added clearer import preview, recovery messaging, and readiness gating in the customer flow
- blocked invite launch until import is explicitly valid and released
- aligned guided self-serve acceptance fixtures and browser coverage with the gated import flow
- made the customer campaign page read the import gate safely without exposing internal delivery controls

## Why
This thread was scoped around making participant file delivery understandable, validatable, recoverable, and impossible to launch from when the dataset is still invalid.

## Impact
Customers now get a stricter, clearer participant import flow with recoverable errors and a hard launch gate. The shared canon and bounded product grammar remain intact.

## Validation
- `npm test -- --run lib/ops-delivery.test.ts lib/guided-self-serve.test.ts lib/implementation-readiness.test.ts lib/client-onboarding.test.ts`
- `npm test -- --run "app/(dashboard)/campaigns/[id]/page.test.ts"`
- `python -m pytest tests/test_api_flows.py -k "respondent_import" -v`
- `npm run test:e2e -- tests/e2e/guided-self-serve-acceptance.spec.ts`