### PR TITLE
docs: harden customer owner activation guidance

### DIFF
--- a/docs/ops/CLIENT_CUSTOMER_OWNER_ACTIVATION_CONTRACT.md
+++ b/docs/ops/CLIENT_CUSTOMER_OWNER_ACTIVATION_CONTRACT.md
@@ -1,0 +1,113 @@
+# Client Customer Owner Activation Contract
+
+Last updated: 2026-04-25
+Status: active
+
+## Purpose
+
+Dit document maakt expliciet wat de klant owner in de huidige assisted self-service route werkelijk draagt, wat Verisight blijft dragen en wanneer activatie en eerste managementgebruik echt bevestigd tellen.
+
+Gebruik dit document wanneer:
+
+- een nieuwe klantroute live gaat
+- een tweede operator een traject overneemt
+- er twijfel ontstaat over wie uitnodigingen, reminders, activatie of de eerste vervolgstap aan klantzijde echt bezit
+
+## Kernregel
+
+Verisight blijft eigenaar van setup, importcontrole, launchdiscipline en bounded delivery.
+
+De klant owner is niet de technische operator van het systeem, maar de expliciete klantvertegenwoordiger die deze vier dingen draagt:
+
+1. deelnemersaanlevering namens de klant
+2. bewuste vrijgave van uitnodigingen en reminders aan klantzijde
+3. bevestiging dat dashboardtoegang en eerste read echt zijn geland
+4. expliciete eerste eigenaar of vervolgstap na de eerste managementread
+
+## Wat de klant owner expliciet moet doen
+
+### Voor launch
+
+- bevestigen dat de juiste doelgroep is gekozen
+- bevestigen dat de klantaanlevering compleet genoeg is voor de gekozen route
+- weten dat owner-only acties bij deze rol liggen:
+  - deelnemers aanleveren
+  - uitnodigingen starten
+  - reminders versturen
+  - uitvoerstatus en vervolgstap bevestigen
+
+### Rond activatie
+
+- bevestigen wie het eerste klantaccount gebruikt
+- bevestigen dat de activatiemail bij de juiste persoon is aangekomen
+- bevestigen dat de eerste gebruiker in de juiste campaign landt
+- na activatie niet blijven hangen in "toegang is verstuurd", maar doorpakken naar eerste read
+
+### Bij eerste managementgebruik
+
+- expliciet maken wat de eerste managementvraag is
+- expliciet maken wie de eerste eigenaar wordt
+- expliciet maken wat de eerste vervolgstap is
+- expliciet maken wanneer het reviewmoment volgt
+
+## Wat Verisight expliciet blijft doen
+
+- routekeuze en implementation intake structureren
+- campaign en organisatie opzetten
+- importpreview en import-QA bewaken
+- launchdatum, communicatiepreview en reminderinstellingen begrensd houden
+- dashboard- en rapportread begeleiden
+- support en recovery oppakken wanneer activatie of delivery vastloopt
+
+## Wat niet impliciet mag blijven
+
+- "de klant weet wel wie de owner is"
+- "de activatiemail is gestuurd dus activatie telt"
+- "de eerste read is waarschijnlijk al gebeurd"
+- "de vervolgstap volgt later wel"
+
+Zodra een van deze aannames optreedt, moet de operator terug naar expliciete bevestiging in de deliverylaag.
+
+## Canonieke bevestigingen
+
+Activatie telt pas echt bevestigd wanneer:
+
+- de juiste klantgebruiker is uitgenodigd
+- accounttoegang actief is
+- de juiste campaign zichtbaar is
+- een eerste dashboard- of rapportmoment concreet ingepland of direct uitgevoerd is
+
+Eerste managementgebruik telt pas echt bevestigd wanneer:
+
+- dashboard of rapport daadwerkelijk is gebruikt in een managementread
+- eerste eigenaar expliciet is vastgelegd
+- eerste vraag of eerste actie expliciet is vastgelegd
+- een reviewmoment expliciet is vastgelegd
+
+## Recovery-signalen
+
+Gebruik extra opvolging zodra een van deze signalen optreedt:
+
+- activatiemail is verstuurd maar blijft pending
+- er is wel toegang, maar nog geen eerste read
+- er is wel een first-value moment, maar nog geen first-management-use bevestiging
+- er is wel een read, maar geen eigenaar of vervolgstap
+
+## Minimale operatorvragen
+
+Stel in ieder actief traject minimaal deze vragen:
+
+- Wie is aan klantzijde de owner voor uitnodigingen en reminders?
+- Wie gebruikt als eerste het dashboard of rapport?
+- Wanneer bevestigen we dat activatie echt geland is?
+- Welke eerste managementvraag openen we?
+- Wie wordt de eerste eigenaar?
+- Wanneer reviewen we opnieuw?
+
+## Acceptance
+
+Dit contract werkt pas als:
+
+- een tweede operator zonder extra context kan uitleggen wie aan klantzijde echt owner is
+- activatie niet meer alleen als mailmoment wordt gelezen, maar als bevestigde toegang plus eerste read
+- eerste managementgebruik niet meer impliciet blijft hangen tussen dashboardread en follow-up

