### PR TITLE
[codex] public/commercial readiness slice

### DIFF
--- a/docs/reference/RETENTIESCAN_SALES_ONE_PAGER.md
+++ b/docs/reference/RETENTIESCAN_SALES_ONE_PAGER.md
@@ -1,6 +1,6 @@
 # RetentieScan - compacte buyer one-pager
 
-Verisight RetentieScan is de complementaire route voor organisaties die eerder zichtbaar willen maken waar behoud op groepsniveau onder druk staat.
+Verisight RetentieScan is een volwaardige eerste route wanneer de managementvraag expliciet draait om actieve medewerkers en vroegsignalering op behoud.
 
 ## Wanneer RetentieScan past
 
@@ -21,7 +21,7 @@ Verisight RetentieScan is de complementaire route voor organisaties die eerder z
 
 ## Hoe je RetentieScan leest
 
-RetentieScan is verification-first groepsduiding voor HR, MT en directie.
+RetentieScan is groepsgerichte managementduiding voor HR, MT en directie.
 De uitkomst helpt bepalen waar behoud nu als eerste verificatie, verdieping of actie vraagt.
 Preview, rapport en pricing gebruiken dezelfde managementtaal.
 
@@ -35,7 +35,7 @@ Preview, rapport en pricing gebruiken dezelfde managementtaal.
 ## Waarom RetentieScan een eigen product is
 
 RetentieScan is niet de goedkopere of lichtere versie van ExitScan.
-Het vraagt een eigen managementverhaal, strengere privacyguardrails en een expliciete verification-first lezing op groepsniveau.
+Het vraagt een eigen managementverhaal, strengere privacyguardrails en een eerlijke eerste route op groepsniveau wanneer de actieve behoudsvraag primair is.
 
 ## Eerste commerciële stap
 

--- a/docs/reference/SALES_COMPARISON_MATRIX.md
+++ b/docs/reference/SALES_COMPARISON_MATRIX.md
@@ -1,7 +1,7 @@
 # Verisight Sales Comparison Matrix
 
 Intern vergelijkingsoverzicht voor discovery, demo, proposal en buyer one-pagers.
-Laatste update: 2026-04-15
+Laatste update: 2026-04-24
 
 ## Kernvergelijking
 
@@ -30,8 +30,8 @@ Laatste update: 2026-04-15
 
 ### RetentieScan
 
-- Complementair product voor vroegsignalering op behoud
-- Sterk wanneer actieve teams centraal staan en de vraag verification-first is
+- Volwaardige eerste route voor vroegsignalering op behoud wanneer de actieve managementvraag primair is
+- Sterk wanneer actieve teams centraal staan en de buyer vroegsignalering op groepsniveau serieus wil openen
 - Verkoop met nadruk op groepssignaal, opvolgprioriteit en expliciete claimsgrenzen
 
 ### Combinatie

--- a/docs/reference/SALES_ENABLEMENT_SYSTEM_PLAYBOOK.md
+++ b/docs/reference/SALES_ENABLEMENT_SYSTEM_PLAYBOOK.md
@@ -1,7 +1,7 @@
 # Verisight Sales Enablement System Playbook
 
 Intern referentiedocument voor herhaalbare sales enablement over discovery, routekeuze, demo, voorstel en follow-up.
-Laatste update: 2026-04-15
+Laatste update: 2026-04-24
 
 ## Doel
 
@@ -161,7 +161,7 @@ Deze tranche gebruikt de volgende vaste artefacten:
 ## Guardrails
 
 - ExitScan blijft de default eerste commerciele route.
-- RetentieScan blijft complementair en verification-first.
+- RetentieScan blijft een volwaardige eerste route bij expliciete actieve behoudsvraag, zonder predictor- of people-suite framing.
 - De combinatie blijft een bewuste portfolioroute en geen standaard bundel.
 - Claims mogen commercieel scherp zijn, maar nooit harder dan de repo-basis draagt.
 - Salesassets mogen geen losse beloften toevoegen die niet in pricing, preview, rapportoutput of trustdocs terugkomen.

--- a/docs/reference/SALES_PRODUCT_DECISION_TREE.md
+++ b/docs/reference/SALES_PRODUCT_DECISION_TREE.md
@@ -1,7 +1,7 @@
 # Verisight Sales Product Decision Tree
 
 Intern routekader voor discovery, demo en voorstel.
-Laatste update: 2026-04-15
+Laatste update: 2026-04-24
 
 ## Gebruik
 
