### PR TITLE
Harden customer ops ownership and follow-up cadence

### DIFF
--- a/docs/CLIENT_ONBOARDING_CHECKLIST.md
+++ b/docs/CLIENT_ONBOARDING_CHECKLIST.md
@@ -8,10 +8,12 @@ Gebruik deze checklist als vaste klantcommunicatie voor assisted onboarding.
 - [ ] Wij controleren het respondentbestand voor import
 - [ ] Wij bewaken uitnodigingen, dashboard en rapport
 - [ ] Wij begeleiden de eerste dashboardread of rapportuitleg
+- [ ] Wij plannen samen met jullie het eerste managementmoment en de eerste review
 
 ## Wat we van de klant nodig hebben
 
 - [ ] Contactpersoon voor de implementation
+- [ ] Interne eigenaar of sponsor voor het eerste managementmoment
 - [ ] Bevestiging van productroute en timing
 - [ ] Respondentbestand met minimaal `email`
 - [ ] Bij voorkeur ook `department` en `role_level`
@@ -22,12 +24,16 @@ Gebruik deze checklist als vaste klantcommunicatie voor assisted onboarding.
 - [ ] Verisight controleert eerst de importpreview
 - [ ] Daarna versturen we uitnodigingen of zetten respondenten bewust klaar
 - [ ] Vervolgens nodigen we de klantcontactpersoon uit voor dashboardtoegang
-- [ ] Na activatie plannen we het eerste gebruik van dashboard of rapport
+- [ ] Na activatie bevestigen we wie intern aansluit bij het eerste managementmoment
+- [ ] Zodra het beeld veilig leesbaar is plannen we het eerste gebruik van dashboard of rapport
+- [ ] In dat eerste moment leggen we eigenaar, eerste stap en reviewmoment vast
 
 ## Verwachtingskader
 
 - [ ] Dashboardtoegang is pas echt live na accountactivatie
+- [ ] Activatie is nog geen afgeronde adoptie
 - [ ] Vanaf 5 responses ontstaat een eerste veilige detailweergave
 - [ ] Vanaf 10 responses wordt patroonduiding steviger
+- [ ] Het eerste managementmoment bepaalt pas welke opvolging logisch is
 - [ ] ExitScan is terugkijkend en bestuurlijk leesbaar
 - [ ] RetentieScan is vroegsignalering op groepsniveau, geen individuele voorspeller

--- a/docs/IMPLEMENTATION_MESSAGE_TEMPLATES.md
+++ b/docs/IMPLEMENTATION_MESSAGE_TEMPLATES.md
@@ -37,7 +37,7 @@ De campaign staat nu live. We hebben de respondentimport gecontroleerd en de uit
 De eerstvolgende stap is nu:
 - respons opbouwen
 - eerste dashboardsignalen volgen
-- daarna een eerste managementread inplannen
+- daarna een eerste managementread inplannen met de juiste interne eigenaar
 
 We laten weten zodra het beeld stevig genoeg is voor de eerste rapport- of dashboarduitleg.
 
@@ -58,6 +58,7 @@ Belangrijk:
 - dashboardtoegang is pas echt afgerond na activatie
 - je hoeft zelf geen setup meer te doen
 - wij begeleiden het eerste gebruik van dashboard en rapport
+- we leggen daarbij ook direct het eerste managementmoment vast
 
 Laat het weten als de activatiemail niet aankomt of als je wilt dat we direct een eerste walkthrough plannen.
 
@@ -79,6 +80,7 @@ In dit eerste moment lopen we samen door:
 - de belangrijkste signalen
 - wat nog indicatief is en wat al steviger ligt
 - welke eerste managementactie of eigenaar logisch is
+- welk reviewmoment en welke follow-up daarna echt tellen
 
 Laat weten welke momenten deze week of volgende week passen.
 

--- a/docs/IMPLEMENTATION_OPERATOR_CHECKLIST.md
+++ b/docs/IMPLEMENTATION_OPERATOR_CHECKLIST.md
@@ -9,6 +9,7 @@ Gebruik deze checklist voor de assisted implementation route vanaf klantakkoord 
 - [ ] Organisatie aangemaakt of gecontroleerd
 - [ ] Campaignnaam, scan_type en add-ons gecontroleerd
 - [ ] Contactpersoon en eerste managementdoel expliciet vastgelegd
