### PR TITLE
[codex] add action center shared core contracts

### DIFF
--- a/backend/products/shared/action_center_adapters.py
+++ b/backend/products/shared/action_center_adapters.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+FutureActionCenterAdapterKey = Literal["exit", "retention", "onboarding", "pulse", "leadership"]
+FutureActionCenterAdapterStatus = Literal["inactive"]
+
+
+@dataclass(frozen=True)
+class FutureActionCenterAdapter:
+    key: FutureActionCenterAdapterKey
+    label: str
+    status: FutureActionCenterAdapterStatus
+    live_entry_enabled: Literal[False]
+
+
+_FUTURE_ADAPTERS: dict[FutureActionCenterAdapterKey, FutureActionCenterAdapter] = {
+    "exit": FutureActionCenterAdapter(
+        key="exit",
+        label="ExitScan-adapter",
+        status="inactive",
+        live_entry_enabled=False,
+    ),
+    "retention": FutureActionCenterAdapter(
+        key="retention",
+        label="RetentieScan-adapter",
+        status="inactive",
+        live_entry_enabled=False,
+    ),
+    "onboarding": FutureActionCenterAdapter(
+        key="onboarding",
+        label="Onboarding-adapter",
+        status="inactive",
+        live_entry_enabled=False,
+    ),
+    "pulse": FutureActionCenterAdapter(
+        key="pulse",
+        label="Pulse-adapter",
+        status="inactive",
+        live_entry_enabled=False,
+    ),
+    "leadership": FutureActionCenterAdapter(
+        key="leadership",
+        label="Leadership-adapter",
+        status="inactive",
+        live_entry_enabled=False,
+    ),
+}
+
+
+def get_future_action_center_adapter(key: FutureActionCenterAdapterKey) -> FutureActionCenterAdapter:
+    return _FUTURE_ADAPTERS[key]

--- a/backend/products/shared/action_center_core.py
+++ b/backend/products/shared/action_center_core.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+MemberRole = Literal["owner", "member", "viewer"]
+ActionCenterWorkspaceKind = Literal["follow_through"]
+ActionCenterDossierStatus = Literal["open", "closed"]
+ActionCenterAssignmentState = Literal["queued", "active", "blocked", "waiting", "completed", "cancelled"]
+ActionCenterAssignmentKind = Literal["follow_up", "review_prep", "closure", "handoff"]
+ActionCenterReviewState = Literal["scheduled", "due", "completed", "cancelled"]
+ActionCenterFollowUpSignalKind = Literal[
+    "decision_due",
+    "owner_missing",
+    "review_due",
+    "blocked_assignment",
+    "awaiting_input",
+    "closure_ready",
+]
+ActionCenterSignalSeverity = Literal["info", "warning", "critical"]
+ActionCenterSignalState = Literal["open", "resolved"]
+
+
+@dataclass(frozen=True)
+class ActionPermissionEnvelope:
+    can_view_workspace: bool
+    can_update_assignments: bool
+    can_schedule_review_moments: bool
+    can_resolve_signals: bool
+    can_close_dossiers: bool
+    can_manage_permissions: bool
+    can_open_product_adapters: Literal[False]
+
+
+@dataclass(frozen=True)
+class ActionDossier:
+    id: str
+    title: str
+    status: ActionCenterDossierStatus
+    owner_id: str | None
+    permission_envelope: ActionPermissionEnvelope
+
+
+@dataclass(frozen=True)
+class ActionAssignment:
+    id: str
+    dossier_id: str
+    title: str
+    state: ActionCenterAssignmentState
+    kind: ActionCenterAssignmentKind
+    owner_id: str | None
+
+
+@dataclass(frozen=True)
+class ActionReviewMoment:
+    id: str
+    dossier_id: str
+    scheduled_for: str
+    state: ActionCenterReviewState
+
+
+@dataclass(frozen=True)
+class ActionFollowUpSignal:
+    id: str
+    dossier_id: str
+    kind: ActionCenterFollowUpSignalKind
+    severity: ActionCenterSignalSeverity
+    state: ActionCenterSignalState
+
+
+@dataclass(frozen=True)
+class ActionWorkspaceSummary:
+    workspace_kind: ActionCenterWorkspaceKind
+    open_dossier_count: int
+    blocked_count: int
+    review_due_count: int
+    escalation_count: int
+    project_plan_count: Literal[0]
+    advisory_count: Literal[0]
+
+
+def build_permission_envelope(role: MemberRole | None) -> ActionPermissionEnvelope:
+    can_view_workspace = role is not None
+    can_edit_follow_through = role == "owner"
+
+    return ActionPermissionEnvelope(
+        can_view_workspace=can_view_workspace,
+        can_update_assignments=can_edit_follow_through,
+        can_schedule_review_moments=can_edit_follow_through,
+        can_resolve_signals=can_edit_follow_through,
+        can_close_dossiers=can_edit_follow_through,
+        can_manage_permissions=can_edit_follow_through,
+        can_open_product_adapters=False,
+    )
+
+
+def summarize_workspace(
+    *,
+    dossiers: list[ActionDossier],
+    assignments: list[ActionAssignment],
+    review_moments: list[ActionReviewMoment],
+    follow_up_signals: list[ActionFollowUpSignal],
+) -> ActionWorkspaceSummary:
+    return ActionWorkspaceSummary(
+        workspace_kind="follow_through",
+        open_dossier_count=sum(1 for dossier in dossiers if dossier.status == "open"),
+        blocked_count=sum(1 for assignment in assignments if assignment.state == "blocked"),
+        review_due_count=sum(1 for review_moment in review_moments if review_moment.state == "due"),
+        escalation_count=sum(
+            1 for signal in follow_up_signals if signal.state == "open" and signal.severity == "critical"
+        ),
+        project_plan_count=0,
+        advisory_count=0,
+    )

