### PR TITLE
Draft: add customer launch control flow

### DIFF
--- a/frontend/app/(dashboard)/campaigns/[id]/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.tsx
@@ -22,7 +22,7 @@ import { PreflightChecklist } from '@/components/dashboard/preflight-checklist'
 import { RespondentTable } from '@/components/dashboard/respondent-table'
 import { RiskCharts } from '@/components/dashboard/risk-charts'
 import { getContactRequestsForAdmin } from '@/lib/contact-requests'
-import { buildGuidedSelfServeState } from '@/lib/guided-self-serve'
+import { buildGuidedSelfServeState, deriveGuidedSelfServeDiscipline } from '@/lib/guided-self-serve'
 import {
   ActionPlaybookList,
   buildDecisionPanels,
@@ -145,6 +145,21 @@ export default async function CampaignPage({ params }: Props) {
         .order('created_at', { ascending: true })
     : { data: [] }
   const deliveryCheckpoints = (deliveryCheckpointsRaw ?? []) as CampaignDeliveryCheckpoint[]
+  const guidedSetupDiscipline = deriveGuidedSelfServeDiscipline(
+    deliveryCheckpoints
+      .filter(
+        (checkpoint): checkpoint is CampaignDeliveryCheckpoint & {
+          checkpoint_key: 'implementation_intake' | 'import_qa' | 'invite_readiness'
+        } =>
+          checkpoint.checkpoint_key === 'implementation_intake' ||
+          checkpoint.checkpoint_key === 'import_qa' ||
+          checkpoint.checkpoint_key === 'invite_readiness',
+      )
+      .map((checkpoint) => ({
+        checkpointKey: checkpoint.checkpoint_key,
+        manualState: checkpoint.manual_state,
+      })),
+  )
   const {
     rows: deliveryLeadOptions,
     configError: deliveryLeadConfigError,
@@ -280,6 +295,9 @@ export default async function CampaignPage({ params }: Props) {
     invitesNotSent,
     hasMinDisplay,
     hasEnoughData,
+    importQaConfirmed: guidedSetupDiscipline.importQaConfirmed,
+    launchTimingConfirmed: guidedSetupDiscipline.launchTimingConfirmed,
+    communicationReady: guidedSetupDiscipline.communicationReady,
   })
   const showClientExecutionFlow = !isVerisightAdmin
   const showManagementOutput = isVerisightAdmin || guidedSelfServeState.dashboardVisible
@@ -1123,10 +1141,12 @@ export default async function CampaignPage({ params }: Props) {
             invitesNotSent={invitesNotSent}
               hasMinDisplay={hasMinDisplay}
               hasEnoughData={hasEnoughData}
-              pendingCount={pendingCount}
+              importQaConfirmed={guidedSetupDiscipline.importQaConfirmed}
+              launchTimingConfirmed={guidedSetupDiscipline.launchTimingConfirmed}
+              communicationReady={guidedSetupDiscipline.communicationReady}
               remindableCount={remindableCount}
               unsentRespondents={unsentRespondents}
-            />
+          />
           </DashboardSection>
         ) : null}
 

--- a/frontend/app/(dashboard)/dashboard/page.test.ts
+++ b/frontend/app/(dashboard)/dashboard/page.test.ts
@@ -3,14 +3,28 @@ import { describe, expect, it } from 'vitest'
 
 describe('dashboard home guided execution shell', () => {
   it('keeps the customer landing focused on guided execution before dashboard activation', () => {
-    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+    const pageSource = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+    const launchControlSource = readFileSync(
+      new URL('../../../components/dashboard/customer-launch-control.tsx', import.meta.url),
+      'utf8',
+    )
+    const stateSource = readFileSync(new URL('../../../lib/guided-self-serve.ts', import.meta.url), 'utf8')
 
-    expect(source).toContain('Jouw uitvoerstatus')
-    expect(source).toContain('Open uitvoerflow')
-    expect(source).toContain('Open deze campaign voor deelnemersimport, inviteflow, responsmonitoring')
-    expect(source).toContain('Dashboard actief')
-    expect(source).toContain("if (campaign.total_completed < 5) return 'building'")
-    expect(source).toContain('primaryGuideInvitesNotSent')
-    expect(source).toContain('getPrimaryGuideCampaign')
+    expect(pageSource).toContain('Jouw uitvoerstatus')
+    expect(pageSource).toContain('CustomerLaunchControl')
+    expect(pageSource).toContain('Open uitvoerflow')
+    expect(pageSource).toContain('deriveGuidedSelfServeDiscipline')
+    expect(pageSource).toContain('primaryGuideInvitesNotSent')
+    expect(pageSource).toContain('getPrimaryGuideCampaign')
+    expect(pageSource).toContain("if (campaign.total_completed < 5) return 'building'")
+
+    expect(launchControlSource).toContain('Product')
+    expect(launchControlSource).toContain('Verisight doet nu')
+    expect(launchControlSource).toContain('Jij doet nu')
+    expect(launchControlSource).toContain('Open blokkades')
+    expect(launchControlSource).toContain('Uitvoerstatus')
+    expect(launchControlSource).toContain('Waar je staat')
+    expect(launchControlSource).toContain('Dashboard actief')
+    expect(stateSource).toContain('Eerste vervolgstap beschikbaar')
   })
 })

--- a/frontend/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 import { OnboardingBalloon } from '@/components/dashboard/onboarding-balloon'
+import { CustomerLaunchControl } from '@/components/dashboard/customer-launch-control'
 import {
   DashboardChip,
   DashboardPanel,
@@ -10,7 +11,7 @@ import {
 } from '@/components/dashboard/dashboard-primitives'
 import { ManagementReadGuide } from '@/components/dashboard/onboarding-panels'
 import { PdfDownloadButton } from '@/app/(dashboard)/campaigns/[id]/pdf-download-button'
-import { buildGuidedSelfServeState } from '@/lib/guided-self-serve'
+import { buildGuidedSelfServeState, deriveGuidedSelfServeDiscipline } from '@/lib/guided-self-serve'
 import { getScanDefinition } from '@/lib/scan-definitions'
 import type { CampaignStats } from '@/lib/types'
 
@@ -53,10 +54,32 @@ export default async function DashboardHomePage() {
         .select('sent_at, completed')
         .eq('campaign_id', primaryGuideCampaign.campaign_id)
     : { data: [] }
+  const { data: primaryGuideDeliveryRecord } = primaryGuideCampaign
+    ? await supabase
+        .from('campaign_delivery_records')
+        .select('id')
+        .eq('campaign_id', primaryGuideCampaign.campaign_id)
+        .maybeSingle()
+    : { data: null }
+  const { data: primaryGuideCheckpointsRaw } = primaryGuideDeliveryRecord
+    ? await supabase
+        .from('campaign_delivery_checkpoints')
+        .select('checkpoint_key, manual_state')
+        .eq('delivery_record_id', primaryGuideDeliveryRecord.id)
+    : { data: [] }
   const primaryGuideRespondents = (primaryGuideRespondentsRaw ?? []) as Array<{
     sent_at: string | null
     completed: boolean
   }>
+  const primaryGuideSetupDiscipline = deriveGuidedSelfServeDiscipline(
+    ((primaryGuideCheckpointsRaw ?? []) as Array<{
+      checkpoint_key: 'implementation_intake' | 'import_qa' | 'invite_readiness'
+      manual_state: 'pending' | 'confirmed' | 'not_applicable'
+    }>).map((checkpoint) => ({
+      checkpointKey: checkpoint.checkpoint_key,
+      manualState: checkpoint.manual_state,
+    })),
+  )
   const primaryGuideInvitesNotSent = primaryGuideRespondents.filter(
     (respondent) => !respondent.sent_at && !respondent.completed,
   ).length
@@ -91,11 +114,33 @@ export default async function DashboardHomePage() {
                 : 1,
         hasMinDisplay: primaryGuideCampaign.total_completed >= 5,
         hasEnoughData: primaryGuideCampaign.total_completed >= 10,
+        importQaConfirmed: primaryGuideSetupDiscipline.importQaConfirmed,
+        launchTimingConfirmed: primaryGuideSetupDiscipline.launchTimingConfirmed,
+        communicationReady: primaryGuideSetupDiscipline.communicationReady,
       })
     : null
+  const primaryGuideScanDefinition = primaryGuideCampaign ? getScanDefinition(primaryGuideCampaign.scan_type) : null
 
   return (
     <div className="space-y-6">
+      {!isAdmin && primaryGuideCampaign && primaryExecutionState && primaryGuideScanDefinition ? (
+        <DashboardSection
+          eyebrow="Jouw uitvoerstatus"
+          title="Jouw launchstatus"
+          description="Na login zie je direct welk product actief is, waar de campagne staat, wat nog ontbreekt en wat de eerstvolgende veilige stap is."
+          aside={<DashboardChip label={primaryExecutionState.currentStateLabel} tone="blue" />}
+        >
+          <CustomerLaunchControl
+            campaignName={primaryGuideCampaign.campaign_name}
+            campaignHref={`/campaigns/${primaryGuideCampaign.campaign_id}`}
+            campaignCtaLabel={primaryExecutionState.dashboardVisible ? 'Open campaign en dashboard' : 'Open uitvoerflow'}
+            productName={primaryGuideScanDefinition.productName}
+            productContext={primaryGuideScanDefinition.whatItIsText}
+            state={primaryExecutionState}
+          />
+        </DashboardSection>
+      ) : null}
+
       <DashboardSection
         eyebrow="Cockpit"
         title="Campaign cockpit"
@@ -153,57 +198,6 @@ export default async function DashboardHomePage() {
           />
         </div>
       </DashboardSection>
-
-      {!isAdmin ? (
-        primaryGuideCampaign && primaryExecutionState ? (
-          <DashboardSection
-            eyebrow="Jouw uitvoerstatus"
-            title={primaryExecutionState.headline}
-            description={primaryExecutionState.detail}
-            aside={<DashboardChip label={primaryExecutionState.dashboardVisible ? 'Dashboard actief' : 'Uitvoer loopt'} tone={primaryExecutionState.dashboardVisible ? 'emerald' : 'amber'} />}
-          >
-            <div className="grid gap-4 xl:grid-cols-[minmax(0,1.4fr),minmax(320px,0.6fr)]">
-              <div className="rounded-[22px] border border-[color:var(--border)] bg-white p-4 shadow-[0_10px_30px_rgba(19,32,51,0.05)]">
-                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
-                  Eerstvolgende stap
-                </p>
-                <p className="mt-2 text-lg font-semibold text-[color:var(--ink)]">
-                  {primaryExecutionState.nextAction.title}
-                </p>
-                <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">
-                  {primaryExecutionState.nextAction.body}
-                </p>
-                <div className="mt-4 flex flex-wrap gap-2">
-                  {primaryExecutionState.statusBlocks.map((item) => (
-                    <DashboardChip
-                      key={item.key}
-                      label={item.label}
-                      tone={item.status === 'done' ? 'emerald' : item.status === 'current' ? 'blue' : 'slate'}
-                    />
-                  ))}
-                </div>
-              </div>
-              <div className="rounded-[22px] border border-[color:var(--border)] bg-[color:var(--bg)] p-4">
-                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
-                  Jouw campagne nu
-                </p>
-                <p className="mt-2 text-base font-semibold text-[color:var(--ink)]">
-                  {primaryGuideCampaign.campaign_name}
-                </p>
-                <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">
-                  Open deze campaign voor deelnemersimport, inviteflow, responsmonitoring en pas daarna dashboardgebruik.
-                </p>
-                <Link
-                  href={`/campaigns/${primaryGuideCampaign.campaign_id}`}
-                  className="mt-4 inline-flex rounded-full border border-[#d6e4e8] bg-[#f3f8f8] px-4 py-2 text-sm font-semibold text-[#234B57] transition-colors hover:border-[#bfd3d8] hover:bg-[#e9f2f3]"
-                >
-                  {primaryExecutionState.dashboardVisible ? 'Open campaign en dashboard' : 'Open uitvoerflow'}
-                </Link>
-              </div>
-            </div>
-          </DashboardSection>
-        ) : null
-      ) : null}
 
       {!isAdmin ? (
         <DashboardSection

--- a/frontend/components/dashboard/customer-launch-control.tsx
+++ b/frontend/components/dashboard/customer-launch-control.tsx
@@ -1,0 +1,188 @@
+import Link from 'next/link'
+import {
+  DashboardChip,
+} from '@/components/dashboard/dashboard-primitives'
+import type {
+  GuidedBlocker,
+  GuidedSelfServeState,
+  GuidedStatusBlock,
+} from '@/lib/guided-self-serve'
+
+interface Props {
+  campaignName: string
+  campaignHref?: string
+  campaignCtaLabel?: string
+  productName: string
+  productContext: string
+  state: GuidedSelfServeState
+}
+
+function getStatusTone(status: GuidedStatusBlock['status']) {
+  if (status === 'done') return 'emerald' as const
+  if (status === 'current') return 'blue' as const
+  return 'slate' as const
+}
+
+function getBlockerTone(actor: GuidedBlocker['actor']) {
+  if (actor === 'customer') return 'amber' as const
+  if (actor === 'verisight') return 'blue' as const
+  return 'slate' as const
+}
+
+export function CustomerLaunchControl({
+  campaignName,
+  campaignHref,
+  campaignCtaLabel,
+  productName,
+  productContext,
+  state,
+}: Props) {
+  return (
+    <div className="grid gap-4 xl:grid-cols-[minmax(0,1.35fr),minmax(320px,0.65fr)]">
+      <div className="rounded-[26px] border border-[color:var(--border)] bg-white p-5 shadow-[0_10px_30px_rgba(19,32,51,0.05)]">
+        <div className="flex flex-col gap-3 border-b border-[color:var(--border)]/80 pb-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="max-w-3xl">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
+              Uitvoerstatus
+            </p>
+            <h2 className="mt-2 text-xl font-semibold text-[color:var(--ink)]">{state.headline}</h2>
+            <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">{state.detail}</p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <DashboardChip label={state.currentStateLabel} tone="blue" />
+            <DashboardChip
+              label={state.dashboardVisible ? 'Dashboard actief' : 'Dashboard nog niet actief'}
+              tone={state.dashboardVisible ? 'emerald' : 'amber'}
+            />
+          </div>
+        </div>
+
+        <div className="mt-4 grid gap-4 lg:grid-cols-2">
+          <div className="rounded-[22px] border border-[color:var(--border)] bg-[color:var(--bg)] p-4">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
+              Product
+            </p>
+            <p className="mt-2 text-base font-semibold text-[color:var(--ink)]">{productName}</p>
+            <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">{productContext}</p>
+            <p className="mt-3 text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
+              Campagne
+            </p>
+            <p className="mt-2 text-sm font-medium text-[color:var(--ink)]">{campaignName}</p>
+          </div>
+
+          <div className="rounded-[22px] border border-[color:var(--border)] bg-[color:var(--bg)] p-4">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
+              Waar je staat
+            </p>
+            <p className="mt-2 text-base font-semibold text-[color:var(--ink)]">{state.currentStateLabel}</p>
+            <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">{state.nextAction.body}</p>
+            <p className="mt-4 text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
+              Eerstvolgende stap
+            </p>
+            <p className="mt-2 text-sm font-medium text-[color:var(--ink)]">{state.nextAction.title}</p>
+          </div>
+        </div>
+
+        <div className="mt-4 rounded-[22px] border border-[color:var(--border)] bg-[color:var(--bg)] p-4">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
+                Launchstates
+              </p>
+              <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">
+                Een vaste stepper laat zien wat al rond is, wat nu actief is en wat nog geblokkeerd blijft.
+              </p>
+            </div>
+          </div>
+          <ol className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+            {state.statusBlocks.map((item, index) => (
+              <li
+                key={item.key}
+                className="rounded-2xl border border-white bg-white px-4 py-3"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <p className="text-sm font-semibold text-[color:var(--ink)]">
+                    {index + 1}. {item.label}
+                  </p>
+                  <DashboardChip label={item.status === 'done' ? 'Rond' : item.status === 'current' ? 'Nu actief' : 'Geblokkeerd'} tone={getStatusTone(item.status)} />
+                </div>
+              </li>
+            ))}
+          </ol>
+        </div>
+
+        <div className="mt-4 grid gap-4 lg:grid-cols-2">
+          <div className="rounded-[22px] border border-[color:var(--border)] bg-white p-4">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
+              Verisight doet nu
+            </p>
+            <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">{state.verisightNow}</p>
+          </div>
+          <div className="rounded-[22px] border border-[color:var(--border)] bg-white p-4">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
+              Jij doet nu
+            </p>
+            <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">{state.customerNow}</p>
+          </div>
+        </div>
+
+        <div className="mt-4 rounded-[22px] border border-[color:var(--border)] bg-white p-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
+            Open blokkades
+          </p>
+          {state.blockers.length === 0 ? (
+            <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">
+              Er zijn geen open blokkades in deze fase. De route kan nu door naar de eerstvolgende productstap.
+            </p>
+          ) : (
+            <div className="mt-4 space-y-3">
+              {state.blockers.map((blocker) => (
+                <div key={`${blocker.title}-${blocker.recovery}`} className="rounded-2xl border border-[color:var(--border)] bg-[color:var(--bg)] px-4 py-4">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="text-sm font-semibold text-[color:var(--ink)]">{blocker.title}</p>
+                    <DashboardChip
+                      label={blocker.actor === 'customer' ? 'Jij' : blocker.actor === 'verisight' ? 'Verisight' : 'Samen'}
+                      tone={getBlockerTone(blocker.actor)}
+                    />
+                  </div>
+                  <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">{blocker.detail}</p>
+                  <p className="mt-2 text-sm font-medium leading-6 text-[color:var(--ink)]">
+                    Herstel: {blocker.recovery}
+                  </p>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        <div className="rounded-[26px] border border-[color:var(--border)] bg-[color:var(--bg)] p-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
+            Volgende stap
+          </p>
+          <p className="mt-2 text-lg font-semibold text-[color:var(--ink)]">{state.nextAction.title}</p>
+          <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">{state.nextAction.body}</p>
+          {campaignHref && campaignCtaLabel ? (
+            <Link
+              href={campaignHref}
+              className="mt-4 inline-flex rounded-full border border-[#d6e4e8] bg-[#f3f8f8] px-4 py-2 text-sm font-semibold text-[#234B57] transition-colors hover:border-[#bfd3d8] hover:bg-[#e9f2f3]"
+            >
+              {campaignCtaLabel}
+            </Link>
+          ) : null}
+        </div>
+
+        <div className="rounded-[26px] border border-[color:var(--border)] bg-white p-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
+            Productgrenzen
+          </p>
+          <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">
+            Verisight houdt billing, signup, surveyarchitectuur en productscope bewust buiten deze flow. Je ziet alleen de
+            actieve campagne, de huidige status en de eerstvolgende toegestane stap.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/components/dashboard/guided-self-serve-panel.tsx
+++ b/frontend/components/dashboard/guided-self-serve-panel.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { resendPendingAction } from '@/app/(dashboard)/campaigns/[id]/actions'
 import { buildResendResultMessage } from '@/app/(dashboard)/campaigns/[id]/reminder-feedback'
+import { CustomerLaunchControl } from '@/components/dashboard/customer-launch-control'
 import {
   DashboardChip,
   DashboardPanel,
@@ -15,6 +16,7 @@ import {
   getInviteDefaultForDeliveryMode,
   getDeliveryModeLabel,
 } from '@/lib/implementation-readiness'
+import { getScanDefinition } from '@/lib/scan-definitions'
 import {
   type DeliveryMode,
   REPORT_ADD_ON_LABELS,
@@ -33,7 +35,9 @@ interface Props {
   invitesNotSent: number
   hasMinDisplay: boolean
   hasEnoughData: boolean
-  pendingCount: number
+  importQaConfirmed: boolean
+  launchTimingConfirmed: boolean
+  communicationReady: boolean
   remindableCount: number
   unsentRespondents: Array<{ token: string; email: string | null }>
 }
@@ -64,12 +68,6 @@ interface ImportResponse {
   emails_sent: number
 }
 
-function getStatusTone(status: 'done' | 'current' | 'blocked') {
-  if (status === 'done') return 'emerald' as const
-  if (status === 'current') return 'blue' as const
-  return 'slate' as const
-}
-
 export function GuidedSelfServePanel({
   campaignId,
   scanType,
@@ -81,11 +79,14 @@ export function GuidedSelfServePanel({
   invitesNotSent,
   hasMinDisplay,
   hasEnoughData,
-  pendingCount,
+  importQaConfirmed,
+  launchTimingConfirmed,
+  communicationReady,
   remindableCount,
   unsentRespondents,
 }: Props) {
   const router = useRouter()
+  const scanDefinition = getScanDefinition(scanType)
   const guidedState = useMemo(
     () =>
       buildGuidedSelfServeState({
@@ -95,8 +96,21 @@ export function GuidedSelfServePanel({
         invitesNotSent,
         hasMinDisplay,
         hasEnoughData,
+        importQaConfirmed,
+        launchTimingConfirmed,
+        communicationReady,
       }),
-    [hasEnoughData, hasMinDisplay, invitesNotSent, isActive, totalCompleted, totalInvited],
+    [
+      communicationReady,
+      hasEnoughData,
+      hasMinDisplay,
+      importQaConfirmed,
+      invitesNotSent,
+      isActive,
+      launchTimingConfirmed,
+      totalCompleted,
+      totalInvited,
+    ],
   )
   const [uploadFile, setUploadFile] = useState<File | null>(null)
   const [uploadSendInvites, setUploadSendInvites] = useState(true)
@@ -236,66 +250,37 @@ export function GuidedSelfServePanel({
 
   return (
     <div className="space-y-4">
-      <div className="rounded-[24px] border border-[#d6e4e8] bg-[#f6fafb] p-4 sm:p-5">
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-          <div className="max-w-3xl">
-            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
-              Begeleide uitvoering
-            </p>
-            <h2 className="mt-2 text-xl font-semibold text-slate-950">{guidedState.headline}</h2>
-            <p className="mt-2 text-sm leading-6 text-slate-700">{guidedState.detail}</p>
-            <p className="mt-3 text-sm font-medium text-slate-900">
-              Volgende stap: {guidedState.nextAction.title}
-            </p>
-            <p className="mt-1 text-sm leading-6 text-slate-700">{guidedState.nextAction.body}</p>
-          </div>
+      <CustomerLaunchControl
+        campaignName={`${scanDefinition.productName} - ${getDeliveryModeLabel(deliveryMode, scanType)}`}
+        productName={scanDefinition.productName}
+        productContext={scanDefinition.whatItIsText}
+        state={guidedState}
+      />
+
+      {localValidationState ? (
+        <div className="rounded-[22px] border border-[#d6e4e8] bg-[#f6fafb] p-4">
           <div className="flex flex-wrap items-center gap-2">
+            <DashboardChip
+              label={localValidationState}
+              tone={hasPreviewErrors ? 'amber' : 'blue'}
+            />
             <DashboardChip
               label={guidedState.dashboardVisible ? 'Dashboard vrijgegeven' : 'Dashboard nog niet actief'}
               tone={guidedState.dashboardVisible ? 'emerald' : 'amber'}
             />
-            {localValidationState ? (
-              <DashboardChip
-                label={localValidationState}
-                tone={hasPreviewErrors ? 'amber' : 'blue'}
-              />
-            ) : null}
           </div>
+          <p className="mt-3 text-sm leading-6 text-slate-700">
+            Deze lokale controle toont direct of de importpreview nog herstel nodig heeft of dat de route klaarstaat om de inviteflow bewust te starten.
+          </p>
         </div>
+      ) : null}
 
-        <div className="mt-4 flex flex-wrap gap-2">
-          {guidedState.statusBlocks.map((item) => (
-            <DashboardChip
-              key={item.key}
-              label={item.label}
-              tone={getStatusTone(item.status)}
-            />
-          ))}
-        </div>
-      </div>
-
-      <div className="grid gap-4 xl:grid-cols-3">
+      <div className="grid gap-4 xl:grid-cols-2">
         <DashboardPanel
-          eyebrow="Verisight doet"
-          title="Provisioning en campaigngrenzen"
-          body="Account, campaign, productkaders en de begrensde outputroute staan al klaar. Je hoeft geen surveytool of setuparchitectuur te beheren."
+          eyebrow="Route"
+          title={`${SCAN_TYPE_LABELS[scanType]} ${getDeliveryModeLabel(deliveryMode, scanType)}`}
+          body={getDeliveryModeDescription(deliveryMode, scanType)}
           tone="blue"
-        />
-        <DashboardPanel
-          eyebrow="Jij doet nu"
-          title={
-            totalInvited === 0
-              ? 'Lever deelnemers aan'
-              : invitesNotSent > 0
-                ? 'Start de inviteflow'
-                : pendingCount > 0
-                  ? 'Volg respons en reminders'
-                  : guidedState.deeperInsightsVisible
-                    ? 'Maak de eerste stap expliciet'
-                    : 'Lees eerst de compacte output'
-          }
-          body={guidedState.nextAction.body}
-          tone="emerald"
         />
         <DashboardPanel
           eyebrow="Dashboardactivatie"

--- a/frontend/lib/guided-self-serve.test.ts
+++ b/frontend/lib/guided-self-serve.test.ts
@@ -2,65 +2,141 @@ import { describe, expect, it } from 'vitest'
 import { buildGuidedSelfServeState } from '@/lib/guided-self-serve'
 
 describe('guided self-serve execution state', () => {
-  it('keeps the customer in data-required mode until a validated participant file exists', () => {
-    const state = buildGuidedSelfServeState({
+  function buildArgs(overrides: Partial<Parameters<typeof buildGuidedSelfServeState>[0]> = {}) {
+    return {
       isActive: true,
       totalInvited: 0,
       totalCompleted: 0,
       invitesNotSent: 0,
       hasMinDisplay: false,
       hasEnoughData: false,
-    })
+      importQaConfirmed: false,
+      launchTimingConfirmed: false,
+      communicationReady: false,
+      ...overrides,
+    }
+  }
 
-    expect(state.phase).toBe('data_required')
+  it('keeps the customer in data-required mode until a validated participant file exists', () => {
+    const state = buildGuidedSelfServeState(buildArgs())
+
+    expect(state.phase).toBe('participant_data_required')
     expect(state.dashboardVisible).toBe(false)
     expect(state.deeperInsightsVisible).toBe(false)
+    expect(state.currentStateLabel).toBe('Deelnemersdata vereist')
     expect(state.nextAction.title.toLowerCase()).toContain('deelnemersbestand')
     expect(state.statusBlocks.find((item) => item.key === 'setup_incomplete')?.status).toBe('current')
-    expect(state.statusBlocks.find((item) => item.key === 'data_required')?.status).toBe('current')
+    expect(state.statusBlocks.find((item) => item.key === 'participant_data_required')?.status).toBe('current')
+    expect(state.statusBlocks.map((item) => item.label)).toEqual([
+      'Setup incompleet',
+      'Deelnemersdata vereist',
+      'Import validatie vereist',
+      'Launchdatum vereist',
+      'Communicatie gereed',
+      'Klaar om uit te nodigen',
+      'Survey running',
+      'Dashboard actief',
+      'Eerste vervolgstap beschikbaar',
+    ])
+    expect(state.blockers[0]?.recovery.toLowerCase()).toContain('csv')
+    expect(state.verisightNow.toLowerCase()).toContain('productgrenzen')
+    expect(state.customerNow.toLowerCase()).toContain('deelnemersbestand')
   })
 
-  it('moves to invite-ready when participants exist but launch has not been sent yet', () => {
-    const state = buildGuidedSelfServeState({
-      isActive: true,
-      totalInvited: 18,
-      totalCompleted: 0,
-      invitesNotSent: 18,
-      hasMinDisplay: false,
-      hasEnoughData: false,
-    })
+  it('keeps import validation as the active blocker until import qa is confirmed', () => {
+    const state = buildGuidedSelfServeState(
+      buildArgs({
+        totalInvited: 18,
+        invitesNotSent: 18,
+      }),
+    )
+
+    expect(state.phase).toBe('import_validation_required')
+    expect(state.currentStateLabel).toBe('Import validatie vereist')
+    expect(state.nextAction.title.toLowerCase()).toContain('import')
+    expect(state.statusBlocks.find((item) => item.key === 'import_validation_required')?.status).toBe('current')
+    expect(state.blockers.map((item) => item.title).join(' ')).toContain('Importcontrole')
+  })
+
+  it('moves to launch-date-required when import is validated but timing is still open', () => {
+    const state = buildGuidedSelfServeState(
+      buildArgs({
+        totalInvited: 18,
+        invitesNotSent: 18,
+        importQaConfirmed: true,
+      }),
+    )
+
+    expect(state.phase).toBe('launch_date_required')
+    expect(state.currentStateLabel).toBe('Launchdatum vereist')
+    expect(state.nextAction.title.toLowerCase()).toContain('launchmoment')
+    expect(state.statusBlocks.find((item) => item.key === 'launch_date_required')?.status).toBe('current')
+    expect(state.blockers.map((item) => item.title).join(' ')).toContain('Launchmoment')
+  })
+
+  it('keeps communication readiness explicit before the inviteflow can be released', () => {
+    const state = buildGuidedSelfServeState(
+      buildArgs({
+        totalInvited: 18,
+        invitesNotSent: 18,
+        importQaConfirmed: true,
+        launchTimingConfirmed: true,
+      }),
+    )
+
+    expect(state.phase).toBe('communication_ready')
+    expect(state.currentStateLabel).toBe('Communicatie gereed')
+    expect(state.nextAction.title.toLowerCase()).toContain('communicatie')
+    expect(state.statusBlocks.find((item) => item.key === 'communication_ready')?.status).toBe('current')
+  })
+
+  it('moves to invite-ready when setup discipline is confirmed and launch has not been sent yet', () => {
+    const state = buildGuidedSelfServeState(
+      buildArgs({
+        totalInvited: 18,
+        invitesNotSent: 18,
+        importQaConfirmed: true,
+        launchTimingConfirmed: true,
+        communicationReady: true,
+      }),
+    )
 
     expect(state.phase).toBe('ready_to_invite')
     expect(state.nextAction.title.toLowerCase()).toContain('uitnodigingen')
     expect(state.statusBlocks.find((item) => item.key === 'ready_to_invite')?.status).toBe('current')
-    expect(state.statusBlocks.find((item) => item.key === 'responses_incoming')?.status).toBe('blocked')
+    expect(state.statusBlocks.find((item) => item.key === 'survey_running')?.status).toBe('blocked')
   })
 
   it('keeps dashboard access locked while responses are still below the first safe threshold', () => {
-    const state = buildGuidedSelfServeState({
-      isActive: true,
+    const state = buildGuidedSelfServeState(
+      buildArgs({
       totalInvited: 24,
       totalCompleted: 3,
       invitesNotSent: 0,
-      hasMinDisplay: false,
-      hasEnoughData: false,
-    })
+        importQaConfirmed: true,
+        launchTimingConfirmed: true,
+        communicationReady: true,
+      }),
+    )
 
-    expect(state.phase).toBe('responses_incoming')
+    expect(state.phase).toBe('survey_running')
     expect(state.dashboardVisible).toBe(false)
     expect(state.detail.toLowerCase()).toContain('vanaf 5')
     expect(state.nextAction.body.toLowerCase()).toContain('responses')
   })
 
   it('activates the dashboard at first-value threshold but keeps deeper insights behind the pattern threshold', () => {
-    const state = buildGuidedSelfServeState({
-      isActive: true,
+    const state = buildGuidedSelfServeState(
+      buildArgs({
       totalInvited: 24,
       totalCompleted: 6,
       invitesNotSent: 0,
       hasMinDisplay: true,
-      hasEnoughData: false,
-    })
+        importQaConfirmed: true,
+        launchTimingConfirmed: true,
+        communicationReady: true,
+      }),
+    )
 
     expect(state.phase).toBe('dashboard_active')
     expect(state.dashboardVisible).toBe(true)
@@ -70,14 +146,18 @@ describe('guided self-serve execution state', () => {
   })
 
   it('switches to first-next-step once readiness and pattern threshold are both reached', () => {
-    const state = buildGuidedSelfServeState({
-      isActive: true,
+    const state = buildGuidedSelfServeState(
+      buildArgs({
       totalInvited: 24,
       totalCompleted: 11,
       invitesNotSent: 0,
       hasMinDisplay: true,
       hasEnoughData: true,
-    })
+        importQaConfirmed: true,
+        launchTimingConfirmed: true,
+        communicationReady: true,
+      }),
+    )
 
     expect(state.phase).toBe('first_next_step_available')
     expect(state.dashboardVisible).toBe(true)
@@ -87,14 +167,17 @@ describe('guided self-serve execution state', () => {
   })
 
   it('keeps a closed campaign out of self-serve execution mode', () => {
-    const state = buildGuidedSelfServeState({
+    const state = buildGuidedSelfServeState(buildArgs({
       isActive: false,
       totalInvited: 24,
       totalCompleted: 11,
       invitesNotSent: 0,
       hasMinDisplay: true,
       hasEnoughData: true,
-    })
+      importQaConfirmed: true,
+      launchTimingConfirmed: true,
+      communicationReady: true,
+    }))
 
     expect(state.phase).toBe('closed')
     expect(state.nextAction.title.toLowerCase()).toContain('vervolggesprek')

--- a/frontend/lib/guided-self-serve.ts
+++ b/frontend/lib/guided-self-serve.ts
@@ -1,25 +1,41 @@
 type GuidedSelfServePhase =
   | 'closed'
-  | 'data_required'
+  | 'participant_data_required'
+  | 'import_validation_required'
+  | 'launch_date_required'
+  | 'communication_ready'
   | 'ready_to_invite'
-  | 'responses_incoming'
+  | 'survey_running'
   | 'dashboard_active'
   | 'first_next_step_available'
 
 type GuidedStatusKey =
   | 'setup_incomplete'
-  | 'data_required'
+  | 'participant_data_required'
+  | 'import_validation_required'
+  | 'launch_date_required'
+  | 'communication_ready'
   | 'ready_to_invite'
-  | 'responses_incoming'
+  | 'survey_running'
   | 'dashboard_active'
   | 'first_next_step_available'
 
+type GuidedCheckpointKey = 'implementation_intake' | 'import_qa' | 'invite_readiness'
+type GuidedCheckpointState = 'pending' | 'confirmed' | 'not_applicable'
+type GuidedActor = 'verisight' | 'customer' | 'shared'
 type GuidedStatusState = 'done' | 'current' | 'blocked'
 
 export interface GuidedStatusBlock {
   key: GuidedStatusKey
   label: string
   status: GuidedStatusState
+}
+
+export interface GuidedBlocker {
+  title: string
+  detail: string
+  recovery: string
+  actor: GuidedActor
 }
 
 export interface GuidedNextAction {
@@ -29,12 +45,21 @@ export interface GuidedNextAction {
 
 export interface GuidedSelfServeState {
   phase: GuidedSelfServePhase
+  currentStateLabel: string
   headline: string
   detail: string
   nextAction: GuidedNextAction
   dashboardVisible: boolean
   deeperInsightsVisible: boolean
+  verisightNow: string
+  customerNow: string
+  blockers: GuidedBlocker[]
   statusBlocks: GuidedStatusBlock[]
+}
+
+export interface GuidedSelfServeDisciplineInput {
+  checkpointKey: GuidedCheckpointKey
+  manualState: GuidedCheckpointState
 }
 
 interface GuidedSelfServeArgs {
@@ -44,40 +69,168 @@ interface GuidedSelfServeArgs {
   invitesNotSent: number
   hasMinDisplay: boolean
   hasEnoughData: boolean
+  importQaConfirmed?: boolean
+  launchTimingConfirmed?: boolean
+  communicationReady?: boolean
 }
 
 const STATUS_FLOW: GuidedStatusKey[] = [
   'setup_incomplete',
-  'data_required',
+  'participant_data_required',
+  'import_validation_required',
+  'launch_date_required',
+  'communication_ready',
   'ready_to_invite',
-  'responses_incoming',
+  'survey_running',
   'dashboard_active',
   'first_next_step_available',
 ]
 
+const PHASE_FLOW: GuidedSelfServePhase[] = [
+  'participant_data_required',
+  'import_validation_required',
+  'launch_date_required',
+  'communication_ready',
+  'ready_to_invite',
+  'survey_running',
+  'dashboard_active',
+  'first_next_step_available',
+]
+
+const PRE_LIVE_PHASES = new Set<GuidedSelfServePhase>([
+  'participant_data_required',
+  'import_validation_required',
+  'launch_date_required',
+  'communication_ready',
+  'ready_to_invite',
+])
+
 const STATUS_LABELS: Record<GuidedStatusKey, string> = {
   setup_incomplete: 'Setup incompleet',
-  data_required: 'Data vereist',
+  participant_data_required: 'Deelnemersdata vereist',
+  import_validation_required: 'Import validatie vereist',
+  launch_date_required: 'Launchdatum vereist',
+  communication_ready: 'Communicatie gereed',
   ready_to_invite: 'Klaar om uit te nodigen',
-  responses_incoming: 'Responses binnen',
+  survey_running: 'Survey running',
   dashboard_active: 'Dashboard actief',
   first_next_step_available: 'Eerste vervolgstap beschikbaar',
 }
 
-function buildStatusBlocks(current: GuidedStatusKey): GuidedStatusBlock[] {
-  const currentIndex = STATUS_FLOW.indexOf(current)
+function checkpointCountsAsConfirmed(state: GuidedCheckpointState | undefined) {
+  return state === 'confirmed' || state === 'not_applicable'
+}
 
-  return STATUS_FLOW.map((key, index) => ({
-    key,
-    label: STATUS_LABELS[key],
-    status: index < currentIndex ? 'done' : index === currentIndex ? 'current' : current === 'setup_incomplete' ? 'blocked' : 'blocked',
-  }))
+export function deriveGuidedSelfServeDiscipline(
+  checkpoints: GuidedSelfServeDisciplineInput[],
+) {
+  const checkpointMap = new Map(checkpoints.map((checkpoint) => [checkpoint.checkpointKey, checkpoint.manualState]))
+
+  return {
+    importQaConfirmed: checkpointCountsAsConfirmed(checkpointMap.get('import_qa')),
+    launchTimingConfirmed: checkpointCountsAsConfirmed(checkpointMap.get('implementation_intake')),
+    communicationReady: checkpointCountsAsConfirmed(checkpointMap.get('invite_readiness')),
+  }
+}
+
+function buildStatusBlocks(phase: GuidedSelfServePhase): GuidedStatusBlock[] {
+  if (phase === 'closed') {
+    return STATUS_FLOW.map((key) => ({
+      key,
+      label: STATUS_LABELS[key],
+      status: 'done',
+    }))
+  }
+
+  const currentPhaseIndex = PHASE_FLOW.indexOf(phase)
+
+  return STATUS_FLOW.map((key) => {
+    if (key === 'setup_incomplete') {
+      return {
+        key,
+        label: STATUS_LABELS[key],
+        status: PRE_LIVE_PHASES.has(phase) ? 'current' : 'done',
+      }
+    }
+
+    const phaseIndex = PHASE_FLOW.indexOf(key as GuidedSelfServePhase)
+    return {
+      key,
+      label: STATUS_LABELS[key],
+      status: phaseIndex < currentPhaseIndex ? 'done' : phaseIndex === currentPhaseIndex ? 'current' : 'blocked',
+    }
+  })
+}
+
+function buildState(
+  phase: Exclude<GuidedSelfServePhase, 'closed'>,
+  overrides: Omit<GuidedSelfServeState, 'phase' | 'currentStateLabel' | 'statusBlocks'>,
+): GuidedSelfServeState {
+  return {
+    phase,
+    currentStateLabel: STATUS_LABELS[phase],
+    statusBlocks: buildStatusBlocks(phase),
+    ...overrides,
+  }
+}
+
+function buildGovernanceCarryoverBlockers(args: {
+  importQaConfirmed: boolean
+  launchTimingConfirmed: boolean
+  communicationReady: boolean
+  invitesNotSent: number
+}) {
+  const items: GuidedBlocker[] = []
+
+  if (!args.importQaConfirmed) {
+    items.push({
+      title: 'Importcontrole mist nog expliciete bevestiging',
+      detail: 'De survey kan al beweging hebben, maar de administratieve import-QA is nog niet handmatig afgerond.',
+      recovery: 'Laat Verisight de importbevestiging netjes vastleggen zodat uitvoerstatus en deliverydiscipline gelijklopen.',
+      actor: 'verisight',
+    })
+  }
+
+  if (!args.launchTimingConfirmed) {
+    items.push({
+      title: 'Launchdiscipline mist nog timingbevestiging',
+      detail: 'Er is al live survey-activiteit, maar het launchmoment is nog niet expliciet bevestigd in deliverycontrol.',
+      recovery: 'Laat het gekozen launchmoment alsnog expliciet vastleggen zodat de route overdraagbaar blijft.',
+      actor: 'shared',
+    })
+  }
+
+  if (!args.communicationReady) {
+    items.push({
+      title: 'Communicatiebevestiging mist nog',
+      detail: 'De survey loopt of heeft gelopen, maar de communicatiegate staat administratief nog open.',
+      recovery: 'Laat de launchcommunicatie alsnog expliciet bevestigen in dezelfde deliveryroute.',
+      actor: 'shared',
+    })
+  }
+
+  if (args.invitesNotSent > 0) {
+    items.push({
+      title: 'Nog niet alle uitnodigingen zijn verstuurd',
+      detail: `${args.invitesNotSent} deelnemer(s) hebben nog geen uitnodiging of verzendbevestiging, terwijl de survey al wel loopt.`,
+      recovery: 'Werk de resterende uitnodigingen of launchbevestigingen bij zodat de survey netjes volledig live staat.',
+      actor: 'customer',
+    })
+  }
+
+  return items
 }
 
 export function buildGuidedSelfServeState(args: GuidedSelfServeArgs): GuidedSelfServeState {
+  const importQaConfirmed = args.importQaConfirmed ?? false
+  const launchTimingConfirmed = args.launchTimingConfirmed ?? false
+  const communicationReady = args.communicationReady ?? false
+  const surveyLive = args.totalCompleted > 0 || args.invitesNotSent === 0
+
   if (!args.isActive) {
     return {
       phase: 'closed',
+      currentStateLabel: 'Eerste vervolgstap beschikbaar',
       headline: 'Campagne gesloten',
       detail: 'De uitvoerfase is afgerond. Gebruik dashboard, rapport en terugblik nu voor het vervolggesprek en de gekozen opvolgroute.',
       nextAction: {
@@ -86,82 +239,223 @@ export function buildGuidedSelfServeState(args: GuidedSelfServeArgs): GuidedSelf
       },
       dashboardVisible: true,
       deeperInsightsVisible: true,
-      statusBlocks: buildStatusBlocks('first_next_step_available'),
+      verisightNow: 'Verisight bewaakt nu vooral de nette close-out, rapporttoegang en bounded follow-up van deze campagne.',
+      customerNow: 'Gebruik de output nu voor terugblik, besluitvorming en het expliciet kiezen van een vervolgroute.',
+      blockers: [],
+      statusBlocks: buildStatusBlocks('closed'),
     }
   }
 
   if (args.totalInvited === 0) {
-    return {
-      phase: 'data_required',
+    return buildState('participant_data_required', {
       headline: 'Deelnemersbestand ontbreekt nog',
-      detail: 'Verisight heeft account en campagne klaargezet. Lever nu eerst het deelnemersbestand aan en controleer daarna de importpreview voordat iemand wordt uitgenodigd.',
+      detail: 'Na login zie je direct waar de campagne staat: account en campagne staan klaar, maar zonder deelnemersbestand blijft setup bewust dicht.',
       nextAction: {
         title: 'Lever het deelnemersbestand aan',
-        body: 'Upload een CSV- of Excel-bestand, controleer de validatie en ga pas daarna door naar uitnodigen.',
+        body: 'Upload een CSV- of Excel-bestand met minimaal e-mailadressen. Pas daarna kan Verisight de importpreview en launchflow veilig vrijgeven.',
       },
       dashboardVisible: false,
       deeperInsightsVisible: false,
-      statusBlocks: buildStatusBlocks('setup_incomplete').map((item) =>
-        item.key === 'data_required' ? { ...item, status: 'current' } : item,
-      ),
+      verisightNow: 'Verisight bewaakt productgrenzen, campagne-opzet en de gesloten launchflow tot er bruikbare deelnemersdata is.',
+      customerNow: 'Lever nu alleen het juiste deelnemersbestand aan. Je hoeft geen surveytool, productsetup of rapportinstellingen te beheren.',
+      blockers: [
+        {
+          title: 'Deelnemersbestand ontbreekt',
+          detail: 'Zonder deelnemers kan de campaign nog niet naar importcontrole of inviteflow bewegen.',
+          recovery: 'Upload een CSV- of Excel-bestand met minimaal e-mailadressen via de uitvoerflow.',
+          actor: 'customer',
+        },
+        {
+          title: 'Setup blijft bewust begrensd',
+          detail: 'Het dashboard gaat pas open als data, importcontrole en launchdiscipline expliciet rond zijn.',
+          recovery: 'Wacht niet op dashboardoutput; lever eerst het bestand aan zodat Verisight de volgende gate kan vrijgeven.',
+          actor: 'verisight',
+        },
+      ],
+    })
+  }
+
+  if (surveyLive) {
+    const governanceCarryoverBlockers = buildGovernanceCarryoverBlockers({
+      importQaConfirmed,
+      launchTimingConfirmed,
+      communicationReady,
+      invitesNotSent: args.invitesNotSent,
+    })
+
+    if (!args.hasMinDisplay) {
+      return buildState('survey_running', {
+        headline: 'Survey running, dashboard nog bewust dicht',
+        detail: `De inviteflow loopt. Er zijn nu ${args.totalCompleted} responses binnen; vanaf 5 responses wordt de eerste dashboardread pas veilig genoeg om te openen.`,
+        nextAction: {
+          title: 'Volg respons en houd de survey running',
+          body: 'Laat de survey eerst verder lopen, stuur zo nodig reminders en bouw meer responses op voordat je volledige dashboarduitlezing verwacht.',
+        },
+        dashboardVisible: false,
+        deeperInsightsVisible: false,
+        verisightNow: 'Verisight bewaakt de begrensde surveyflow, reminders en deliverykwaliteit terwijl de eerste responses binnenkomen.',
+        customerNow: 'Volg nu alleen respons en wacht met conclusies tot de eerste veilige dashboarddrempel is bereikt.',
+        blockers: [
+          {
+            title: 'Nog onder de eerste leesdrempel',
+            detail: `Met ${args.totalCompleted} responses is de survey live, maar het dashboard nog niet veilig genoeg voor eerste duiding.`,
+            recovery: 'Bouw verder op naar minimaal 5 ingevulde responses voordat je dashboardgebruik verwacht.',
+            actor: 'shared',
+          },
+          ...governanceCarryoverBlockers,
+        ],
+      })
     }
+
+    if (!args.hasEnoughData) {
+      return buildState('dashboard_active', {
+        headline: 'Dashboard actief, nog bewust compact',
+        detail: `De eerste veilige drempel is gehaald. Vanaf ${args.totalCompleted} responses is de eerste dashboardread bruikbaar, maar verdiepende patroonduiding blijft bewust dicht tot minstens 10 responses.`,
+        nextAction: {
+          title: 'Gebruik nu de compacte dashboardread',
+          body: 'Lees wat al zichtbaar is, houd conclusies voorlopig indicatief en blijf tegelijk respons opbouwen richting patroonniveau.',
+        },
+        dashboardVisible: true,
+        deeperInsightsVisible: false,
+        verisightNow: 'Verisight laat nu alleen de veilige eerste dashboardlaag zien en houdt verdiepende patronen nog bewust begrensd.',
+        customerNow: 'Gebruik nu de compacte dashboardread voor eerste richting, maar blijf respons opbouwen voordat je zwaarder gaat besluiten.',
+        blockers: [
+          {
+            title: 'Verdieping blijft nog beperkt',
+            detail: 'Het dashboard is open, maar patroonduiding en stevigere follow-through horen pas bij meer respons.',
+            recovery: 'Werk door naar minstens 10 ingevulde responses voor een volwaardiger eerste vervolgstap.',
+            actor: 'shared',
+          },
+          ...governanceCarryoverBlockers,
+        ],
+      })
+    }
+
+    return buildState('first_next_step_available', {
+      headline: 'Eerste vervolgstap beschikbaar',
+      detail: 'De campagne heeft nu genoeg respons voor veilige dashboardactivatie en eerste patroonduiding. Vanaf hier hoort de flow door te schuiven naar de eerste managementstap, niet terug naar setup.',
+      nextAction: {
+        title: 'Maak de eerste vervolgstap expliciet',
+        body: 'Gebruik dashboard en rapport nu om eerste eigenaar, eerste managementactie en reviewmoment vast te leggen.',
+      },
+      dashboardVisible: true,
+      deeperInsightsVisible: true,
+      verisightNow: 'Verisight bewaakt nu vooral dat de route bounded blijft en netjes doorloopt naar managementgebruik en follow-up.',
+      customerNow: 'Leg nu vast wat de eerste managementactie is, wie eigenaar wordt en wanneer jullie de vervolgstap reviewen.',
+      blockers: governanceCarryoverBlockers,
+    })
+  }
+
+  if (!importQaConfirmed) {
+    return buildState('import_validation_required', {
+      headline: 'Import validatie vereist',
+      detail: `${args.totalInvited} deelnemer(s) staan in de campaign, maar de importcontrole is nog niet expliciet bevestigd. Daardoor blijft launch bewust geblokkeerd.`,
+      nextAction: {
+        title: 'Rond de importcontrole af',
+        body: 'Controleer preview, metadata en fouten eerst volledig. Pas na een schone import hoort deze flow door te schuiven naar launchdiscipline.',
+      },
+      dashboardVisible: false,
+      deeperInsightsVisible: false,
+      verisightNow: 'Verisight bewaakt de importgrenzen, previewkwaliteit en foutopvang zodat de launchflow geen vervuilde deelnemerslaag krijgt.',
+      customerNow: 'Controleer nu alleen of het juiste deelnemersbestand is aangeleverd en herstel eventuele importissues in dezelfde flow.',
+      blockers: [
+        {
+          title: 'Importcontrole staat nog open',
+          detail: 'De campaign heeft deelnemers, maar er is nog geen expliciete QA-bevestiging op preview, metadata en importkeuze.',
+          recovery: 'Bevestig eerst dat de aangeleverde rijen kloppen en herstel fouten voordat je verdergaat.',
+          actor: 'shared',
+        },
+      ],
+    })
+  }
+
+  if (!launchTimingConfirmed) {
+    return buildState('launch_date_required', {
+      headline: 'Launchmoment staat nog niet vast',
+      detail: 'De deelnemerslaag is gevalideerd, maar de survey hoort nog niet live te gaan zolang timing en launchmoment niet expliciet zijn bevestigd.',
+      nextAction: {
+        title: 'Bevestig het launchmoment',
+        body: 'Maak expliciet wanneer de uitnodigingen de deur uit mogen. Daarna kan de flow pas naar communicatiecontrole en bewuste release.',
+      },
+      dashboardVisible: false,
+      deeperInsightsVisible: false,
+      verisightNow: 'Verisight houdt de inviteflow bewust tegen tot timing, doelgroep en launchdiscipline expliciet zijn bevestigd.',
+      customerNow: 'Bevestig nu wanneer de survey echt mag starten. Nog niet uitnodigen voordat dit launchmoment helder is.',
+      blockers: [
+        {
+          title: 'Launchmoment ontbreekt',
+          detail: 'Zonder bevestigd launchmoment wordt uitnodigen te vroeg of oncontroleerbaar.',
+          recovery: 'Leg vast op welk moment de uitnodigingen veilig live mogen gaan.',
+          actor: 'customer',
+        },
+      ],
+    })
+  }
+
+  if (!communicationReady) {
+    return buildState('communication_ready', {
+      headline: 'Communicatie moet nog launch-klaar worden',
+      detail: 'Timing staat, maar de launchflow blijft nog dicht tot de communicatie en contactroute expliciet gereed zijn verklaard.',
+      nextAction: {
+        title: 'Bevestig dat de communicatie gereed is',
+        body: 'Zorg dat aankondiging, intern contactmoment en deliveryverwachting kloppen. Pas dan hoort de inviteflow echt vrijgegeven te worden.',
+      },
+      dashboardVisible: false,
+      deeperInsightsVisible: false,
+      verisightNow: 'Verisight bewaakt releasecontrole, invitegrenzen en deliverydiscipline totdat communicatie en timing samen groen zijn.',
+      customerNow: 'Bevestig nu dat de interne communicatie klaarstaat en dat deelnemers het juiste contactmoment krijgen.',
+      blockers: [
+        {
+          title: 'Communicatie is nog niet vrijgegeven',
+          detail: 'De campaign heeft wel data en timing, maar nog geen expliciete bevestiging dat de launchcommunicatie klopt.',
+          recovery: 'Bevestig eerst dat de aankondiging en het contactmoment gereed zijn voor deze launch.',
+          actor: 'shared',
+        },
+      ],
+    })
   }
 
   if (args.invitesNotSent > 0) {
-    return {
-      phase: 'ready_to_invite',
+    return buildState('ready_to_invite', {
       headline: 'De setup staat klaar voor launch',
-      detail: `${args.totalInvited} deelnemer(s) staan klaar, maar ${args.invitesNotSent} uitnodiging(en) zijn nog niet verstuurd. Controleer de aanlevering en start daarna pas de inviteflow.`,
+      detail: `${args.totalInvited} deelnemer(s) staan klaar. Product, import, launchmoment en communicatie zijn gecontroleerd; de inviteflow wacht alleen nog op bewuste start.`,
       nextAction: {
-        title: 'Verstuur de uitnodigingen',
-        body: 'Zodra het bestand klopt kun je de inviteflow veilig starten. Tot die tijd blijft het dashboard bewust gesloten.',
+        title: 'Start de uitnodigingen',
+        body: 'Open nu bewust de inviteflow. Daarna verschuift de aandacht van setup naar survey running en responsmonitoring.',
       },
       dashboardVisible: false,
       deeperInsightsVisible: false,
-      statusBlocks: buildStatusBlocks('ready_to_invite'),
-    }
+      verisightNow: 'Verisight heeft de veilige launchflow voorbereid en houdt de release begrensd tot deze bewuste startstap.',
+      customerNow: 'Start nu de inviteflow voor deze campaign. Daarna hoef je vooral nog respons te volgen, niet terug naar setup.',
+      blockers: [
+        {
+          title: 'Uitnodigingen zijn nog niet gestart',
+          detail: 'De launchflow is verder groen, maar zonder invite-release blijft de survey nog stil.',
+          recovery: 'Start de uitnodigingen vanuit deze flow zodra het gekozen moment bereikt is.',
+          actor: 'customer',
+        },
+      ],
+    })
   }
 
-  if (!args.hasMinDisplay) {
-    return {
-      phase: 'responses_incoming',
-      headline: 'Responses lopen binnen',
-      detail: `Er zijn ${args.totalCompleted} responses binnen. Vanaf 5 responses wordt de eerste dashboardread veilig genoeg om zichtbaar te maken.`,
-      nextAction: {
-        title: 'Volg respons en stuur zo nodig een reminder',
-        body: 'Laat de inviteflow eerst verder lopen en bouw meer responses op. Het dashboard gaat pas open zodra de eerste veilige responsegrens is gehaald.',
-      },
-      dashboardVisible: false,
-      deeperInsightsVisible: false,
-      statusBlocks: buildStatusBlocks('responses_incoming'),
-    }
-  }
-
-  if (!args.hasEnoughData) {
-    return {
-      phase: 'dashboard_active',
-      headline: 'Dashboard actief, nog bewust compact',
-      detail: `De eerste veilige drempel is gehaald. Vanaf ${args.totalCompleted} responses is de dashboardread bruikbaar, maar verdiepende patroonduiding blijft bewust dicht tot minstens 10 responses.`,
-      nextAction: {
-        title: 'Gebruik nu de compacte dashboardread',
-        body: 'Lees wat al zichtbaar is, houd conclusies voorlopig indicatief en blijf tegelijk respons opbouwen richting patroonniveau.',
-      },
-      dashboardVisible: true,
-      deeperInsightsVisible: false,
-      statusBlocks: buildStatusBlocks('dashboard_active'),
-    }
-  }
-
-  return {
-    phase: 'first_next_step_available',
-    headline: 'Eerste vervolgstap beschikbaar',
-    detail: 'De campagne heeft nu genoeg respons voor veilige dashboardactivatie en eerste patroonduiding. Vanaf hier hoort de flow door te schuiven naar de eerste managementstap, niet terug naar setup.',
+  return buildState('ready_to_invite', {
+    headline: 'De setup staat klaar voor launch',
+    detail: `${args.totalInvited} deelnemer(s) staan klaar. Product, import, launchmoment en communicatie zijn gecontroleerd; de inviteflow wacht alleen nog op bewuste start.`,
     nextAction: {
-      title: 'Maak de eerste vervolgstap expliciet',
-      body: 'Gebruik dashboard en rapport nu om eerste eigenaar, eerste managementactie en reviewmoment vast te leggen.',
+      title: 'Start de uitnodigingen',
+      body: 'Open nu bewust de inviteflow. Daarna verschuift de aandacht van setup naar survey running en responsmonitoring.',
     },
-    dashboardVisible: true,
-    deeperInsightsVisible: true,
-    statusBlocks: buildStatusBlocks('first_next_step_available'),
-  }
+    dashboardVisible: false,
+    deeperInsightsVisible: false,
+    verisightNow: 'Verisight heeft de veilige launchflow voorbereid en houdt de release begrensd tot deze bewuste startstap.',
+    customerNow: 'Start nu de inviteflow voor deze campaign. Daarna hoef je vooral nog respons te volgen, niet terug naar setup.',
+    blockers: [
+      {
+        title: 'Uitnodigingen zijn nog niet gestart',
+        detail: 'De launchflow is verder groen, maar zonder invite-release blijft de survey nog stil.',
+        recovery: 'Start de uitnodigingen vanuit deze flow zodra het gekozen moment bereikt is.',
+        actor: 'customer',
+      },
+    ],
+  })
 }

--- a/frontend/tests/e2e/guided-self-serve-acceptance.helpers.ts
+++ b/frontend/tests/e2e/guided-self-serve-acceptance.helpers.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import * as path from 'node:path'
 import { promisify } from 'node:util'
+import { createClient } from '@supabase/supabase-js'
 
 const execFileAsync = promisify(execFile)
 
@@ -10,6 +11,8 @@ const frontendRoot = process.cwd()
 const repoRoot = path.resolve(frontendRoot, '..')
 const defaultPythonExecutable = path.join(repoRoot, '.venv', 'Scripts', 'python.exe')
 const runtimePath = path.join(repoRoot, '.acceptance-runtime', 'guided-self-serve.json')
+const setupCampaignName = 'Guided Self-Serve - Setup Journey'
+const thresholdCampaignName = 'Guided Self-Serve - Threshold Journey'
 
 interface GuidedSelfServeAcceptanceRuntime {
   mode: 'local' | 'remote'
@@ -69,7 +72,56 @@ export async function loadGuidedSelfServeAcceptanceRuntime(): Promise<GuidedSelf
 
 export async function loadGuidedSelfServeAcceptanceFixture(): Promise<GuidedSelfServeAcceptanceFixture> {
   const runtime = await loadGuidedSelfServeAcceptanceRuntime()
-  return runtime.fixture
+  const supabaseUrl = runtime.env.NEXT_PUBLIC_SUPABASE_URL ?? runtime.env.SUPABASE_URL
+  const serviceRoleKey = runtime.env.SUPABASE_SERVICE_ROLE_KEY
+  const orgSlug =
+    runtime.env.PLAYWRIGHT_GUIDED_SELF_SERVE_ORG_SLUG ??
+    process.env.PLAYWRIGHT_GUIDED_SELF_SERVE_ORG_SLUG ??
+    'guided-self-serve-acceptance'
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    return runtime.fixture
+  }
+
+  const admin = createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  })
+
+  const { data: org, error: orgError } = await admin
+    .from('organizations')
+    .select('id')
+    .eq('slug', orgSlug)
+    .single()
+
+  if (orgError || !org) {
+    return runtime.fixture
+  }
+
+  const { data: campaigns, error: campaignsError } = await admin
+    .from('campaigns')
+    .select('id,name')
+    .eq('organization_id', org.id)
+    .in('name', [setupCampaignName, thresholdCampaignName])
+
+  if (campaignsError || !campaigns) {
+    return runtime.fixture
+  }
+
+  const setupCampaign = campaigns.find((campaign) => campaign.name === setupCampaignName)
+  const thresholdCampaign = campaigns.find((campaign) => campaign.name === thresholdCampaignName)
+
+  if (!setupCampaign || !thresholdCampaign) {
+    return runtime.fixture
+  }
+
+  return {
+    ...runtime.fixture,
+    setup_campaign_id: setupCampaign.id,
+    threshold_campaign_id: thresholdCampaign.id,
+  }
 }
 
 export async function advanceGuidedSelfServeAcceptanceFixture(phase: 'min_display' | 'patterns') {

--- a/frontend/tests/e2e/guided-self-serve-acceptance.spec.ts
+++ b/frontend/tests/e2e/guided-self-serve-acceptance.spec.ts
@@ -47,7 +47,7 @@ test.describe.serial('guided self-serve acceptance', () => {
     await page.getByRole('button', { name: /^bestand controleren$/i }).click()
 
     await expect(page.getByText(/import validatie vereist/i).first()).toBeVisible()
-    await expect(page.getByText(/dit e-mailadres staat dubbel in het bestand/i)).toBeVisible()
+    await expect(page.getByText(/corrigeer eerst deze rijen/i)).toBeVisible()
     await expect(page.getByText(/valid email address/i)).toBeVisible()
 
     await page.locator('input[type="file"]').setInputFiles(validImportPath)
@@ -65,7 +65,7 @@ test.describe.serial('guided self-serve acceptance', () => {
     await page.getByRole('button', { name: /start uitnodigingen \(2\)/i }).click()
 
     await expect(page.getByText(/2 uitnodiging\(en\) gestart/i)).toBeVisible()
-    await expect(page.getByText(/responses lopen binnen/i).first()).toBeVisible()
+    await expect(page.getByText(/survey running/i).first()).toBeVisible()
     await expect(page.getByRole('button', { name: /pdf-rapport/i })).toHaveCount(0)
     await expect(page.getByText(/dashboard nog niet actief/i).first()).toBeVisible()
   })
@@ -78,7 +78,7 @@ test.describe.serial('guided self-serve acceptance', () => {
     await loginAsAcceptanceUser(page, fixture)
     await page.goto(`/campaigns/${fixture.threshold_campaign_id}`)
 
-    await expect(page.getByText(/responses lopen binnen/i).first()).toBeVisible()
+    await expect(page.getByText(/survey running/i).first()).toBeVisible()
     await expect(page.getByText(/dashboard nog niet actief/i).first()).toBeVisible()
     await expect(page.getByRole('button', { name: /pdf-rapport/i })).toHaveCount(0)
 


### PR DESCRIPTION
## Samenvatting
- voeg een gedeelde customer launch control toe voor dashboard home en campaignflow
- maak de guided self-serve state-machine hard op launchstates, blockers en next action
- toon productcontext, rolverdeling en bounded productgrenzen direct na login
- koppel launchdiscipline aan bestaande delivery checkpoints

## Verificatie
- `npm test -- "guided-self-serve.test.ts" "app/(dashboard)/dashboard/page.test.ts"`
- `npm run build`

## Nog open
- `npm run test:e2e:guided-self-serve` is op deze branch nog niet stabiel groen. De laatste run faalde in de acceptance-omgeving tijdens import met `Ongeldige API-sleutel`, nadat eerder in deze thread dezelfde flow wel groen liep.
- daarom staat deze PR bewust als draft totdat de acceptance-run weer reproduceerbaar groen is.