+- [ ] Verisight delivery owner expliciet vastgelegd
 
 ## 2. Klantbestand en import
 
@@ -26,6 +27,8 @@ Gebruik deze checklist voor de assisted implementation route vanaf klantakkoord 
 - [ ] Eventuele resend of reminderlogica afgestemd
 - [ ] Klantdashboardtoegang uitgenodigd
 - [ ] Activatie daadwerkelijk bevestigd
+- [ ] Klantowner of managementsponsor bevestigd
+- [ ] First management use-slot voorlopig gepland
 
 ## 4. Launch en acceptatie
 
@@ -37,6 +40,8 @@ Gebruik deze checklist voor de assisted implementation route vanaf klantakkoord 
 - [ ] PDF-rapport werkt
 - [ ] Eerste dashboardread of rapportuitleg ingepland
 - [ ] Eerste managementgebruik bevestigd
+- [ ] Eerste eigenaar, eerste actie en reviewmoment vastgelegd
+- [ ] Follow-upstatus vastgelegd
 
 ## 5. Extra aandacht bij live routes
 
@@ -44,3 +49,4 @@ Gebruik deze checklist voor de assisted implementation route vanaf klantakkoord 
 - [ ] Timing en eigenaarschap nogmaals bevestigd
 - [ ] Uitnodigingen niet automatisch verstuurd zonder laatste controle
 - [ ] Eerste contactmoment na livegang expliciet ingepland
+- [ ] Reviewmoment staat uiterlijk in de eerstvolgende managementweek na first management use

--- a/docs/ops/CEO_OPERATING_CADENCE.md
+++ b/docs/ops/CEO_OPERATING_CADENCE.md
@@ -40,7 +40,19 @@ Gebruik dit ritme een keer per week, bij voorkeur op een vaste ochtend.
 - bijgewerkte leadpipeline in `Verisight_CRM.xlsx`
 - bijgewerkte [CEO_WEEKLY_SCORECARD.xlsx](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/CEO_WEEKLY_SCORECARD.xlsx)
 - actuele deliverystatus in de app-surfaces
+- expliciet beeld van actieve campaigns met status op activation, first management use, review due en follow-up decided
 - eventuele aanvulling in [DECISION_LOG.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/DECISION_LOG.md)
+
+### Weekly delivery gate
+
+Toets actieve klanttrajecten elke week minimaal op:
+
+- activation pending versus confirmed
+- first management use scheduled versus held
+- review due versus held
+- follow-up decided versus operationeel open
+
+Gebruik hiervoor de afspraken uit [CLIENT_OWNERSHIP_AND_FOLLOW_UP_CADENCE.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/CLIENT_OWNERSHIP_AND_FOLLOW_UP_CADENCE.md).
 
 ## Monthly cadence
 

--- a/docs/ops/CLIENT_ONBOARDING_FLOW_SYSTEM.md
+++ b/docs/ops/CLIENT_ONBOARDING_FLOW_SYSTEM.md
@@ -11,6 +11,7 @@ Het sluit direct aan op:
 
 - [COMMERCIAL_ARCHITECTURE_CANON.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/COMMERCIAL_ARCHITECTURE_CANON.md)
 - [CLIENT_ONBOARDING_PLAYBOOK.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/CLIENT_ONBOARDING_PLAYBOOK.md)
+- [CLIENT_OWNERSHIP_AND_FOLLOW_UP_CADENCE.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/CLIENT_OWNERSHIP_AND_FOLLOW_UP_CADENCE.md)
 - [REPORT_STRUCTURE_CANON.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/REPORT_STRUCTURE_CANON.md)
 - [REPORT_TO_ACTION_PROGRAM_PLAN.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/REPORT_TO_ACTION_PROGRAM_PLAN.md)
 
@@ -122,6 +123,7 @@ Gebruik `Combinatie` alleen als:
 ### Beslisregels
 
 - geen first-value claim zonder bruikbare responsbasis
+- activatie is pas confirmed als klanttoegang, Verisight delivery owner, klantowner en first management use-slot duidelijk zijn
 - dashboard en rapport moeten dezelfde leeslijn volgen
 - klant moet begrijpen:
   - wat al leesbaar is
@@ -134,6 +136,7 @@ Gebruik `Combinatie` alleen als:
 - klant kan inloggen
 - juiste campaign zichtbaar
 - rapport/dashboards bruikbaar binnen drempels