--- a/backend/products/shared/action_center_mto.py
+++ b/backend/products/shared/action_center_mto.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass(frozen=True)
+class MtoDesignInput:
+    source: Literal["mto"]
+    themes: list[str]
+    notes: str | None
+
+
+@dataclass(frozen=True)
+class MtoDesignInputSummary:
+    source: Literal["mto"]
+    mode: Literal["design_input_only"]
+    theme_count: int
+    notes: str | None
+    can_create_assignments: Literal[False]
+    can_open_carrier: Literal[False]
+
+
+def describe_mto_design_input(input_data: MtoDesignInput) -> MtoDesignInputSummary:
+    return MtoDesignInputSummary(
+        source=input_data.source,
+        mode="design_input_only",
+        theme_count=len(input_data.themes),
+        notes=input_data.notes,
+        can_create_assignments=False,
+        can_open_carrier=False,
+    )

--- a/frontend/lib/action-center-adapters.ts
+++ b/frontend/lib/action-center-adapters.ts
@@ -1,0 +1,27 @@
+export type FutureActionCenterAdapterKey =
+  | 'exit'
+  | 'retention'
+  | 'onboarding'
+  | 'pulse'
+  | 'leadership'
+
+export type FutureActionCenterAdapterStatus = 'inactive'
+
+export interface FutureActionCenterAdapter {
+  key: FutureActionCenterAdapterKey
+  label: string
+  status: FutureActionCenterAdapterStatus
+  liveEntryEnabled: false
+}
+
+const FUTURE_ADAPTERS: Record<FutureActionCenterAdapterKey, FutureActionCenterAdapter> = {
+  exit: { key: 'exit', label: 'ExitScan-adapter', status: 'inactive', liveEntryEnabled: false },
+  retention: { key: 'retention', label: 'RetentieScan-adapter', status: 'inactive', liveEntryEnabled: false },
+  onboarding: { key: 'onboarding', label: 'Onboarding-adapter', status: 'inactive', liveEntryEnabled: false },
+  pulse: { key: 'pulse', label: 'Pulse-adapter', status: 'inactive', liveEntryEnabled: false },
+  leadership: { key: 'leadership', label: 'Leadership-adapter', status: 'inactive', liveEntryEnabled: false },
+}
+
+export function getFutureActionCenterAdapter(key: FutureActionCenterAdapterKey) {
+  return FUTURE_ADAPTERS[key]
+}

--- a/frontend/lib/action-center-mto.ts
+++ b/frontend/lib/action-center-mto.ts
@@ -1,0 +1,25 @@
+export interface MtoDesignInput {
+  source: 'mto'
+  themes: string[]
+  notes: string | null
+}
+
+export interface MtoDesignInputSummary {
+  source: 'mto'
+  mode: 'design_input_only'
+  themeCount: number
+  notes: string | null
+  canCreateAssignments: false
+  canOpenCarrier: false
+}
+
+export function describeMtoDesignInput(input: MtoDesignInput): MtoDesignInputSummary {
+  return {
+    source: input.source,
+    mode: 'design_input_only',
+    themeCount: input.themes.length,
+    notes: input.notes,
+    canCreateAssignments: false,
+    canOpenCarrier: false,
+  }
+}

