### PR TITLE
[codex] align strategy and pricing truth

### DIFF
--- a/docs/active/PRICING_AND_PACKAGING_PROGRAM_PLAN.md
+++ b/docs/active/PRICING_AND_PACKAGING_PROGRAM_PLAN.md
@@ -2,17 +2,19 @@
 
 ## 1. Summary
 
-Dit traject heeft van de bestaande prijsankers, package-vormen en commerciële uitleg van Verisight één strakke, verkoopbare en repo-consistente pricing- en packaginglaag gemaakt.
+Dit traject heeft van de bestaande prijsankers, package-vormen en commerciële uitleg van Verisight één strakke, verkoopbare en repo-consistente pricing- en packaginglaag gemaakt. De strategische alignment in deze reviewronde trekt dat verhaal opnieuw gelijk met de huidige productwaarheid: guided execution, assisted self-service discipline, twee eerlijke first-buy routes en een bewust bounded portfolio.
 
 De uitgevoerde richting in deze tranche:
 
-- één canonieke pricing- en packagingarchitectuur vastgelegd rond eerste trajecten, vervolgvormen, add-ons en een portfolioroute
-- ExitScan Baseline expliciet gehouden als primaire publieke eerste route
+- één canonieke pricing- en packagingarchitectuur vastgelegd rond twee first-buy routes, guided vervolgvormen, add-ons en een bounded portfolioroute
+- ExitScan Baseline expliciet gehouden als default publieke eerste route, niet als geforceerde enige entree
 - ExitScan ritmeroute expliciet gehouden als quote-only vervolgroute na baseline of bestaand exitvolume
-- RetentieScan Baseline expliciet gehouden als eigen eerste route voor actieve-populatie vroegsignalering
+- RetentieScan Baseline expliciet gehouden als volwaardige eerste route voor actieve-populatie vroegsignalering
 - RetentieScan ritmeroute expliciet gehouden als buyer-facing vervolgvorm na baseline
 - `Retentie vervolgmeting` genormaliseerd tot compacte vervolgcomponent binnen de RetentieScan-ritmeroute
 - `segment_deep_dive` expliciet gehouden als enige repo-brede add-on
+- guided execution en assisted self-service expliciet behandeld als productrealiteit onder pricing en packaging
+- bounded portfolioverhoudingen expliciet bewaakt zodat combinatie of vervolgroutes geen nieuwe suite- of pricingfantasie openen
 - publieke pricing, salesdocs, proposalspines, buyer-assets en paritytests op dezelfde packageboom gezet
 
 Belangrijkste repo-observaties waarop deze uitvoering is gebaseerd:
@@ -22,11 +24,13 @@ Belangrijkste repo-observaties waarop deze uitvoering is gebaseerd:
 - `segment_deep_dive` was al de enige echte repo-brede add-on
 - `delivery_mode` bestond backendmatig, maar droeg `ExitScan ritmeroute` nog niet als volwaardige publieke productmodus
 - RetentieScan had commercieel meer package-varianten dan ExitScan, waardoor package-uitleg sneller diffuus kon worden
+- frontend-, funnel- en dashboardlagen stuurden inmiddels al op question-first eerste routekeuze en guided self-service discipline
+- portfolio-architectuur en producttaal maakten duidelijk dat bounded vervolgroutes niet als extra kernproducten of brede pricinglaag mogen worden geframed
 - strategie, trust en roadmap maakten expliciet dat pricing assisted/productized moest blijven en niet mocht doorschieten naar plans, seats, subscriptions of Stripe-logica
 
-Status 2026-04-15:
+Status 2026-04-24:
 
-- Uitgevoerd in deze ronde:
+- Oorspronkelijk uitgevoerd op 2026-04-15:
   - `docs/active/PRICING_AND_PACKAGING_PROGRAM_PLAN.md`
   - publieke pricingcopy in `frontend/components/marketing/site-content.ts`
   - tarieflaag in `frontend/app/tarieven/page.tsx`
@@ -42,12 +46,17 @@ Status 2026-04-15:
   - handmatige acceptance in `docs/reference/PRICING_AND_PACKAGING_ACCEPTANCE_CHECKLIST.md`
   - regressietests in `frontend/lib/marketing-positioning.test.ts` en `tests/test_pricing_packaging_system.py`
   - prompt closure in `docs/prompts/PROMPT_CHECKLIST.xlsx`
