### PR TITLE
[codex] close out main environment notes

### DIFF
--- a/docs/ops/SETUP.md
+++ b/docs/ops/SETUP.md
@@ -125,8 +125,16 @@ Open `frontend/.env.local` en vul in:
 ```env
 NEXT_PUBLIC_SUPABASE_URL=https://jouw-project-id.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=jouw-anon-public-key
+SUPABASE_SERVICE_ROLE_KEY=jouw-service-role-key
+FRONTEND_URL=http://localhost:3000
 NEXT_PUBLIC_API_URL=http://localhost:8000
+BACKEND_ADMIN_TOKEN=jouw-backend-admin-token
 ```
+
+Extra context:
+- `SUPABASE_SERVICE_ROLE_KEY` blijft server-only, maar is nodig voor dashboardroutes die invites, organisatiegeheimen en admin-acties afhandelen.
+- `FRONTEND_URL` houdt auth- en invite-redirects expliciet.
+- `BACKEND_ADMIN_TOKEN` is nodig voor de interne backend-proxy rond rapportdownload en contactaanvragen.
 
 ### Dependencies installeren
 
@@ -222,14 +230,25 @@ npm run dev
 3. Stel de omgevingsvariabelen in:
    - `NEXT_PUBLIC_SUPABASE_URL`
    - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+   - `SUPABASE_SERVICE_ROLE_KEY`
+   - `FRONTEND_URL`
    - `NEXT_PUBLIC_API_URL` → jouw Railway-URL
+   - `BACKEND_ADMIN_TOKEN`
 4. Vercel deployt automatisch bij elke push naar `main`
+
+Zet deze set zowel voor `Preview` als `Production`, zodat auth-, invite- en dashboardflows niet alleen lokaal maar ook op preview consistent blijven werken.
 
 ### Supabase CORS instellen
 
 In Supabase → **Authentication → URL Configuration**:
 - **Site URL**: jouw Vercel-URL (bijv. `https://Verisight.vercel.app`)
 - **Redirect URLs**: `https://Verisight.vercel.app/**`
+
+Voeg daarnaast ook je preview-URL's toe als je invite- of authflows op preview wilt testen.
+
+### Google Fonts-buildnuance
+
+De frontend gebruikt IBM Plex Sans via `next/font/google`. Daardoor blijft `next build` afhankelijk van bereikbaarheid van Google Fonts. In Vercel en normale online CI is dat meestal geen probleem, maar in afgesloten netwerken kan dit als externe buildafhankelijkheid terugkomen.
 
 ---
 

--- a/docs/reference/ARCHITECTURE.md
+++ b/docs/reference/ARCHITECTURE.md
@@ -272,8 +272,10 @@ analyses
 |-----------|-----------|-------------|
 | `NEXT_PUBLIC_SUPABASE_URL` | ✅ | Supabase project URL |
 | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | ✅ | Publieke anon-sleutel (veilig in browser) |
+| `SUPABASE_SERVICE_ROLE_KEY` | ✅ | Server-only sleutel voor adminhelpers, invites en organization secrets |
+| `FRONTEND_URL` | ✅ voor expliciete redirects | Canonieke app-origin voor auth- en invite-links |
 | `NEXT_PUBLIC_API_URL` | ✅ | Railway backend URL |
-| `SENTRY_DSN` | ⬜ | Optioneel: error monitoring |
+| `BACKEND_ADMIN_TOKEN` | ✅ voor backend-proxy's | Server-only token voor interne backendacties |
 
 ---
 