+- first management use is ingepland of expliciet geblokkeerd met reden
 
 ### Handoff
 
@@ -159,6 +162,7 @@ Gebruik `Combinatie` alleen als:
 - rapport blijft managementinput, geen bewijs van oorzaak
 - eerste actie moet klein, toetsbaar en eigenaar-gebonden zijn
 - reviewmoment direct vastleggen
+- default: reviewmoment binnen 10 werkdagen of eerder in bestaand managementoverleg
 
 ### Output
 
@@ -190,11 +194,12 @@ Gebruik `Combinatie` alleen als:
 
 - nieuwe productroute openen zonder expliciete managementvraag
 - bounded support route verkopen als nieuwe hoofdroute
-- vervolg starten zonder dat first value en first action echt zijn geland
+- vervolg starten zonder dat first value, first management use en first action echt zijn geland
 
 ### Output
 
 - expliciete next step
+- expliciete follow-up status: open, bounded vervolg, bredere duiding of bewust niet opschalen
 - bounded vervolg of verdieping
 - geen productverwarring
 

--- a/docs/ops/CLIENT_ONBOARDING_PLAYBOOK.md
+++ b/docs/ops/CLIENT_ONBOARDING_PLAYBOOK.md
@@ -13,7 +13,9 @@ Belangrijke defaults:
 - RetentieScan blijft complementair en verification-first.
 - Verisight beheert setup, importcontrole, invite-activatie en dashboardtoegang.
 - De klant levert input aan en gebruikt daarna dashboard en rapport.
+- Activatie telt pas als bevestigd wanneer klanttoegang live is, de Verisight delivery owner vastligt en first management use voorlopig is ingepland.
 - Adoptie is pas geslaagd wanneer de klant de output echt gebruikt voor het eerste managementgesprek.
+- Follow-up is pas gesloten wanneer eerste eigenaar, eerste actie, reviewmoment en vervolgstatus expliciet zijn vastgelegd.
 - Vroege learnings worden voortaan vastgelegd in `/beheer/klantlearnings`.
 - Een campaign meet standaard live vanaf campagnestart; een retrospectieve baseline of 12-maandsbeeld moet expliciet zo worden ingericht.
 - Voor actieve klanttrajecten is de app-deliverylaag leidend; workbooks zijn alleen samenvatting of governance-mirror.
@@ -96,13 +98,13 @@ Nuance:
 
 - Eigenaar: Verisight
 - Type: klantmoment
-- Doel: klantaccount activeren en de gebruiker in het juiste dashboard laten landen
+- Doel: klantaccount activeren, de gebruiker in het juiste dashboard laten landen en first management use voorlopig inplannen
 
 ### 6. Eerste dashboardread
 
 - Eigenaar: klant
 - Type: klantmoment
-- Doel: begrijpen wat al leesbaar is, wat nog indicatief is en wat de eerstvolgende managementvraag wordt
+- Doel: begrijpen wat al leesbaar is, wat nog indicatief is, welke managementvraag eerst telt en of de managementsessie direct kan worden gehouden
 
 ### 7. Rapportuitleg
 
@@ -114,7 +116,18 @@ Nuance:
 
 - Eigenaar: klant
 - Type: gedeeld
-- Doel: eerste eigenaar, eerste vraag en eerste vervolgstap expliciet maken
+- Doel: eerste eigenaar, eerste vraag, eerste vervolgstap en reviewmoment expliciet maken
+
+## Operating cadence
+
+Gebruik voor alle actieve trajecten ook [CLIENT_OWNERSHIP_AND_FOLLOW_UP_CADENCE.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/CLIENT_OWNERSHIP_AND_FOLLOW_UP_CADENCE.md).
+
+Samengevat:
+
+- activatie is pas bevestigd als eigenaar, toegang en first management use-slot helder zijn
+- first management use gebeurt in dezelfde of eerstvolgende managementweek zodra output veilig leesbaar is
+- reviewmoment wordt direct in het eerste managementgesprek vastgelegd
+- follow-up blijft open totdat vervolgrichting en learning handoff zijn bijgewerkt
 
 ## Verplichte learning handoff
 