--- a/docs/ops/CLIENT_ONBOARDING_PLAYBOOK.md
+++ b/docs/ops/CLIENT_ONBOARDING_PLAYBOOK.md
@@ -13,6 +13,7 @@ Belangrijke defaults:
 - RetentieScan blijft complementair en verification-first.
 - Verisight beheert setup, importcontrole, invite-activatie en dashboardtoegang.
 - De klant levert input aan en gebruikt daarna dashboard en rapport.
+- De klant owner moet expliciet bekend zijn voordat owner-only acties eerlijk uitvoerbaar zijn.
 - Adoptie is pas geslaagd wanneer de klant de output echt gebruikt voor het eerste managementgesprek.
 - Vroege learnings worden voortaan vastgelegd in `/beheer/klantlearnings`.
 - Een campaign meet standaard live vanaf campagnestart; een retrospectieve baseline of 12-maandsbeeld moet expliciet zo worden ingericht.
@@ -98,6 +99,12 @@ Nuance:
 - Type: klantmoment
 - Doel: klantaccount activeren en de gebruiker in het juiste dashboard laten landen
 
+Wat hierbij expliciet moet zijn:
+
+- wie de klant owner is
+- wie de eerste gebruiker wordt
+- dat activatie pas telt wanneer toegang en eerste read echt geland zijn
+
 ### 6. Eerste dashboardread
 
 - Eigenaar: klant
@@ -115,6 +122,10 @@ Nuance:
 - Eigenaar: klant
 - Type: gedeeld
 - Doel: eerste eigenaar, eerste vraag en eerste vervolgstap expliciet maken
+
+Voor customer-owner en activatiegrenzen:
+
+- zie ook [CLIENT_CUSTOMER_OWNER_ACTIVATION_CONTRACT.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/CLIENT_CUSTOMER_OWNER_ACTIVATION_CONTRACT.md)
 
 ## Verplichte learning handoff
 
@@ -206,6 +217,7 @@ Dashboard en rapport zijn vanaf een bruikbare responsbasis het eerste management
 
 - context, timing en contactpersoon bevestigen
 - respondentbestand aanleveren
+- klant owner expliciet aanwijzen voor owner-only acties
 - dashboard en rapport gebruiken voor het eerste managementgesprek
 - prioriteiten, verificatievragen en vervolgstappen bepalen
 