--- a/frontend/lib/action-center-shared-core.test.ts
+++ b/frontend/lib/action-center-shared-core.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildActionCenterPermissionEnvelope,
+  buildActionCenterWorkspaceSummary,
+  getFutureActionCenterAdapter,
+} from '@/lib/action-center-shared-core'
+import { describeMtoDesignInput } from '@/lib/action-center-mto'
+
+describe('action center shared core', () => {
+  it('keeps the workspace bounded to follow-through signals instead of generic project planning', () => {
+    const summary = buildActionCenterWorkspaceSummary({
+      dossiers: [
+        {
+          id: 'dos-1',
+          title: 'Pilot learning closure',
+          status: 'open',
+          ownerId: 'owner-1',
+          permissionEnvelope: buildActionCenterPermissionEnvelope({
+            role: 'owner',
+          }),
+        },
+      ],
+      assignments: [
+        {
+          id: 'asg-1',
+          dossierId: 'dos-1',
+          title: 'Bevestig follow-upbesluit',
+          state: 'blocked',
+          kind: 'follow_up',
+          ownerId: 'owner-1',
+        },
+      ],
+      reviewMoments: [
+        {
+          id: 'rev-1',
+          dossierId: 'dos-1',
+          scheduledFor: '2026-05-01',
+          state: 'due',
+        },
+      ],
+      followUpSignals: [
+        {
+          id: 'sig-1',
+          dossierId: 'dos-1',
+          kind: 'decision_due',
+          severity: 'critical',
+          state: 'open',
+        },
+      ],
+    })
+
+    expect(summary.workspaceKind).toBe('follow_through')
+    expect(summary.openDossierCount).toBe(1)
+    expect(summary.blockedCount).toBe(1)
+    expect(summary.reviewDueCount).toBe(1)
+    expect(summary.escalationCount).toBe(1)
+    expect(summary.projectPlanCount).toBe(0)
+    expect(summary.advisoryCount).toBe(0)
+  })
+
+  it('keeps the permission envelope limited to follow-through actions', () => {
+    const memberEnvelope = buildActionCenterPermissionEnvelope({ role: 'member' })
+    const ownerEnvelope = buildActionCenterPermissionEnvelope({ role: 'owner' })
+
+    expect(memberEnvelope.canViewWorkspace).toBe(true)
+    expect(memberEnvelope.canUpdateAssignments).toBe(false)
+    expect(memberEnvelope.canManagePermissions).toBe(false)
+    expect(memberEnvelope.canOpenProductAdapters).toBe(false)
+
+    expect(ownerEnvelope.canUpdateAssignments).toBe(true)
+    expect(ownerEnvelope.canScheduleReviewMoments).toBe(true)
+    expect(ownerEnvelope.canCloseDossiers).toBe(true)
+    expect(ownerEnvelope.canOpenProductAdapters).toBe(false)
+  })
+
+  it('keeps MTO input as design-only and future adapters inactive', () => {
+    const mtoDesignInput = describeMtoDesignInput({
+      source: 'mto',
+      themes: ['werkdruk', 'rolhelderheid'],
+      notes: 'Gebruik alleen als ontwerpinspiratie voor dossiervelden.',
+    })
+    const exitAdapter = getFutureActionCenterAdapter('exit')
+
+    expect(mtoDesignInput.mode).toBe('design_input_only')
+    expect(mtoDesignInput.canCreateAssignments).toBe(false)
+    expect(mtoDesignInput.canOpenCarrier).toBe(false)
+    expect(exitAdapter.status).toBe('inactive')
+    expect(exitAdapter.liveEntryEnabled).toBe(false)
+  })
+})