@@ -217,7 +230,7 @@ Adoptie is pas geslaagd wanneer:
 - de juiste campaign zichtbaar is
 - dashboard of rapport bruikbaar is binnen de juiste drempel
 - een eerste managementread heeft plaatsgevonden
-- een eerste eigenaar of vervolgstap expliciet is gemaakt
+- een eerste eigenaar, eerste vervolgstap en reviewmoment expliciet zijn gemaakt
 
 ## Repo-afhankelijkheden
 

--- a/docs/ops/CLIENT_OWNERSHIP_AND_FOLLOW_UP_CADENCE.md
+++ b/docs/ops/CLIENT_OWNERSHIP_AND_FOLLOW_UP_CADENCE.md
@@ -1,0 +1,80 @@
+# Client Ownership And Follow-Up Cadence
+
+Last updated: 2026-04-25
+Status: active
+
+## Purpose
+
+Dit document maakt de operating cadence expliciet rond klantactivatie, first management use, reviewmoment en follow-up.
+
+Gebruik altijd samen met:
+
+- [CLIENT_ONBOARDING_PLAYBOOK.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/CLIENT_ONBOARDING_PLAYBOOK.md)
+- [CLIENT_ONBOARDING_FLOW_SYSTEM.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/CLIENT_ONBOARDING_FLOW_SYSTEM.md)
+- [CLIENT_REPORT_TO_ACTION_FLOW.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/CLIENT_REPORT_TO_ACTION_FLOW.md)
+- [ONBOARDING_ACCEPTANCE_CHECKLIST.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/ONBOARDING_ACCEPTANCE_CHECKLIST.md)
+
+## Core operating rule
+
+Een actief klanttraject blijft operationeel open totdat vier gates expliciet bevestigd zijn:
+
+1. activatie bevestigd
+2. first management use gepland en gehouden
+3. eerste eigenaar, eerste actie en reviewmoment vastgelegd
+4. follow-upbesluit en learning handoff vastgelegd
+
+## Operating cadence
+
+### Gate 1 - Activation confirmed
+
+- Verisight delivery owner is expliciet benoemd.
+- Klantcontact en managementsponsor zijn expliciet benoemd.
+- Klantaccount is geactiveerd of geblokkeerd met reden.
+- Een eerste management use-slot staat voorlopig in dezelfde of eerstvolgende managementweek.
+
+### Gate 2 - First management use
+
+- Zodra dashboard en/of rapport veilig leesbaar zijn, vindt first management use plaats in dezelfde of eerstvolgende managementweek.
+- Verisight begeleidt de eerste leeslijn; de klant kiest de eerste managementvraag.
+- Activatie telt niet als adoptie zolang dit moment niet echt is gehouden.
+
+### Gate 3 - Reviewmoment locked
+
+- Tijdens first management use worden eerste eigenaar, eerste actie en reviewmoment vastgelegd.
+- Default: reviewmoment binnen 10 werkdagen of eerder in het eerstvolgende bestaande managementoverleg.
+- Zonder reviewdatum blijft follow-up operationeel open.
+
+### Gate 4 - Follow-up decided
+
+- Na het reviewmoment kiest de klant expliciet tussen bounded vervolg, bredere duiding of bewust niet opschalen.
+- Verisight werkt lifecycle-status, next step en learninglog binnen 1 werkdag bij.
+- De 30-90 dagen review blijft een aparte learninglaag en vervangt de eerste follow-up niet.
+
+## Product
+
+- Product ondersteunt alleen de readiness- en handofflaag rond activatie, eerste managementread en bounded follow-up.
+- Product sluit first management use of follow-up niet automatisch; die bevestiging blijft operationeel.
+- Kleine productteksten mogen wel expliciet sturen naar first management use, eigenaar, reviewmoment en bounded follow-up.
+- Geen nieuwe dashboard- of analyticslaag openen om deze cadence af te dwingen.
+
+## Ops
+
+- Verisight bewaakt de lifecycle van implementation intake tot follow-upbesluit.
+- Elke actieve campaign heeft een expliciete delivery owner, next step en exception-status.
+- De wekelijkse cadence toetst minimaal: activation pending/confirmed, first management use scheduled/held, review due/held en follow-up decided/open.
+- Een traject is overdue zodra activation wel bevestigd is maar first management use, reviewmoment of follow-upbesluit nog openstaan zonder expliciete reden.
+
+## Onboarding
+
+- Klantcommunicatie benoemt expliciet wat Verisight doet, wat de klant doet en wat activatie wel of niet betekent.
+- Bij activatie wordt niet alleen toegang bevestigd, maar ook wie intern aansluit bij first management use.
+- Bij first value wordt niet alleen output gedeeld, maar ook de stap naar eigenaar, reviewmoment en vervolg voorbereid.
+- Nieuwe vervolgroutes worden pas besproken nadat first management use en eerste follow-up echt geland zijn.
+
+## Expectation
+
+- Activatie is geen adoptie.
+- First value is geen first management use.
+- First management use is geen gesloten follow-up.
+- Een nieuw productspoor is geen standaardverlenging van een eerste read.
+- Zonder expliciete eigenaar, reviewdatum en vervolgstatus blijft het traject operationeel open.