@@ -330,6 +332,7 @@ app.add_middleware(CORSMiddleware,
 - Fix: `git config --global user.email "larshengel08@hotmail.com"`
 - Als build mislukt door missing package: voeg toe aan `frontend/package.json` dependencies.
 - `@sentry/nextjs` config: gebruik **camelCase** (`sendDefaultPii`, niet `send_default_pii`).
+- `frontend/app/layout.tsx` gebruikt `next/font/google` voor IBM Plex Sans, dus `next build` blijft afhankelijk van externe bereikbaarheid van Google Fonts.
 
 ### Railway (backend)
 - Draait op poort `8080` (Railway default) — niet 8000 zoals lokaal.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,36 +1,58 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Verisight frontend
 
-## Getting Started
+Next.js 15 App Router frontend voor de publieke site, loginflow en het dashboard.
 
-First, run the development server:
+## Lokale setup
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+1. Kopieer `frontend/.env.local.example` naar `frontend/.env.local`.
+2. Vul minimaal deze variabelen in:
+
+```env
+NEXT_PUBLIC_SUPABASE_URL=https://jouw-project-id.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=jouw-anon-public-key
+SUPABASE_SERVICE_ROLE_KEY=jouw-service-role-key
+FRONTEND_URL=http://localhost:3000
+NEXT_PUBLIC_API_URL=http://localhost:8000
+BACKEND_ADMIN_TOKEN=jouw-backend-admin-token
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Toelichting:
+- `NEXT_PUBLIC_SUPABASE_URL` en `NEXT_PUBLIC_SUPABASE_ANON_KEY` zijn nodig voor login, middleware en server-side Supabase helpers.
+- `SUPABASE_SERVICE_ROLE_KEY` blijft server-only, maar is wel nodig voor dashboardroutes die organisatiegeheimen of invites beheren.
+- `FRONTEND_URL` wordt gebruikt voor canonieke invite- en auth-redirectlinks.
+- `NEXT_PUBLIC_API_URL` is nodig voor de FastAPI-proxyroutes.
+- `BACKEND_ADMIN_TOKEN` is nodig voor server-only routes die de backend-adminproxy gebruiken.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+Installeer dependencies en start daarna de devserver:
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+```bash
+npm install
+npm run dev
+```
 
-## Learn More
+## Build en verificatie
 
-To learn more about Next.js, take a look at the following resources:
+Gebruik voor een lokale productiecheck dezelfde minimale env-set als hierboven en draai daarna:
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+```bash
+npm run build
+```
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+Voor een CI-achtige check kun je dezelfde build met `CI=true` draaien. De repo gebruikt lokaal een aparte `NEXT_DIST_DIR`, maar in Vercel en CI valt die bewust terug naar de standaard `.next` output.
 
-## Deploy on Vercel
+## Vercel preview en production
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+Zet in Vercel zowel voor `Preview` als `Production` minimaal deze variabelen:
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `FRONTEND_URL`
+- `NEXT_PUBLIC_API_URL`
+- `BACKEND_ADMIN_TOKEN`
+
+Voor previewdeploys mag `FRONTEND_URL` naar de preview-URL wijzen; voor productie moet dit de canonieke productiedomeinnaam zijn.
+
+## Bekende buildnuance
+
+`frontend/app/layout.tsx` gebruikt `next/font/google` voor IBM Plex Sans. Daardoor blijft de build afhankelijk van bereikbaarheid van Google Fonts tijdens `next build`. In normale Vercel- en online CI-omgevingen is dat geen blocker, maar in volledig afgesloten of instabiele netwerken kan dit alsnog een externe buildnuance zijn.

--- a/frontend/components/marketing/site-content.ts
+++ b/frontend/components/marketing/site-content.ts
@@ -64,6 +64,21 @@ export const homepageProductRoutes = [
   },
 ] as const
 
+export const homepageCoreProductRoutes = homepageProductRoutes.filter((route) => route.chip === 'Kernroute')
+
+const combinationHomepageRoute = homepageProductRoutes.find((route) => route.name === 'Combinatie')
+
+if (!combinationHomepageRoute) {
+  throw new Error('Homepage portfolioroute ontbreekt.')
+}
+
+export const homepagePortfolioRoute = {
+  label: 'Portfolioroute',
+  title: combinationHomepageRoute.title,
+  body: combinationHomepageRoute.body,
+  href: combinationHomepageRoute.href,
+} as const
+
 export const homepageComparisonRows = [
   [
     'Je wilt begrijpen waarom mensen zijn gegaan',

--- a/frontend/lib/marketing-flow.test.ts
+++ b/frontend/lib/marketing-flow.test.ts
@@ -10,6 +10,8 @@ import {
 import { getBuyerFacingShowcaseAssets } from '@/lib/sample-showcase-assets'
 import {
   approachSteps,
+  homepageCoreProductRoutes,
+  homepagePortfolioRoute,
   homepageProductRoutes,
   homepageUtilityLinks,
   included,
@@ -45,6 +47,16 @@ describe('marketing flow defaults', () => {
     expect(homepageProductRoutes[0]?.chip).toBe('Kernroute')
     expect(homepageProductRoutes[1]?.chip).toBe('Kernroute')
     expect(homepageProductRoutes[2]?.body.toLowerCase()).toContain('nadat de eerste helder staat')
+  })
+
+  it('keeps the homepage compatibility exports aligned with the route split used by the landing page', () => {
+    expect(homepageCoreProductRoutes.map((route) => route.name)).toEqual(['ExitScan', 'RetentieScan'])
+    expect(homepagePortfolioRoute).toEqual({
+      label: 'Portfolioroute',
+      title: homepageProductRoutes[2]?.title,
+      body: homepageProductRoutes[2]?.body,
+      href: homepageProductRoutes[2]?.href,
+    })
   })
 
   it('keeps homepage utility links aligned with buyer flow and due diligence', () => {


### PR DESCRIPTION
## What changed
- restored the homepage compatibility exports consumed by `frontend/app/page.tsx`, so `main` builds again without reopening the landed dashboard slice
- updated the frontend setup docs to list the full auth/Supabase/backend env set needed locally and on Vercel preview/production
- documented the remaining Google Fonts dependency as an external network/build nuance instead of a product blocker

## Why
A narrow environment closeout exposed two gaps on `main`: a compile-time homepage import mismatch that blocked follow-up frontend builds, and incomplete/stale setup docs around the frontend auth/Supabase environment. The goal here was to remove those blockers without reopening dashboard scope or broader marketing/product work.

## Developer impact
- local and preview setup now explicitly call out `SUPABASE_SERVICE_ROLE_KEY`, `FRONTEND_URL`, and `BACKEND_ADMIN_TOKEN`
- the homepage build contract is covered by a regression test
- CI-like local builds can be reproduced with placeholder envs

## Validation
- `npm run test -- --run lib/marketing-flow.test.ts`
- `npm run build` with placeholder frontend envs
- `CI=true npm run build` with placeholder frontend envs
- `npm run start` smoke + `GET /` returned `200` and contained `Verisight`