--- a/frontend/lib/action-center-shared-core.ts
+++ b/frontend/lib/action-center-shared-core.ts
@@ -1,0 +1,118 @@
+import type { MemberRole } from '@/lib/types'
+
+export { getFutureActionCenterAdapter } from '@/lib/action-center-adapters'
+
+export type ActionCenterWorkspaceKind = 'follow_through'
+export type ActionCenterDossierStatus = 'open' | 'closed'
+export type ActionCenterAssignmentState =
+  | 'queued'
+  | 'active'
+  | 'blocked'
+  | 'waiting'
+  | 'completed'
+  | 'cancelled'
+export type ActionCenterAssignmentKind = 'follow_up' | 'review_prep' | 'closure' | 'handoff'
+export type ActionCenterReviewState = 'scheduled' | 'due' | 'completed' | 'cancelled'
+export type ActionCenterFollowUpSignalKind =
+  | 'decision_due'
+  | 'owner_missing'
+  | 'review_due'
+  | 'blocked_assignment'
+  | 'awaiting_input'
+  | 'closure_ready'
+export type ActionCenterSignalSeverity = 'info' | 'warning' | 'critical'
+export type ActionCenterSignalState = 'open' | 'resolved'
+
+export interface ActionCenterPermissionEnvelope {
+  canViewWorkspace: boolean
+  canUpdateAssignments: boolean
+  canScheduleReviewMoments: boolean
+  canResolveSignals: boolean
+  canCloseDossiers: boolean
+  canManagePermissions: boolean
+  canOpenProductAdapters: false
+}
+
+export interface ActionCenterDossier {
+  id: string
+  title: string
+  status: ActionCenterDossierStatus
+  ownerId: string | null
+  permissionEnvelope: ActionCenterPermissionEnvelope
+}
+
+export interface ActionCenterAssignment {
+  id: string
+  dossierId: string
+  title: string
+  state: ActionCenterAssignmentState
+  kind: ActionCenterAssignmentKind
+  ownerId: string | null
+}
+
+export interface ActionCenterReviewMoment {
+  id: string
+  dossierId: string
+  scheduledFor: string
+  state: ActionCenterReviewState
+}
+
+export interface ActionCenterFollowUpSignal {
+  id: string
+  dossierId: string
+  kind: ActionCenterFollowUpSignalKind
+  severity: ActionCenterSignalSeverity
+  state: ActionCenterSignalState
+}
+
+export interface ActionCenterWorkspaceSummary {
+  workspaceKind: ActionCenterWorkspaceKind
+  openDossierCount: number
+  blockedCount: number
+  reviewDueCount: number
+  escalationCount: number
+  projectPlanCount: 0
+  advisoryCount: 0
+}
+
+export function buildActionCenterPermissionEnvelope(args: {
+  role: MemberRole | null | undefined
+}): ActionCenterPermissionEnvelope {
+  const role = args.role
+  const canViewWorkspace = Boolean(role)
+  const canEditFollowThrough = role === 'owner'
+
+  return {
+    canViewWorkspace,
+    canUpdateAssignments: canEditFollowThrough,
+    canScheduleReviewMoments: canEditFollowThrough,
+    canResolveSignals: canEditFollowThrough,
+    canCloseDossiers: canEditFollowThrough,
+    canManagePermissions: canEditFollowThrough,
+    canOpenProductAdapters: false,
+  }
+}
+
+export function buildActionCenterWorkspaceSummary(args: {
+  dossiers: ActionCenterDossier[]
+  assignments: ActionCenterAssignment[]
+  reviewMoments: ActionCenterReviewMoment[]
+  followUpSignals: ActionCenterFollowUpSignal[]
+}): ActionCenterWorkspaceSummary {
+  const openDossierCount = args.dossiers.filter((dossier) => dossier.status === 'open').length
+  const blockedCount = args.assignments.filter((assignment) => assignment.state === 'blocked').length
+  const reviewDueCount = args.reviewMoments.filter((reviewMoment) => reviewMoment.state === 'due').length
+  const escalationCount = args.followUpSignals.filter(
+    (signal) => signal.state === 'open' && signal.severity === 'critical',
+  ).length
+
+  return {
+    workspaceKind: 'follow_through',
+    openDossierCount,
+    blockedCount,
+    reviewDueCount,
+    escalationCount,
+    projectPlanCount: 0,
+    advisoryCount: 0,
+  }
+}