--- a/docs/ops/ONBOARDING_ACCEPTANCE_CHECKLIST.md
+++ b/docs/ops/ONBOARDING_ACCEPTANCE_CHECKLIST.md
@@ -12,6 +12,7 @@ Gebruik deze checklist om te beoordelen of een assisted klantstart niet alleen l
 - [ ] Scanmodus en doelgroep bevestigd
 - [ ] Scanperiode expliciet vastgelegd als live vanaf start of bewust retrospectief opgezet
 - [ ] Contactpersoon en eerste managementdoel vastgelegd
+- [ ] Verisight delivery owner vastgelegd
 - [ ] Metadata-verwachting expliciet gemaakt
 
 ## Setup and import
@@ -36,9 +37,14 @@ Gebruik deze checklist om te beoordelen of een assisted klantstart niet alleen l
 ## Activation and first use
 
 - [ ] Klantaccount geactiveerd
+- [ ] Klantowner of managementsponsor bevestigd voor first management use
 - [ ] Eerste dashboardread mogelijk
 - [ ] Eerste rapportuitleg geleverd of ingepland
+- [ ] First management use in dezelfde of eerstvolgende managementweek gepland
 - [ ] Eerste managementgebruik bevestigd
+- [ ] Eerste eigenaar, eerste actie en reviewmoment vastgelegd
+- [ ] Reviewmoment staat binnen 10 werkdagen of eerder in bestaand managementoverleg
+- [ ] Follow-upstatus vastgelegd als open, bounded vervolg, bredere duiding of bewust niet opschalen
 
 ### Managed V1 route check
 
@@ -69,6 +75,7 @@ Praktische signalen zonder zware analytics-stack:
 - [ ] Checkpoint `implementation intake` ingevuld
 - [ ] Checkpoint `launch en eerste output` ingevuld zodra responses bruikbaar zijn
 - [ ] Checkpoint `eerste managementgebruik` ingevuld na walkthrough of managementread
+- [ ] Checkpoint `reviewmoment en follow-upbesluit` ingevuld zodra de eerste opvolging is gekozen
 - [ ] Volgende review of stopreden vastgelegd voor 30-90 dagen follow-up
 
 ## Governance

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -48,6 +48,8 @@ Voor het huidige fix-programma gebruik je deze volgorde:
   - canonieke route van akkoord naar eerste managementwaarde
 - [CLIENT_ONBOARDING_FLOW_SYSTEM.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/CLIENT_ONBOARDING_FLOW_SYSTEM.md)
   - praktisch flow-based naslagwerk voor routekeuze, intake, first value en report-to-action
+- [CLIENT_OWNERSHIP_AND_FOLLOW_UP_CADENCE.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/CLIENT_OWNERSHIP_AND_FOLLOW_UP_CADENCE.md)
+  - expliciete cadence voor activatie, first management use, reviewmoment en follow-up
 - [ONBOARDING_ACCEPTANCE_CHECKLIST.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/ONBOARDING_ACCEPTANCE_CHECKLIST.md)
   - acceptancecheck voor onboarding
 - [OPS_DELIVERY_FAILURE_MATRIX.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/OPS_DELIVERY_FAILURE_MATRIX.md)

