### PR TITLE
fix: harden customer owner activation and no-access campaign flow

### DIFF
--- a/frontend/app/(auth)/complete-account/page.tsx
+++ b/frontend/app/(auth)/complete-account/page.tsx
@@ -66,7 +66,7 @@ export default function CompleteAccountPage() {
       return
     }
 
-    setSuccess('Account geactiveerd. Je wordt doorgestuurd naar het dashboard...')
+    setSuccess('Account geactiveerd en vrijgegeven voor je eerste read. Je wordt doorgestuurd naar het dashboard...')
     setTimeout(() => router.push('/dashboard'), 1200)
   }
 
@@ -96,7 +96,8 @@ export default function CompleteAccountPage() {
                 <h1 className="mb-2 text-xl font-semibold text-gray-900">Kies direct een wachtwoord</h1>
                 <p className="mb-6 text-sm text-gray-500">
                   Je bent ingelogd via de activatiemail voor {email ?? 'jouw account'}. Stel nu meteen een wachtwoord in,
-                  zodat je later gewoon via de inlogpagina kunt terugkomen.
+                  zodat je later gewoon via de inlogpagina kunt terugkomen. Na deze stap is je account vrijgegeven voor
+                  het juiste dashboard en de juiste campaign voor je eerste read.
                 </p>
 
                 <form onSubmit={handleSubmit} className="space-y-4">
@@ -175,7 +176,7 @@ export default function CompleteAccountPage() {
               <p className="text-xs font-semibold uppercase tracking-[0.2em] text-gray-400">Assisted onboarding</p>
               <p className="mt-3 text-sm leading-6 text-gray-600">
                 Verisight verkoopt geen self-service surveytool. Dit account is het handoff-moment naar jouw dashboard en
-                rapport, nadat de campaign en respondentflow al voor je zijn voorbereid.
+                rapport, nadat de campaign en respondentflow al voor je zijn voorbereid en bewust voor jouw eerste read zijn vrijgegeven.
               </p>
             </div>
           </div>

--- a/frontend/app/(auth)/login/page.test.ts
+++ b/frontend/app/(auth)/login/page.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('auth release wording', () => {
+  it('keeps login and activation copy tied to dashboard and campaign release', () => {
+    const loginSource = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+    const completeAccountSource = readFileSync(new URL('../complete-account/page.tsx', import.meta.url), 'utf8')
+
+    expect(loginSource).toContain('vrijgegeven')
+    expect(loginSource).toContain('eerste read')
+    expect(completeAccountSource).toContain('vrijgegeven')
+    expect(completeAccountSource).toContain('juiste dashboard')
+    expect(completeAccountSource).toContain('juiste campaign')
+  })
+})

--- a/frontend/app/(auth)/login/page.tsx
+++ b/frontend/app/(auth)/login/page.tsx
@@ -105,7 +105,10 @@ export default function LoginPage() {
           </a>
         </p>
         <p className="text-center text-xs text-gray-400 mt-2">
-          Uitgenodigd voor dashboardtoegang? Open eerst de activatiemail, kies daar je wachtwoord en log daarna in met hetzelfde e-mailadres.
+          Uitgenodigd voor dashboardtoegang? Open eerst de activatiemail, kies daar je wachtwoord en log daarna in met hetzelfde e-mailadres zodra je account is vrijgegeven voor je eerste read.
+        </p>
+        <p className="text-center text-xs text-gray-400 mt-2">
+          Activatie betekent hier niet alleen mail openen of een wachtwoord kiezen, maar dat het juiste dashboard en de juiste campaign voor jouw eerste read zijn vrijgegeven.
         </p>
         <p className="text-center text-xs text-gray-400 mt-3">
           Verisight v2.0 · Vertrouwelijk platform

--- a/frontend/app/(dashboard)/campaigns/[id]/page.route-shell.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.route-shell.test.ts
@@ -11,4 +11,13 @@ describe('campaign detail first-next-step shell', () => {
     expect(source).toContain('Geen standaard vervolg')
     expect(source).toContain('followOnSuggestions.map')
   })
+
+  it('keeps no-access and role clarity inside the same campaign shell', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+
+    expect(source).toContain('getCustomerRoleSummary')
+    expect(source).toContain('Geen toegang tot deze campaign')
+    expect(source).toContain('Terug naar dashboard')
+    expect(source).toContain('Jouw rol')
+  })
 })

