### PR TITLE
[codex] Refine dashboard shell and presentation system

### DIFF
--- a/frontend/app/(dashboard)/campaigns/[id]/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.tsx
@@ -4,11 +4,13 @@ import { createClient } from '@/lib/supabase/server'
 import { CampaignActions } from './campaign-actions'
 import { PdfDownloadButton } from './pdf-download-button'
 import {
+  DashboardChartPanel,
   DashboardChip,
   DashboardDisclosure,
   DashboardHero,
   DashboardKeyValue,
   DashboardPanel,
+  DashboardRecommendationRail,
   DashboardSection,
   DashboardSummaryBar,
   DashboardTimeline,
@@ -823,12 +825,13 @@ export default async function CampaignPage({ params }: Props) {
           id: 'signalen',
           label: productExperience.signalTabLabel,
           content: (
-            <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4 sm:p-5">
-              <h3 className="text-sm font-semibold text-slate-950">{productExperience.signalTabTitle}</h3>
-              <p className="mt-1 text-sm leading-6 text-slate-600">
-                {productExperience.signalTabDescription}
-              </p>
-              <div className="mt-4">
+            <DashboardChartPanel
+              eyebrow="Signaalbeeld"
+              title={productExperience.signalTabTitle}
+              description={productExperience.signalTabDescription}
+              tone="slate"
+            >
+              <div className="mt-1">
                 <RiskCharts
                   distribution={riskDistribution}
                   histogramBins={riskHistogram}
@@ -836,7 +839,7 @@ export default async function CampaignPage({ params }: Props) {
                   scanType={stats.scan_type}
                 />
               </div>
-            </div>
+            </DashboardChartPanel>
           ),
         },
         {
@@ -1410,12 +1413,12 @@ export default async function CampaignPage({ params }: Props) {
               </div>
             ) : null}
 
-            <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4 sm:p-5">
-              <h3 className="text-sm font-semibold text-slate-950">{productExperience.focusQuestionTitle}</h3>
-              <p className="mt-1 text-sm leading-6 text-slate-600">
-                {productExperience.focusQuestionDescription}
-              </p>
-              <div className="mt-4">
+            <DashboardRecommendationRail
+              eyebrow="Eerste managementvragen"
+              title={productExperience.focusQuestionTitle}
+              description={productExperience.focusQuestionDescription}
+              tone="emerald"
+            >
                 <RecommendationList
                   factorAverages={factorData.orgAverages}
                   scanType={stats.scan_type}
@@ -1425,20 +1428,21 @@ export default async function CampaignPage({ params }: Props) {
                       : undefined
                   }
                 />
-              </div>
-            </div>
+            </DashboardRecommendationRail>
 
             {stats.scan_type === 'retention' || stats.scan_type === 'exit' || stats.scan_type === 'pulse' || stats.scan_type === 'team' || stats.scan_type === 'onboarding' || stats.scan_type === 'leadership' ? (
               <>
-                <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4 sm:p-5">
-                  <h3 className="text-sm font-semibold text-slate-950">{productExperience.playbookTitle}</h3>
-                  <p className="mt-1 text-sm leading-6 text-slate-600">
-                    {productExperience.playbookDescription}
-                  </p>
-                  {stats.scan_type === 'retention' && playbookCalibrationNote ? (
-                    <p className="mt-2 text-xs leading-6 text-slate-500">{playbookCalibrationNote}</p>
-                  ) : null}
-                  <div className="mt-4">
+                <DashboardRecommendationRail
+                  eyebrow="Eerste playbook"
+                  title={productExperience.playbookTitle}
+                  description={productExperience.playbookDescription}
+                  tone="blue"
+                  aside={
+                    stats.scan_type === 'retention' && playbookCalibrationNote ? (
+                      <p className="text-xs leading-6 text-[color:var(--dashboard-text)]">{playbookCalibrationNote}</p>
+                    ) : null
+                  }
+                >
                     <ActionPlaybookList
                       factorAverages={factorData.orgAverages}
                       scanType={stats.scan_type}
@@ -1448,16 +1452,15 @@ export default async function CampaignPage({ params }: Props) {
                           : undefined
                       }
                     />
-                  </div>
-                </div>
+                </DashboardRecommendationRail>
 
                 {stats.scan_type === 'retention' && hasSegmentDeepDive ? (
-                  <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4 sm:p-5">
-                    <h3 className="text-sm font-semibold text-slate-950">Segment-specifieke playbooks</h3>
-                    <p className="mt-1 text-sm leading-6 text-slate-600">
-                      Alleen zichtbaar als segmentvergelijking voldoende respons en metadata heeft.
-                    </p>
-                    <div className="mt-4">
+                  <DashboardRecommendationRail
+                    eyebrow="Segmentvergelijking"
+                    title="Segment-specifieke playbooks"
+                    description="Alleen zichtbaar als segmentvergelijking voldoende respons en metadata heeft."
+                    tone="slate"
+                  >
                       {retentionSegmentPlaybooks.length > 0 ? (
                         <SegmentPlaybookList segments={retentionSegmentPlaybooks} />
                       ) : (
@@ -1465,8 +1468,7 @@ export default async function CampaignPage({ params }: Props) {
                           Nog geen segmenten met voldoende n en voldoende afwijking om apart te tonen.
                         </div>
                       )}
-                    </div>
-                  </div>
+                  </DashboardRecommendationRail>
                 ) : null}
               </>
             ) : null}

--- a/frontend/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/page.tsx
@@ -110,7 +110,7 @@ export default async function DashboardHomePage() {
               <DashboardChip label="Operations cockpit" tone="blue" />
               <Link
                 href="/beheer"
-                className="inline-flex rounded-full bg-[color:var(--ink)] px-4 py-2 text-sm font-semibold text-[color:var(--bg)] transition-colors hover:bg-[#1B2E45]"
+                className="inline-flex rounded-full border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-ink)] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#1B2E45]"
               >
                 Nieuwe campaign
               </Link>
@@ -163,7 +163,7 @@ export default async function DashboardHomePage() {
             aside={<DashboardChip label={primaryExecutionState.dashboardVisible ? 'Dashboard actief' : 'Uitvoer loopt'} tone={primaryExecutionState.dashboardVisible ? 'emerald' : 'amber'} />}
           >
             <div className="grid gap-4 xl:grid-cols-[minmax(0,1.4fr),minmax(320px,0.6fr)]">
-              <div className="rounded-[22px] border border-[color:var(--border)] bg-white p-4 shadow-[0_10px_30px_rgba(19,32,51,0.05)]">
+              <div className="rounded-[28px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)] p-5 shadow-[0_18px_40px_rgba(17,24,39,0.07)]">
                 <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
                   Eerstvolgende stap
                 </p>
@@ -183,7 +183,7 @@ export default async function DashboardHomePage() {
                   ))}
                 </div>
               </div>
-              <div className="rounded-[22px] border border-[color:var(--border)] bg-[color:var(--bg)] p-4">
+              <div className="rounded-[28px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)] p-5">
                 <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
                   Jouw campagne nu
                 </p>
@@ -195,7 +195,7 @@ export default async function DashboardHomePage() {
                 </p>
                 <Link
                   href={`/campaigns/${primaryGuideCampaign.campaign_id}`}
-                  className="mt-4 inline-flex rounded-full border border-[#d6e4e8] bg-[#f3f8f8] px-4 py-2 text-sm font-semibold text-[#234B57] transition-colors hover:border-[#bfd3d8] hover:bg-[#e9f2f3]"
+                  className="mt-4 inline-flex rounded-full border border-[color:var(--dashboard-accent-soft-border)] bg-[color:var(--dashboard-accent-soft)] px-4 py-2 text-sm font-semibold text-[color:var(--dashboard-accent-strong)] transition-colors hover:brightness-[0.98]"
                 >
                   {primaryExecutionState.dashboardVisible ? 'Open campaign en dashboard' : 'Open uitvoerflow'}
                 </Link>
@@ -336,8 +336,8 @@ function CampaignRow({
   const readiness = getCampaignReadiness(campaign)
 
   return (
-    <div className="rounded-[24px] border border-[color:var(--border)] bg-white px-4 py-4 shadow-[0_10px_30px_rgba(19,32,51,0.05)]">
-      <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+    <div className="rounded-[28px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)] px-4 py-4 shadow-[0_18px_40px_rgba(17,24,39,0.07)]">
+      <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between xl:gap-6">
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-2">
             <DashboardChip label={scanDefinition.productName} tone={campaign.scan_type === 'retention' ? 'emerald' : 'blue'} />
@@ -349,7 +349,7 @@ function CampaignRow({
           <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">{nextAction.body}</p>
         </div>
 
-        <div className="grid gap-3 sm:grid-cols-2 xl:min-w-[420px] xl:grid-cols-4">
+        <div className="grid gap-3 sm:grid-cols-2 xl:min-w-[420px] xl:grid-cols-2 2xl:min-w-[560px] 2xl:grid-cols-4">
           <StatCell label="Respons" value={`${campaign.completion_rate_pct ?? 0}%`} />
           <StatCell label="Ingevuld" value={`${campaign.total_completed}`} />
           <StatCell label="Uitgenodigd" value={`${campaign.total_invited}`} />
@@ -362,7 +362,7 @@ function CampaignRow({
 
       <div className="mt-4 flex flex-col gap-3 border-t border-[color:var(--border)]/80 pt-4 lg:flex-row lg:items-center lg:justify-between">
         <div className="flex flex-wrap items-center gap-2 text-sm">
-          <span className="rounded-full bg-[color:var(--bg)] px-3 py-1 font-medium text-[color:var(--text)]">
+          <span className="rounded-full bg-[color:var(--dashboard-soft)] px-3 py-1 font-medium text-[color:var(--dashboard-text)]">
             {nextAction.label}
           </span>
           <span className="text-[color:var(--muted)]">•</span>
@@ -374,7 +374,7 @@ function CampaignRow({
           {isAdmin && getCampaignBucket(campaign) === 'setup' ? (
             <Link
               href="/beheer"
-              className="inline-flex rounded-full border border-[color:var(--border)] bg-[color:var(--bg)] px-4 py-2 text-sm font-semibold text-[color:var(--ink)] transition-colors hover:border-[#d6e4e8] hover:text-[#234B57]"
+              className="inline-flex rounded-full border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)] px-4 py-2 text-sm font-semibold text-[color:var(--dashboard-ink)] transition-colors hover:border-[color:var(--dashboard-accent-soft-border)] hover:text-[color:var(--dashboard-accent-strong)]"
             >
               Naar setup
             </Link>
@@ -383,7 +383,7 @@ function CampaignRow({
             {showOnboarding ? <OnboardingBalloon step={1} label="Open je campagne" align="left" /> : null}
             <Link
               href={`/campaigns/${campaign.campaign_id}`}
-              className="inline-flex rounded-full border border-[#d6e4e8] bg-[#f3f8f8] px-4 py-2 text-sm font-semibold text-[#234B57] transition-colors hover:border-[#bfd3d8] hover:bg-[#e9f2f3]"
+              className="inline-flex rounded-full border border-[color:var(--dashboard-accent-soft-border)] bg-[color:var(--dashboard-accent-soft)] px-4 py-2 text-sm font-semibold text-[color:var(--dashboard-accent-strong)] transition-colors hover:brightness-[0.98]"
             >
               {!isAdmin && getCampaignBucket(campaign) !== 'ready' ? 'Open uitvoerflow' : 'Open dashboard'}
             </Link>
@@ -411,13 +411,13 @@ function UtilityCard({
   cta: string
 }) {
   return (
-    <div className="rounded-[22px] border border-[color:var(--border)] bg-white p-4 shadow-[0_10px_30px_rgba(19,32,51,0.05)]">
+    <div className="rounded-[28px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)] p-5 shadow-[0_18px_40px_rgba(17,24,39,0.07)]">
       <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">{eyebrow}</p>
       <p className="mt-2 text-base font-semibold text-[color:var(--ink)]">{title}</p>
       <p className="mt-3 text-sm leading-6 text-[color:var(--text)]">{body}</p>
       <Link
         href={href}
-        className="mt-4 inline-flex rounded-full border border-[color:var(--border)] bg-[color:var(--bg)] px-4 py-2 text-sm font-semibold text-[color:var(--ink)] transition-colors hover:border-[#d6e4e8] hover:text-[#234B57]"
+        className="mt-4 inline-flex rounded-full border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)] px-4 py-2 text-sm font-semibold text-[color:var(--dashboard-ink)] transition-colors hover:border-[color:var(--dashboard-accent-soft-border)] hover:text-[color:var(--dashboard-accent-strong)]"
       >
         {cta}
       </Link>
@@ -438,7 +438,7 @@ function StatCell({ label, value }: { label: string; value: string }) {
             : null
 
   return (
-    <div className="rounded-2xl border border-[color:var(--border)] bg-[color:var(--bg)] px-4 py-3">
+    <div className="rounded-[22px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)] px-4 py-3">
       <div className="flex items-center gap-1.5">
         <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">{label}</p>
         {helpText ? <InfoTooltip text={helpText} /> : null}

--- a/frontend/app/(dashboard)/layout.tsx
+++ b/frontend/app/(dashboard)/layout.tsx
@@ -1,9 +1,7 @@
-﻿import { createClient } from '@/lib/supabase/server'
-import { redirect } from 'next/navigation'
-import Link from 'next/link'
-import { LogoutButton } from '@/components/ui/logout-button'
-import { MobileNav } from '@/components/ui/mobile-nav'
+import { DashboardShellFrame } from '@/components/dashboard/dashboard-shell'
+import { createClient } from '@/lib/supabase/server'
 import { syncPendingOrgInvitesForUser } from '@/lib/supabase/sync-org-invites'
+import { redirect } from 'next/navigation'
 
 export default async function DashboardLayout({
   children,
@@ -11,14 +9,14 @@ export default async function DashboardLayout({
   children: React.ReactNode
 }) {
   const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
 
   if (!user) redirect('/login')
 
   const { acceptedCount } = await syncPendingOrgInvitesForUser(supabase)
 
-  // isAdmin = alleen accounts met is_verisight_admin = true in profiles
-  // HR-klanten hebben altijd false, ook als ze owner/member zijn van een org
   const { data: profile } = await supabase
     .from('profiles')
     .select('is_verisight_admin')
@@ -26,69 +24,10 @@ export default async function DashboardLayout({
     .single()
 
   const isAdmin = profile?.is_verisight_admin === true
-  const accountLabel = isAdmin ? 'Verisight beheer' : 'Klantdashboard'
 
   return (
-    <div className="dashboard-shell min-h-screen flex flex-col bg-[color:var(--bg)] text-[color:var(--ink)]">
-      {/* Top navigatiebalk */}
-      <header className="sticky top-0 z-40 border-b border-[color:var(--border)] bg-[color:var(--surface)]/95 backdrop-blur">
-        <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-4 sm:px-6">
-          <div className="flex items-center gap-4">
-            {/* Hamburger voor mobiel */}
-            <MobileNav isAdmin={isAdmin} />
-            <Link href="/dashboard" className="text-lg font-bold tracking-tight text-[color:var(--ink)]">
-              Verisight
-            </Link>
-            <nav className="hidden sm:flex items-center gap-1">
-              <NavLink href="/dashboard">Campaigns</NavLink>
-              {/* Setup is alleen zichtbaar voor Verisight-beheerders, niet voor HR-klanten */}
-              {isAdmin && <NavLink href="/beheer">Setup</NavLink>}
-              {isAdmin && <NavLink href="/beheer/contact-aanvragen">Leads</NavLink>}
-            </nav>
-          </div>
-          <div className="flex items-center gap-3">
-            <span
-              className={`hidden sm:inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-semibold ${
-                isAdmin
-                  ? 'border-[#d6e4e8] bg-[#f3f8f8] text-[#234B57]'
-                  : 'border-[#d2e6e0] bg-[#eef7f4] text-[#3C8D8A]'
-              }`}
-            >
-              {accountLabel}
-            </span>
-            <span className="hidden max-w-[160px] truncate text-xs text-[color:var(--muted)] sm:block">
-              {user.email}
-            </span>
-            <LogoutButton />
-          </div>
-        </div>
-      </header>
-
-      {/* Pagina-inhoud */}
-      <main className="mx-auto flex-1 w-full max-w-7xl px-4 py-8 sm:px-6">
-        {acceptedCount > 0 && (
-          <div className="mb-6 rounded-xl border border-[#d2e6e0] bg-[#eef7f4] px-4 py-3 text-sm text-[#234B57]">
-            Jouw account is gekoppeld aan {acceptedCount} organisatie{acceptedCount === 1 ? '' : 's'}.
-            Je ziet nu automatisch het juiste klantdashboard en de bijbehorende rapportages.
-          </div>
-        )}
-        {children}
-      </main>
-
-      <footer className="border-t border-[color:var(--border)] py-4 text-center text-xs text-[color:var(--muted)]">
-        Verisight v2.0 · Vertrouwelijk platform
-      </footer>
-    </div>
-  )
-}
-
-function NavLink({ href, children }: { href: string; children: React.ReactNode }) {
-  return (
-    <Link
-      href={href}
-      className="rounded-full px-3 py-1.5 text-sm font-medium text-[color:var(--text)] transition-colors hover:bg-[color:var(--bg)] hover:text-[color:var(--ink)]"
-    >
+    <DashboardShellFrame isAdmin={isAdmin} userEmail={user.email ?? ''} acceptedCount={acceptedCount}>
       {children}
-    </Link>
+    </DashboardShellFrame>
   )
 }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -27,6 +27,25 @@
   --marketing-shadow-strong: 0 28px 72px rgba(19, 32, 51, 0.11);
   --dashboard-shadow-soft: 0 16px 42px rgba(19, 32, 51, 0.06);
   --dashboard-shadow-strong: 0 18px 44px rgba(19, 32, 51, 0.1);
+
+  /* Dashboard presentation system */
+  --dashboard-canvas: #f4eee6;
+  --dashboard-surface: #fffaf4;
+  --dashboard-soft: #f3ece2;
+  --dashboard-ink: #132033;
+  --dashboard-text: #4e5b67;
+  --dashboard-muted: #7c8a95;
+  --dashboard-frame-border: rgba(35, 75, 87, 0.14);
+  --dashboard-rail: #172332;
+  --dashboard-rail-text: #f6f1e9;
+  --dashboard-rail-border: rgba(255, 255, 255, 0.08);
+  --dashboard-topbar: rgba(249, 244, 237, 0.84);
+  --dashboard-topbar-strong: rgba(249, 244, 237, 0.92);
+  --dashboard-accent-soft: #e8f0ed;
+  --dashboard-accent-soft-border: rgba(60, 141, 138, 0.18);
+  --dashboard-accent-strong: #2d6f6c;
+  --dashboard-blue-soft: #e9f0f3;
+  --dashboard-amber-soft: #f7efd9;
 }
 
 @theme inline {
@@ -451,6 +470,35 @@ details > summary::-webkit-details-marker {
     color: var(--ink);
   }
 
+  .dashboard-shell-root {
+    background:
+      radial-gradient(circle at top right, rgba(255, 255, 255, 0.9), transparent 26%),
+      linear-gradient(180deg, var(--dashboard-canvas) 0%, #efe7dc 100%);
+  }
+
+  .dashboard-mode-admin {
+    --dashboard-canvas: #f3f1ed;
+    --dashboard-surface: #fcfbf8;
+    --dashboard-soft: #f2f0eb;
+    --dashboard-text: #55606a;
+    --dashboard-muted: #7f8a93;
+    --dashboard-frame-border: rgba(35, 75, 87, 0.11);
+    --dashboard-topbar: rgba(246, 243, 238, 0.86);
+    --dashboard-topbar-strong: rgba(246, 243, 238, 0.94);
+    --dashboard-blue-soft: #ebf0f3;
+    --dashboard-accent-soft: #edf2f1;
+    --dashboard-accent-soft-border: rgba(60, 141, 138, 0.14);
+    --dashboard-accent-strong: #305864;
+  }
+
+  .dashboard-mode-buyer {
+    --dashboard-canvas: #f4eee6;
+    --dashboard-surface: #fffaf4;
+    --dashboard-soft: #f3ece2;
+    --dashboard-topbar: rgba(249, 244, 237, 0.84);
+    --dashboard-topbar-strong: rgba(249, 244, 237, 0.92);
+  }
+
   .dashboard-surface {
     border: 1px solid var(--border);
     background: var(--surface);
@@ -477,6 +525,40 @@ details > summary::-webkit-details-marker {
     font-weight: 700;
     letter-spacing: 0.2em;
     text-transform: uppercase;
+  }
+
+  .dashboard-mode-buyer .bg-slate-50,
+  .dashboard-mode-admin .bg-slate-50 {
+    background-color: var(--dashboard-soft) !important;
+  }
+
+  .dashboard-mode-buyer .bg-white,
+  .dashboard-mode-admin .bg-white {
+    background-color: color-mix(in srgb, var(--dashboard-surface) 94%, white 6%) !important;
+  }
+
+  .dashboard-mode-buyer .border-slate-200,
+  .dashboard-mode-admin .border-slate-200 {
+    border-color: var(--dashboard-frame-border) !important;
+  }
+
+  .dashboard-mode-buyer .text-slate-950,
+  .dashboard-mode-admin .text-slate-950 {
+    color: var(--dashboard-ink) !important;
+  }
+
+  .dashboard-mode-buyer .text-slate-700,
+  .dashboard-mode-admin .text-slate-700 {
+    color: var(--dashboard-text) !important;
+  }
+
+  .dashboard-mode-buyer .text-slate-600,
+  .dashboard-mode-admin .text-slate-600,
+  .dashboard-mode-buyer .text-slate-500,
+  .dashboard-mode-admin .text-slate-500,
+  .dashboard-mode-buyer .text-slate-400,
+  .dashboard-mode-admin .text-slate-400 {
+    color: var(--dashboard-muted) !important;
   }
 
   .marketing-flow-stack > * {

--- a/frontend/components/dashboard/dashboard-primitives.tsx
+++ b/frontend/components/dashboard/dashboard-primitives.tsx
@@ -1,19 +1,61 @@
-import type { ReactNode } from 'react'
+import React, { type ReactNode } from 'react'
 
 type Tone = 'slate' | 'blue' | 'emerald' | 'amber'
 
-const TONE_STYLES: Record<Tone, string> = {
-  slate: 'border-[color:var(--border)] bg-white',
-  blue: 'border-[#d6e4e8] bg-[#f3f8f8]',
-  emerald: 'border-[#d2e6e0] bg-[#eef7f4]',
-  amber: 'border-[#eadfbe] bg-[#faf6ea]',
+const TONE_SURFACES: Record<Tone, string> = {
+  slate: 'border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)]',
+  blue: 'border-[#c8d7df] bg-[color:var(--dashboard-blue-soft)]',
+  emerald: 'border-[color:var(--dashboard-accent-soft-border)] bg-[color:var(--dashboard-accent-soft)]',
+  amber: 'border-[#e6d6af] bg-[color:var(--dashboard-amber-soft)]',
 }
 
-const TONE_ACCENTS: Record<Tone, string> = {
-  slate: 'text-[color:var(--text)]',
-  blue: 'text-[#234B57]',
-  emerald: 'text-[#3C8D8A]',
-  amber: 'text-[#8C6B1F]',
+const TONE_LABELS: Record<Tone, string> = {
+  slate: 'text-[color:var(--dashboard-text)]',
+  blue: 'text-[#204655]',
+  emerald: 'text-[color:var(--dashboard-accent-strong)]',
+  amber: 'text-[#7a5b18]',
+}
+
+const CARD_SHADOW = 'shadow-[0_18px_40px_rgba(17,24,39,0.07)]'
+const PANEL_GLOW = 'before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-white/72'
+
+function joinClasses(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(' ')
+}
+
+function DashboardSectionHeader({
+  eyebrow,
+  title,
+  description,
+  aside,
+  tone,
+}: {
+  eyebrow?: string
+  title: string
+  description?: string
+  aside?: ReactNode
+  tone: Tone
+}) {
+  return (
+    <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+      <div className="min-w-0">
+        {eyebrow ? (
+          <p className={joinClasses('text-[11px] font-semibold uppercase tracking-[0.24em]', TONE_LABELS[tone])}>
+            {eyebrow}
+          </p>
+        ) : null}
+        <h2 className="mt-2 max-w-4xl text-[1.65rem] font-semibold tracking-[-0.04em] text-[color:var(--dashboard-ink)] sm:text-[1.85rem]">
+          {title}
+        </h2>
+        {description ? (
+          <p className="mt-3 max-w-4xl text-sm leading-7 text-[color:var(--dashboard-text)] sm:text-[0.95rem]">
+            {description}
+          </p>
+        ) : null}
+      </div>
+      {aside ? <div className="shrink-0 lg:max-w-[340px] lg:text-right">{aside}</div> : null}
+    </div>
+  )
 }
 
 export function DashboardHero({
@@ -34,17 +76,32 @@ export function DashboardHero({
   tone?: Tone
 }) {
   return (
-    <section className={`overflow-visible rounded-[30px] border p-6 shadow-[0_18px_48px_rgba(19,32,51,0.08)] ${TONE_STYLES[tone]}`}>
-      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.5fr),minmax(320px,0.9fr)]">
-        <div>
-          <p className={`text-xs font-semibold uppercase tracking-[0.22em] ${TONE_ACCENTS[tone]}`}>{eyebrow}</p>
-          <h1 className="mt-3 text-3xl font-bold tracking-tight text-[color:var(--ink)]">{title}</h1>
-          <p className="mt-3 max-w-3xl text-sm leading-7 text-[color:var(--text)]">{description}</p>
+    <section
+      data-dashboard-primitive="hero"
+      className={joinClasses(
+        'relative overflow-hidden rounded-[34px] border px-6 py-6 sm:px-7 sm:py-7',
+        CARD_SHADOW,
+        PANEL_GLOW,
+        TONE_SURFACES[tone],
+      )}
+    >
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(255,255,255,0.86),transparent_36%)]" />
+      <div className="relative grid gap-5 xl:grid-cols-[minmax(0,1.4fr),minmax(280px,0.6fr)] xl:items-start">
+        <div className="min-w-0">
+          <p className={joinClasses('text-[11px] font-semibold uppercase tracking-[0.24em]', TONE_LABELS[tone])}>
+            {eyebrow}
+          </p>
+          <h1 className="mt-3 max-w-4xl text-[2rem] font-semibold tracking-[-0.05em] text-[color:var(--dashboard-ink)] sm:text-[2.45rem]">
+            {title}
+          </h1>
+          <p className="mt-4 max-w-4xl text-sm leading-7 text-[color:var(--dashboard-text)] sm:text-[0.97rem]">
+            {description}
+          </p>
           {meta ? <div className="mt-5 flex flex-wrap gap-2">{meta}</div> : null}
-          {actions ? <div className="mt-5 flex flex-wrap items-center gap-3">{actions}</div> : null}
+          {actions ? <div className="mt-6 flex flex-wrap items-center gap-3">{actions}</div> : null}
         </div>
         {aside ? (
-          <div className="rounded-3xl border border-white/80 bg-white/90 p-5 shadow-[0_16px_40px_rgba(19,32,51,0.06)]">
+          <div className="rounded-[28px] border border-white/75 bg-white/84 p-5 shadow-[0_20px_40px_rgba(17,24,39,0.07)] backdrop-blur">
             {aside}
           </div>
         ) : null}
@@ -71,18 +128,24 @@ export function DashboardSection({
   tone?: Tone
 }) {
   return (
-    <section id={id} className={`scroll-mt-36 rounded-[28px] border p-5 shadow-[0_16px_42px_rgba(19,32,51,0.06)] sm:p-6 ${TONE_STYLES[tone]}`}>
-      <div className="flex flex-col gap-4 border-b border-[color:var(--border)]/80 pb-4 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-          {eyebrow ? (
-            <p className={`text-xs font-semibold uppercase tracking-[0.22em] ${TONE_ACCENTS[tone]}`}>{eyebrow}</p>
-          ) : null}
-          <h2 className="mt-1 text-lg font-semibold text-[color:var(--ink)]">{title}</h2>
-          {description ? <p className="mt-2 max-w-3xl text-sm leading-6 text-[color:var(--text)]">{description}</p> : null}
-        </div>
-        {aside ? <div className="sm:text-right">{aside}</div> : null}
-      </div>
-      <div className="mt-5">{children}</div>
+    <section
+      id={id}
+      data-dashboard-primitive="section"
+      className={joinClasses(
+        'relative scroll-mt-40 overflow-hidden rounded-[32px] border px-5 py-5 sm:px-6 sm:py-6',
+        CARD_SHADOW,
+        PANEL_GLOW,
+        TONE_SURFACES[tone],
+      )}
+    >
+      <DashboardSectionHeader
+        eyebrow={eyebrow}
+        title={title}
+        description={description}
+        aside={aside}
+        tone={tone}
+      />
+      <div className="mt-5 border-t border-white/72 pt-5">{children}</div>
     </section>
   )
 }
@@ -103,28 +166,32 @@ export function DashboardDisclosure({
   return (
     <details
       open={defaultOpen}
-      className="group scroll-mt-36 rounded-[24px] border border-[color:var(--border)] bg-white shadow-[0_14px_36px_rgba(19,32,51,0.05)]"
+      className={joinClasses(
+        'group scroll-mt-40 overflow-hidden rounded-[30px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)]',
+        CARD_SHADOW,
+      )}
     >
-      <summary className="flex cursor-pointer list-none items-center justify-between gap-4 px-5 py-4 sm:px-6">
-        <div>
-          <p className="text-base font-semibold text-[color:var(--ink)]">{title}</p>
-          {description ? <p className="mt-1 text-sm leading-6 text-[color:var(--text)]">{description}</p> : null}
+      <summary className="flex cursor-pointer list-none flex-col gap-4 px-5 py-4 sm:px-6 lg:flex-row lg:items-center lg:justify-between">
+        <div className="min-w-0">
+          <p className="text-base font-semibold text-[color:var(--dashboard-ink)]">{title}</p>
+          {description ? (
+            <p className="mt-2 max-w-3xl text-sm leading-6 text-[color:var(--dashboard-text)]">{description}</p>
+          ) : null}
         </div>
-        <div className="flex items-center gap-3">
+        <div className="flex flex-wrap items-center gap-2">
           {badge}
-          <span className="rounded-full border border-[color:var(--border)] bg-[color:var(--bg)] px-3 py-1 text-xs font-medium text-[color:var(--text)]">
-            <span className="group-open:hidden">Toon</span>
-            <span className="hidden group-open:inline">Verberg</span>
-            {' '}detail
+          <span className="rounded-full border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)] px-3 py-1.5 text-xs font-semibold text-[color:var(--dashboard-text)]">
+            <span className="group-open:hidden">Toon detail</span>
+            <span className="hidden group-open:inline">Verberg detail</span>
           </span>
         </div>
       </summary>
-      <div className="border-t border-[color:var(--border)]/80 px-5 py-5 sm:px-6">{children}</div>
+      <div className="border-t border-[color:var(--dashboard-frame-border)] px-5 py-5 sm:px-6">{children}</div>
     </details>
   )
 }
 
-export function DashboardPanel({
+export function DashboardStatCard({
   title,
   value,
   body,
@@ -138,12 +205,113 @@ export function DashboardPanel({
   eyebrow?: string
 }) {
   return (
-    <div className={`rounded-[24px] border p-4 shadow-[0_8px_24px_rgba(19,32,51,0.04)] sm:p-5 ${TONE_STYLES[tone]}`}>
-      {eyebrow ? <p className={`text-xs font-semibold uppercase tracking-[0.18em] ${TONE_ACCENTS[tone]}`}>{eyebrow}</p> : null}
-      <p className="mt-1 text-sm font-semibold text-[color:var(--ink)]">{title}</p>
-      {value ? <p className="mt-3 text-3xl font-bold tracking-tight text-[color:var(--ink)]">{value}</p> : null}
-      <p className="mt-3 text-sm leading-6 text-[color:var(--text)]">{body}</p>
+    <div
+      data-dashboard-primitive="stat-card"
+      className={joinClasses(
+        'relative overflow-hidden rounded-[28px] border px-4 py-4 sm:px-5 sm:py-5',
+        CARD_SHADOW,
+        PANEL_GLOW,
+        TONE_SURFACES[tone],
+      )}
+    >
+      {eyebrow ? (
+        <p className={joinClasses('text-[11px] font-semibold uppercase tracking-[0.22em]', TONE_LABELS[tone])}>
+          {eyebrow}
+        </p>
+      ) : null}
+      <p className="mt-2 text-sm font-semibold text-[color:var(--dashboard-ink)]">{title}</p>
+      {value ? (
+        <p className="mt-4 text-[2.15rem] font-semibold tracking-[-0.06em] text-[color:var(--dashboard-ink)]">
+          {value}
+        </p>
+      ) : null}
+      <p className="mt-3 text-sm leading-6 text-[color:var(--dashboard-text)]">{body}</p>
     </div>
+  )
+}
+
+export const DashboardPanel = DashboardStatCard
+
+export function DashboardChartPanel({
+  eyebrow,
+  title,
+  description,
+  aside,
+  children,
+  tone = 'slate',
+}: {
+  eyebrow?: string
+  title: string
+  description?: string
+  aside?: ReactNode
+  children: ReactNode
+  tone?: Tone
+}) {
+  return (
+    <div
+      data-dashboard-primitive="chart-panel"
+      className={joinClasses(
+        'relative overflow-hidden rounded-[28px] border px-4 py-4 sm:px-5 sm:py-5',
+        CARD_SHADOW,
+        PANEL_GLOW,
+        TONE_SURFACES[tone],
+      )}
+    >
+      <DashboardSectionHeader
+        eyebrow={eyebrow}
+        title={title}
+        description={description}
+        aside={aside}
+        tone={tone}
+      />
+      <div className="mt-5 border-t border-white/70 pt-5">{children}</div>
+    </div>
+  )
+}
+
+export function DashboardRecommendationRail({
+  eyebrow,
+  title,
+  description,
+  aside,
+  children,
+  tone = 'blue',
+}: {
+  eyebrow?: string
+  title: string
+  description?: string
+  aside?: ReactNode
+  children: ReactNode
+  tone?: Tone
+}) {
+  return (
+    <section
+      data-dashboard-primitive="recommendation-rail"
+      className={joinClasses(
+        'relative overflow-hidden rounded-[30px] border px-4 py-4 sm:px-5 sm:py-5',
+        CARD_SHADOW,
+        PANEL_GLOW,
+        TONE_SURFACES[tone],
+      )}
+    >
+      <div className="grid gap-5 xl:grid-cols-[minmax(220px,0.34fr),minmax(0,0.66fr)] xl:items-start">
+        <div className="rounded-[24px] border border-white/70 bg-white/78 px-4 py-4">
+          {eyebrow ? (
+            <p className={joinClasses('text-[11px] font-semibold uppercase tracking-[0.24em]', TONE_LABELS[tone])}>
+              {eyebrow}
+            </p>
+          ) : null}
+          <h3 className="mt-3 text-[1.35rem] font-semibold tracking-[-0.04em] text-[color:var(--dashboard-ink)]">
+            {title}
+          </h3>
+          {description ? (
+            <p className="mt-3 text-sm leading-7 text-[color:var(--dashboard-text)]">{description}</p>
+          ) : null}
+          {aside ? <div className="mt-4">{aside}</div> : null}
+        </div>
+        <div className="min-w-0">{children}</div>
+      </div>
+    </section>
   )
 }
 
@@ -155,7 +323,13 @@ export function DashboardChip({
   tone?: Tone
 }) {
   return (
-    <span className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold ${TONE_STYLES[tone]} ${TONE_ACCENTS[tone]}`}>
+    <span
+      className={joinClasses(
+        'inline-flex items-center rounded-full border px-3 py-1.5 text-xs font-semibold',
+        TONE_SURFACES[tone],
+        TONE_LABELS[tone],
+      )}
+    >
       {label}
     </span>
   )
@@ -173,12 +347,14 @@ export function DashboardKeyValue({
   helpText?: string
 }) {
   return (
-    <div className="rounded-2xl border border-[color:var(--border)] bg-[color:var(--bg)] px-4 py-3">
+    <div className="rounded-[24px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)] px-4 py-3">
       <div className="flex items-center gap-1.5">
-        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--muted)]">{label}</p>
+        <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[color:var(--dashboard-muted)]">
+          {label}
+        </p>
         {helpText ? <InfoTooltip text={helpText} /> : null}
       </div>
-      <p className={`mt-2 text-lg font-semibold text-[color:var(--ink)] ${accent ?? ''}`}>{value}</p>
+      <p className={joinClasses('mt-2 text-lg font-semibold text-[color:var(--dashboard-ink)]', accent)}>{value}</p>
     </div>
   )
 }
@@ -193,32 +369,35 @@ export function DashboardSummaryBar({
   actions?: ReactNode
 }) {
   return (
-    <div className="sticky top-[4.35rem] z-30 space-y-3">
-      <div className="rounded-[24px] border border-[color:var(--border)] bg-[color:var(--surface)]/95 p-3 shadow-[0_18px_44px_rgba(19,32,51,0.10)] backdrop-blur">
+    <div className="sticky top-[5.85rem] z-30 space-y-3">
+      <div className="rounded-[28px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-topbar-strong)] p-3 shadow-[0_24px_52px_rgba(17,24,39,0.10)] backdrop-blur-xl">
         <div className="grid gap-3 xl:grid-cols-[minmax(0,1fr),auto] xl:items-start">
-          <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
             {items.map((item) => (
               <div
                 key={item.label}
-                className={`rounded-2xl border px-4 py-3 ${TONE_STYLES[item.tone ?? 'slate']}`}
+                className={joinClasses(
+                  'rounded-[22px] border px-4 py-3',
+                  TONE_SURFACES[item.tone ?? 'slate'],
+                  TONE_LABELS[item.tone ?? 'slate'],
+                )}
               >
-                <p className={`text-[11px] font-semibold uppercase tracking-[0.18em] ${TONE_ACCENTS[item.tone ?? 'slate']}`}>
-                  {item.label}
-                </p>
-                <p className="mt-2 text-sm font-semibold text-[color:var(--ink)]">{item.value}</p>
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em]">{item.label}</p>
+                <p className="mt-2 text-sm font-semibold text-[color:var(--dashboard-ink)]">{item.value}</p>
               </div>
             ))}
           </div>
           {actions ? <div className="flex flex-wrap items-center gap-2 xl:justify-end">{actions}</div> : null}
         </div>
       </div>
-      <nav className="rounded-[22px] border border-[color:var(--border)] bg-[color:var(--surface)]/95 px-3 py-2 shadow-[0_12px_28px_rgba(19,32,51,0.08)] backdrop-blur">
+
+      <nav className="rounded-[24px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-topbar-strong)] px-3 py-2 shadow-[0_16px_34px_rgba(17,24,39,0.07)] backdrop-blur-xl">
         <div className="flex flex-wrap gap-2">
           {anchors.map((anchor) => (
             <a
               key={anchor.id}
               href={`#${anchor.id}`}
-              className="rounded-full border border-[color:var(--border)] bg-[color:var(--bg)] px-3 py-2 text-xs font-semibold text-[color:var(--text)] transition-colors hover:border-[color:var(--teal)] hover:text-[color:var(--ink)]"
+              className="rounded-full border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)] px-3 py-2 text-xs font-semibold text-[color:var(--dashboard-text)] transition-colors hover:border-[color:var(--dashboard-accent-soft-border)] hover:text-[color:var(--dashboard-accent-strong)]"
             >
               {anchor.label}
             </a>
@@ -239,24 +418,30 @@ export function DashboardTimeline({
   items: Array<{ title: string; body: string; tone?: Tone }>
 }) {
   return (
-    <div className="rounded-[24px] border border-[color:var(--border)] bg-[color:var(--bg)] p-4 sm:p-5">
-      {title ? <h3 className="text-sm font-semibold text-[color:var(--ink)]">{title}</h3> : null}
-      {description ? <p className="mt-1 text-sm leading-6 text-[color:var(--text)]">{description}</p> : null}
-      <div className="mt-4 space-y-4">
+    <div className="rounded-[28px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)] p-4 sm:p-5">
+      {title ? <h3 className="text-sm font-semibold text-[color:var(--dashboard-ink)]">{title}</h3> : null}
+      {description ? <p className="mt-2 text-sm leading-6 text-[color:var(--dashboard-text)]">{description}</p> : null}
+      <div className="mt-5 space-y-4">
         {items.map((item, index) => (
-          <div key={`${item.title}-${index}`} className="grid gap-4 md:grid-cols-[84px,minmax(0,1fr)]">
+          <div key={`${item.title}-${index}`} className="grid gap-4 md:grid-cols-[88px,minmax(0,1fr)]">
             <div className="flex items-start gap-3 md:flex-col md:gap-2">
-              <span className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-[color:var(--ink)] text-sm font-semibold text-[color:var(--bg)]">
+              <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-[color:var(--dashboard-ink)] text-sm font-semibold text-white">
                 {index + 1}
               </span>
-              <div className="hidden h-full w-px bg-[color:var(--border)] md:block" />
+              <div className="hidden h-full w-px bg-[color:var(--dashboard-frame-border)] md:block" />
             </div>
-            <div className={`rounded-[22px] border p-4 ${TONE_STYLES[item.tone ?? 'slate']}`}>
-              <p className={`text-xs font-semibold uppercase tracking-[0.18em] ${TONE_ACCENTS[item.tone ?? 'slate']}`}>
+            <div
+              className={joinClasses(
+                'rounded-[24px] border px-4 py-4',
+                TONE_SURFACES[item.tone ?? 'slate'],
+                CARD_SHADOW,
+              )}
+            >
+              <p className={joinClasses('text-[11px] font-semibold uppercase tracking-[0.18em]', TONE_LABELS[item.tone ?? 'slate'])}>
                 Fase {index + 1}
               </p>
-              <p className="mt-2 text-sm font-semibold text-[color:var(--ink)]">{item.title}</p>
-              <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">{item.body}</p>
+              <p className="mt-2 text-sm font-semibold text-[color:var(--dashboard-ink)]">{item.title}</p>
+              <p className="mt-2 text-sm leading-6 text-[color:var(--dashboard-text)]">{item.body}</p>
             </div>
           </div>
         ))}
@@ -271,11 +456,11 @@ export function InfoTooltip({ text }: { text: string }) {
       <button
         type="button"
         aria-label="Meer informatie"
-        className="inline-flex h-4 w-4 items-center justify-center rounded-full border border-[color:var(--border)] bg-white text-[10px] font-semibold leading-none text-[color:var(--muted)] transition-colors hover:border-[color:var(--text)] hover:text-[color:var(--ink)] focus:border-[color:var(--teal)] focus:text-[color:var(--teal)] focus:outline-none focus:ring-2 focus:ring-[color:var(--teal-light)]"
+        className="inline-flex h-4 w-4 items-center justify-center rounded-full border border-[color:var(--dashboard-frame-border)] bg-white text-[10px] font-semibold leading-none text-[color:var(--dashboard-muted)] transition-colors hover:border-[color:var(--dashboard-accent-soft-border)] hover:text-[color:var(--dashboard-accent-strong)] focus:border-[color:var(--dashboard-accent-soft-border)] focus:text-[color:var(--dashboard-accent-strong)] focus:outline-none focus:ring-2 focus:ring-[color:var(--dashboard-accent-soft)]"
       >
         i
       </button>
-      <span className="pointer-events-none absolute bottom-full left-1/2 z-30 mb-2 hidden w-64 -translate-x-1/2 rounded-xl bg-[color:var(--ink)] px-3 py-2 text-xs font-medium leading-5 text-white shadow-xl group-hover:block group-focus-within:block">
+      <span className="pointer-events-none absolute bottom-full left-1/2 z-30 mb-2 hidden w-64 -translate-x-1/2 rounded-2xl bg-[color:var(--dashboard-ink)] px-3 py-2 text-xs font-medium leading-5 text-white shadow-xl group-hover:block group-focus-within:block">
         {text}
       </span>
     </span>

--- a/frontend/components/dashboard/dashboard-shell.tsx
+++ b/frontend/components/dashboard/dashboard-shell.tsx
@@ -1,0 +1,201 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { useState } from 'react'
+import { LogoutButton } from '@/components/ui/logout-button'
+import {
+  getDashboardShellConfig,
+  isDashboardNavActive,
+} from '@/lib/dashboard/dashboard-shell-config'
+
+export function DashboardShellFrame({
+  isAdmin,
+  userEmail,
+  acceptedCount,
+  children,
+}: {
+  isAdmin: boolean
+  userEmail: string
+  acceptedCount: number
+  children: React.ReactNode
+}) {
+  const pathname = usePathname()
+  const [mobileNavOpen, setMobileNavOpen] = useState(false)
+  const config = getDashboardShellConfig({
+    isAdmin,
+    pathname,
+    acceptedCount,
+    userEmail,
+  })
+
+  return (
+    <div
+      className={`dashboard-shell-root dashboard-mode-${config.mode} min-h-screen bg-[color:var(--dashboard-canvas)] text-[color:var(--dashboard-ink)]`}
+      data-shell-mode={config.mode}
+    >
+      <div className="mx-auto flex min-h-screen w-full max-w-[1680px]">
+        <aside className="hidden w-[318px] shrink-0 border-r border-[color:var(--dashboard-rail-border)] bg-[color:var(--dashboard-rail)] text-[color:var(--dashboard-rail-text)] lg:flex">
+          <div className="sticky top-0 flex h-screen w-full flex-col px-6 py-7">
+            <Link
+              href="/dashboard"
+              className="rounded-[28px] border border-white/10 bg-white/[0.06] px-5 py-5 transition-colors hover:bg-white/10"
+            >
+              <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-white/[0.58]">Verisight suite</p>
+              <p className="mt-3 text-[1.75rem] font-semibold tracking-[-0.04em] text-white">Dashboard shell</p>
+              <p className="mt-3 text-sm leading-6 text-white/[0.72]">
+                Premium rust aan de buyer-kant, sobere controle aan de admin-kant. De execution-flow blijft zichtbaar en eerlijk.
+              </p>
+            </Link>
+
+            <div className="mt-6 rounded-[28px] border border-white/[0.08] bg-white/[0.06] px-5 py-5">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-white/[0.58]">Mode</p>
+              <p className="mt-3 text-base font-semibold text-white">{config.accountLabel}</p>
+              <p className="mt-2 text-sm leading-6 text-white/[0.72]">{config.modeLabel}</p>
+            </div>
+
+            <nav className="mt-8 flex-1 space-y-2">
+              {config.navigation.map((item) => {
+                const active = isDashboardNavActive(pathname, item.href)
+
+                return (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    className={`block rounded-[24px] border px-4 py-4 transition-all ${
+                      active
+                        ? 'border-white/[0.12] bg-white text-[color:var(--dashboard-ink)] shadow-[0_18px_36px_rgba(15,23,42,0.24)]'
+                        : 'border-transparent bg-transparent text-white/[0.82] hover:border-white/[0.08] hover:bg-white/[0.08]'
+                    }`}
+                  >
+                    <p
+                      className={`text-xs font-semibold uppercase tracking-[0.2em] ${
+                        active ? 'text-[color:var(--dashboard-accent-strong)]' : 'text-white/[0.5]'
+                      }`}
+                    >
+                      {item.label}
+                    </p>
+                    <p
+                      className={`mt-2 text-sm leading-6 ${
+                        active ? 'text-[color:var(--dashboard-text)]' : 'text-white/[0.68]'
+                      }`}
+                    >
+                      {item.detail}
+                    </p>
+                  </Link>
+                )
+              })}
+            </nav>
+
+            <div className="rounded-[26px] border border-white/[0.08] bg-white/[0.06] px-5 py-4">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-white/[0.5]">Account</p>
+              <p className="mt-2 truncate text-sm font-medium text-white">{config.userEmail}</p>
+              <div className="mt-4">
+                <LogoutButton className="w-full justify-center rounded-full border border-white/[0.12] bg-white/[0.08] px-4 py-2 text-sm font-semibold text-white hover:bg-white/[0.14]" />
+              </div>
+            </div>
+          </div>
+        </aside>
+
+        <div className="flex min-w-0 flex-1 flex-col">
+          <header className="sticky top-0 z-40 border-b border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-topbar)] backdrop-blur-xl">
+            <div className="mx-auto flex w-full max-w-[1360px] items-center gap-3 px-4 py-4 sm:px-6 xl:px-8">
+              <button
+                type="button"
+                onClick={() => setMobileNavOpen((open) => !open)}
+                className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)] text-[color:var(--dashboard-ink)] shadow-[0_12px_28px_rgba(15,23,42,0.08)] transition-colors hover:border-[color:var(--dashboard-accent-soft-border)] hover:text-[color:var(--dashboard-accent-strong)] lg:hidden"
+                aria-label="Navigatie openen"
+              >
+                <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  {mobileNavOpen ? (
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M6 6l12 12M18 6L6 18" />
+                  ) : (
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M4 7h16M4 12h16M4 17h16" />
+                  )}
+                </svg>
+              </button>
+
+              <div className="min-w-0 flex-1">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[color:var(--dashboard-muted)]">
+                  {config.accountLabel}
+                </p>
+                <div className="mt-1 flex flex-wrap items-center gap-2">
+                  <h1 className="text-xl font-semibold tracking-[-0.03em] text-[color:var(--dashboard-ink)]">
+                    {config.currentLabel}
+                  </h1>
+                  <span className="hidden rounded-full border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)] px-3 py-1 text-xs font-semibold text-[color:var(--dashboard-text)] sm:inline-flex">
+                    {config.modeLabel}
+                  </span>
+                </div>
+              </div>
+
+              <div className="hidden items-center gap-3 lg:flex">
+                <span className="max-w-[220px] truncate text-sm text-[color:var(--dashboard-text)]">
+                  {config.userEmail}
+                </span>
+                <LogoutButton className="rounded-full border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)] px-4 py-2 text-sm font-semibold text-[color:var(--dashboard-ink)] hover:border-[color:var(--dashboard-accent-soft-border)] hover:text-[color:var(--dashboard-accent-strong)]" />
+              </div>
+            </div>
+
+            {mobileNavOpen ? (
+              <div className="border-t border-[color:var(--dashboard-frame-border)] px-4 py-4 sm:px-6 lg:hidden">
+                <div className="space-y-3 rounded-[28px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)] p-3 shadow-[0_24px_50px_rgba(15,23,42,0.12)]">
+                  {config.navigation.map((item) => {
+                    const active = isDashboardNavActive(pathname, item.href)
+
+                    return (
+                      <Link
+                        key={item.href}
+                        href={item.href}
+                        onClick={() => setMobileNavOpen(false)}
+                        className={`block rounded-[22px] border px-4 py-3 ${
+                          active
+                            ? 'border-[color:var(--dashboard-accent-soft-border)] bg-[color:var(--dashboard-accent-soft)]'
+                            : 'border-transparent bg-[color:var(--dashboard-soft)]'
+                        }`}
+                      >
+                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
+                          {item.label}
+                        </p>
+                        <p className="mt-2 text-sm leading-6 text-[color:var(--dashboard-text)]">{item.detail}</p>
+                      </Link>
+                    )
+                  })}
+                  <div className="rounded-[22px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)] px-4 py-3">
+                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
+                      Account
+                    </p>
+                    <p className="mt-2 truncate text-sm font-medium text-[color:var(--dashboard-ink)]">
+                      {config.userEmail}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            ) : null}
+          </header>
+
+          <main className="flex-1">
+            <div className="mx-auto flex w-full max-w-[1360px] flex-col gap-5 px-4 py-5 sm:px-6 xl:px-8">
+              {config.bannerText ? (
+                <div className="rounded-[26px] border border-[color:var(--dashboard-accent-soft-border)] bg-[color:var(--dashboard-accent-soft)] px-5 py-4 text-sm leading-6 text-[color:var(--dashboard-accent-strong)] shadow-[0_18px_38px_rgba(31,41,55,0.07)]">
+                  {config.bannerText}
+                </div>
+              ) : null}
+
+              <div className="dashboard-content-frame min-w-0 rounded-[34px] border border-[color:var(--dashboard-frame-border)] bg-[linear-gradient(180deg,rgba(255,255,255,0.94)_0%,rgba(255,250,244,0.86)_100%)] p-4 shadow-[0_30px_70px_rgba(17,24,39,0.08)] sm:p-5 xl:p-6">
+                {children}
+              </div>
+            </div>
+          </main>
+
+          <footer className="border-t border-[color:var(--dashboard-frame-border)] px-4 py-4 text-xs text-[color:var(--dashboard-muted)] sm:px-6 xl:px-8">
+            <div className="mx-auto flex w-full max-w-[1360px] items-center justify-between gap-3">
+              <span>Verisight dashboard family</span>
+              <span>Buyer premium, admin sober, canon bounded</span>
+            </div>
+          </footer>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/components/dashboard/risk-charts.tsx
+++ b/frontend/components/dashboard/risk-charts.tsx
@@ -16,7 +16,7 @@ interface Props {
   scanType: ScanType
 }
 
-const COLORS = { HOOG: '#DC2626', MIDDEN: '#F59E0B', LAAG: '#16A34A' }
+const COLORS = { HOOG: '#B45309', MIDDEN: '#C78924', LAAG: '#2D6F6C' }
 
 export function RiskCharts({ distribution, histogramBins, averageScore, scanType }: Props) {
   const scanDefinition = getScanDefinition(scanType)
@@ -80,8 +80,8 @@ export function RiskCharts({ distribution, histogramBins, averageScore, scanType
 
   return (
     <div className="space-y-4">
-      <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700">
-        <p className="font-medium text-slate-900">
+      <div className="rounded-[24px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)] px-4 py-4 text-sm text-[color:var(--dashboard-text)]">
+        <p className="font-medium text-[color:var(--dashboard-ink)]">
           {scanType === 'exit'
             ? 'Wat zegt dit over het vertrekbeeld?'
             : scanType === 'team'
@@ -91,7 +91,7 @@ export function RiskCharts({ distribution, histogramBins, averageScore, scanType
               : 'Wat betekent dit voor behoudsduiding?'}
         </p>
         <p className="mt-1">{introText}</p>
-        <p className="mt-2 text-slate-800">{insightText}</p>
+        <p className="mt-2 text-[color:var(--dashboard-ink)]">{insightText}</p>
       </div>
 
       <ResponsiveContainer width="100%" height={160}>
@@ -123,10 +123,10 @@ export function RiskCharts({ distribution, histogramBins, averageScore, scanType
             <YAxis tick={{ fontSize: 10 }} allowDecimals={false} />
             <ReferenceLine
               x={`${Math.floor(averageScore)}-${Math.ceil(averageScore)}`}
-              stroke="#6B7280"
+              stroke="#7C8A95"
               strokeDasharray="3 3"
             />
-            <Bar dataKey="count" fill="#2563EB" radius={[2, 2, 0, 0]} />
+            <Bar dataKey="count" fill="#305864" radius={[2, 2, 0, 0]} />
             <Tooltip formatter={(v) => [`${v} responses`, 'Aantal']} />
           </BarChart>
         </ResponsiveContainer>

--- a/frontend/components/ui/logout-button.tsx
+++ b/frontend/components/ui/logout-button.tsx
@@ -3,7 +3,7 @@
 import { createClient } from '@/lib/supabase/client'
 import { useRouter } from 'next/navigation'
 
-export function LogoutButton() {
+export function LogoutButton({ className }: { className?: string }) {
   const router = useRouter()
   const supabase = createClient()
 
@@ -16,7 +16,10 @@ export function LogoutButton() {
   return (
     <button
       onClick={handleLogout}
-      className="text-xs text-gray-500 hover:text-gray-800 px-2 py-1 rounded hover:bg-gray-100 transition-colors"
+      className={
+        className ??
+        'rounded px-2 py-1 text-xs text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-800'
+      }
     >
       Uitloggen
     </button>

--- a/frontend/lib/dashboard/dashboard-primitives.test.ts
+++ b/frontend/lib/dashboard/dashboard-primitives.test.ts
@@ -1,0 +1,59 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import {
+  DashboardChartPanel,
+  DashboardRecommendationRail,
+  DashboardStatCard,
+} from '../../components/dashboard/dashboard-primitives'
+
+describe('dashboard primitives', () => {
+  it('renders stat cards with premium metric framing', () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(DashboardStatCard, {
+        eyebrow: 'Management-ready',
+        title: 'Campagnes',
+        value: '4',
+        body: 'Campagnes met genoeg respons om verantwoord te lezen.',
+        tone: 'blue',
+      }),
+    )
+
+    expect(markup).toContain('data-dashboard-primitive="stat-card"')
+    expect(markup).toContain('Management-ready')
+    expect(markup).toContain('Campagnes')
+    expect(markup).toContain('4')
+  })
+
+  it('renders chart and recommendation rails as separate dashboard surfaces', () => {
+    const chartMarkup = renderToStaticMarkup(
+      React.createElement(
+        DashboardChartPanel,
+        {
+          eyebrow: 'Signaalbeeld',
+          title: 'Verdeling',
+          description: 'Hoe breed het patroon nu zichtbaar wordt.',
+        },
+        React.createElement('div', null, 'chart'),
+      ),
+    )
+
+    const railMarkup = renderToStaticMarkup(
+      React.createElement(
+        DashboardRecommendationRail,
+        {
+          eyebrow: 'Wat eerst',
+          title: 'Aanbevelingsrail',
+          description: 'Begrens de eerste managementvragen.',
+          tone: 'emerald',
+        },
+        React.createElement('div', null, 'rail'),
+      ),
+    )
+
+    expect(chartMarkup).toContain('data-dashboard-primitive="chart-panel"')
+    expect(chartMarkup).toContain('Verdeling')
+    expect(railMarkup).toContain('data-dashboard-primitive="recommendation-rail"')
+    expect(railMarkup).toContain('Aanbevelingsrail')
+  })
+})

--- a/frontend/lib/dashboard/dashboard-shell-config.ts
+++ b/frontend/lib/dashboard/dashboard-shell-config.ts
@@ -1,0 +1,93 @@
+export type DashboardShellMode = 'buyer' | 'admin'
+
+export type DashboardNavItem = {
+  href: string
+  label: string
+  detail: string
+}
+
+export type DashboardShellConfig = {
+  mode: DashboardShellMode
+  accountLabel: string
+  modeLabel: string
+  currentLabel: string
+  bannerText: string | null
+  navigation: DashboardNavItem[]
+  userEmail: string
+}
+
+type DashboardShellConfigArgs = {
+  isAdmin: boolean
+  pathname: string
+  acceptedCount: number
+  userEmail: string
+}
+
+const BUYER_NAVIGATION: DashboardNavItem[] = [
+  {
+    href: '/dashboard',
+    label: 'Cockpit',
+    detail: 'Campaignstatus, managementread en rapportdiscipline.',
+  },
+]
+
+const ADMIN_NAVIGATION: DashboardNavItem[] = [
+  {
+    href: '/dashboard',
+    label: 'Cockpit',
+    detail: 'Buyer-facing waarheid, bewaakt vanuit operations.',
+  },
+  {
+    href: '/beheer',
+    label: 'Setup',
+    detail: 'Organisaties, campagnes en launchdiscipline.',
+  },
+  {
+    href: '/beheer/contact-aanvragen',
+    label: 'Leads',
+    detail: 'Sales-to-delivery context en overdracht.',
+  },
+  {
+    href: '/beheer/klantlearnings',
+    label: 'Learnings',
+    detail: 'Deliverylessen, repeat-signalen en closeout.',
+  },
+]
+
+export function getDashboardShellConfig({
+  isAdmin,
+  pathname,
+  acceptedCount,
+  userEmail,
+}: DashboardShellConfigArgs): DashboardShellConfig {
+  const mode: DashboardShellMode = isAdmin ? 'admin' : 'buyer'
+
+  return {
+    mode,
+    accountLabel: isAdmin ? 'Verisight beheer' : 'Klantdashboard',
+    modeLabel: isAdmin ? 'admin view · operations sober' : 'buyer view · premium guided execution',
+    currentLabel: getDashboardCurrentLabel(pathname),
+    bannerText:
+      acceptedCount > 0
+        ? `Jouw account is gekoppeld aan ${acceptedCount} organisatie${acceptedCount === 1 ? '' : 's'}. Je ziet nu automatisch het juiste klantdashboard en de bijbehorende rapportages.`
+        : null,
+    navigation: isAdmin ? ADMIN_NAVIGATION : BUYER_NAVIGATION,
+    userEmail,
+  }
+}
+
+export function isDashboardNavActive(pathname: string, href: string) {
+  if (href === '/dashboard') {
+    return pathname === '/dashboard' || pathname.startsWith('/campaigns/')
+  }
+
+  return pathname === href || pathname.startsWith(`${href}/`)
+}
+
+function getDashboardCurrentLabel(pathname: string) {
+  if (pathname.startsWith('/campaigns/')) return 'Campaign detail'
+  if (pathname.startsWith('/beheer/contact-aanvragen')) return 'Lead context'
+  if (pathname.startsWith('/beheer/klantlearnings')) return 'Learning workbench'
+  if (pathname.startsWith('/beheer')) return 'Setup en beheer'
+  return 'Campaign cockpit'
+}

--- a/frontend/lib/dashboard/dashboard-shell.test.ts
+++ b/frontend/lib/dashboard/dashboard-shell.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { getDashboardShellConfig } from './dashboard-shell-config'
+
+describe('dashboard shell config', () => {
+  it('keeps buyer mode premium but execution-honest', () => {
+    const config = getDashboardShellConfig({
+      isAdmin: false,
+      pathname: '/campaigns/demo-campaign',
+      acceptedCount: 2,
+      userEmail: 'buyer@example.com',
+    })
+
+    expect(config.mode).toBe('buyer')
+    expect(config.accountLabel).toBe('Klantdashboard')
+    expect(config.bannerText).toContain('2 organisatie')
+    expect(config.navigation[0]?.label).toBe('Cockpit')
+    expect(config.currentLabel).toBe('Campaign detail')
+    expect(config.modeLabel).toContain('buyer view')
+  })
+
+  it('keeps admin mode in the same family but deliberately soberer', () => {
+    const config = getDashboardShellConfig({
+      isAdmin: true,
+      pathname: '/beheer/contact-aanvragen',
+      acceptedCount: 0,
+      userEmail: 'admin@example.com',
+    })
+
+    expect(config.mode).toBe('admin')
+    expect(config.accountLabel).toBe('Verisight beheer')
+    expect(config.bannerText).toBeNull()
+    expect(config.navigation.some((item) => item.href === '/beheer/klantlearnings')).toBe(true)
+    expect(config.currentLabel).toBe('Lead context')
+    expect(config.modeLabel).toContain('admin view')
+  })
+})


### PR DESCRIPTION
## Samenvatting
- bouwt een nieuwe dashboard shell-owner met sidebar, sticky topbar, content frame en buyer/admin visual mode split
- brengt dashboard-scoped presentation primitives op één premium, warme en rustige discipline voor headers, KPI-cards, chart-panels en recommendation rails
- houdt execution-truth, bounded taal en de bestaande dashboard/report grammar intact terwijl home en campaign detail visueel worden opgetild

## Waarom
Deze wave moest de buyer-facing dashboardfamilie naar premium productniveau brengen zonder de bestaande execution-flow, state-logica of productcanon opnieuw open te breken.

## Verificatie
- `npm test -- "lib/dashboard/dashboard-shell.test.ts" "lib/dashboard/dashboard-primitives.test.ts" "app/(dashboard)/dashboard/page.test.ts" "app/(dashboard)/campaigns/[id]/page.test.ts"`
- `npm run build`
- visuele check met acceptance fixture op `/dashboard` en `/campaigns/[id]` inclusief screenshots en browsercontrole zonder error overlay of console-errors

## Canonbewaking
- geen nieuwe state-definities geopend
- geen flowlogica herschreven
- buyer premium, maar pre-launch en execution states blijven expliciet zichtbaar
- admin blijft in dezelfde technische familie, bewust soberder