--- a/frontend/lib/response-activation.test.ts
+++ b/frontend/lib/response-activation.test.ts
@@ -36,6 +36,7 @@ describe('response activation thresholds', () => {
     expect(state.deeperInsightsVisible).toBe(false)
     expect(state.remainingToInsights).toBe(FIRST_INSIGHT_THRESHOLD - (FIRST_DASHBOARD_THRESHOLD + 1))
     expect(state.statusDetail).toContain('Nog 4 responses')
+    expect(state.statusDetail).toContain('first management use')
   })
 
   it('switches to active insights once the pattern threshold is reached', () => {
@@ -47,5 +48,7 @@ describe('response activation thresholds', () => {
     expect(state.reportVisible).toBe(true)
     expect(state.deeperInsightsVisible).toBe(true)
     expect(state.heroActionLabel).toBe('Eerste inzichten actief')
+    expect(state.statusDetail).toContain('reviewmoment')
+    expect(state.statusDetail).toContain('follow-up')
   })
 })

--- a/frontend/lib/response-activation.ts
+++ b/frontend/lib/response-activation.ts
@@ -58,8 +58,8 @@ export function buildResponseActivationState(totalCompleted: number): ResponseAc
       remainingToInsights,
       statusDetail:
         remainingToInsights === 1
-          ? 'Dashboard en rapport zijn nu zichtbaar. Nog 1 response tot eerste patroonduiding; gebruik deze fase om first management use te plannen en de follow-up owner alvast scherp te zetten.'
-          : `Dashboard en rapport zijn nu zichtbaar. Nog ${formatResponseCount(remainingToInsights)} tot eerste patroonduiding; gebruik deze fase om first management use te plannen en de follow-up owner alvast scherp te zetten.`,
+          ? 'Dashboard en rapport zijn nu zichtbaar. Nog 1 response tot eerste patroonduiding; gebruik deze fase om first management use te plannen en de eerste eigenaar alvast scherp te zetten.'
+          : `Dashboard en rapport zijn nu zichtbaar. Nog ${formatResponseCount(remainingToInsights)} tot eerste patroonduiding; gebruik deze fase om first management use te plannen en de eerste eigenaar alvast scherp te zetten.`,
       heroActionLabel:
         remainingToInsights === 1
           ? 'Nog 1 response tot eerste inzichten'

--- a/frontend/lib/response-activation.ts
+++ b/frontend/lib/response-activation.ts
@@ -58,8 +58,8 @@ export function buildResponseActivationState(totalCompleted: number): ResponseAc
       remainingToInsights,
       statusDetail:
         remainingToInsights === 1
-          ? 'Dashboard en rapport zijn nu zichtbaar. Nog 1 response tot eerste patroonduiding; tot die tijd blijft de read bewust compact.'
-          : `Dashboard en rapport zijn nu zichtbaar. Nog ${formatResponseCount(remainingToInsights)} tot eerste patroonduiding; tot die tijd blijft de read bewust compact.`,
+          ? 'Dashboard en rapport zijn nu zichtbaar. Nog 1 response tot eerste patroonduiding; gebruik deze fase om first management use te plannen en de follow-up owner alvast scherp te zetten.'
+          : `Dashboard en rapport zijn nu zichtbaar. Nog ${formatResponseCount(remainingToInsights)} tot eerste patroonduiding; gebruik deze fase om first management use te plannen en de follow-up owner alvast scherp te zetten.`,
       heroActionLabel:
         remainingToInsights === 1
           ? 'Nog 1 response tot eerste inzichten'
@@ -76,7 +76,7 @@ export function buildResponseActivationState(totalCompleted: number): ResponseAc
     remainingToDashboard,
     remainingToInsights,
     statusDetail:
-      'De campagne heeft nu genoeg respons voor veilige dashboardactivatie, rapportvrijgave en eerste patroonduiding.',
+      'De campagne heeft nu genoeg respons voor veilige dashboardactivatie, rapportvrijgave en eerste patroonduiding. Gebruik dit moment om first management use te houden en eigenaar, reviewmoment en follow-up expliciet vast te leggen.',
     heroActionLabel: 'Eerste inzichten actief',
   }
 }


### PR DESCRIPTION
## Summary
- add a focused ops cadence doc for activation, first management use, review moments, and follow-up closure
- align onboarding playbooks, flow docs, checklists, and templates around explicit delivery ownership and lifecycle gates
- tighten supporting activation copy so product text reinforces first management use and bounded follow-up without reopening dashboard scope

## Verification
- `npm test -- response-activation.test.ts`
- `npm run lint -- lib/response-activation.ts lib/response-activation.test.ts`
- `git diff --check`