### PR TITLE
[codex] Harmonize SQLite guided demo seed parity

### DIFF
--- a/demo_environment.py
+++ b/demo_environment.py
@@ -9,7 +9,15 @@ from typing import Literal
 from sqlalchemy import inspect, text
 from sqlalchemy.orm import Session
 
-from backend.models import Campaign, Organization, OrganizationSecret, Respondent, SurveyResponse
+from backend.models import (
+    Campaign,
+    CampaignDeliveryCheckpoint,
+    CampaignDeliveryRecord,
+    Organization,
+    OrganizationSecret,
+    Respondent,
+    SurveyResponse,
+)
 from generate_voorbeeldrapport import (
     DEPARTMENTS,
     EXIT_PROFILES,
@@ -52,6 +60,16 @@ RESPONSE_THRESHOLDS = {
     "detail": 5,
     "pattern": 10,
 }
+
+DELIVERY_CHECKPOINT_KEYS = (
+    "implementation_intake",
+    "import_qa",
+    "invite_readiness",
+    "client_activation",
+    "first_value",
+    "report_delivery",
+    "first_management_use",
+)
 
 
 def _is_uuid_like(value: str | None) -> bool:
@@ -431,7 +449,14 @@ def _ensure_org_secret(db: Session, org: Organization) -> None:
 
 
 def _has_table(db: Session, table_name: str) -> bool:
-    return inspect(db.bind).has_table(table_name)
+    return inspect(db.connection()).has_table(table_name)
+
+
+def _qualify_table_name(db: Session, table_name: str) -> str:
+    bind = db.get_bind()
+    if bind is not None and bind.dialect.name == "sqlite":
+        return table_name
+    return f"public.{table_name}"
 
 
 def _ensure_role_memberships(
@@ -453,12 +478,14 @@ def _ensure_role_memberships(
         assignments.append((admin_user_id, "owner", True))
     assignments.extend((user_id, "member", False) for user_id in member_user_ids)
     assignments.extend((user_id, "viewer", False) for user_id in viewer_user_ids)
+    profiles_table = _qualify_table_name(db, "profiles")
+    org_members_table = _qualify_table_name(db, "org_members")
 
     for user_id, role, is_admin in assignments:
         db.execute(
             text(
-                """
-                insert into public.profiles (id, is_verisight_admin)
+                f"""
+                insert into {profiles_table} (id, is_verisight_admin)
                 values (:user_id, :is_admin)
                 on conflict (id) do update
                 set is_verisight_admin = excluded.is_verisight_admin
@@ -468,8 +495,8 @@ def _ensure_role_memberships(
         )
         db.execute(
             text(
-                """
-                insert into public.org_members (org_id, user_id, role)
+                f"""
+                insert into {org_members_table} (org_id, user_id, role)
                 values (:org_id, :user_id, :role)
                 on conflict (org_id, user_id) do update
                 set role = excluded.role
@@ -477,6 +504,46 @@ def _ensure_role_memberships(
             ),
             {"org_id": org.id, "user_id": user_id, "role": role},
         )
+
+
+def _ensure_delivery_sidecars(db: Session, campaign: Campaign) -> None:
+    if not (_has_table(db, "campaign_delivery_records") and _has_table(db, "campaign_delivery_checkpoints")):
+        return
+
+    delivery_record = (
+        db.query(CampaignDeliveryRecord)
+        .filter(CampaignDeliveryRecord.campaign_id == campaign.id)
+        .one_or_none()
+    )
+    if delivery_record is None:
+        delivery_record = CampaignDeliveryRecord(
+            campaign=campaign,
+            organization_id=campaign.organization_id,
+            lifecycle_stage="setup_in_progress",
+            exception_status="none",
+        )
+        db.add(delivery_record)
+        db.flush()
+
+    existing_checkpoint_keys = {
+        checkpoint_key
+        for (checkpoint_key,) in db.query(CampaignDeliveryCheckpoint.checkpoint_key)
+        .filter(CampaignDeliveryCheckpoint.delivery_record_id == delivery_record.id)
+        .all()
+    }
+    for checkpoint_key in DELIVERY_CHECKPOINT_KEYS:
+        if checkpoint_key in existing_checkpoint_keys:
+            continue
+        db.add(
+            CampaignDeliveryCheckpoint(
+                delivery_record=delivery_record,
+                checkpoint_key=checkpoint_key,
+                auto_state="unknown",
+                manual_state="pending",
+                exception_status="none",
+            )
+        )
+    db.flush()
 
 
 def _purge_campaign(db: Session, campaign: Campaign) -> None:
@@ -529,6 +596,7 @@ def _create_exit_campaign(db: Session, *, org: Organization, fixture: ExitSalesF
     )
     db.add(campaign)
     db.flush()
+    _ensure_delivery_sidecars(db, campaign)
     return campaign
 
 
@@ -547,6 +615,7 @@ def _create_retention_campaign(db: Session, *, org: Organization, fixture: Reten
     )
     db.add(campaign)
     db.flush()
+    _ensure_delivery_sidecars(db, campaign)
     return campaign
 
 
@@ -728,6 +797,7 @@ def _create_guided_self_serve_fixture_campaign(
     )
     db.add(campaign)
     db.flush()
+    _ensure_delivery_sidecars(db, campaign)
     return campaign
 
 

--- a/tests/test_demo_environment_system.py
+++ b/tests/test_demo_environment_system.py
@@ -1,16 +1,22 @@
 from __future__ import annotations
 
-from backend.models import Campaign, Organization, Respondent
+import uuid
+
+from sqlalchemy import text
+
+from backend.models import Campaign, CampaignDeliveryCheckpoint, CampaignDeliveryRecord, Organization, Respondent
 from demo_environment import (
     BUYER_FACING_SAMPLE_ORG_SLUG,
     DEMO_LAYER_CONTRACTS,
     DEMO_SCENARIOS,
+    DELIVERY_CHECKPOINT_KEYS,
     GUIDED_SELF_SERVE_ACCEPTANCE_ORG_SLUG,
     GUIDED_SELF_SERVE_SETUP_CAMPAIGN_NAME,
     GUIDED_SELF_SERVE_THRESHOLD_CAMPAIGN_NAME,
     INTERNAL_SALES_DEMO_ORG_SLUG,
     RESPONSE_THRESHOLDS,
     SAFE_DEMO_EMAIL_DOMAIN,
+    _ensure_delivery_sidecars,
     advance_guided_self_serve_acceptance,
     seed_guided_self_serve_acceptance,
     seed_sales_demo_exit,
@@ -151,6 +157,145 @@ def test_seed_guided_self_serve_acceptance_creates_setup_and_threshold_journeys(
     assert all(
         respondent.email is None or respondent.email.endswith(f"@{SAFE_DEMO_EMAIL_DOMAIN}")
         for respondent in threshold_campaign.respondents
+    )
+
+
+def _create_sqlite_auth_shadow_tables(db_session) -> None:
+    db_session.execute(
+        text(
+            """
+            create table profiles (
+                id text primary key,
+                is_verisight_admin boolean not null default 0,
+                created_at text
+            )
+            """
+        )
+    )
+    db_session.execute(
+        text(
+            """
+            create table org_members (
+                org_id text not null,
+                user_id text not null,
+                role text not null,
+                unique(org_id, user_id)
+            )
+            """
+        )
+    )
+    db_session.commit()
+
+
+def test_seed_guided_self_serve_acceptance_mirrors_viewer_access_and_delivery_sidecars(db_session):
+    _create_sqlite_auth_shadow_tables(db_session)
+    viewer_user_id = str(uuid.uuid4())
+
+    seed_guided_self_serve_acceptance(db_session, viewer_user_id=viewer_user_id)
+
+    org = db_session.query(Organization).filter(Organization.slug == GUIDED_SELF_SERVE_ACCEPTANCE_ORG_SLUG).one()
+    campaigns = (
+        db_session.query(Campaign)
+        .filter(Campaign.organization_id == org.id, Campaign.scan_type == "exit")
+        .order_by(Campaign.name.asc())
+        .all()
+    )
+
+    membership = db_session.execute(
+        text("select role from org_members where org_id = :org_id and user_id = :user_id"),
+        {"org_id": org.id, "user_id": viewer_user_id},
+    ).scalar_one()
+    assert membership == "viewer"
+
+    delivery_records = (
+        db_session.query(CampaignDeliveryRecord)
+        .filter(CampaignDeliveryRecord.organization_id == org.id)
+        .order_by(CampaignDeliveryRecord.campaign_id.asc())
+        .all()
+    )
+
+    assert len(delivery_records) == 2
+    assert {record.campaign_id for record in delivery_records} == {campaign.id for campaign in campaigns}
+    assert all(record.lifecycle_stage == "setup_in_progress" for record in delivery_records)
+    assert all(record.exception_status == "none" for record in delivery_records)
+    assert all(len(record.checkpoints) == 7 for record in delivery_records)
+    assert all(
+        {checkpoint.checkpoint_key for checkpoint in record.checkpoints}
+        == {
+            "implementation_intake",
+            "import_qa",
+            "invite_readiness",
+            "client_activation",
+            "first_value",
+            "report_delivery",
+            "first_management_use",
+        }
+        for record in delivery_records
+    )
+    assert all(
+        checkpoint.auto_state == "unknown"
+        and checkpoint.manual_state == "pending"
+        and checkpoint.exception_status == "none"
+        for record in delivery_records
+        for checkpoint in record.checkpoints
+    )
+
+
+def test_delivery_sidecar_harmonization_is_idempotent_when_acceptance_sidecars_already_exist(db_session):
+    org = Organization(
+        name=GUIDED_SELF_SERVE_ACCEPTANCE_ORG_SLUG,
+        slug=GUIDED_SELF_SERVE_ACCEPTANCE_ORG_SLUG,
+        contact_email="guided-acceptance@verisight.nl",
+        is_active=True,
+    )
+    db_session.add(org)
+    db_session.flush()
+
+    campaign = Campaign(
+        organization_id=org.id,
+        name=GUIDED_SELF_SERVE_SETUP_CAMPAIGN_NAME,
+        scan_type="exit",
+        delivery_mode="baseline",
+        is_active=True,
+    )
+    db_session.add(campaign)
+    db_session.flush()
+
+    delivery_record = CampaignDeliveryRecord(
+        organization_id=org.id,
+        campaign_id=campaign.id,
+        lifecycle_stage="setup_in_progress",
+        exception_status="none",
+    )
+    db_session.add(delivery_record)
+    db_session.flush()
+
+    for checkpoint_key in DELIVERY_CHECKPOINT_KEYS:
+        db_session.add(
+            CampaignDeliveryCheckpoint(
+                delivery_record_id=delivery_record.id,
+                checkpoint_key=checkpoint_key,
+                auto_state="unknown",
+                manual_state="pending",
+                exception_status="none",
+            )
+        )
+    db_session.flush()
+
+    _ensure_delivery_sidecars(db_session, campaign)
+    db_session.commit()
+
+    assert (
+        db_session.query(CampaignDeliveryRecord)
+        .filter(CampaignDeliveryRecord.campaign_id == campaign.id)
+        .count()
+        == 1
+    )
+    assert (
+        db_session.query(CampaignDeliveryCheckpoint)
+        .filter(CampaignDeliveryCheckpoint.delivery_record_id == delivery_record.id)
+        .count()
+        == len(DELIVERY_CHECKPOINT_KEYS)
     )
 
 


### PR DESCRIPTION
## Summary
- harmonize the SQLite guided self-serve demo seed with the acceptance-side campaign delivery sidecars
- make auth shadow-table membership seeding work on SQLite without relying on Postgres-only `public.` qualifiers
- add regression coverage for viewer membership parity, delivery checkpoint parity, and idempotent coexistence with pre-existing acceptance sidecars

## Root cause
The SQLite test layer seeded campaigns directly through SQLAlchemy, but missed two Postgres-backed acceptance behaviors from `supabase/schema.sql`:
1. campaign creation in acceptance auto-creates `campaign_delivery_records` and default checkpoints via DB trigger
2. viewer bootstrap writes to `profiles` and `org_members`, while the SQLite path still used Postgres-qualified table names

That meant local SQLite tests could pass while the guided execution flow was not exercising the same lifecycle and access assumptions as acceptance.

## Validation
- `python -m pytest tests/test_demo_environment_system.py tests/test_acceptance_environment.py -q`
- `npm run test -- "lib/guided-self-serve.test.ts" "lib/ops-delivery.test.ts" "app/(dashboard)/campaigns/[id]/page.test.ts"`
- `python manage_demo_environment.py run qa_guided_self_serve_acceptance` against a temporary SQLite database smoke path

## Impact
SQLite demo-seed regressions now recreate the same minimal guided execution prerequisites as acceptance without changing the Postgres-backed acceptance contract. Existing Postgres-triggered sidecars remain idempotent and untouched.