+- Strategisch aangescherpt op 2026-04-24:
+  - `docs/active/PRICING_AND_PACKAGING_PROGRAM_PLAN.md`
+  - `docs/strategy/STRATEGY.md`
+  - first-buy logica opnieuw gelijkgetrokken met guided execution, assisted self-service en bounded portfolio guardrails
 - Bewust niet uitgevoerd in deze ronde:
   - geen Stripe, billing, subscription- of seatlogica
   - geen self-service checkout of publieke planmatrix
   - geen nieuwe technische campaign-entiteiten voor elke commerciële vervolgroute
   - geen groot website-redesign buiten package- en pricingalignment
   - geen admin/dashboardcopy-wijziging, omdat de huidige interne termen de publieke packagecopy nu niet blokkeren
+  - geen nieuwe pricinglaag voor bounded vervolgroutes of portfolioverbreding zonder apart besluit
 
 ## 2. Milestones
 
@@ -70,7 +79,7 @@ Dependency: none
 
 #### Validation
 - [x] Observaties waren herleidbaar naar actuele repo-bestanden.
-- [x] ExitScan bleef zichtbaar de primaire wedge in de baselineanalyse.
+- [x] ExitScan bleef zichtbaar als commerciële default, terwijl RetentieScan expliciet als volwaardige first-buy route herkenbaar bleef bij een actieve behoudsvraag.
 - [x] Geen bevinding leunde op aannames buiten de repo.
 
 ### Milestone 1 - Define The Canonical Verisight Pricing And Packaging Architecture
@@ -79,17 +88,17 @@ Dependency: Milestone 0
 - [x] Uitgevoerd op 2026-04-15: een decision-complete pricing- en packagingarchitectuur vastgelegd.
 
 #### Tasks
-- [x] De vaste packagehiërarchie vastgelegd: ExitScan Baseline, ExitScan ritmeroute, RetentieScan Baseline, RetentieScan ritmeroute, Segment deep dive en combinatie als portfolioroute.
+- [x] De vaste packagearchitectuur vastgelegd rond twee first-buy routes: ExitScan Baseline en RetentieScan Baseline, plus guided vervolgvormen, `Segment deep dive` en combinatie als bounded portfolioroute.
 - [x] Beslist dat `Retentie vervolgmeting` niet als parallelle hoofdpackage blijft bestaan, maar als compacte vervolgcomponent binnen de RetentieScan-ritmeroute.
 - [x] Vastgelegd dat Baseline en vervolgvormen asymmetrisch mogen zijn per product.
 - [x] Vastgelegd welke prijsankers publiek blijven en welke bewust quote-only zijn.
 - [x] Vaste buyer-facing package-termen vastgelegd: product, eerste traject, vervolgvorm, add-on en portfolioroute.
-- [x] Vastgelegd dat pricing in deze fase verkoopstructuur is en geen billingmodel.
+- [x] Vastgelegd dat pricing in deze fase guided execution ondersteunt, assisted/productized blijft en geen billingmodel is.
 
 #### Definition of done
 - [x] Verisight heeft één decision-complete pricing- en packagingarchitectuur.
 - [x] Elk package-element heeft een vaste plaats in de commerciële boom.
-- [x] De architectuur ondersteunt ExitScan als wedge zonder RetentieScan te degraderen tot feature.
+- [x] De architectuur ondersteunt question-first first-buy routes zonder RetentieScan te degraderen tot afgeleide feature.
 
 #### Validation
 - [x] De architectuur botst niet met strategie-, methodiek- en trustdocs.
@@ -103,17 +112,17 @@ Dependency: Milestone 1
 
 #### Tasks
 - [x] De publieke pricinglaag herschikt naar primaire prijsankers, vervolgvormen, add-ons, combinatie op aanvraag, keuzehulp en FAQ.
-- [x] ExitScan op de tarieflaag zichtbaarder als default eerste route gehouden.
+- [x] ExitScan op de tarieflaag zichtbaar gehouden als default eerste route zonder RetentieScan te verlagen tot pseudo-secundaire optie.
 - [x] Expliciet gemaakt dat ExitScan ritmeroute vooral logisch is na baseline of bestaand volume en daarom quote-only blijft.
 - [x] Expliciet gemaakt dat RetentieScan ritmeroute een vervolgvorm is en geen parallel eerste pakket.
 - [x] `Retentie vervolgmeting` herpositioneerd als compacte vervolgcomponent binnen de ritmelaag.
 - [x] `Segment deep dive` scherp gehouden als bewuste verdieping en niet als standaard inbegrepen laag.
 - [x] Combinatie-taal strikt route-gedreven gehouden: op aanvraag, geen bundel en geen kortingstaal.