--- a/docs/ops/CUSTOMER_OPERATION_VALIDATION_REPORT_2026-04-25.md
+++ b/docs/ops/CUSTOMER_OPERATION_VALIDATION_REPORT_2026-04-25.md
@@ -1,0 +1,106 @@
+# Assisted Self-Service Customer Operation Validation
+
+## Korte samenvatting
+
+De huidige `main`-basis is bruikbaar genoeg om assisted self-service gecontroleerd uit te voeren, vooral op importguardrails, launchgating, response-thresholds en expliciete ownership-afbakening. De grootste resterende frictie zit nu minder in ontbrekende productfundamenten en meer in operationele discipline: intakekwaliteit, klant-owner duidelijkheid, activatie-opvolging, bevestiging van eerste managementgebruik en een validatie/demo-basis die niet overal even robuust herhaalbaar is.
+
+Het beeld is dus niet "nog veel product bouwen", maar "de assisted operating cadence harder maken". Alleen als dezelfde frictie later herhaaldelijk in echte klantobservaties terugkomt, is versimpelend productwerk logisch.
+
+## Welke klant- en operatieflows zijn beoordeeld
+
+- Import van respondenten via bestaande backendflow en huidige klantinput-specificatie.
+- Launchdiscipline via huidige import-QA, launch confirmation, communicatiepreview en reminderinstellingen.
+- Reminderlogica en reminderrechten binnen de huidige guided self-service flow.
+- Dashboardgebruik op home- en campaignniveau, inclusief threshold-based vrijgave van output.
+- First-next-step begrip via huidige campaign- en dashboardguidance.
+- Ownership tussen klant en Verisight via klantrollen, kritieke acties, activation flow en operating-discipline lagen.
+- Semireele demo-/fixturebasis via de bestaande demo scenario orchestrator.
+
+## Wat al sterk genoeg werkt in assisted self-service
+
+- Import is productmatig al behoorlijk scherp begrensd. De backendflow accepteert gecontroleerde imports, ondersteunt dry-run validatie en blokkeert duplicaten zonder persist.
+- Launch wordt niet lichtzinnig vrijgegeven. Startdatum, communicatiepreview, reminderinstellingen en expliciete launchbevestiging vormen samen een duidelijke release-gate.
+- De thresholdlogica is helder en consistent: onder 5 responses geen dashboardread, tussen 5 en 9 alleen compacte/indicatieve read, vanaf 10 pas eerste patroonduiding en first-next-step ruimte.
+- Ownership is niet impliciet gelaten. `owner`, `member` en `viewer` zijn functioneel onderscheiden en uitvoerkritieke acties blijven bewust bij de klant owner.
+- Dashboardcopy en operating layers proberen al netjes te scheiden tussen "wat nu leesbaar is", "wat nog indicatief is" en "wat de eerste vervolgstap wordt".
+- De assisted waarheid blijft productmatig intact: Verisight beheert setup, importkwaliteit, invite/reminder-discipline en bounded release, terwijl de klant vooral leest, duidt en bevestigt.
+
+## Waar nog echte frictie zit
+
+- Import werkt technisch, maar blijft sterk afhankelijk van goede implementation intake. Zonder vooraf scherp route-, metadata- en managementdoelbegrip wordt de flow snel administratief in plaats van vanzelfsprekend.
+- Launchdiscipline is inhoudelijk goed, maar telt veel expliciete bevestigingen. Voor operators is dat verdedigbaar; voor klanten kan het voelen als meerdere kleine gates in plaats van een begrijpelijke "klaar om live te gaan"-stap.
+- Remindercontrole is bewust begrensd en preset-based. Dat beschermt kwaliteit, maar maakt de ervaring minder intuitief voor klanten die "self-service" horen en vervolgens weinig timingvrijheid blijken te hebben.
+- Dashboardgebruik is guardrail-sterk, maar de betekenis van fasen als "deels zichtbaar", "dashboard actief", "first value" en "eerste vervolgstap" vraagt nog uitleg. Dit lijkt nu eerder begeleid leeswerk dan vanzelfsprekende zelfbediening.
+- Ownership tussen klant en Verisight is expliciet, maar nog kwetsbaar in de praktijk: klant owner, activatie, eerste managementgebruik en follow-up vragen allemaal actieve bevestiging. Zonder strakke supportcadence blijft dat procesmatig broos.
+
+## Indeling van frictie
+
+- productissue: De flow gebruikt meerdere begrippen en lagen om van setup naar eerste managementactie te gaan. Dat is logisch vanuit governance, maar kan voor klanten cognitief zwaar blijven voordat echte managementwaarde zichtbaar wordt. Launch- en dashboardstaten zijn goed afgeschermd, maar nog niet helemaal samengevouwen tot een eenduidige klantread over "wat kan ik nu veilig doen".
+- onboardingissue: Goede intake blijft cruciaal: gekozen route, timing, doelgroep, metadata en eerste managementdoel moeten vooraf scherp zijn, anders landt frictie later onterecht in import of dashboard. De rol van de klant owner moet vooraf harder worden gezet; anders voelt owner-only gedrag later als beperking in plaats van bewuste governance.
+- supportissue: Activatiemail, eerste dashboardtoegang, eerste rapportread en eerste managementgebruik vragen nog duidelijke menselijke opvolging.
+- verwachtingsissue: "Assisted self-service" kan te snel als "vrij self-serve" worden opgevat, terwijl de huidige waarheid duidelijk assisted blijft. Klanten kunnen meer vrijheid verwachten rond reminders, launch en uitvoerkritieke acties dan de huidige productgrenzen bewust toestaan.
+
+## Wat dit betekent voor volgende fases
+
+De volgende fase hoeft geen brede productherbouw te zijn. Eerst moet customer-ops-hardening scherper maken of de bestaande assisted operating cadence reproduceerbaar genoeg is:
+
+- intake discipline
+- klant-owner explicitering
+- activatie-opvolging
+- first-management-use bevestiging
+- follow-up closure
+- betrouwbare demo- en validatiefixtures
+
+Later productwerk is pas logisch als echte observaties blijven laten zien dat klanten ondanks goede onboarding en support structureel verdwalen in launchstatus, first-next-step of ownership.
+
+## Verificatie en observatiegrond
+
+Echt of semireeel doorlopen in deze draad:
+
+- `python -m pytest tests/test_api_flows.py -k "respondent_import or implementation_smoke_flow"`
+  - bevestigt create -> import -> optioneel invites -> submit -> stats -> report op de huidige `main`-basis
+- `python manage_demo_environment.py list`
+  - bevestigt de huidige canonieke demo- en fixturelagen
+- `python manage_demo_environment.py run sales_demo_exit`
+  - bevestigt serieel dat de gedeelde ExitScan sales demo opnieuw kan worden opgebouwd
+- `python manage_demo_environment.py run sales_demo_retention`
+  - bevestigt serieel dat ook de retention demo op dezelfde lokale sqlite-flow kan worden opgebouwd
+- lokale sqlite-inspectie van `verisight-sales-demo`
+  - bevestigde zowel ExitScan- als RetentieScan-demo campaigns met actieve en gesloten staten en verschillende invited/completed/pending verhoudingen
+- eerdere parallelle validatieruns tegen gedeelde demo-orgs
+  - veroorzaakten een misleidend beeld over slug-collision en ontbrekende observeerbaarheid; dat bleek een validatiemethode-issue, geen bewezen productissue in de seriele demo seedflow
+- `npx vitest run "app/(dashboard)/campaigns/[id]/actions.test.ts" "app/(dashboard)/campaigns/[id]/page.test.ts" "app/(dashboard)/campaigns/[id]/page.route-shell.test.ts" "app/(dashboard)/dashboard/page.test.ts" "lib/ops-delivery.test.ts" "lib/client-onboarding.test.ts" "lib/response-activation.test.ts"`
+  - bevestigt de huidige contracten voor dashboardstaten, ownership, reminderrechten, delivery governance en onboardingthresholds
+
+Afgeleid uit bestaande tests/acceptance en broncode, niet live waargenomen in een ingelogde klantdashboardsessie:
+
+- daadwerkelijke visuele frictie tijdens klantnavigatie in een echte authenticated campaign
+- hoe soepel first-next-step door een echte klant zonder begeleiding wordt begrepen
+- hoe vaak owner/member/viewer-onderscheid in echte klantteams tot misverstanden leidt
+- of activation follow-up en first-management-use in echte klantoperatie consistent genoeg worden vastgelegd
+
+Geen valse zekerheid:
+
+- Er is in deze draad geen echte klantobservatie of live authenticated dashboardsessie gedaan.
+- Het oordeel over dashboardgebruik, ownershipfrictie en first-next-step begrip is daarom deels contractmatig en semireeel, niet volledig gedragsevident uit live klantgebruik.
+
+## Git-status
+
+- branch: `codex/customer-operation-validation`
+- commit: nog niet vastgelegd in commit ten tijde van deze validatie
+- pushstatus: nog niet gepusht
+- PR-status: geen PR geopend
+
+## Oordeel
+
+- bruikbaar validatiebeeld
+
+## Aanbevolen volgende stap
+
+Voer geen brede nieuwe buildwave uit. Gebruik dit beeld eerst voor een smalle customer-ops-hardening pass buiten dashboardscope:
+
+- maak de intake- en ownerverwachting explicieter in onboarding en support
+- leg activation en first-management-use strakker operationeel vast
+- maak de demo-/fixturelaag betrouwbaar genoeg voor herhaalbare operatorvalidatie
+
+Pas als echte klantobservaties daarna laten zien dat mensen ondanks goede begeleiding nog steeds op dezelfde punten vastlopen, is een gerichte productsimplificatie van launch/ownership/first-next-step logisch.