--- a/tests/test_action_center_shared_core.py
+++ b/tests/test_action_center_shared_core.py
@@ -1,0 +1,91 @@
+from backend.products.shared.action_center_adapters import get_future_action_center_adapter
+from backend.products.shared.action_center_core import (
+    ActionAssignment,
+    ActionDossier,
+    ActionFollowUpSignal,
+    ActionReviewMoment,
+    build_permission_envelope,
+    summarize_workspace,
+)
+from backend.products.shared.action_center_mto import MtoDesignInput, describe_mto_design_input
+
+
+def test_action_center_summary_stays_follow_through_bounded():
+    summary = summarize_workspace(
+        dossiers=[
+            ActionDossier(
+                id="dos-1",
+                title="Pilot learning closure",
+                status="open",
+                owner_id="owner-1",
+                permission_envelope=build_permission_envelope("owner"),
+            )
+        ],
+        assignments=[
+            ActionAssignment(
+                id="asg-1",
+                dossier_id="dos-1",
+                title="Bevestig follow-upbesluit",
+                state="blocked",
+                kind="follow_up",
+                owner_id="owner-1",
+            )
+        ],
+        review_moments=[
+            ActionReviewMoment(
+                id="rev-1",
+                dossier_id="dos-1",
+                scheduled_for="2026-05-01",
+                state="due",
+            )
+        ],
+        follow_up_signals=[
+            ActionFollowUpSignal(
+                id="sig-1",
+                dossier_id="dos-1",
+                kind="decision_due",
+                severity="critical",
+                state="open",
+            )
+        ],
+    )
+
+    assert summary.workspace_kind == "follow_through"
+    assert summary.open_dossier_count == 1
+    assert summary.blocked_count == 1
+    assert summary.review_due_count == 1
+    assert summary.escalation_count == 1
+    assert summary.project_plan_count == 0
+    assert summary.advisory_count == 0
+
+
+def test_permission_envelope_stays_within_follow_through_surface():
+    member_envelope = build_permission_envelope("member")
+    owner_envelope = build_permission_envelope("owner")
+
+    assert member_envelope.can_view_workspace is True
+    assert member_envelope.can_update_assignments is False
+    assert member_envelope.can_manage_permissions is False
+    assert member_envelope.can_open_product_adapters is False
+
+    assert owner_envelope.can_update_assignments is True
+    assert owner_envelope.can_schedule_review_moments is True
+    assert owner_envelope.can_close_dossiers is True
+    assert owner_envelope.can_open_product_adapters is False
+
+
+def test_mto_and_future_adapters_stay_explicitly_separate():
+    design_input = describe_mto_design_input(
+        MtoDesignInput(
+            source="mto",
+            themes=["werkdruk", "rolhelderheid"],
+            notes="Gebruik alleen als ontwerpinspiratie voor dossiervelden.",
+        )
+    )
+    exit_adapter = get_future_action_center_adapter("exit")
+
+    assert design_input.mode == "design_input_only"
+    assert design_input.can_create_assignments is False
+    assert design_input.can_open_carrier is False
+    assert exit_adapter.status == "inactive"
+    assert exit_adapter.live_entry_enabled is False


### PR DESCRIPTION
## Korte samenvatting
- Bouwt een neutrale Action Center shared core als contractlaag in backend en frontend.
- Houdt MTO expliciet op design-input-niveau en laat toekomstige productadapters bewust inactief.
- Voegt gerichte tests toe om follow-through scope, permission envelope en adaptergrenzen te bewaken.

## Wat in de shared core is gebouwd
- Shared backend-contracten voor dossiers, assignments, reviewmomenten, follow-up signalen en permission envelope.
- Shared frontend-contracten en samenvattingshelpers voor dezelfde follow-through workspace.
- Een expliciete scheiding tussen shared core, MTO-design-input en toekomstige adapteringangen.

## Welke delen bewust nog niet zijn geactiveerd
- Geen live adapters voor ExitScan, RetentieScan, Onboarding, Pulse of Leadership.
- Geen automatische MTO-carrier of assignment-creatie vanuit MTO-input.
- Geen nieuwe generieke projectmanager- of advieslaag buiten follow-through.

## Welke tests en verificatie zijn gedaan
- `python -m pytest tests/test_action_center_shared_core.py`
- `python -m py_compile backend/products/shared/action_center_core.py backend/products/shared/action_center_mto.py backend/products/shared/action_center_adapters.py`
- `npm.cmd test -- action-center-shared-core.test.ts`
- `npm.cmd run lint -- lib/action-center-shared-core.ts lib/action-center-mto.ts lib/action-center-adapters.ts lib/action-center-shared-core.test.ts`

## Oordeel
- De wijziging blijft bewust smal en current-main-ready: alleen nieuwe shared-core contracten en tests, zonder verbreding naar productadapters of MTO-carrierlogica.