### PR TITLE
Harden owner activation routing and messaging

### DIFF
--- a/frontend/app/(dashboard)/campaigns/[id]/campaign-access.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/campaign-access.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { buildCampaignAccessState } from './campaign-access'
+
+describe('campaign access state', () => {
+  it('makes viewer read-only scope and Verisight ownership explicit', () => {
+    const state = buildCampaignAccessState({
+      isVerisightAdmin: false,
+      membershipRole: 'viewer',
+    })
+
+    expect(state.canRead).toBe(true)
+    expect(state.canManage).toBe(false)
+    expect(state.roleChip).toBe('Viewer - klantread')
+    expect(state.scopeChip).toBe('Alleen lezen')
+    expect(state.noteTitle).toBe('Je leest mee, maar Verisight beheert deze route')
+    expect(state.noteBody).toContain('Verisight blijft owner')
+    expect(state.noteBody).toContain('eerste volgende stap')
+  })
+
+  it('keeps member access distinct from the first route owner', () => {
+    const state = buildCampaignAccessState({
+      isVerisightAdmin: false,
+      membershipRole: 'member',
+    })
+
+    expect(state.canRead).toBe(true)
+    expect(state.canManage).toBe(true)
+    expect(state.roleChip).toBe('Member - Verisight delivery')
+    expect(state.noteBody).toContain('accountrol')
+    expect(state.noteBody).toContain('eerste eigenaar')
+  })
+
+  it('returns a denied state when there is no readable relationship to the campaign', () => {
+    const state = buildCampaignAccessState({
+      isVerisightAdmin: false,
+      membershipRole: null,
+    })
+
+    expect(state.canRead).toBe(false)
+    expect(state.deniedTitle).toBe('Deze campaign is niet beschikbaar')
+    expect(state.deniedBody).toContain('geen toegang')
+  })
+})