-- [x] Homepage-, product-, aanpak- en tarieven-copy consistenter gemaakt in wat je koopt, wanneer je dit koopt en wat daarna logisch volgt.
+- [x] Homepage-, product-, aanpak- en tarieven-copy consistenter gemaakt in wat je koopt, wanneer je dit koopt, hoe guided execution werkt en wat daarna logisch volgt.
 
 #### Definition of done
 - [x] Een buyer kan de publieke packageboom in ongeveer één minuut begrijpen.
-- [x] De site maakt duidelijk onderscheid tussen eerste traject, vervolgvorm en add-on.
+- [x] De site maakt duidelijk onderscheid tussen eerste route, guided vervolgvorm, add-on en portfolioroute.
 - [x] ExitScan, RetentieScan en combinatie kannibaliseren elkaar minder op de pricinglaag.
 
 #### Validation
@@ -133,7 +142,7 @@ Dependency: Milestone 2
 - [x] `RetentieScan ritmeroute` en compacte retentie vervolgmeting hiërarchisch consistent gemaakt.
 - [x] Combinatie-assets en proposals vrijgehouden van bundel- of discountlogica.
 - [x] De vaste regel intact gehouden: geen gratis pilot als standaard, wel een betaald eerste traject.
-- [x] Pricinguitleg direct bruikbaar gemaakt voor discovery, demo en voorstelovergang.
+- [x] Pricinguitleg direct bruikbaar gemaakt voor discovery, demo en voorstelovergang zonder terug te vallen op een geforceerde oude ExitScan-first hiërarchie.
 
 #### Definition of done
 - [x] Site, sales en proposal-lagen vertellen dezelfde pricing- en packaginglijn.
@@ -155,6 +164,7 @@ Dependency: Milestone 3
 - [x] Expliciet vastgelegd hoe `ExitScan ritmeroute` verkocht mag worden zolang `delivery_mode` nog geen volwaardige publieke productmodus is: guided vervolgroute, quote-only, niet self-serve.
 - [x] Expliciet vastgelegd dat `segment_deep_dive` de enige repo-breed echte add-on is en dat andere commerciële vervolgvormen geen technisch add-on-contract hoeven te zijn.
 - [x] Pricing gekoppeld gehouden aan echte voorbeeldoutput en report-structuur.
+- [x] Pricing expliciet gekoppeld gehouden aan guided execution, assisted self-service discipline en bounded portfolio guardrails uit de actuele productlaag.
 - [x] Vastgelegd welke packageclaims niet mogen: always-on live monitoring alsof dit al product-led standaard is, benchmark- of ROI-claims zonder basis en SaaS-planframing.
 - [x] Interne admin/dashboardcopy beoordeeld; geen directe wijziging nodig geacht in deze tranche.
 
@@ -175,7 +185,7 @@ Dependency: Milestone 4
 
 #### Tasks
 - [x] Regressiebescherming toegevoegd voor pricing- en packagingpariteit over publieke pricingcopy, homepage/product/aanpak-routes, sales assets, trustgrenzen en previewproof.
-- [x] Handmatige acceptance toegevoegd voor first-time buyer begrip, ExitScan als default wedge, RetentieScan als eigen product, logische vervolgvormen en combinatie als route.
+- [x] Handmatige acceptance toegevoegd voor first-time buyer begrip, ExitScan als default route, RetentieScan als volwaardige first-buy route, logische vervolgvormen en combinatie als bounded route.
 - [x] Governance vastgelegd voor toekomstige pricingwijzigingen: eerst pricing source of truth, daarna site, sales, assets en tests.
 - [x] Het traject administratief afgesloten met actief planbestand en bijgewerkte `PROMPT_CHECKLIST.xlsx`.
 
@@ -192,13 +202,13 @@ Dependency: Milestone 4
 ## 3. Execution Breakdown By Subsystem
 
 ### Pricing canon and package architecture