--- a/frontend/app/(dashboard)/campaigns/[id]/page.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.test.ts
@@ -50,6 +50,15 @@ describe('campaign detail review guardrails', () => {
     expect(preflightSource).toContain('Klant owner')
   })
 
+  it('keeps owner guidance and the first next step visible above the fold', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+
+    expect(source).toContain('Jouw rol')
+    expect(source).toContain('Eerste volgende stap')
+    expect(source).toContain('Deze vervolgstap wordt bevestigd door de klant owner')
+    expect(source).toContain('defaultOpen={!hasEnoughData || (canManageCampaign && !readinessState.launchReady)}')
+  })
+
   it('keeps module hierarchy differentiated by role, evidence order and trust placement', () => {
     const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
 

--- a/frontend/app/(dashboard)/campaigns/[id]/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.tsx
@@ -65,7 +65,7 @@ import {
 import { buildCampaignReadinessState, getDeliveryModeLabel } from '@/lib/implementation-readiness'
 import { getFirstNextStepGuidance } from '@/lib/client-onboarding'
 import { type CampaignAuditEventRecord } from '@/lib/campaign-audit'
-import { getCustomerActionPermission } from '@/lib/customer-permissions'
+import { getCustomerActionPermission, getCustomerRoleSummary } from '@/lib/customer-permissions'
 import type { CampaignDeliveryCheckpoint, CampaignDeliveryRecord } from '@/lib/ops-delivery'
 import { buildTeamLocalReadState, buildTeamPriorityReadState } from '@/lib/products/team'
 import { getProductModule } from '@/lib/products/shared/registry'
@@ -241,6 +241,88 @@ export default async function CampaignPage({ params }: Props) {
     profile?.is_verisight_admin === true ||
     getCustomerActionPermission(membership?.role ?? null, 'review_launch')
   const isVerisightAdmin = profile?.is_verisight_admin === true
+  const roleSummary = isVerisightAdmin
+    ? {
+        label: 'Verisight beheer',
+        description:
+          'Begeleidt deze campaign namens Verisight, maar houdt ownerduiding, activatie en eerste managementgebruik nog steeds expliciet.',
+      }
+    : getCustomerRoleSummary(membership?.role ?? null)
+
+  if (!isVerisightAdmin && !membership?.role) {
+    return (
+      <div className="space-y-6">
+        <Link
+          href="/dashboard"
+          className="text-sm font-medium text-slate-500 transition-colors hover:text-slate-700"
+        >
+          ← Terug naar campaignoverzicht
+        </Link>
+
+        <div id="samenvatting" className="scroll-mt-36 space-y-4">
+          <DashboardHero
+            eyebrow="Campaigntoegang"
+            title="Geen toegang tot deze campaign"
+            description="Deze campaign is voor dit account nog niet vrijgegeven. Je dashboardtoegang blijft bewust begrensd tot campaigns die al aan jouw rol zijn gekoppeld."
+            tone="slate"
+            meta={
+              <>
+                <DashboardChip label="Campaign niet vrijgegeven" tone="amber" />
+                <DashboardChip label="Owner bevestigt vrijgave" tone="slate" />
+              </>
+            }
+            actions={
+              <Link
+                href="/dashboard"
+                className="inline-flex rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition-colors hover:border-slate-300 hover:bg-slate-50"
+              >
+                Terug naar dashboard
+              </Link>
+            }
+            aside={
+              <div className="space-y-3">
+                <DashboardKeyValue
+                  label="Jouw rol"
+                  value={roleSummary.label}
+                  helpText={roleSummary.description}
+                />
+                <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
+                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Vrijgave</p>
+                  <p className="mt-2 text-sm leading-6 text-slate-700">
+                    Vraag de klant owner of Verisight om te bevestigen wanneer deze campaign voor jouw account wordt
+                    vrijgegeven.
+                  </p>
+                </div>
+              </div>
+            }
+          />
+        </div>
+
+        <DashboardSection
+          id="toegang"
+          eyebrow="Toegangscontext"
+          title="Wat je nu wel en niet kunt verwachten"
+          description="Dit is een vrijgave- en verwachtingsvraag, geen nieuw dashboardspoor. Eerst moet duidelijk zijn wie de owner is en wanneer deze campaign echt voor jouw account openstaat."
+          aside={<DashboardChip label="Geen redesign" tone="slate" />}
+        >
+          <div className="grid gap-4 md:grid-cols-2">
+            <DashboardPanel
+              eyebrow="Ownerduiding"
+              title="De klant owner bevestigt de vrijgave"
+              body="Invite-, reminder- en reviewbevestiging blijven bij de klant owner. Zonder die koppeling hoort deze campaign hier niet half-open te blijven."
+              tone="slate"
+            />
+            <DashboardPanel
+              eyebrow="Volgende stap"
+              title="Ga terug naar het dashboard"
+              body="Gebruik alleen campaigns die al aan jouw account zijn gekoppeld. Zodra de juiste campaign is vrijgegeven, kun je vanaf het dashboard of via de juiste link opnieuw instappen."
+              tone="slate"
+            />
+          </div>
+        </DashboardSection>
+      </div>
+    )
+  }
   const canExecuteCampaign =
     isVerisightAdmin ||
     getCustomerActionPermission(membership?.role ?? null, 'import_respondents') ||
@@ -563,6 +645,19 @@ export default async function CampaignPage({ params }: Props) {
     ),
   ).length
   const firstNextStepGuidance = getFirstNextStepGuidance(stats.scan_type)
+  const firstNextStepAction =
+    firstNextStepGuidance.cards.find((card) => card.key === 'action') ?? firstNextStepGuidance.cards[0]
+  const firstNextStepTitle =
+    canManageCampaign || isVerisightAdmin ? readinessState.nextStep : dashboardViewModel.nextStep.title
+  const firstNextStepBody =
+    canManageCampaign || isVerisightAdmin
+      ? `${firstNextStepAction.body} Eerst concreet: ${readinessState.nextStep}.`
+      : `${firstNextStepAction.body} Volg deze stap read-first en stem invite, reminder of reviewbevestiging af met de klant owner.`
+  const firstNextStepConfirmation = isVerisightAdmin
+    ? 'Deze vervolgstap wordt bevestigd door de klant owner of door Verisight wanneer de begeleide uitvoer daar ligt.'
+    : membership?.role === 'owner'
+      ? 'Jij draagt als klant owner invite-, reminder- en reviewbevestiging voor deze campaign.'
+      : 'Deze vervolgstap wordt bevestigd door de klant owner zodra invite-, reminder- of reviewbevestiging nodig is.'
   const primaryTeamPriority =
     stats.scan_type === 'team' && teamPriorityRead?.status === 'ready'
       ? teamPriorityRead.groups.find((group) => group.isPrimary) ?? null
@@ -1481,6 +1576,9 @@ export default async function CampaignPage({ params }: Props) {
                 ))}
               </div>
               <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
+                <DashboardKeyValue label="Jouw rol" value={roleSummary.label} helpText={roleSummary.description} />
+              </div>
+              <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
                 <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Campagnestatus</p>
                 <p className="mt-2 text-sm leading-6 text-slate-700">
                   {`${stats.total_completed}/${stats.total_invited || 0} ingevuld`}.{' '}
@@ -1551,6 +1649,31 @@ export default async function CampaignPage({ params }: Props) {
           )
         }
       />