--- a/frontend/app/(dashboard)/campaigns/[id]/campaign-access.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/campaign-access.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildCampaignAccessState } from './campaign-access'
+import { buildCampaignAccessState, buildCampaignRouteUnavailableState } from './campaign-access'
 
 describe('campaign access state', () => {
   it('makes viewer read-only scope and Verisight ownership explicit', () => {
@@ -39,5 +39,14 @@ describe('campaign access state', () => {
     expect(state.canRead).toBe(false)
     expect(state.deniedTitle).toBe('Deze campaign is niet beschikbaar')
     expect(state.deniedBody).toContain('geen toegang')
+  })
+
+  it('keeps missing campaign data distinct from true denied access', () => {
+    const state = buildCampaignRouteUnavailableState('missing_data')
+
+    expect(state.eyebrow).toBe('Campaign nu niet beschikbaar')
+    expect(state.chipLabel).toBe('404-achtig gedrag')
+    expect(state.body).toContain('bestaat wel')
+    expect(state.body).not.toContain('geen toegang')
   })
 })

--- a/frontend/app/(dashboard)/campaigns/[id]/campaign-access.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/campaign-access.ts
@@ -11,6 +11,13 @@ export type CampaignAccessState = {
   deniedBody: string
 }
 
+export type CampaignRouteUnavailableState = {
+  eyebrow: string
+  chipLabel: string
+  title: string
+  body: string
+}
+
 export function buildCampaignAccessState(args: {
   isVerisightAdmin: boolean
   membershipRole: MemberRole | null | undefined
@@ -82,6 +89,26 @@ export function buildCampaignAccessState(args: {
     noteBody: null,
     deniedTitle: 'Deze campaign is niet beschikbaar',
     deniedBody:
+      'Je hebt geen toegang tot deze campaign of hij bestaat niet meer binnen jouw accountbereik. Ga terug naar het campaignoverzicht of vraag Verisight om de juiste route vrij te geven.',
+  }
+}
+
+export function buildCampaignRouteUnavailableState(reason: 'denied' | 'missing_data'): CampaignRouteUnavailableState {
+  if (reason === 'missing_data') {
+    return {
+      eyebrow: 'Campaign nu niet beschikbaar',
+      chipLabel: '404-achtig gedrag',
+      title: 'Deze campaign is nu niet beschikbaar',
+      body:
+        'De campaign bestaat wel, maar heeft nog geen leesbare route of campaigndata om hier veilig te tonen. Ga terug naar het campaignoverzicht en open alleen campaigns die daar al expliciet zichtbaar zijn.',
+    }
+  }
+
+  return {
+    eyebrow: 'Geen campaigntoegang',
+    chipLabel: 'Denied / no-access',
+    title: 'Deze campaign is niet beschikbaar',
+    body:
       'Je hebt geen toegang tot deze campaign of hij bestaat niet meer binnen jouw accountbereik. Ga terug naar het campaignoverzicht of vraag Verisight om de juiste route vrij te geven.',
   }
 }

--- a/frontend/app/(dashboard)/campaigns/[id]/campaign-access.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/campaign-access.ts
@@ -1,0 +1,87 @@
+import type { MemberRole } from '@/lib/types'
+
+export type CampaignAccessState = {
+  canRead: boolean
+  canManage: boolean
+  roleChip: string
+  scopeChip: string
+  noteTitle: string | null
+  noteBody: string | null
+  deniedTitle: string
+  deniedBody: string
+}
+
+export function buildCampaignAccessState(args: {
+  isVerisightAdmin: boolean
+  membershipRole: MemberRole | null | undefined
+}): CampaignAccessState {
+  if (args.isVerisightAdmin) {
+    return {
+      canRead: true,
+      canManage: true,
+      roleChip: 'Verisight admin',
+      scopeChip: 'Volledige campaignbediening',
+      noteTitle: null,
+      noteBody: null,
+      deniedTitle: 'Deze campaign is niet beschikbaar',
+      deniedBody:
+        'Je hebt geen toegang tot deze campaign of hij bestaat niet meer binnen jouw accountbereik.',
+    }
+  }
+
+  if (args.membershipRole === 'owner') {
+    return {
+      canRead: true,
+      canManage: true,
+      roleChip: 'Owner - Verisight',
+      scopeChip: 'Volledige campaignbediening',
+      noteTitle: null,
+      noteBody: null,
+      deniedTitle: 'Deze campaign is niet beschikbaar',
+      deniedBody:
+        'Je hebt geen toegang tot deze campaign of hij bestaat niet meer binnen jouw accountbereik.',
+    }
+  }
+
+  if (args.membershipRole === 'member') {
+    return {
+      canRead: true,
+      canManage: true,
+      roleChip: 'Member - Verisight delivery',
+      scopeChip: 'Beheer + meelezen',
+      noteTitle: 'Je leest en beheert mee, maar de eerste eigenaar blijft expliciet',
+      noteBody:
+        'Je accountrol geeft je beheerrechten, maar is niet automatisch de eerste eigenaar van deze route. Kijk in Actie welke eerste eigenaar en eerste volgende stap nu leidend zijn.',
+      deniedTitle: 'Deze campaign is niet beschikbaar',
+      deniedBody:
+        'Je hebt geen toegang tot deze campaign of hij bestaat niet meer binnen jouw accountbereik.',
+    }
+  }
+
+  if (args.membershipRole === 'viewer') {
+    return {
+      canRead: true,
+      canManage: false,
+      roleChip: 'Viewer - klantread',
+      scopeChip: 'Alleen lezen',
+      noteTitle: 'Je leest mee, maar Verisight beheert deze route',
+      noteBody:
+        'Dit account is read-only voor dashboard en PDF. Verisight blijft owner van setup, activatievrijgave en delivery; in Actie zie je welke eerste volgende stap nu voorligt.',
+      deniedTitle: 'Deze campaign is niet beschikbaar',
+      deniedBody:
+        'Je hebt geen toegang tot deze campaign of hij bestaat niet meer binnen jouw accountbereik.',
+    }
+  }
+
+  return {
+    canRead: false,
+    canManage: false,
+    roleChip: 'Geen campaigntoegang',
+    scopeChip: 'Geen toegang',
+    noteTitle: null,
+    noteBody: null,
+    deniedTitle: 'Deze campaign is niet beschikbaar',
+    deniedBody:
+      'Je hebt geen toegang tot deze campaign of hij bestaat niet meer binnen jouw accountbereik. Ga terug naar het campaignoverzicht of vraag Verisight om de juiste route vrij te geven.',
+  }
+}

--- a/frontend/app/(dashboard)/campaigns/[id]/page-helpers.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/page-helpers.test.ts
@@ -166,6 +166,7 @@ describe('action execution core', () => {
 
     expect(model.route.title).toBe('Start met rolhelderheid')
     expect(model.owner.title).toBe('HR business partner')
+    expect(model.firstStep.body).toContain('Eerste concrete stap')
     expect(model.firstStep.body).toContain('onduidelijkheid')
     expect(model.review.title).toBe('Review binnen 3 weken')
     expect(model.supportPrompt).toContain('Alleen openklappen')

--- a/frontend/app/(dashboard)/campaigns/[id]/page-helpers.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page-helpers.tsx
@@ -722,6 +722,9 @@ export function buildActionExecutionCore(args: {
   highlightedActionQuestion: string | null
   followThroughCard: DashboardFollowThroughCard | null
 }): ActionExecutionCore {
+  const firstAction = args.selectedPlaybook?.actions[0] ?? args.nextStep.title
+  const firstStepGuidance = args.highlightedActionQuestion ?? args.selectedPlaybook?.validate ?? args.nextStep.body
+
   return {
     route: {
       title: args.selectedPlaybook?.title ?? args.nextStep.title,
@@ -734,8 +737,8 @@ export function buildActionExecutionCore(args: {
       tone: 'blue',
     },
     firstStep: {
-      title: args.selectedPlaybook?.actions[0] ?? 'Kies een eerste gerichte verificatie',
-      body: args.highlightedActionQuestion ?? args.selectedPlaybook?.validate ?? args.nextStep.body,
+      title: firstAction,
+      body: `Eerste concrete stap: ${firstAction}. ${firstStepGuidance}`,
       tone: 'blue',
     },
     review: {

--- a/frontend/app/(dashboard)/campaigns/[id]/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.tsx
@@ -1,7 +1,9 @@
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
+import { createAdminClient } from '@/lib/supabase/admin'
 import { createClient } from '@/lib/supabase/server'
 import { CampaignActions } from './campaign-actions'
+import { buildCampaignAccessState } from './campaign-access'
 import { PdfDownloadButton } from './pdf-download-button'
 import {
   DashboardChip,
@@ -76,7 +78,7 @@ import { buildTeamLocalReadState, buildTeamPriorityReadState } from '@/lib/produ
 import { getProductModule } from '@/lib/products/shared/registry'
 import { getScanDefinition } from '@/lib/scan-definitions'
 import { FACTOR_LABELS, hasCampaignAddOn } from '@/lib/types'
-import type { CampaignStats, Respondent, SurveyResponse } from '@/lib/types'
+import type { CampaignStats, MemberRole, Respondent, SurveyResponse } from '@/lib/types'
 
 interface Props {
   params: Promise<{ id: string }>
@@ -90,14 +92,31 @@ export default async function CampaignPage({ params, searchParams }: Props) {
   const {
     data: { user },
   } = await supabase.auth.getUser()
+  const { data: profile } = user
+    ? await supabase.from('profiles').select('is_verisight_admin').eq('id', user.id).maybeSingle()
+    : { data: null }
+  const isVerisightAdmin = profile?.is_verisight_admin === true
 
   const { data: statsRow } = await supabase
     .from('campaign_stats')
     .select('*')
     .eq('campaign_id', id)
-    .single()
+    .maybeSingle()
 
-  if (!statsRow) notFound()
+  if (!statsRow) {
+    if (!(await campaignExists(id))) {
+      notFound()
+    }
+
+    return (
+      <CampaignRouteUnavailable
+        state={buildCampaignAccessState({
+          isVerisightAdmin,
+          membershipRole: null,
+        })}
+      />
+    )
+  }
   const stats = statsRow as CampaignStats
 
   const { data: previousStatsRows } = await supabase
@@ -111,16 +130,12 @@ export default async function CampaignPage({ params, searchParams }: Props) {
   const previousStats = (previousStatsRows?.[0] as CampaignStats | undefined) ?? null
 
   const [
-    { data: profile },
     { data: membership },
     { data: campaignMeta },
     { data: organization },
     { count: activeClientAccessCount },
     { count: pendingClientInviteCount },
   ] = await Promise.all([
-    user
-      ? supabase.from('profiles').select('is_verisight_admin').eq('id', user.id).maybeSingle()
-      : Promise.resolve({ data: null }),
     user
       ? supabase
           .from('org_members')
@@ -142,12 +157,16 @@ export default async function CampaignPage({ params, searchParams }: Props) {
       .eq('org_id', stats.organization_id)
       .is('accepted_at', null),
   ])
+  const accessState = buildCampaignAccessState({
+    isVerisightAdmin,
+    membershipRole: (membership?.role ?? null) as MemberRole | null,
+  })
 
-  const canManageCampaign =
-    profile?.is_verisight_admin === true ||
-    membership?.role === 'owner' ||
-    membership?.role === 'member'
-  const isVerisightAdmin = profile?.is_verisight_admin === true
+  if (!accessState.canRead) {
+    return <CampaignRouteUnavailable state={accessState} />
+  }
+
+  const canManageCampaign = accessState.canManage
   const hasSegmentDeepDive = hasCampaignAddOn(campaignMeta, 'segment_deep_dive')
   const { data: deliveryRecordRaw } = await supabase
     .from('campaign_delivery_records')
@@ -1018,6 +1037,8 @@ export default async function CampaignPage({ params, searchParams }: Props) {
             <DashboardChip label={stats.is_active ? 'Actief' : 'Archief'} tone={stats.is_active ? 'emerald' : 'slate'} />
             <DashboardChip label={`${organization?.name ?? 'Organisatie'} · ${formatCampaignPeriod(stats.created_at)}`} tone="slate" />
             <DashboardChip label={readinessLabel} tone={hasEnoughData ? 'blue' : 'amber'} />
+            <DashboardChip label={accessState.roleChip} tone={accessState.canManage ? 'blue' : 'slate'} />
+            <DashboardChip label={accessState.scopeChip} tone={accessState.canManage ? 'emerald' : 'slate'} />
             {hasSegmentDeepDive ? <DashboardChip label="Segment deep dive" tone="emerald" /> : null}
           </>
         }
@@ -1040,6 +1061,14 @@ export default async function CampaignPage({ params, searchParams }: Props) {
           </div>
         }
       />
+
+      {accessState.noteTitle && accessState.noteBody ? (
+        <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Accountrol en ownerduiding</p>
+          <p className="mt-2 text-sm font-semibold text-slate-900">{accessState.noteTitle}</p>
+          <p className="mt-2 text-sm leading-6 text-slate-700">{accessState.noteBody}</p>
+        </div>
+      ) : null}
 
       <DashboardPrimaryNav items={primaryNavItems} />
 
@@ -1737,6 +1766,55 @@ function ActionCoreRouteCard({
       <p className={`text-xs font-semibold uppercase tracking-[0.18em] ${eyebrowClass}`}>Gekozen route</p>
       <p className="mt-3 text-xl font-semibold text-[color:var(--ink)]">{title}</p>
       <p className="mt-3 max-w-2xl text-sm leading-7 text-[color:var(--text)]">{body}</p>
+    </div>
+  )
+}
+
+async function campaignExists(id: string) {
+  try {
+    const admin = createAdminClient()
+    const { data } = await admin.from('campaigns').select('id').eq('id', id).maybeSingle()
+    return Boolean(data)
+  } catch {
+    return false
+  }
+}
+
+function CampaignRouteUnavailable({
+  state,
+}: {
+  state: ReturnType<typeof buildCampaignAccessState>
+}) {
+  return (
+    <div className="space-y-6 pb-8">
+      <Link
+        href="/dashboard"
+        className="text-sm font-medium text-slate-500 transition-colors hover:text-slate-700"
+      >
+        Terug naar campaignoverzicht
+      </Link>
+
+      <DashboardSection
+        eyebrow="Geen campaigntoegang"
+        title={state.deniedTitle}
+        description={state.deniedBody}
+        aside={<DashboardChip label="Denied / no-access" tone="amber" />}
+      >
+        <div className="grid gap-4 md:grid-cols-2">
+          <DashboardPanel
+            eyebrow="Waarom je dit ziet"
+            title="Route niet vrijgegeven voor dit account"
+            body="Deze route stopt hier bewust vroeg, zodat denied of no-access direct zichtbaar wordt in plaats van als laadstaat te blijven hangen."
+            tone="amber"
+          />
+          <DashboardPanel
+            eyebrow="Volgende stap"
+            title="Open alleen campaigns uit je eigen overzicht"
+            body="Ga terug naar het campaignoverzicht of laat Verisight bevestigen welke campaign voor jouw account zichtbaar hoort te zijn."
+            tone="blue"
+          />
+        </div>
+      </DashboardSection>
     </div>
   )
 }

--- a/frontend/app/(dashboard)/campaigns/[id]/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from 'next/navigation'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { createClient } from '@/lib/supabase/server'
 import { CampaignActions } from './campaign-actions'
-import { buildCampaignAccessState } from './campaign-access'
+import { buildCampaignAccessState, buildCampaignRouteUnavailableState } from './campaign-access'
 import { PdfDownloadButton } from './pdf-download-button'
 import {
   DashboardChip,
@@ -110,10 +110,7 @@ export default async function CampaignPage({ params, searchParams }: Props) {
 
     return (
       <CampaignRouteUnavailable
-        state={buildCampaignAccessState({
-          isVerisightAdmin,
-          membershipRole: null,
-        })}
+        state={buildCampaignRouteUnavailableState('missing_data')}
       />
     )
   }
@@ -163,7 +160,7 @@ export default async function CampaignPage({ params, searchParams }: Props) {
   })
 
   if (!accessState.canRead) {
-    return <CampaignRouteUnavailable state={accessState} />
+    return <CampaignRouteUnavailable state={buildCampaignRouteUnavailableState('denied')} />
   }
 
   const canManageCampaign = accessState.canManage
@@ -1783,7 +1780,7 @@ async function campaignExists(id: string) {
 function CampaignRouteUnavailable({
   state,
 }: {
-  state: ReturnType<typeof buildCampaignAccessState>
+  state: ReturnType<typeof buildCampaignRouteUnavailableState>
 }) {
   return (
     <div className="space-y-6 pb-8">
@@ -1795,10 +1792,10 @@ function CampaignRouteUnavailable({
       </Link>
 
       <DashboardSection
-        eyebrow="Geen campaigntoegang"
-        title={state.deniedTitle}
-        description={state.deniedBody}
-        aside={<DashboardChip label="Denied / no-access" tone="amber" />}
+        eyebrow={state.eyebrow}
+        title={state.title}
+        description={state.body}
+        aside={<DashboardChip label={state.chipLabel} tone="amber" />}
       >
         <div className="grid gap-4 md:grid-cols-2">
           <DashboardPanel

--- a/frontend/components/dashboard/client-access-list.tsx
+++ b/frontend/components/dashboard/client-access-list.tsx
@@ -74,7 +74,7 @@ export function ClientAccessList({ invites }: Props) {
           const isActive = Boolean(invite.accepted_at)
           const cooldownMinutes = !isActive ? getRemainingCooldownMinutes(invite.invited_at) : 0
           const resendBlocked = cooldownMinutes > 0
-          const statusLabel = isActive ? 'Actieve dashboardtoegang' : 'Wacht op accountactivatie'
+          const statusLabel = isActive ? 'Dashboard vrijgegeven' : 'Wacht op vrijgave via activatie'
           const statusCls = isActive
             ? 'bg-green-50 text-green-700 border-green-100'
             : 'bg-amber-50 text-amber-700 border-amber-100'
@@ -105,8 +105,8 @@ export function ClientAccessList({ invites }: Props) {
                   </p>
                   <p className="mt-1 text-xs text-gray-500">
                     {isActive
-                      ? 'Dashboardtoegang is actief. Volgende stap: bevestig het eerste dashboard- of rapportgebruik.'
-                      : 'Activatie loopt nog. Bevestig de activatiemail en plan daarna het eerste klantcontact rond dashboardtoegang.'}
+                      ? 'Dashboardtoegang is actief. De campaign is nu vrijgegeven voor eerste dashboard- of rapportread; bevestig daarna het eerste echte gebruik.'
+                      : 'Activatie loopt nog. De campaign is pas vrijgegeven zodra het account is geactiveerd; plan daarna direct het eerste klantcontact rond dashboard of rapport.'}
                   </p>
                   {!isActive && resendBlocked && (
                     <p className="mt-1 text-xs text-amber-700">

--- a/frontend/components/dashboard/onboarding-panels.tsx
+++ b/frontend/components/dashboard/onboarding-panels.tsx
@@ -87,9 +87,9 @@ export function ActivationJourneyPanel() {
       <p className="text-xs font-semibold uppercase tracking-[0.2em] text-blue-700">Wat gebeurt er nu?</p>
       <div className="mt-4 grid gap-3 md:grid-cols-3">
         {[
-          'Je account is bedoeld voor dashboardtoegang. Verisight heeft organisatie, campaign en respondentimport al voorbereid.',
-          'Open na activatie eerst je campaignoverzicht. Daar zie je welke campagne al klaar is voor eerste managementread en welke nog respons opbouwt.',
-          'Gebruik daarna dashboard en rapport samen voor het eerste managementgesprek. Je hoeft geen setup of surveylogica meer te beheren.',
+          'Je account wordt met activatie echt vrijgegeven voor dashboardtoegang. Verisight heeft organisatie, campaign en respondentimport al voorbereid.',
+          'Open na activatie eerst je campaignoverzicht. Dat is je eerste volgende stap: daar zie je welke campaign nu al vrijgegeven is voor eerste managementread en welke nog respons opbouwt.',
+          'Gebruik daarna dashboard en rapport samen voor de eerste read. Je hoeft geen setup, reminders of surveylogica meer te beheren; Verisight blijft daarvan owner.',
         ].map((item, index) => (
           <div key={item} className="rounded-2xl border border-white/80 bg-white/90 p-4 shadow-sm">
             <p className="text-xs font-semibold uppercase tracking-[0.2em] text-blue-500">Stap {index + 1}</p>

--- a/frontend/lib/implementation-readiness.test.ts
+++ b/frontend/lib/implementation-readiness.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { buildCampaignReadinessState } from './implementation-readiness'
+
+describe('buildCampaignReadinessState', () => {
+  it('treats client activation as the release moment instead of only an email event', () => {
+    const state = buildCampaignReadinessState({
+      totalInvited: 18,
+      totalCompleted: 7,
+      invitesNotSent: 0,
+      incompleteScores: 0,
+      hasMinDisplay: true,
+      hasEnoughData: false,
+      activeClientAccessCount: 0,
+      pendingClientInviteCount: 2,
+    })
+
+    expect(state.headline).toBe('Vrijgave via klantactivatie loopt')
+    expect(state.detail).toContain('pas echt vrijgegeven')
+    expect(state.nextStep).toContain('Bevestig accountactivatie')
+    expect(state.nextStep).toContain('eerste dashboard- of rapportread')
+  })
+})

--- a/frontend/lib/implementation-readiness.ts
+++ b/frontend/lib/implementation-readiness.ts
@@ -148,9 +148,10 @@ export function buildCampaignReadinessState({
       clientAccessActivated,
       clientActivationPending,
       launchReady,
-      headline: 'Klantactivatie loopt',
-      detail: 'De activatiemail is verstuurd, maar dashboardtoegang is nog niet bevestigd. Houd support en eerste klantcontact daarom actief in de gaten.',
-      nextStep: 'Bevestig accountactivatie en begeleid daarna het eerste dashboard- of rapportgebruik.',
+      headline: 'Vrijgave via klantactivatie loopt',
+      detail:
+        'De activatiemail is verstuurd, maar deze campaign is pas echt vrijgegeven zodra dashboardtoegang is bevestigd en het eerste klantcontact klaarstaat.',
+      nextStep: 'Bevestig accountactivatie en begeleid daarna direct de eerste dashboard- of rapportread.',
     }
   }
 


### PR DESCRIPTION
## Summary
- harden the campaign route so denied or no-access states short-circuit into an explicit unavailable view instead of lingering in the full loading path
- make member/viewer account scope and owner guidance explicit on the campaign page
- sharpen activation and first-next-step copy so activation reads as the real release moment and the next action is visible sooner

## Verification
- `npx vitest run "app/(dashboard)/campaigns/[id]/campaign-access.test.ts" "lib/implementation-readiness.test.ts" "app/(dashboard)/campaigns/[id]/page-helpers.test.ts"`
- `npm run lint` passes with two pre-existing warnings in `app/(dashboard)/campaigns/[id]/page.tsx`
- `npm test` still has the pre-existing failure in `lib/seo-conversion.test.ts`
- `npm run build` still has the pre-existing homepage import error in `app/page.tsx`

## Scope notes
This stays intentionally narrow: no broad redesign, no guided-execution rebuild, only explicit hardening around denied/no-access, owner wording, activation release framing and first next step visibility.