-- [x] Eén vaste commerciële boom gedefinieerd met onderscheid tussen product, eerste traject, vervolgvorm, add-on en portfolioroute.
+- [x] Eén vaste commerciële boom gedefinieerd met onderscheid tussen first-buy route, guided vervolgvorm, add-on en bounded portfolioroute.
 - [x] Publieke prijsankers compact en boardroom-geschikt gehouden.
 - [x] Quote-only routes bruikbaar gehouden voor sales zonder publieke verwarring te creëren.
 
 ### Website and buyer-facing surfaces
 - [x] Dezelfde pricinglogica doorgetrokken naar homepage, producten, aanpak en tarieven.
-- [x] ExitScan als eerste route laten domineren zonder RetentieScan kleiner te maken om de verkeerde reden.
+- [x] ExitScan als default eerste route behouden zonder RetentieScan kleiner te maken dan de productwaarheid draagt.
 - [x] Keuzehulp en FAQ gebruikt om verkeerde buyer-interpretaties actief te corrigeren.
 
 ### Sales, proposal and buyer assets
@@ -210,6 +220,7 @@ Dependency: Milestone 4
 - [x] Packageclaims verankerd in echte report-, preview- en campaignrealiteit.
 - [x] `ExitScan ritmeroute` gepositioneerd als guided vervolgroute in plaats van volwaardige publieke productmodus.
 - [x] Alleen echte add-ons technisch en copymatig als add-on laten voelen.
+- [x] Guided execution en assisted self-service expliciet behandeld als deel van de prijs- en packagewaarheid.
 
 ### QA and governance
 - [x] Pricing paritytests en acceptance-checks toegevoegd.
@@ -222,6 +233,7 @@ Dependency: Milestone 4
 - [x] RetentieScan heeft nog steeds een rijkere vervolglijn dan ExitScan; dit wordt nu beter gekaderd, maar moet commercieel bewaakt blijven.
 - [x] `ExitScan ritmeroute` blijft afhankelijk van begeleide delivery en voldoende volume; de quote-only framing verkleint hier het risico op overselling.
 - [x] Alleen `segment_deep_dive` is repo-breed een echte add-on; dit blijft expliciet bewaakt in copy en tests.
+- [x] Oude ExitScan-first taal kan nog steeds terugkeren en de vraaggestuurde first-buy logica onnodig vernauwen.
 - [x] Premature SaaS-logica is in deze tranche bewust buiten scope gehouden.
 - [x] Trust-erosie door te harde packageclaims is verkleind via alignment met preview, trustdocs en paritytests.
 
@@ -231,6 +243,7 @@ Dependency: Milestone 4
 - [ ] Willen we `ExitScan ritmeroute` later publiek prominenter maken zodra `delivery_mode` ook frontend- en admin-breed verder is uitgewerkt?
 - [ ] Willen we later een compactere executive pricing-view naast de huidige tariefpagina?
 - [ ] Willen we combinatie later semi-gestandaardiseerd tonen als portfolio-opbouw, of structureel `op aanvraag` houden?
+- [ ] Willen we bounded vervolgroutes later publiek/commercieel explicieter maken, of blijven die pas na aparte sign-off zichtbaar buiten de huidige kernpricing?
 - [ ] Willen we toekomstige productfamilies pas pricingmatig zichtbaar maken zodra hun packagecontract net zo scherp is als voor ExitScan en RetentieScan?
 
 ## 6. Follow-up Ideas
@@ -247,6 +260,7 @@ Dependency: Milestone 4
 - [x] Geen plan-, seat- of usage-architectuur.
 - [x] Geen herbouw van productmethodiek, scoring of report-engine buiten pricingpariteit.
 - [x] Geen nieuwe productfamilies buiten ExitScan, RetentieScan en combinatie.
+- [x] Geen heropening van bounded vervolgroutes als nieuwe publieke pricinglaag zonder apart besluit.
 - [x] Geen groot website-redesign buiten wat nodig is om pricing- en packagecopy te alignen.
 - [x] Geen verzonnen ROI-, benchmark- of klantproofclaims.
 - [x] Geen verplichting om elke commerciële vervolgroute technisch als aparte campaign- of billing-entiteit te modelleren.
@@ -254,12 +268,12 @@ Dependency: Milestone 4
 ## 8. Defaults Chosen
 
 - [x] `docs/active/PRICING_AND_PACKAGING_PROGRAM_PLAN.md` is de source of truth voor dit traject.