+
+      {showManagementOutput ? (
+        <DashboardSection
+          id="eerste-volgende-stap"
+          eyebrow="Eerste vervolgstap"
+          title="Eerste volgende stap"
+          description="Houd de eerste vervolgstap boven de vouw expliciet, zodat owner, vrijgave en eerste managementgebruik niet pas later in de route duidelijk worden."
+          aside={<DashboardChip label={canManageCampaign || isVerisightAdmin ? 'Actiestap expliciet' : 'Read-first context'} tone="slate" />}
+        >
+          <div className="grid gap-4 lg:grid-cols-[minmax(0,1.1fr),minmax(280px,0.9fr)]">
+            <DashboardPanel
+              eyebrow="Eerste volgende stap"
+              title={firstNextStepTitle}
+              body={firstNextStepBody}
+              tone={canManageCampaign || isVerisightAdmin ? 'amber' : 'slate'}
+            />
+            <DashboardPanel
+              eyebrow="Owner en bevestiging"
+              title="Wie bevestigt deze stap"
+              body={`${firstNextStepConfirmation} Eerste eigenaar: ${presentationMetrics.owner.value}.`}
+              tone="slate"
+            />
+          </div>
+        </DashboardSection>
+      ) : null}
 
       {showClientExecutionFlow ? (
         <DashboardSection
@@ -2028,7 +2151,7 @@ export default async function CampaignPage({ params }: Props) {
           <div className="space-y-4">
             {canManageCampaign ? (
               <DashboardDisclosure
-                defaultOpen={!hasEnoughData}
+                defaultOpen={!hasEnoughData || (canManageCampaign && !readinessState.launchReady)}
                 title="Campagnestatus en uitvoercontrole"
                 description="Gebruik deze laag voor lifecycle, readiness, handoff en foutopvang nadat het managementbeeld helder is."
                 badge={<DashboardChip label={readinessState.launchReady ? 'Uitvoer op orde' : 'Aandacht nodig'} tone={readinessState.launchReady ? 'emerald' : 'amber'} />}

--- a/frontend/lib/client-onboarding.test.ts
+++ b/frontend/lib/client-onboarding.test.ts
@@ -25,6 +25,16 @@ describe('client onboarding defaults', () => {
     ])
   })
 
+  it('keeps activatie defined as release to the correct dashboard and campaign', () => {
+    const activationPhase = CANONICAL_ONBOARDING_PHASES.find((phase) => phase.key === 'activation')
+
+    expect(activationPhase?.outcome.toLowerCase()).toContain('vrijgegeven')
+    expect(activationPhase?.outcome.toLowerCase()).toContain('juiste dashboard')
+    expect(activationPhase?.outcome.toLowerCase()).toContain('juiste campaign')
+    expect(activationPhase?.customerAction.toLowerCase()).toContain('vrijgegeven')
+    expect(activationPhase?.customerAction.toLowerCase()).toContain('eerste read')
+  })
+
   it('keeps first-value thresholds aligned with dashboard guardrails', () => {
     expect(FIRST_VALUE_THRESHOLDS).toEqual([
       expect.objectContaining({ minResponses: 0, maxResponses: 4 }),
@@ -76,11 +86,14 @@ describe('client onboarding defaults', () => {
     expect(getFirstManagementReadSteps('exit')[2]?.toLowerCase()).toContain('reviewmoment')
     expect(getFirstManagementReadSteps('retention')[2]?.toLowerCase()).toContain('eerste eigenaar')
     expect(getAdoptionSuccessDefinition('exit').toLowerCase()).toContain('dashboard en rapport')
+    expect(getAdoptionSuccessDefinition('exit').toLowerCase()).toContain('vrijgegeven')
     expect(getAdoptionSuccessDefinition('retention').toLowerCase()).toContain('behoud')
+    expect(getAdoptionSuccessDefinition('retention').toLowerCase()).toContain('vrijgegeven')
     expect(getAdoptionSuccessDefinition('pulse').toLowerCase()).toContain('bounded checkmoment')
     expect(getAdoptionSuccessDefinition('team').toLowerCase()).toContain('lokaal reviewmoment')
     expect(getAdoptionSuccessDefinition('onboarding').toLowerCase()).toContain('checkpoint')
     expect(getAdoptionSuccessDefinition('onboarding').toLowerCase()).toContain('eerste eigenaar')
+    expect(getAdoptionSuccessDefinition('onboarding').toLowerCase()).toContain('vrijgegeven')
     expect(getAdoptionSuccessDefinition('leadership').toLowerCase()).toContain('managementread')
     expect(getAdoptionSuccessDefinition('leadership').toLowerCase()).toContain('begrensde verificatie')
     expect(getAdoptionSuccessDefinition('exit').toLowerCase()).toContain('reviewmoment')

--- a/frontend/lib/client-onboarding.ts
+++ b/frontend/lib/client-onboarding.ts
@@ -65,8 +65,8 @@ export const CANONICAL_ONBOARDING_PHASES = [
     title: 'Klantactivatie',
     owner: 'Verisight',
     boundary: 'client',
-    outcome: 'De klant kan inloggen en ziet direct het juiste dashboard.',
-    customerAction: 'Activeer account en open de juiste campagne of het overzicht.',
+    outcome: 'De klant kan inloggen en krijgt het juiste dashboard en de juiste campaign vrijgegeven voor een eerste read.',
+    customerAction: 'Activeer account en open daarna de vrijgegeven campaign of het juiste dashboard voor de eerste read.',
   },
   {
     key: 'dashboard',
@@ -582,7 +582,7 @@ export function getFirstManagementReadSteps(scanType: ScanType) {
 
 export function getAdoptionSuccessDefinition(scanType: ScanType) {
   if (scanType === 'retention') {
-    return 'Adoptie is pas geslaagd wanneer de klant niet alleen operationeel draait, maar het dashboard en rapport gebruikt om een eerste managementsessie over behoud, verificatie, eerste eigenaar, routekeuze en reviewmoment te voeren.'
+    return 'Adoptie is pas geslaagd wanneer de klant niet alleen operationeel draait, maar het vrijgegeven dashboard en rapport gebruikt om een eerste managementsessie over behoud, verificatie, eerste eigenaar, routekeuze en reviewmoment te voeren.'
   }
   if (scanType === 'pulse') {
     return 'Adoptie is pas geslaagd wanneer de klant Pulse gebruikt om een eerste reviewvraag, kleine correctie en volgend bounded checkmoment expliciet te maken.'
@@ -591,10 +591,10 @@ export function getAdoptionSuccessDefinition(scanType: ScanType) {
     return 'Adoptie is pas geslaagd wanneer de klant TeamScan gebruikt om een eerste lokale verificatievraag, afdeling, begrensde actie en lokaal reviewmoment expliciet te maken.'
   }
   if (scanType === 'onboarding') {
-    return 'Adoptie is pas geslaagd wanneer de klant onboarding gebruikt om een eerste checkpointread, eerste eigenaar, begrensde borg- of correctiestap en logisch vervolgmoment expliciet te maken.'
+    return 'Adoptie is pas geslaagd wanneer de klant onboarding gebruikt om een vrijgegeven eerste checkpointread, eerste eigenaar, begrensde borg- of correctiestap en logisch vervolgmoment expliciet te maken.'
   }
   if (scanType === 'leadership') {
     return 'Adoptie is pas geslaagd wanneer de klant Leadership Scan gebruikt om een eerste managementread, eerste eigenaar, begrensde verificatie of correctie en logisch reviewmoment expliciet te maken.'
   }
-  return 'Adoptie is pas geslaagd wanneer de klant niet alleen operationeel draait, maar het dashboard en rapport gebruikt om een eerste managementsessie over vertrekduiding, prioriteiten, routekeuze en reviewmoment te voeren.'
+  return 'Adoptie is pas geslaagd wanneer de klant niet alleen operationeel draait, maar het vrijgegeven dashboard en rapport gebruikt om een eerste managementsessie over vertrekduiding, prioriteiten, routekeuze en reviewmoment te voeren.'
 }

--- a/frontend/lib/customer-permissions.ts
+++ b/frontend/lib/customer-permissions.ts
@@ -64,7 +64,7 @@ export function getCustomerRoleSummary(role: MemberRole | null | undefined) {
     return {
       label: 'Klant owner',
       description:
-        'Draagt de klantuitvoering op uitvoerkritieke stappen en houdt ownership, timing en vervolgstap expliciet.',
+        'Draagt invite-, reminder- en reviewbevestiging en houdt ownership, activatie en eerste vervolgstap expliciet.',
       allowedActions: [
         ACTION_LABELS.import_respondents,
         ACTION_LABELS.launch_invites,
@@ -79,7 +79,7 @@ export function getCustomerRoleSummary(role: MemberRole | null | undefined) {
     return {
       label: 'Member',
       description:
-        'Heeft ondersteunende toegang binnen begeleide uitvoering, maar uitvoerkritieke klantacties blijven bewust bij de klant owner.',
+        'Heeft ondersteunende toegang binnen begeleide uitvoering, maar de klant owner blijft verantwoordelijk voor vrijgave, invites, reminders en reviewbevestiging.',
       allowedActions: [ACTION_LABELS.view_dashboard, ACTION_LABELS.view_report],
       restrictedActions: [
         ACTION_LABELS.import_respondents,
@@ -94,7 +94,7 @@ export function getCustomerRoleSummary(role: MemberRole | null | undefined) {
     return {
       label: 'Viewer',
       description:
-        'Blijft read-first: gebruikt dashboard en rapport, maar neemt geen uitvoerkritieke acties.',
+        'Blijft read-first: gebruikt dashboard en rapport, maar de klant owner draagt nog steeds vrijgave, invites, reminders en reviewbevestiging.',
       allowedActions: [ACTION_LABELS.view_dashboard, ACTION_LABELS.view_report],
       restrictedActions: [
         ACTION_LABELS.import_respondents,
@@ -107,7 +107,7 @@ export function getCustomerRoleSummary(role: MemberRole | null | undefined) {
 
   return {
     label: 'Geen rol',
-    description: 'Deze gebruiker heeft nog geen expliciete klantrol voor deze campaign.',
+    description: 'Deze gebruiker heeft nog geen expliciete klantrol of vrijgave voor deze campaign.',
     allowedActions: [] as string[],
     restrictedActions: [
       ACTION_LABELS.import_respondents,


### PR DESCRIPTION
## Summary
- fix the no-access campaign route so unaffiliated users get an explicit in-shell state instead of a loading dead-end
- make ownerduiding, activation-as-release and first-next-step copy more explicit on the current campaign/auth flow
- keep this pass deliberately narrow: no redesign, no new wave, no Action Center buildout

## What changed
- added an explicit no-access state inside the existing campaign shell with a clear path back to `/dashboard`
- surfaced `Jouw rol` near the existing owner/context signals and reused current role helpers
- moved the first next step above the fold on readable campaign detail views and opened execution/readiness context when action is still pending
- sharpened activation wording in onboarding, login and complete-account so activation means the right dashboard/campaign is vrijgegeven for first read
- added targeted tests for the route shell, campaign page and auth/onboarding wording

## Guardrails kept
- no dashboard redesign
- no new dashboard scope
- no public/commercial scope
- Action Center and design files intentionally untouched outside the reserved narrow hardening files

## Verification
- `npx vitest run "app/(dashboard)/campaigns/[id]/page.route-shell.test.ts" "app/(dashboard)/campaigns/[id]/page.test.ts" "app/(dashboard)/dashboard/page.test.ts" "lib/client-onboarding.test.ts" "lib/ops-delivery.test.ts" "app/(auth)/login/page.test.ts"`