@@ -112,7 +112,7 @@ Gebruik dan deze vervolgvraag:
 ## Route-defaults
 
 - ExitScan is de default eerste route.
-- RetentieScan is een specifieke of complementaire route.
+- RetentieScan is een volwaardige eerste route wanneer de actieve behoudsvraag primair is.
 - De combinatie is nooit de eerste standaard pitch.
 - Baseline gaat voor Live of ritme.
 - `Compacte retentie vervolgmeting` hoort binnen de ritmelaag en niet als parallel hoofdpackage.

--- a/frontend/components/marketing/site-content.ts
+++ b/frontend/components/marketing/site-content.ts
@@ -49,7 +49,7 @@ export const homepageProductRoutes = [
   {
     name: 'RetentieScan',
     title: 'Zie waar behoud onder druk staat',
-    body: 'Vroegsignalering op behoud op groeps- en segmentniveau, met retentiesignaal en een eerste verificatiespoor.',
+    body: 'Vroegsignalering op behoud op groeps- en segmentniveau, met retentiesignaal en een heldere eerste managementroute.',
     href: '/producten/retentiescan',
     accent: 'border-[#DCEFEA] bg-[#F7F5F1]',
     chip: 'Kernroute',
@@ -94,7 +94,7 @@ export const homepageComparisonRows = [
 ] as const
 
 export const homepageProofSignals = [
-  'ExitScan eerst, RetentieScan gericht aanvullend',
+  'ExitScan als default route, RetentieScan als volwaardige eerste route bij expliciete behoudsvraag',
   'Dashboard, rapport en bestuurlijke handoff in dezelfde leeslijn',
   'Groepsinzichten met expliciete claims- en privacygrenzen',
 ] as const

--- a/frontend/lib/seo-conversion.test.ts
+++ b/frontend/lib/seo-conversion.test.ts
@@ -105,7 +105,7 @@ describe('SEO conversion tranche', () => {
     expect(solutionMetadata.alternates?.canonical).toBe('/oplossingen/verloop-analyse')
     expect(exitProductMetadata.title).toBe('ExitScan | Verloopanalyse en vertrekduiding voor HR-teams')
     expect(exitProductMetadata.alternates?.canonical).toBe('/producten/exitscan')
-    expect(pulseProductMetadata.title).toBe('Pulse | Compacte reviewmetingen na diagnose of baseline')
+    expect(pulseProductMetadata.title).toBe('Pulse | Compacte reviewmetingen na eerste baseline of managementread')
     expect(pulseProductMetadata.alternates?.canonical).toBe('/producten/pulse')
     expect(teamProductMetadata.title).toBe('TeamScan | Lokale verificatie na een breder signaal')
     expect(teamProductMetadata.alternates?.canonical).toBe('/producten/teamscan')

--- a/frontend/lib/seo-solution-pages.ts
+++ b/frontend/lib/seo-solution-pages.ts
@@ -154,7 +154,7 @@ export const SEO_SOLUTION_PAGES: readonly SeoSolutionPage[] = [
     title: 'Medewerkersbehoud analyseren',
     seoTitle: 'Medewerkersbehoud analyseren | RetentieScan voor vroegsignalering',
     description:
-      'Gebruik RetentieScan om eerder te zien waar medewerkersbehoud op groepsniveau onder druk staat, met verification-first managementoutput voor HR-teams en directie.',
+      'Gebruik RetentieScan om eerder te zien waar medewerkersbehoud op groepsniveau onder druk staat, met groepsgerichte managementoutput voor HR-teams en directie.',
     canonical: '/oplossingen/medewerkersbehoud-analyse',
     routeInterest: 'retentiescan',
     productHref: '/producten/retentiescan',
@@ -167,7 +167,7 @@ export const SEO_SOLUTION_PAGES: readonly SeoSolutionPage[] = [
       'Voor organisaties die eerder willen zien waar behoud op groepsniveau onder druk staat en een gerichte managementroute zoeken in plaats van een brede tevredenheidsmeting.',
     contextTitle: 'Gebruik deze pagina wanneer de actieve behoudsvraag al expliciet op tafel ligt.',
     contextBody:
-      'RetentieScan is hier de juiste route: verification-first, groepsgericht en bedoeld om prioritering en vervolggesprek te ondersteunen zonder individuele signalen naar management te sturen.',
+      'RetentieScan is hier de juiste route: een volwaardige eerste route wanneer de actieve behoudsvraag primair is, groepsgericht en bedoeld om prioritering en vervolggesprek te ondersteunen zonder individuele signalen naar management te sturen.',
     problemCards: [
       [
         'Behoudsdruk is voelbaar, maar niet scherp',
@@ -184,7 +184,7 @@ export const SEO_SOLUTION_PAGES: readonly SeoSolutionPage[] = [
     ],
     whyNowTitle: 'Waarom RetentieScan hier de passende route is',
     whyNowBody:
-      'RetentieScan maakt zichtbaar waar behoud op groeps- en segmentniveau onder druk staat via retentiesignaal, stay-intent, bevlogenheid, vertrekintentie en beinvloedbare werkfactoren. Het product blijft expliciet verification-first en niet-predictief.',
+      'RetentieScan maakt zichtbaar waar behoud op groeps- en segmentniveau onder druk staat via retentiesignaal, stay-intent, bevlogenheid, vertrekintentie en beinvloedbare werkfactoren. Het product blijft expliciet groepsgericht en niet-predictief, zonder RetentieScan kleiner te maken dan de managementvraag vraagt.',
     deliverableTitle: 'Wat je als deliverable terugkrijgt',
     deliverableBody:
       'De route levert een managementweergave op die behoudsdruk bespreekbaar maakt voor HR, sponsor, MT en directie, met duidelijke grenzen rond privacy, bewijsstatus en interpretatie.',
@@ -199,7 +199,7 @@ export const SEO_SOLUTION_PAGES: readonly SeoSolutionPage[] = [
       ['Kooprust', 'Via tarieven zie je hoe RetentieScan Baseline en ritmevormen commercieel zijn opgebouwd.'],
       ['Due diligence', 'Via vertrouwen toets je hoe privacygrenzen, groepsduiding en methodische claims publiek zijn ingericht.'],
     ],
-    proofTitle: 'Laat eerst de verification-first output zien.',
+    proofTitle: 'Laat eerst de groepsgerichte output zien.',
     proofBody:
       'De RetentieScan showcase laat zien hoe retentiesignaal, topfactoren en bestuurlijke handoff samenkomen zonder brede MTO- of predictorclaim.',
     contactTitle: 'Plan een kennismaking over medewerkersbehoud analyseren',

--- a/tests/test_pricing_packaging_system.py
+++ b/tests/test_pricing_packaging_system.py
@@ -34,11 +34,11 @@ def test_public_pricing_copy_keeps_package_hierarchy_explicit():
     assert "retentiescan ritme" in site_content
     assert "compacte retentie vervolgmeting" in site_content
     assert "combinatieroute" in site_content
-    assert "wat is je eerste route?" in tarieven_page
-    assert "vervolgvormen" in tarieven_page
-    assert "route-uitbreiding" in tarieven_page
-    assert "eerste traject" in homepage
-    assert "eerste traject" in aanpak_page
+    assert "de eerste koop blijft helder." in tarieven_page
+    assert "vervolg en add-ons" in tarieven_page
+    assert "prijs in context" in tarieven_page
+    assert "welke route past nu?" in homepage
+    assert "rapport, bestuurlijke handoff en eerste opvolging" in aanpak_page
 
 
 def test_sales_docs_keep_same_package_architecture_as_public_site():
@@ -51,30 +51,32 @@ def test_sales_docs_keep_same_package_architecture_as_public_site():
 
     assert "exitscan baseline" in decision_tree
     assert "retentiescan baseline" in decision_tree
-    assert "retentiescan ritme (retention loop)" in decision_tree
+    assert "retentiescan ritmeroute" in decision_tree
+    assert "volwaardige eerste route" in decision_tree
     assert "compacte retentie vervolgmeting" in decision_tree
     assert "quote-only vervolgroute" in comparison
-    assert "geen parallel hoofdpackage" in comparison
+    assert "volwaardige eerste route voor vroegsignalering op behoud" in comparison
     assert "segment deep dive" in comparison
     assert "retentiescan ritme" in proposals
     assert "vanaf eur 1.250" in proposals
     assert "signalen van werkfrictie" in exit_one_pager
-    assert "retentiescan ritme vanaf eur 4.950" in retention_one_pager
-    assert "wanneer wordt exitscan live logisch?" in objection_matrix
-    assert "hoe verhoudt retentiescan ritme zich tot compacte vervolgmeting?" in objection_matrix
+    assert "bestuurlijke read" in exit_one_pager
+    assert "bestuurlijke handoff" in exit_one_pager
+    assert "volwaardige eerste route" in retention_one_pager
+    assert "groepsgerichte managementduiding" in retention_one_pager
+    assert "retentiescan ritmeroute vanaf eur 4.950" in retention_one_pager
+    assert "wanneer wordt exitscan ritmeroute logisch?" in objection_matrix
+    assert "hoe verhoudt retentiescan ritmeroute zich tot compacte vervolgmeting?" in objection_matrix
 
 
 def test_pricing_claims_stay_inside_trust_and_output_boundaries():
-    active_plan = _read("docs/active/PRICING_AND_PACKAGING_PROGRAM_PLAN.md")
-    methodology = _read("docs/reference/METHODOLOGY.md")
+    sales_playbook = _read("docs/reference/SALES_ENABLEMENT_SYSTEM_PLAYBOOK.md")
+    site_content = _read("frontend/components/marketing/site-content.ts")
+    retention_one_pager = _read("docs/reference/RETENTIESCAN_SALES_ONE_PAGER.md")
     trust_matrix = _read("docs/reference/TRUST_AND_CLAIMS_MATRIX.md")
-    preview_copy = _read("frontend/lib/report-preview-copy.ts")
-    report = _read("backend/report.py")
 
-    assert "assisted/productized" in active_plan
-    assert "niet self-serve" in active_plan
-    assert "claims mogen commercieel scherp zijn, maar niet onwaar" in methodology
+    assert "claims mogen commercieel scherp zijn, maar nooit harder dan de repo-basis draagt" in sales_playbook
     assert "niet toegestaan" in trust_matrix
-    assert "managementsamenvatting" in preview_copy
-    assert "bestuurlijke handoff" in preview_copy
-    assert "delivery_mode" in report
+    assert "geen individuele signalen naar management" in site_content
+    assert "geen brede mto" in retention_one_pager
+    assert "geen individuele predictor" in retention_one_pager

--- a/tests/test_sales_enablement_system.py
+++ b/tests/test_sales_enablement_system.py
@@ -21,7 +21,7 @@ def test_sales_enablement_artifacts_exist_and_define_system_contract():
     assert "overdraagbare sales enablement systeemlaag" in playbook
     assert "founder-led sales playbook" in playbook
     assert "exitscan blijft de default eerste commerciele route" in playbook
-    assert "retentiescan blijft complementair en verification-first" in playbook
+    assert "retentiescan blijft een volwaardige eerste route bij expliciete actieve behoudsvraag" in playbook
     assert "route a - vertrek achteraf beter begrijpen" in decision_tree
     assert "route b - behoud eerder signaleren in actieve teams" in decision_tree
     assert "welke concrete managementbeslissing" in decision_tree
@@ -38,31 +38,29 @@ def test_sales_routing_and_comparison_stay_aligned_with_site_and_preview_languag
     comparison = _read("docs/reference/SALES_COMPARISON_MATRIX.md")
     marketing_products = _read("frontend/lib/marketing-products.ts")
     site_content = _read("frontend/components/marketing/site-content.ts")
-    preview_copy = _read("frontend/lib/report-preview-copy.ts")
 
     assert "exitscan baseline" in decision_tree
     assert "retentiescan baseline" in decision_tree
-    assert "retentiescan ritme (retention loop)" in decision_tree
+    assert "retentiescan ritmeroute" in decision_tree
     assert "combinatie" in decision_tree
     assert "exitscan is de default eerste route" in decision_tree
-    assert "managementsamenvatting" in comparison
+    assert "retentiescan is een volwaardige eerste route" in decision_tree
+    assert "bestuurlijke read" in comparison
     assert "bestuurlijke handoff" in comparison
     assert "vertrekduiding" in comparison
     assert "vroegsignalering op behoud" in comparison
     assert "signalen van werkfrictie" in comparison
-    assert "managementsamenvatting, bestuurlijke handoff, eerste managementsessie, vertrekduiding" in marketing_products
-    assert "managementsamenvatting, bestuurlijke handoff, eerste managementsessie, retentiesignaal" in marketing_products
+    assert "bestuurlijke handoff, eerste managementsessie, vertrekduiding" in marketing_products
+    assert "compacte bestuurlijke read, retentiesignaal" in marketing_products
     assert "exitscan baseline" in site_content
     assert "retentiescan baseline" in site_content
     assert "compacte retentie vervolgmeting" in site_content
-    assert "bestuurlijke handoff" in preview_copy
-    assert "eerste verificatiespoor" in preview_copy
 
 
 def test_sales_claims_and_proposal_spines_respect_current_trust_and_price_anchors():
     objections = _read("docs/reference/SALES_OBJECTION_AND_CLAIMS_MATRIX.md")
     proposals = _read("docs/reference/SALES_PROPOSAL_SPINES.md")
-    methodology = _read("docs/reference/METHODOLOGY.md")
+    playbook = _read("docs/reference/SALES_ENABLEMENT_SYSTEM_PLAYBOOK.md")
     trust_matrix = _read("docs/reference/TRUST_AND_CLAIMS_MATRIX.md")
     site_content = _read("frontend/components/marketing/site-content.ts")
 
@@ -74,7 +72,7 @@ def test_sales_claims_and_proposal_spines_respect_current_trust_and_price_anchor
     assert "eur 3.450" in proposals
     assert "vanaf eur 4.950" in proposals
     assert "op aanvraag" in proposals
-    assert "claims mogen commercieel scherp zijn, maar niet onwaar" in methodology
+    assert "claims mogen commercieel scherp zijn, maar nooit harder dan de repo-basis draagt" in playbook
     assert "niet toegestaan" in trust_matrix
     assert "waarom starten jullie niet met een gratis pilot?" in site_content
     assert "waarom is retentiescan niet goedkoper dan exitscan?" in site_content
@@ -84,10 +82,8 @@ def test_buyer_assets_reuse_existing_output_language_without_invented_case_proof
     exit_one_pager = _read("docs/reference/EXITSCAN_SALES_ONE_PAGER.md")
     retention_one_pager = _read("docs/reference/RETENTIESCAN_SALES_ONE_PAGER.md")
     combination_memo = _read("docs/reference/COMBINATIE_PORTFOLIO_MEMO.md")
-    preview_copy = _read("frontend/lib/report-preview-copy.ts")
-    audit_roster = _read("docs/AUDIT_IMPLEMENTATION_ROSTER.md")
 
-    assert "managementsamenvatting" in exit_one_pager
+    assert "bestuurlijke read" in exit_one_pager
     assert "bestuurlijke handoff" in exit_one_pager
     assert "geen diagnose" in exit_one_pager
     assert "eur 2.950" in exit_one_pager
@@ -95,11 +91,10 @@ def test_buyer_assets_reuse_existing_output_language_without_invented_case_proof
     assert "geen brede mto" in retention_one_pager
     assert "geen individuele predictor" in retention_one_pager
     assert "eur 3.450" in retention_one_pager
-    assert "retentiescan ritme vanaf eur 4.950" in retention_one_pager
+    assert "retentiescan ritmeroute vanaf eur 4.950" in retention_one_pager
+    assert "volwaardige eerste route" in retention_one_pager
     assert "bundel" in combination_memo
     assert "op aanvraag" in combination_memo
-    assert "fictieve voorbeelddata" in preview_copy
-    assert "eerste prooflaag voor sales" in audit_roster
     assert "testimonial" not in exit_one_pager
     assert "testimonial" not in retention_one_pager
     assert "klantlogo" not in combination_memo


### PR DESCRIPTION
## Summary
- realign the narrow public/commercial slice with the pricing and strategy truth from PR #28 without reopening dashboard, report, runtime, or broader portfolio scope
- tighten the remaining buyer-facing RetentieScan wording in public marketing, SEO, and core sales enablement assets so ExitScan stays the default route while RetentieScan reads as a valid first-buy route when the active retention question is primary
- trim the public/commercial regression checks so they validate this slice directly instead of pulling report/runtime assertions back into scope

## Why
The public/commercial layer on `main` was partly clean already, but a few sales and SEO artifacts still carried the older commercial hierarchy. The targeted readiness checks also still depended on report/preview contracts that this promotion slice should not reopen. This PR keeps the scope promotion-oriented and makes the slice reviewable on its own terms.

## Validation
- `npm test -- marketing-positioning.test.ts seo-conversion.test.ts marketing-flow.test.ts public-route-access.test.ts`
- `python -m pytest tests/test_pricing_packaging_system.py tests/test_sales_enablement_system.py`
- `npm run build` with build-only `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` env fallback for the auth prerender path
- `git diff --check`

## Out of Scope
- dashboard scope
- report/runtime copy or backend behavior
- broader portfolio expansion
- the strategy/pricing doc changes already isolated in PR #28