--- a/docs/ops/ONBOARDING_ACCEPTANCE_CHECKLIST.md
+++ b/docs/ops/ONBOARDING_ACCEPTANCE_CHECKLIST.md
@@ -13,6 +13,7 @@ Gebruik deze checklist om te beoordelen of een assisted klantstart niet alleen l
 - [ ] Scanperiode expliciet vastgelegd als live vanaf start of bewust retrospectief opgezet
 - [ ] Contactpersoon en eerste managementdoel vastgelegd
 - [ ] Metadata-verwachting expliciet gemaakt
+- [ ] Klant owner expliciet aangewezen voor owner-only acties
 
 ## Setup and import
 
@@ -36,9 +37,11 @@ Gebruik deze checklist om te beoordelen of een assisted klantstart niet alleen l
 ## Activation and first use
 
 - [ ] Klantaccount geactiveerd
+- [ ] Eerste gebruiker voor dashboardtoegang expliciet bevestigd
 - [ ] Eerste dashboardread mogelijk
 - [ ] Eerste rapportuitleg geleverd of ingepland
 - [ ] Eerste managementgebruik bevestigd
+- [ ] Eerste eigenaar of vervolgstap expliciet vastgelegd
 
 ### Managed V1 route check
 
@@ -76,3 +79,7 @@ Praktische signalen zonder zware analytics-stack:
 - Eerst plan en docs aanpassen
 - Daarna UI, flows en tests aanpassen
 - Daarna acceptance-run en checklist opnieuw nalopen