-- [x] ExitScan Baseline blijft de primaire publieke eerste route en `EUR 2.950` het standaard eerste prijsanker.
-- [x] RetentieScan Baseline blijft een specifieke complementaire eerste route op `EUR 3.450`, niet een goedkopere of lichtere afgeleide van ExitScan.
+- [x] ExitScan Baseline blijft de default publieke eerste route en `EUR 2.950` het standaard eerste prijsanker.
+- [x] RetentieScan Baseline blijft een volwaardige first-buy route op `EUR 3.450`, niet een goedkopere of lichtere afgeleide van ExitScan.
 - [x] ExitScan ritmeroute blijft een secundaire vervolgroute op aanvraag, niet een concurrerende publieke eerste package.
 - [x] RetentieScan ritmeroute blijft de buyer-facing vervolgvorm na baseline, met `vanaf EUR 4.950` als anker.
 - [x] `Compacte retentie vervolgmeting` blijft een compact vervolg binnen de RetentieScan-ritmeroute en niet een parallelle hoofdpackage.
 - [x] `Segment deep dive` blijft de enige expliciete add-on die repo-breed technisch en commercieel herkenbaar is.
 - [x] Combinatie blijft een portfolioroute op aanvraag, geen bundel, korting of standaard upsell.
-- [x] Pricing blijft assisted/productized en boardroom-geschikt, zonder premature SaaS-billinglogica.
+- [x] Pricing blijft guided execution ondersteunen, assisted/productized en boardroom-geschikt, zonder premature SaaS-billinglogica.
 - [x] Claims mogen commercieel scherp zijn, maar nooit verder gaan dan huidige output, trustgrenzen en productrealiteit dragen.

--- a/docs/strategy/STRATEGY.md
+++ b/docs/strategy/STRATEGY.md
@@ -1,27 +1,35 @@
 # Verisight - Strategie En Beslissingen
 
 Levend document. Dit is de strategische samenvatting van wat Verisight nu verkoopt, hoe we het positioneren en welke guardrails gelden.
-Laatste update: 2026-04-16
+Laatste update: 2026-04-24
 
 ## Wat we nu bouwen en verkopen
 
-Verisight is nu geen brede people-suite en ook nog geen self-service SaaS in volle vorm. Verisight is op dit moment een begeleid, productized people-insight aanbod met twee nauw verwante producten:
+Verisight is nu geen brede people-suite en ook nog geen full self-service SaaS. Verisight is op dit moment een guided execution propositie met assisted self-service discipline, twee buyer-facing kernroutes en een bewust bounded portfolio.
 
 - **ExitScan**
-  - primaire entreepropositie
+  - default eerste route wanneer vertrekduiding eerst telt
   - terugkijkende vertrekduiding
   - bedoeld om patronen in vertrek zichtbaar en bestuurbaar te maken
 
 - **RetentieScan**
-  - complementair aan ExitScan
+  - volwaardige eerste route wanneer de buyer-vraag expliciet draait om actieve-populatie behoud
   - vroegsignalering in actieve populaties
   - bedoeld om behoudsrelevante signalen eerder zichtbaar te maken
 
+- **Guided execution-laag**
+  - begeleidt intake, launchdiscipline, dashboardactivatie en eerste vervolgstap
+  - laat de klant zelf werken binnen begrensde product- en deliveryrails
+
+- **Bounded portfoliolaag**
+  - houdt combinatie en andere bounded vervolgroutes ondergeschikt aan de kernroutes
+  - mag pas zichtbaarder worden nadat een eerste route echte managementwaarde heeft opgeleverd
+
 De commerciele default in deze fase is:
 
-- ExitScan Baseline als standaard eerste instap
-- ExitScan Live als doorgroeivorm of maatwerkroute, niet als los hoofdproduct
-- RetentieScan alleen als primaire eerste route wanneer de buyer-vraag expliciet draait om actieve-populatie vroegsignalering
+- first-buy logica is vraaggestuurd: ExitScan is de default, RetentieScan is de eerlijke eerste route bij een expliciete actieve behoudsvraag
+- Baseline blijft de standaard eerste vorm; ritme en live blijven guided vervolg- of deliveryvormen en geen losse hoofdproducten
+- bounded portfolioroutes worden niet als standaard eerste pitch gebruikt en openen de kernhierarchie niet opnieuw
 
 ## Huidige fase
 
