### PR TITLE
[codex] Close out suite sanity-check blocker

### DIFF
--- a/frontend/lib/pulse-page-shell.test.ts
+++ b/frontend/lib/pulse-page-shell.test.ts
@@ -33,15 +33,16 @@ describe('Pulse buyer-facing shell', () => {
       'utf8',
     )
 
-    expect(campaignPageSource).toContain('compacte managementread')
     expect(campaignPageSource).toContain('Reviewcontext')
+    expect(campaignPageSource).toContain('Reviewlaag · bounded repeat motion')
     expect(campaignPageSource).toContain('Pulse groepsread en bounded vergelijking')
     expect(campaignPageSource).not.toContain('Deze laag vertaalt Pulse naar een bestuurlijk leesbare momentopname')
     expect(campaignPageSource).not.toContain('Snapshotcontext')
     expect(campaignPageSource).not.toContain('Pulse snapshot en reviewdelta')
 
+    expect(campaignHelpersSource).toContain('compacte managementread')
     expect(campaignHelpersSource).toContain('Lees Pulse als compacte groepsread')
-    expect(campaignHelpersSource).toContain('compacte groepsread met reviewcontext')
+    expect(campaignHelpersSource).toContain('bounded reviewlaag')
     expect(campaignHelpersSource).not.toContain('Lees Pulse als snapshot')
     expect(campaignHelpersSource).not.toContain('snapshot met reviewcontext')
 


### PR DESCRIPTION
## Summary
- close out the suite sanity-check branch with the single Pulse shell guardrail blocker fix
- realign the Pulse review guard test with the current bounded-copy split between campaign detail sources
- keep the PR scoped to the sanity-check closeout only

## Why
The sanity-check on suite base `ab9b95e75d7bfc193e4574c4a0364b1e8b433bb7` found one real blocker: `frontend/lib/pulse-page-shell.test.ts` still expected an older Pulse phrase on the wrong source file, while the bounded review copy itself was already correct.

## Impact
- no new implementation scope
- no design pass
- no product behavior change
- regression suite aligns with the landed Pulse shell wording again

## Validation
- `npm test`
- `npm run build`
- `npm run test:e2e -- tests/e2e/login-guided-flow.spec.ts`
- `npm run test:e2e:guided-self-serve`