+
+Zie voor owner- en activatiegrenzen ook:
+
+- [CLIENT_CUSTOMER_OWNER_ACTIVATION_CONTRACT.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/CLIENT_CUSTOMER_OWNER_ACTIVATION_CONTRACT.md)

--- a/docs/ops/OPS_DELIVERY_FAILURE_MATRIX.md
+++ b/docs/ops/OPS_DELIVERY_FAILURE_MATRIX.md
@@ -94,6 +94,10 @@ Belangrijke defaults:
 - Klantcommunicatie:
   ja, wanneer toegang of timing direct moet worden afgestemd
 
+Extra operatorregel:
+
+- controleer expliciet wie de klant owner is, wie de eerste gebruiker wordt en of activatie al naar eerste read is doorgezet
+
 ### 5. Report delivery gaps
 
 - Detectie:
@@ -119,6 +123,10 @@ Belangrijke defaults:
   bevestig eerste managementsessie, leg eerste eigenaar/vervolgstap vast of zet follow-up open
 - Klantcommunicatie:
   ja, wanneer Verisight actief de eerste read of walkthrough begeleidt
+
+Extra operatorregel:
+
+- first management use telt pas als de eerste managementvraag, eerste eigenaar en eerste vervolgstap expliciet zijn bevestigd
 
 ## Exception language
 
@@ -154,3 +162,4 @@ Neem dit minimaal op in de weekreview:
 - acceptance- en recoverycheckpoints: `campaign_delivery_checkpoints`
 - learning en vervolguitkomst: `pilot_learning_dossiers` en `pilot_learning_checkpoints`
 - actieve tranche: `docs/active/OPS_AND_DELIVERY_SYSTEM_PLAN.md`
+- owner- en activatiegrenzen: `docs/ops/CLIENT_CUSTOMER_OWNER_ACTIVATION_CONTRACT.md`

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -48,6 +48,8 @@ Voor het huidige fix-programma gebruik je deze volgorde:
   - canonieke route van akkoord naar eerste managementwaarde
 - [CLIENT_ONBOARDING_FLOW_SYSTEM.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/CLIENT_ONBOARDING_FLOW_SYSTEM.md)
   - praktisch flow-based naslagwerk voor routekeuze, intake, first value en report-to-action
+- [CLIENT_CUSTOMER_OWNER_ACTIVATION_CONTRACT.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/CLIENT_CUSTOMER_OWNER_ACTIVATION_CONTRACT.md)
+  - expliciteert wie aan klantzijde owner is voor owner-only acties, activatie en eerste managementgebruik
 - [ONBOARDING_ACCEPTANCE_CHECKLIST.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/ONBOARDING_ACCEPTANCE_CHECKLIST.md)
   - acceptancecheck voor onboarding
 - [OPS_DELIVERY_FAILURE_MATRIX.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/OPS_DELIVERY_FAILURE_MATRIX.md)


### PR DESCRIPTION
## Samenvatting
- voeg een compact customer owner activation contract toe voor owner-only acties, activatie en first management use
- koppel dit contract aan onboarding playbook, acceptance checklist, ops failure matrix en ops README
- corrigeer het validatierapport zodat seriele demo-seeds als bewijsbasis gelden en een eerdere parallelle mislezing niet meer als productfrictie telt

## Verificatie
- `python manage_demo_environment.py run sales_demo_exit`
- `python manage_demo_environment.py run sales_demo_retention`
- lokale sqlite-inspectie van `verisight-sales-demo`
- documentreferenties en ASCII-check op aangepaste ops-docs