@@ -62,9 +70,13 @@ Gebruik deze volgorde als er spanning ontstaat tussen documenten:
    - fasehistorie, exit gates en strategische volgorde van het opgebouwde systeem
 3. [CEO_GROWTH_SYSTEM_2026.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/strategy/CEO_GROWTH_SYSTEM_2026.md)
    - huidig forward-looking bedrijfsbesturingssysteem
-4. deze strategie
+4. [PRODUCT_LANGUAGE_CANON.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/PRODUCT_LANGUAGE_CANON.md)
+   - actuele producttaal, bounded routegrenzen en embedded truth parity
+5. [PORTFOLIO_ARCHITECTURE_PROGRAM_PLAN.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/PORTFOLIO_ARCHITECTURE_PROGRAM_PLAN.md)
+   - buyer-facing kernroutes, portfoliorollen en begrenzing van vervolgroutes
+6. deze strategie
    - positionering, guardrails en beslissingen
-5. [Docs_External](C:/Users/larsh/Desktop/Business/Docs_External)
+7. [Docs_External](C:/Users/larsh/Desktop/Business/Docs_External)
    - referentie, uitwerking, assets, archief of gevoelige operationele context
 
 ## Product- en commerciële guardrails
@@ -85,25 +97,29 @@ Wat nu niet te hard geclaimd mag worden:
 - exact vaststellen wat vermijdbaar was
 - causale zekerheid op basis van één scan of rapport
 
-### Productvolgorde
+### Product-, route- en portfoliovolgorde
 
-- ExitScan blijft de primaire entree
-- RetentieScan blijft complementair
-- Baseline versus Live is een belangrijke commerciële structuur, maar geen reden om productverwarring te creëren
-- ExitScan blijft één product; Baseline en Live zijn uitvoeringsvormen, geen aparte productfamilies of aparte websites
-- publieke pricing blijft in beginsel op Baseline gericht; Live blijft op aanvraag of vervolgroute totdat de commerciële en operationele realiteit dat breder draagt
+- guided execution is nu een deel van de productwaarheid en niet alleen een deliveryvoetnoot
+- ExitScan en RetentieScan zijn de twee buyer-facing kernroutes; ExitScan blijft de default, maar niet de enige legitieme first-buy route
+- RetentieScan wordt niet lager gezet dan de productrealiteit draagt; het is een eigen eerste kooproute wanneer de managementvraag daarom vraagt
+- Baseline, live, ritme en compacte vervolgmetingen zijn leverings- of vervolgvormen en geen losse productfamilies
+- combinatie en andere bounded vervolgroutes blijven portfolio-keuzes na een eerste route, niet nieuwe kernproducten of nieuwe standaardinstappen
+- publieke pricing blijft gericht op wat delivery en ops nu echt kunnen dragen; geen verbreding zonder expliciet besluit
 
 ### Verkoopvorm nu
 
 De huidige passende vorm is:
-- begeleid
+- guided execution
+- assisted self-service
 - productized
 - professioneel
+- bounded in launch, activatie en opvolging
 - niet overmatig maatwerkgedreven
 
 Nog niet de hoofdvorm:
 - volledig self-service
 - consultancy-intensief traject zonder productkader
+- gefakete product-led motion zonder onderliggende waarheid
 
 ## SaaS-readiness nu
 
@@ -113,12 +129,13 @@ Verisight beweegt wel richting een SaaS-model, maar zit nu nog in een assisted/p
 
 - productfundament met scans, dashboards, rapportage en organisatie-/campagnestructuur
 - beveiligde appflows met auth, login, invites en beheer
+- guided self-service discipline rond intake, importcontrole, launch, dashboardactivatie en eerste vervolgstap
 - demo- en sample-infrastructuur voor assisted verkoop, validatie en showcase
 
 ### Deels aanwezig
 
 - herhaalbare productvorm en steeds scherpere packaging
-- assisted buyer journey die SaaS-readiness ondersteunt
+- assisted self-service buyer journey die SaaS-readiness ondersteunt
 - groeiende standaardisatie in output, demo's en operationele flows
 
 ### Ontbreekt nog
@@ -132,6 +149,7 @@ Verisight beweegt wel richting een SaaS-model, maar zit nu nog in een assisted/p
 De juiste stap nu is niet om Verisight kunstmatig als volledige SaaS te forceren, maar om doelgericht te bouwen aan SaaS-readiness via:
 
 - pricing en packaging
+- guided execution enablement
 - sales enablement
 - sample output en showcase
 - onboarding en adoption
@@ -143,10 +161,11 @@ De juiste stap nu is niet om Verisight kunstmatig als volledige SaaS te forceren
 De hoogste prioriteit ligt nu op:
 
 - herhaalbare omzet en geloofwaardig bewijs
-- strakke eerste kooproute met ExitScan als entree
+- strakke first-buy logica: ExitScan als default, RetentieScan als volwaardige eerste route wanneer de actieve behoudsvraag primair is
 - een duidelijke ICP-focus op organisaties met ongeveer 200 tot 1.000 medewerkers waar uitstroom structureel speelt
-- voorspelbare delivery van akkoord naar managementwaarde
+- voorspelbare guided execution van akkoord naar eerste managementwaarde
 - capture van case proof, bezwaren en leerfeedback
+- eerlijke bounded portfolioverhoudingen zonder suite- of pricinginflatie
 - wekelijkse en maandelijkse bestuurlijke ritmes
 
 Ondersteunend daaraan:
@@ -177,16 +196,19 @@ Niet alles wat nu belangrijk is, zit in code. Deze afhankelijkheden tellen mee i
 - grote self-service onboarding
 - Stripe en brede billing-automatisering
 - nieuwe productfamilies buiten ExitScan/RetentieScan
+- portfolioverbreding of bounded route-promotie zonder expliciet besluit
 - publiek API-werk
 - brede contentmachine zonder stabiele kernpropositie
 
 ## Belangrijke defaults
 
+- waarheid en positionering worden eerst gecorrigeerd; bredere public/commercial promotie volgt pas daarna
 - website-redesign volgt op trust- en packagingwerk
 - sample output is een fundament voor sales en website
 - externe documentmappen zijn in scope voor alignment, maar niet leidend boven repo truth
 - gevoelige operationele data hoort niet in plandocumenten of roadmaps thuis
 - founder-led lean blijft de default totdat omzet, bewijs en deliveryritme sterk genoeg zijn voor structurele capaciteitsuitbreiding
-- ExitScan blijft de primaire entreepropositie
-- RetentieScan blijft complementair en wordt niet als losse hoofdroute geforceerd
-- de eerste commerciële mijlpaal is niet een nieuwe feature, maar een eerste reeks betaalde trajecten via dezelfde kernpropositie
+- ExitScan blijft de default eerste route in generieke gesprekken, maar niet de enige eerlijke first-buy route
+- RetentieScan blijft een kernroute en wordt niet kunstmatig lager gezet wanneer de actieve behoudsvraag primair is
+- bounded portfolioroutes blijven ondergeschikt aan een scherp gekozen eerste route en openen geen nieuwe pricing- of propositiescope
+- de eerste commerciële mijlpaal is niet een nieuwe feature, maar een eerste reeks betaalde trajecten via dezelfde truth-aligned routearchitectuur


### PR DESCRIPTION
## Summary
- realign `docs/strategy/STRATEGY.md` with the current guided execution and assisted self-service product truth
- realign `docs/active/PRICING_AND_PACKAGING_PROGRAM_PLAN.md` with the same first-buy logic and bounded portfolio guardrails
- remove wording that pushed an older hard ExitScan-first hierarchy harder than the current product reality supports

## Why
The strategy and pricing/package docs had drifted away from the current repo truth. Product and funnel surfaces already reflect a question-first first-buy motion, guided execution discipline, and bounded portfolio relationships. These docs needed to match that reality without introducing new product claims, broader portfolio scope, or pricing promises delivery cannot yet carry.

## Impact
- ExitScan remains the default first route, but no longer reads as the only legitimate first-buy path
- RetentieScan is explicitly framed as a valid first-buy route when the active-population retention question is primary
- guided execution and assisted self-service are now treated as part of the product truth beneath packaging
- bounded portfolio routes stay bounded and are not reopened as a new public pricing or promotion wave

## Validation
- `git diff --check`
- keyword consistency check across both updated docs for guided execution, assisted self-service, bounded portfolio, and first-buy framing
- negative drift check confirming older hard ExitScan-first phrases are absent from the two updated docs