### PR TITLE
[codex] Land MTO on the shared Action Center core

### DIFF
--- a/backend/products/shared/action_center_mto.py
+++ b/backend/products/shared/action_center_mto.py
@@ -3,6 +3,26 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
+from .action_center_core import (
+    ActionAssignment,
+    ActionDossier,
+    ActionFollowUpSignal,
+    ActionReviewMoment,
+    ActionWorkspaceSummary,
+    MemberRole,
+    build_permission_envelope,
+    summarize_workspace,
+)
+
+
+MtoDesignMode = Literal["active_follow_through"]
+MtoCarrierStatus = Literal["active"]
+MtoCarrierOwnerModel = Literal["hr_central"]
+MtoCarrierManagerScope = Literal["department_only"]
+MtoTriageStatus = Literal["nieuw", "bevestigd", "geparkeerd", "uitgevoerd", "verworpen"]
+
+_OPEN_TRIAGE_STATUSES = {"nieuw", "bevestigd"}
+
 
 @dataclass(frozen=True)
 class MtoDesignInput:
@@ -14,19 +34,222 @@ class MtoDesignInput:
 @dataclass(frozen=True)
 class MtoDesignInputSummary:
     source: Literal["mto"]
-    mode: Literal["design_input_only"]
+    mode: MtoDesignMode
     theme_count: int
     notes: str | None
-    can_create_assignments: Literal[False]
-    can_open_carrier: Literal[False]
+    can_create_assignments: Literal[True]
+    can_open_carrier: Literal[True]
+
+
+@dataclass(frozen=True)
+class MtoActionCenterCarrier:
+    key: Literal["mto"]
+    label: str
+    status: MtoCarrierStatus
+    workspace_kind: Literal["follow_through"]
+    owner_model: MtoCarrierOwnerModel
+    manager_scope: MtoCarrierManagerScope
+    review_pressure_visible: Literal[True]
+    dossier_first: Literal[True]
+    can_open_other_product_adapters: Literal[False]
+
+
+@dataclass(frozen=True)
+class MtoDossierInput:
+    id: str
+    title: str
+    triage_status: MtoTriageStatus
+    department_label: str | None
+    manager_label: str | None
+    first_action_taken: str | None
+    review_moment: str | None
+    management_action_outcome: str | None
+    next_route: str | None
+    stop_reason: str | None
+
+
+@dataclass(frozen=True)
+class MtoActionCenterWorkspace:
+    carrier: MtoActionCenterCarrier
+    summary: ActionWorkspaceSummary
+    dossiers: list[ActionDossier]
+    assignments: list[ActionAssignment]
+    review_moments: list[ActionReviewMoment]
+    follow_up_signals: list[ActionFollowUpSignal]
+    manager_departments: tuple[str, ...]
+
+
+_MTO_ACTION_CENTER_CARRIER = MtoActionCenterCarrier(
+    key="mto",
+    label="MTO-carrier",
+    status="active",
+    workspace_kind="follow_through",
+    owner_model="hr_central",
+    manager_scope="department_only",
+    review_pressure_visible=True,
+    dossier_first=True,
+    can_open_other_product_adapters=False,
+)
+
+
+def _build_actor_id(prefix: str, value: str | None) -> str | None:
+    if not value:
+        return None
+    normalized = "-".join(value.strip().lower().split())
+    return f"{prefix}:{normalized}" if normalized else None
+
+
+def _is_open(triage_status: MtoTriageStatus) -> bool:
+    return triage_status in _OPEN_TRIAGE_STATUSES
 
 
 def describe_mto_design_input(input_data: MtoDesignInput) -> MtoDesignInputSummary:
     return MtoDesignInputSummary(
         source=input_data.source,
-        mode="design_input_only",
+        mode="active_follow_through",
         theme_count=len(input_data.themes),
         notes=input_data.notes,
-        can_create_assignments=False,
-        can_open_carrier=False,
+        can_create_assignments=True,
+        can_open_carrier=True,
+    )
+
+
+def get_mto_action_center_carrier() -> MtoActionCenterCarrier:
+    return _MTO_ACTION_CENTER_CARRIER
+
+
+def build_mto_action_center_workspace(
+    *,
+    role: MemberRole | None,
+    dossiers: list[MtoDossierInput],
+) -> MtoActionCenterWorkspace:
+    shared_dossiers: list[ActionDossier] = []
+    assignments: list[ActionAssignment] = []
+    review_moments: list[ActionReviewMoment] = []
+    follow_up_signals: list[ActionFollowUpSignal] = []
+    manager_departments = sorted({dossier.department_label for dossier in dossiers if dossier.department_label})
+
+    for dossier in dossiers:
+        permission_envelope = build_permission_envelope(role)
+        is_open = _is_open(dossier.triage_status)
+        has_follow_through_decision = bool(
+            dossier.management_action_outcome or dossier.next_route or dossier.stop_reason
+        )
+        department_owner_id = _build_actor_id("department", dossier.department_label)
+        manager_owner_id = _build_actor_id("manager", dossier.manager_label)
+
+        shared_dossiers.append(
+            ActionDossier(
+                id=dossier.id,
+                title=dossier.title,
+                status="open" if is_open else "closed",
+                owner_id=manager_owner_id or department_owner_id,
+                permission_envelope=permission_envelope,
+            )
+        )
+
+        assignment_state = (
+            "completed"
+            if dossier.triage_status == "uitgevoerd"
+            else "cancelled"
+            if dossier.triage_status == "verworpen"
+            else "waiting"
+            if dossier.triage_status == "geparkeerd"
+            else "active"
+            if dossier.first_action_taken
+            else "blocked"
+        )
+        assignment_kind = (
+            "handoff"
+            if has_follow_through_decision
+            else "follow_up"
+            if dossier.first_action_taken
+            else "review_prep"
+        )
+        assignments.append(
+            ActionAssignment(
+                id=f"asg-{dossier.id}",
+                dossier_id=dossier.id,
+                title=dossier.first_action_taken or "Leg eerste bounded stap vast",
+                state=assignment_state,
+                kind=assignment_kind,
+                owner_id=manager_owner_id or department_owner_id,
+            )
+        )
+
+        review_state = (
+            "completed"
+            if dossier.triage_status == "uitgevoerd"
+            else "cancelled"
+            if dossier.triage_status in {"geparkeerd", "verworpen"}
+            else "due"
+        )
+        review_moments.append(
+            ActionReviewMoment(
+                id=f"rev-{dossier.id}",
+                dossier_id=dossier.id,
+                scheduled_for=dossier.review_moment or "Reviewmoment nog vastleggen",
+                state=review_state,
+            )
+        )
+
+        if is_open and not dossier.first_action_taken:
+            follow_up_signals.append(
+                ActionFollowUpSignal(
+                    id=f"sig-step-{dossier.id}",
+                    dossier_id=dossier.id,
+                    kind="blocked_assignment",
+                    severity="critical",
+                    state="open",
+                )
+            )
+
+        if is_open and not dossier.manager_label and dossier.department_label:
+            follow_up_signals.append(
+                ActionFollowUpSignal(
+                    id=f"sig-owner-{dossier.id}",
+                    dossier_id=dossier.id,
+                    kind="owner_missing",
+                    severity="warning",
+                    state="open",
+                )
+            )
+
+        if is_open:
+            follow_up_signals.append(
+                ActionFollowUpSignal(
+                    id=f"sig-review-{dossier.id}",
+                    dossier_id=dossier.id,
+                    kind="review_due",
+                    severity="warning",
+                    state="open",
+                )
+            )
+
+        if is_open and not has_follow_through_decision:
+            follow_up_signals.append(
+                ActionFollowUpSignal(
+                    id=f"sig-decision-{dossier.id}",
+                    dossier_id=dossier.id,
+                    kind="decision_due",
+                    severity="warning",
+                    state="open",
+                )
+            )
+
+    summary = summarize_workspace(
+        dossiers=shared_dossiers,
+        assignments=assignments,
+        review_moments=review_moments,
+        follow_up_signals=follow_up_signals,
+    )
+
+    return MtoActionCenterWorkspace(
+        carrier=_MTO_ACTION_CENTER_CARRIER,
+        summary=summary,
+        dossiers=shared_dossiers,
+        assignments=assignments,
+        review_moments=review_moments,
+        follow_up_signals=follow_up_signals,
+        manager_departments=tuple(manager_departments),
     )

--- a/frontend/app/(dashboard)/beheer/klantlearnings/page.test.ts
+++ b/frontend/app/(dashboard)/beheer/klantlearnings/page.test.ts
@@ -1,14 +1,17 @@
 import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
-describe('beheer klantlearnings admin alignment', () => {
-  it('keeps the learning workbench compact, operational and anchored in admin terminology', () => {
+describe('klantlearnings action center landing', () => {
+  it('keeps MTO on the shared action center core without opening other carriers', () => {
     const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
 
-    expect(source).toContain('surface="ops"')
-    expect(source).toContain('Operations learninglog')
-    expect(source).toContain('Adminroute voor pilot- en klantlessen')
-    expect(source).toContain('Leg lessen compact vast per lead of campaign')
-    expect(source).toContain('Geen buyer-facing claims')
+    expect(source).toContain("buildMtoActionCenterWorkspace")
+    expect(source).toContain('Action Center voor MTO-follow-through')
+    expect(source).toContain('Operations Action Center')
+    expect(source).toContain('Shared follow-through voor cockpit, dossiers en reviews')
+    expect(source).toContain('HR blijft de centrale eigenaar')
+    expect(source).toContain('Reviewdruk')
+    expect(source).toContain('Dossier-first')
+    expect(source).toContain('Nog geen open MTO-dossiers')
   })
 })

--- a/frontend/app/(dashboard)/beheer/klantlearnings/page.tsx
+++ b/frontend/app/(dashboard)/beheer/klantlearnings/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { PilotLearningWorkbench } from '@/components/dashboard/pilot-learning-workbench'
+import { buildMtoActionCenterWorkspace } from '@/lib/action-center-mto'
 import {
   DashboardChip,
   DashboardHero,
@@ -129,14 +130,45 @@ export default async function KlantLearningsPage({ searchParams }: Props) {
   const confirmedLessons = checkpoints.filter((checkpoint) => checkpoint.status === 'bevestigd').length
   const campaignLinkedDossiers = dossiers.filter((dossier) => dossier.campaign_id).length
   const leadLinkedDossiers = dossiers.filter((dossier) => dossier.contact_request_id).length
+  const checkpointsByDossier = checkpoints.reduce<Record<string, PilotLearningCheckpoint[]>>((acc, checkpoint) => {
+    acc[checkpoint.dossier_id] ??= []
+    acc[checkpoint.dossier_id].push(checkpoint)
+    return acc
+  }, {})
+  const mtoWorkspace = buildMtoActionCenterWorkspace({
+    role: 'owner',
+    dossiers: dossiers
+      .filter((dossier) => dossier.scan_type === 'team' || dossier.route_interest === 'teamscan')
+      .map((dossier) => {
+        const dossierCheckpoints = checkpointsByDossier[dossier.id] ?? []
+        const firstManagementCheckpoint =
+          dossierCheckpoints.find((checkpoint) => checkpoint.checkpoint_key === 'first_management_use') ?? null
+
+        return {
+          id: dossier.id,
+          title: dossier.title,
+          triageStatus: dossier.triage_status,
+          departmentLabel: null,
+          managerLabel: firstManagementCheckpoint?.owner_label ?? null,
+          firstActionTaken: dossier.first_action_taken,
+          reviewMoment: dossier.review_moment,
+          managementActionOutcome: dossier.management_action_outcome,
+          nextRoute: dossier.next_route,
+          stopReason: dossier.stop_reason,
+        }
+      }),
+  })
+  const openMtoDossiers = mtoWorkspace.dossiers.filter((dossier) => dossier.status === 'open')
+  const reviewPressureItems = mtoWorkspace.reviewMoments.filter((reviewMoment) => reviewMoment.state === 'due')
+  const openSignals = mtoWorkspace.followUpSignals.filter((signal) => signal.state === 'open')
 
   return (
     <div className="space-y-6">
       <DashboardHero
         surface="ops"
-        eyebrow="Adminroute voor pilot- en klantlessen"
-        title="Operations learninglog"
-        description="Leg lessen compact vast per lead of campaign en gebruik deze workbench als interne log voor triage, bewijsstatus en vervolgstappen. Geen buyer-facing claims: alleen operationele observaties, bevestigde lessen en case-readiness."
+        eyebrow="Action Center voor MTO-follow-through"
+        title="Operations Action Center"
+        description="Laat MTO als eerste actieve carrier landen op de shared Action Center-core: HR blijft centraal, reviewdruk blijft zichtbaar en dossiers houden de follow-through bij elkaar zonder andere productkoppelingen te openen."
         tone="slate"
         meta={
           <>
@@ -182,6 +214,16 @@ export default async function KlantLearningsPage({ searchParams }: Props) {
         surface="ops"
         items={[
           {
+            label: 'MTO dossiers',
+            value: `${mtoWorkspace.summary.openDossierCount}`,
+            tone: mtoWorkspace.summary.openDossierCount > 0 ? 'slate' : 'amber',
+          },
+          {
+            label: 'Reviewdruk',
+            value: `${mtoWorkspace.summary.reviewDueCount}`,
+            tone: mtoWorkspace.summary.reviewDueCount > 0 ? 'amber' : 'slate',
+          },
+          {
             label: 'Dossiers',
             value: `${dossiers.length} actief`,
             tone: dossiers.length > 0 ? 'slate' : 'amber',
@@ -203,11 +245,144 @@ export default async function KlantLearningsPage({ searchParams }: Props) {
           },
         ]}
         anchors={[
+          { id: 'action-center', label: 'Action Center' },
           { id: 'dekking', label: 'Dekking' },
           { id: 'issues', label: 'Issues' },
           { id: 'workbench', label: 'Workbench' },
         ]}
       />
+
+      <DashboardSection
+        id="action-center"
+        surface="ops"
+        eyebrow="MTO carrier"
+        title="Shared follow-through voor cockpit, dossiers en reviews"
+        description="Deze bovenlaag gebruikt dezelfde shared Action Center-core voor dossierstatus, reviewdruk en follow-through-signalen. HR blijft de centrale eigenaar; afdelingsscope blijft pas actief zodra een dossier of lokale read die expliciet maakt."
+        aside={
+          <DashboardChip
+            surface="ops"
+            label={`${mtoWorkspace.carrier.label} · ${mtoWorkspace.carrier.status}`}
+            tone="slate"
+          />
+        }
+      >
+        <div className="grid gap-4 xl:grid-cols-4">
+          <DashboardPanel
+            surface="ops"
+            eyebrow="HR centraal"
+            title="Shared eigenaar"
+            value="HR centraal"
+            body="Deze carrier houdt de centrale follow-through bij HR. Managers landen alleen op hun eigen afdeling zodra die lokale context expliciet en veilig leesbaar is."
+            tone="slate"
+          />
+          <DashboardPanel
+            surface="ops"
+            eyebrow="Reviewdruk"
+            title="Actieve reviewqueue"
+            value={`${mtoWorkspace.summary.reviewDueCount}`}
+            body="Elke open MTO-dossierregel blijft zichtbaar in de reviewdruk tot reviewmoment, uitkomst of stopbesluit expliciet zijn vastgelegd."
+            tone={mtoWorkspace.summary.reviewDueCount > 0 ? 'amber' : 'slate'}
+          />
+          <DashboardPanel
+            surface="ops"
+            eyebrow="Dossier-first"
+            title="Open follow-through"
+            value={`${mtoWorkspace.summary.openDossierCount}`}
+            body="Besluiten, eerste stap en vervolgrichting blijven dossier-first gegroepeerd in plaats van te verspreiden over losse campaignnotities."
+            tone={mtoWorkspace.summary.openDossierCount > 0 ? 'slate' : 'amber'}
+          />
+          <DashboardPanel
+            surface="ops"
+            eyebrow="Afdelingsscope"
+            title="Managerbinding"
+            value={
+              mtoWorkspace.managerDepartmentLabels.length > 0
+                ? `${mtoWorkspace.managerDepartmentLabels.length} afdeling${mtoWorkspace.managerDepartmentLabels.length === 1 ? '' : 'en'}`
+                : 'Nog niet expliciet'
+            }
+            body={
+              mtoWorkspace.managerDepartmentLabels.length > 0
+                ? `Actieve afdelingssporen: ${mtoWorkspace.managerDepartmentLabels.join(', ')}.`
+                : 'Maak de afdeling expliciet in de lokale read of het dossier zodra managergebonden follow-through echt nodig is.'
+            }
+            tone="slate"
+          />
+        </div>
+
+        <div className="mt-4 grid gap-4 xl:grid-cols-2">
+          <div className="rounded-[24px] border border-slate-200 bg-white p-5 shadow-sm">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Dossiers</p>
+                <h3 className="mt-2 text-lg font-semibold text-slate-950">Open MTO follow-through</h3>
+              </div>
+              <DashboardChip
+                surface="ops"
+                label={`${openMtoDossiers.length} open`}
+                tone={openMtoDossiers.length > 0 ? 'amber' : 'slate'}
+              />
+            </div>
+            <div className="mt-4 space-y-3">
+              {openMtoDossiers.length === 0 ? (
+                <p className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-3 text-sm leading-6 text-slate-600">
+                  Nog geen open MTO-dossiers. Zodra TeamScan/MTO follow-through leerwaarde geeft, verschijnt de dossierqueue hier automatisch.
+                </p>
+              ) : (
+                openMtoDossiers.slice(0, 5).map((dossier) => {
+                  const assignment = mtoWorkspace.assignments.find((item) => item.dossierId === dossier.id)
+                  return (
+                    <div key={dossier.id} className="rounded-2xl border border-slate-200 bg-slate-50/70 px-4 py-4">
+                      <p className="text-sm font-semibold text-slate-950">{dossier.title}</p>
+                      <p className="mt-2 text-sm leading-6 text-slate-600">
+                        Eerste stap: {assignment?.title ?? 'Nog niet vastgelegd'}.
+                      </p>
+                      <p className="mt-1 text-xs text-slate-500">
+                        Status {assignment?.state ?? 'onbekend'} · Permission shared-core: {dossier.permissionEnvelope.canUpdateAssignments ? 'bewerkbaar' : 'read-only'}
+                      </p>
+                    </div>
+                  )
+                })
+              )}
+            </div>
+          </div>
+
+          <div className="rounded-[24px] border border-slate-200 bg-white p-5 shadow-sm">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Reviews</p>
+                <h3 className="mt-2 text-lg font-semibold text-slate-950">Reviewdruk en open signalen</h3>
+              </div>
+              <DashboardChip
+                surface="ops"
+                label={`${reviewPressureItems.length} review${reviewPressureItems.length === 1 ? '' : 's'}`}
+                tone={reviewPressureItems.length > 0 ? 'amber' : 'slate'}
+              />
+            </div>
+            <div className="mt-4 space-y-3">
+              {reviewPressureItems.length === 0 ? (
+                <p className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-3 text-sm leading-6 text-slate-600">
+                  Geen actieve reviewdruk. De shared core houdt deze lijst leeg zodra dossiers geparkeerd, uitgevoerd of bewust gestopt zijn.
+                </p>
+              ) : (
+                reviewPressureItems.slice(0, 5).map((reviewMoment) => {
+                  const dossier = mtoWorkspace.dossiers.find((item) => item.id === reviewMoment.dossierId)
+                  const signals = openSignals.filter((signal) => signal.dossierId === reviewMoment.dossierId)
+
+                  return (
+                    <div key={reviewMoment.id} className="rounded-2xl border border-slate-200 bg-slate-50/70 px-4 py-4">
+                      <p className="text-sm font-semibold text-slate-950">{dossier?.title ?? reviewMoment.dossierId}</p>
+                      <p className="mt-2 text-sm leading-6 text-slate-600">{reviewMoment.scheduledFor}</p>
+                      <p className="mt-1 text-xs text-slate-500">
+                        Open signalen: {signals.map((signal) => signal.kind).join(', ') || 'geen'}
+                      </p>
+                    </div>
+                  )
+                })
+              )}
+            </div>
+          </div>
+        </div>
+      </DashboardSection>
 
       <div id="dekking" className="grid gap-4 xl:grid-cols-4">
         <DashboardPanel

--- a/frontend/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/page.tsx
@@ -474,11 +474,11 @@ export default async function DashboardHomePage({
                 cta="Open leadlijst"
               />
               <UtilityCard
-                eyebrow="Learning"
-                title="Klantlearnings en workbench"
-                body="Leg buyer-signalen, implementationlessen en vervolgkeuzes vast zodra een campagne leerwaarde oplevert."
+                eyebrow="Action Center"
+                title="MTO follow-through en dossiers"
+                body="Open de shared Action Center-laag voor MTO om reviewdruk, dossier-first follow-through en de learning-workbench vanuit één boundary te beheren."
                 href="/beheer/klantlearnings"
-                cta="Open learning-workbench"
+                cta="Open Action Center"
               />
             </>
           ) : (

--- a/frontend/app/api/learning-dossiers/[id]/route.ts
+++ b/frontend/app/api/learning-dossiers/[id]/route.ts
@@ -20,7 +20,7 @@ type UpdateLearningDossierBody = {
   campaign_id?: string | null
   contact_request_id?: string | null
   title?: string
-  route_interest?: 'exitscan' | 'retentiescan' | 'combinatie' | 'nog-onzeker'
+  route_interest?: 'exitscan' | 'retentiescan' | 'teamscan' | 'combinatie' | 'nog-onzeker'
   triage_status?: 'nieuw' | 'bevestigd' | 'geparkeerd' | 'uitgevoerd' | 'verworpen'
   buyer_question?: string | null
   expected_first_value?: string | null

--- a/frontend/app/api/learning-dossiers/route.ts
+++ b/frontend/app/api/learning-dossiers/route.ts
@@ -15,7 +15,7 @@ type CreateLearningDossierBody = {
   campaign_id?: string | null
   contact_request_id?: string | null
   title?: string
-  route_interest?: 'exitscan' | 'retentiescan' | 'combinatie' | 'nog-onzeker'
+  route_interest?: 'exitscan' | 'retentiescan' | 'teamscan' | 'combinatie' | 'nog-onzeker'
   buyer_question?: string | null
   expected_first_value?: string | null
   buying_reason?: string | null
@@ -88,7 +88,7 @@ export async function POST(request: Request) {
   }
 
   const routeInterest = body.route_interest ?? 'exitscan'
-  if (!['exitscan', 'retentiescan', 'combinatie', 'nog-onzeker'].includes(routeInterest)) {
+  if (!['exitscan', 'retentiescan', 'teamscan', 'combinatie', 'nog-onzeker'].includes(routeInterest)) {
     return NextResponse.json({ detail: 'Ongeldige route_interest.' }, { status: 400 })
   }
 

--- a/frontend/components/dashboard/pilot-learning-workbench.tsx
+++ b/frontend/components/dashboard/pilot-learning-workbench.tsx
@@ -23,6 +23,8 @@ import {
   CASE_PERMISSION_STATUS_OPTIONS,
   CASE_POTENTIAL_OPTIONS,
   getCheckpointDefinition,
+  getLearningRouteInterestForCampaign,
+  normalizeLearningRouteInterest,
   getLearningStatusLabel,
   getLearningStrengthLabel,
   getSuggestedLearningDossierTitle,
@@ -303,9 +305,9 @@ export function PilotLearningWorkbench({
     setCreateForm((current) => ({
       ...current,
       contact_request_id: lead.id,
-      route_interest: normalizeContactRouteInterest(lead.route_interest),
+      route_interest: normalizeLearningRouteInterest(normalizeContactRouteInterest(lead.route_interest)),
       title: getSuggestedLearningDossierTitle({
-        routeInterest: normalizeContactRouteInterest(lead.route_interest),
+        routeInterest: normalizeLearningRouteInterest(normalizeContactRouteInterest(lead.route_interest)),
         organizationName: lead.organization,
       }),
       buyer_question: lead.current_question,
@@ -333,9 +335,9 @@ export function PilotLearningWorkbench({
       ...current,
       organization_id: campaign.organization_id,
       campaign_id: campaign.id,
-      route_interest: campaign.scan_type === 'exit' ? 'exitscan' : 'retentiescan',
+      route_interest: getLearningRouteInterestForCampaign(campaign.scan_type),
       title: getSuggestedLearningDossierTitle({
-        routeInterest: campaign.scan_type === 'exit' ? 'exitscan' : 'retentiescan',
+        routeInterest: getLearningRouteInterestForCampaign(campaign.scan_type),
         campaignName: campaign.name,
         organizationName: orgById[campaign.organization_id]?.name,
       }),

--- a/frontend/lib/action-center-mto.ts
+++ b/frontend/lib/action-center-mto.ts
@@ -1,3 +1,22 @@
+import {
+  buildActionCenterPermissionEnvelope,
+  buildActionCenterWorkspaceSummary,
+  type ActionCenterAssignment,
+  type ActionCenterDossier,
+  type ActionCenterFollowUpSignal,
+  type ActionCenterReviewMoment,
+  type ActionCenterWorkspaceSummary,
+} from '@/lib/action-center-shared-core'
+import type { MemberRole } from '@/lib/types'
+
+export type MtoDesignMode = 'active_follow_through'
+export type MtoCarrierStatus = 'active'
+export type MtoCarrierOwnerModel = 'hr_central'
+export type MtoCarrierManagerScope = 'department_only'
+export type MtoTriageStatus = 'nieuw' | 'bevestigd' | 'geparkeerd' | 'uitgevoerd' | 'verworpen'
+
+const OPEN_TRIAGE_STATUSES = new Set<MtoTriageStatus>(['nieuw', 'bevestigd'])
+
 export interface MtoDesignInput {
   source: 'mto'
   themes: string[]
@@ -6,20 +25,202 @@ export interface MtoDesignInput {
 
 export interface MtoDesignInputSummary {
   source: 'mto'
-  mode: 'design_input_only'
+  mode: MtoDesignMode
   themeCount: number
   notes: string | null
-  canCreateAssignments: false
-  canOpenCarrier: false
+  canCreateAssignments: true
+  canOpenCarrier: true
+}
+
+export interface MtoActionCenterCarrier {
+  key: 'mto'
+  label: string
+  status: MtoCarrierStatus
+  workspaceKind: 'follow_through'
+  ownerModel: MtoCarrierOwnerModel
+  managerScope: MtoCarrierManagerScope
+  reviewPressureVisible: true
+  dossierFirst: true
+  canOpenOtherProductAdapters: false
+}
+
+export interface MtoDossierInput {
+  id: string
+  title: string
+  triageStatus: MtoTriageStatus
+  departmentLabel: string | null
+  managerLabel: string | null
+  firstActionTaken: string | null
+  reviewMoment: string | null
+  managementActionOutcome: string | null
+  nextRoute: string | null
+  stopReason: string | null
+}
+
+export interface MtoActionCenterWorkspace {
+  carrier: MtoActionCenterCarrier
+  summary: ActionCenterWorkspaceSummary
+  dossiers: ActionCenterDossier[]
+  assignments: ActionCenterAssignment[]
+  reviewMoments: ActionCenterReviewMoment[]
+  followUpSignals: ActionCenterFollowUpSignal[]
+  managerDepartmentLabels: string[]
+}
+
+const MTO_ACTION_CENTER_CARRIER: MtoActionCenterCarrier = {
+  key: 'mto',
+  label: 'MTO-carrier',
+  status: 'active',
+  workspaceKind: 'follow_through',
+  ownerModel: 'hr_central',
+  managerScope: 'department_only',
+  reviewPressureVisible: true,
+  dossierFirst: true,
+  canOpenOtherProductAdapters: false,
+}
+
+function buildActorId(prefix: string, value: string | null) {
+  if (!value) return null
+  const normalized = value.trim().toLowerCase().split(/\s+/).join('-')
+  return normalized ? `${prefix}:${normalized}` : null
+}
+
+function isOpen(triageStatus: MtoTriageStatus) {
+  return OPEN_TRIAGE_STATUSES.has(triageStatus)
 }
 
 export function describeMtoDesignInput(input: MtoDesignInput): MtoDesignInputSummary {
   return {
     source: input.source,
-    mode: 'design_input_only',
+    mode: 'active_follow_through',
     themeCount: input.themes.length,
     notes: input.notes,
-    canCreateAssignments: false,
-    canOpenCarrier: false,
+    canCreateAssignments: true,
+    canOpenCarrier: true,
+  }
+}
+
+export function getMtoActionCenterCarrier() {
+  return MTO_ACTION_CENTER_CARRIER
+}
+
+export function buildMtoActionCenterWorkspace(args: {
+  role: MemberRole | null | undefined
+  dossiers: MtoDossierInput[]
+}): MtoActionCenterWorkspace {
+  const dossiers: ActionCenterDossier[] = []
+  const assignments: ActionCenterAssignment[] = []
+  const reviewMoments: ActionCenterReviewMoment[] = []
+  const followUpSignals: ActionCenterFollowUpSignal[] = []
+  const managerDepartmentLabels = Array.from(
+    new Set(args.dossiers.map((dossier) => dossier.departmentLabel).filter((value): value is string => Boolean(value))),
+  ).sort((left, right) => left.localeCompare(right))
+
+  for (const dossier of args.dossiers) {
+    const permissionEnvelope = buildActionCenterPermissionEnvelope({ role: args.role })
+    const open = isOpen(dossier.triageStatus)
+    const hasFollowThroughDecision = Boolean(
+      dossier.managementActionOutcome || dossier.nextRoute || dossier.stopReason,
+    )
+    const departmentOwnerId = buildActorId('department', dossier.departmentLabel)
+    const managerOwnerId = buildActorId('manager', dossier.managerLabel)
+
+    dossiers.push({
+      id: dossier.id,
+      title: dossier.title,
+      status: open ? 'open' : 'closed',
+      ownerId: managerOwnerId ?? departmentOwnerId,
+      permissionEnvelope,
+    })
+
+    const assignmentState =
+      dossier.triageStatus === 'uitgevoerd'
+        ? 'completed'
+        : dossier.triageStatus === 'verworpen'
+          ? 'cancelled'
+          : dossier.triageStatus === 'geparkeerd'
+            ? 'waiting'
+            : dossier.firstActionTaken
+              ? 'active'
+              : 'blocked'
+    const assignmentKind =
+      hasFollowThroughDecision ? 'handoff' : dossier.firstActionTaken ? 'follow_up' : 'review_prep'
+
+    assignments.push({
+      id: `asg-${dossier.id}`,
+      dossierId: dossier.id,
+      title: dossier.firstActionTaken ?? 'Leg eerste bounded stap vast',
+      state: assignmentState,
+      kind: assignmentKind,
+      ownerId: managerOwnerId ?? departmentOwnerId,
+    })
+
+    const reviewState =
+      dossier.triageStatus === 'uitgevoerd'
+        ? 'completed'
+        : dossier.triageStatus === 'geparkeerd' || dossier.triageStatus === 'verworpen'
+          ? 'cancelled'
+          : 'due'
+    reviewMoments.push({
+      id: `rev-${dossier.id}`,
+      dossierId: dossier.id,
+      scheduledFor: dossier.reviewMoment ?? 'Reviewmoment nog vastleggen',
+      state: reviewState,
+    })
+
+    if (open && !dossier.firstActionTaken) {
+      followUpSignals.push({
+        id: `sig-step-${dossier.id}`,
+        dossierId: dossier.id,
+        kind: 'blocked_assignment',
+        severity: 'critical',
+        state: 'open',
+      })
+    }
+
+    if (open && !dossier.managerLabel && dossier.departmentLabel) {
+      followUpSignals.push({
+        id: `sig-owner-${dossier.id}`,
+        dossierId: dossier.id,
+        kind: 'owner_missing',
+        severity: 'warning',
+        state: 'open',
+      })
+    }
+
+    if (open) {
+      followUpSignals.push({
+        id: `sig-review-${dossier.id}`,
+        dossierId: dossier.id,
+        kind: 'review_due',
+        severity: 'warning',
+        state: 'open',
+      })
+    }
+
+    if (open && !hasFollowThroughDecision) {
+      followUpSignals.push({
+        id: `sig-decision-${dossier.id}`,
+        dossierId: dossier.id,
+        kind: 'decision_due',
+        severity: 'warning',
+        state: 'open',
+      })
+    }
+  }
+
+  return {
+    carrier: MTO_ACTION_CENTER_CARRIER,
+    summary: buildActionCenterWorkspaceSummary({
+      dossiers,
+      assignments,
+      reviewMoments,
+      followUpSignals,
+    }),
+    dossiers,
+    assignments,
+    reviewMoments,
+    followUpSignals,
+    managerDepartmentLabels,
   }
 }

--- a/frontend/lib/action-center-shared-core.test.ts
+++ b/frontend/lib/action-center-shared-core.test.ts
@@ -5,7 +5,11 @@ import {
   buildActionCenterWorkspaceSummary,
   getFutureActionCenterAdapter,
 } from '@/lib/action-center-shared-core'
-import { describeMtoDesignInput } from '@/lib/action-center-mto'
+import {
+  buildMtoActionCenterWorkspace,
+  describeMtoDesignInput,
+  getMtoActionCenterCarrier,
+} from '@/lib/action-center-mto'
 
 describe('action center shared core', () => {
   it('keeps the workspace bounded to follow-through signals instead of generic project planning', () => {
@@ -74,18 +78,71 @@ describe('action center shared core', () => {
     expect(ownerEnvelope.canOpenProductAdapters).toBe(false)
   })
 
-  it('keeps MTO input as design-only and future adapters inactive', () => {
+  it('activates MTO as the first action center carrier while future adapters stay inactive', () => {
     const mtoDesignInput = describeMtoDesignInput({
       source: 'mto',
       themes: ['werkdruk', 'rolhelderheid'],
       notes: 'Gebruik alleen als ontwerpinspiratie voor dossiervelden.',
     })
+    const carrier = getMtoActionCenterCarrier()
     const exitAdapter = getFutureActionCenterAdapter('exit')
 
-    expect(mtoDesignInput.mode).toBe('design_input_only')
-    expect(mtoDesignInput.canCreateAssignments).toBe(false)
-    expect(mtoDesignInput.canOpenCarrier).toBe(false)
+    expect(carrier.status).toBe('active')
+    expect(carrier.workspaceKind).toBe('follow_through')
+    expect(carrier.ownerModel).toBe('hr_central')
+    expect(carrier.managerScope).toBe('department_only')
+    expect(carrier.reviewPressureVisible).toBe(true)
+    expect(carrier.dossierFirst).toBe(true)
+    expect(carrier.canOpenOtherProductAdapters).toBe(false)
+    expect(mtoDesignInput.mode).toBe('active_follow_through')
+    expect(mtoDesignInput.canCreateAssignments).toBe(true)
+    expect(mtoDesignInput.canOpenCarrier).toBe(true)
     expect(exitAdapter.status).toBe('inactive')
     expect(exitAdapter.liveEntryEnabled).toBe(false)
+  })
+
+  it('projects MTO dossiers and review pressure onto the shared follow-through core', () => {
+    const workspace = buildMtoActionCenterWorkspace({
+      role: 'owner',
+      dossiers: [
+        {
+          id: 'dos-1',
+          title: 'Werkdruk - Support',
+          triageStatus: 'bevestigd',
+          departmentLabel: 'Support',
+          managerLabel: 'Sanne',
+          firstActionTaken: 'Roosterdruk binnen 2 weken herverdelen',
+          reviewMoment: 'Herlees over 30 dagen',
+          managementActionOutcome: null,
+          nextRoute: null,
+          stopReason: null,
+        },
+        {
+          id: 'dos-2',
+          title: 'Rolhelderheid - Sales',
+          triageStatus: 'nieuw',
+          departmentLabel: 'Sales',
+          managerLabel: null,
+          firstActionTaken: null,
+          reviewMoment: null,
+          managementActionOutcome: null,
+          nextRoute: null,
+          stopReason: null,
+        },
+      ],
+    })
+
+    expect(workspace.carrier.ownerModel).toBe('hr_central')
+    expect(workspace.carrier.managerScope).toBe('department_only')
+    expect(workspace.summary.workspaceKind).toBe('follow_through')
+    expect(workspace.summary.openDossierCount).toBe(2)
+    expect(workspace.summary.blockedCount).toBe(1)
+    expect(workspace.summary.reviewDueCount).toBe(2)
+    expect(workspace.summary.escalationCount).toBe(1)
+    expect(workspace.managerDepartmentLabels).toEqual(['Sales', 'Support'])
+    expect(workspace.assignments[0]?.state).toBe('active')
+    expect(workspace.assignments[1]?.state).toBe('blocked')
+    expect(workspace.followUpSignals.some((signal) => signal.kind === 'owner_missing')).toBe(true)
+    expect(workspace.followUpSignals.some((signal) => signal.kind === 'decision_due')).toBe(true)
   })
 })

--- a/frontend/lib/pilot-learning.test.ts
+++ b/frontend/lib/pilot-learning.test.ts
@@ -8,8 +8,10 @@ import {
   CASE_PERMISSION_STATUS_OPTIONS,
   CASE_POTENTIAL_OPTIONS,
   createDefaultLearningCheckpoints,
+  getLearningRouteInterestForCampaign,
   LEARNING_CHECKPOINT_DEFINITIONS,
   LEARNING_DESTINATION_OPTIONS,
+  LEARNING_ROUTE_OPTIONS,
   LEARNING_TRIAGE_STATUS_OPTIONS,
 } from '@/lib/pilot-learning'
 
@@ -68,6 +70,14 @@ describe('pilot learning defaults', () => {
       'stevig',
     ])
     expect(CASE_OUTCOME_CLASS_OPTIONS.map((option) => option.value)).toContain('management_adoptie')
+    expect(LEARNING_ROUTE_OPTIONS.map((option) => option.value)).toContain('teamscan')
+  })
+
+  it('maps TeamScan campaigns onto the MTO learning route without opening other carriers', () => {
+    expect(getLearningRouteInterestForCampaign('team')).toBe('teamscan')
+    expect(getLearningRouteInterestForCampaign('exit')).toBe('exitscan')
+    expect(getLearningRouteInterestForCampaign('retention')).toBe('retentiescan')
+    expect(getLearningRouteInterestForCampaign('pulse')).toBe('nog-onzeker')
   })
 
   it('builds route-aware objective signals from lead and campaign context', () => {

--- a/frontend/lib/pilot-learning.ts
+++ b/frontend/lib/pilot-learning.ts
@@ -20,6 +20,10 @@ import type {
 import { SCAN_TYPE_LABELS, type CampaignStats, type DeliveryMode, type ScanType } from '@/lib/types'
 
 export type LearningTriageStatus = 'nieuw' | 'bevestigd' | 'geparkeerd' | 'uitgevoerd' | 'verworpen'
+export type LearningRouteInterest = Extract<
+  ContactRouteInterest,
+  'exitscan' | 'retentiescan' | 'teamscan' | 'combinatie' | 'nog-onzeker'
+>
 export type LearningCheckpointKey =
   | 'lead_route_hypothesis'
   | 'implementation_intake'
@@ -72,7 +76,7 @@ export interface PilotLearningDossier {
   campaign_id: string | null
   contact_request_id: string | null
   title: string
-  route_interest: ContactRouteInterest
+  route_interest: LearningRouteInterest
   scan_type: ScanType | null
   delivery_mode: DeliveryMode | null
   triage_status: LearningTriageStatus
@@ -186,12 +190,28 @@ export const LEARNING_STRENGTH_OPTIONS: Array<{ value: LearningStrength; label: 
   { value: 'direct_uitvoerbare_verbetering', label: 'Direct uitvoerbare verbetering' },
 ]
 
-export const LEARNING_ROUTE_OPTIONS: Array<{ value: ContactRouteInterest; label: string }> = [
+export const LEARNING_ROUTE_OPTIONS: Array<{ value: LearningRouteInterest; label: string }> = [
   { value: 'exitscan', label: 'ExitScan' },
   { value: 'retentiescan', label: 'RetentieScan' },
+  { value: 'teamscan', label: 'MTO / TeamScan' },
   { value: 'combinatie', label: 'Combinatie' },
   { value: 'nog-onzeker', label: 'Nog niet zeker' },
 ]
+
+export function getLearningRouteInterestForCampaign(scanType: ScanType): LearningRouteInterest {
+  if (scanType === 'exit') return 'exitscan'
+  if (scanType === 'retention') return 'retentiescan'
+  if (scanType === 'team') return 'teamscan'
+  return 'nog-onzeker'
+}
+
+export function normalizeLearningRouteInterest(value: ContactRouteInterest | null | undefined): LearningRouteInterest {
+  if (value === 'exitscan' || value === 'retentiescan' || value === 'teamscan' || value === 'combinatie') {
+    return value
+  }
+
+  return 'nog-onzeker'
+}
 
 export const CASE_EVIDENCE_CLOSURE_OPTIONS: Array<{ value: CaseEvidenceClosureStatus; label: string }> = [
   { value: 'lesson_only', label: 'Lesson only' },
@@ -262,7 +282,7 @@ export function getLearningStrengthLabel(value: LearningStrength) {
 }
 
 export function getSuggestedLearningDossierTitle(args: {
-  routeInterest: ContactRouteInterest
+  routeInterest: LearningRouteInterest
   campaignName?: string | null
   organizationName?: string | null
 }) {

--- a/migrations/2026_04_25_add_teamscan_learning_route.sql
+++ b/migrations/2026_04_25_add_teamscan_learning_route.sql
@@ -1,0 +1,20 @@
+-- Migration: voeg teamscan toe aan pilot_learning_dossiers.route_interest
+-- Datum: 2026-04-25
+-- Uitvoeren in: Supabase Dashboard -> SQL Editor
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name = 'pilot_learning_dossiers'
+  ) THEN
+    ALTER TABLE public.pilot_learning_dossiers
+      DROP CONSTRAINT IF EXISTS pilot_learning_dossiers_route_interest_check;
+
+    ALTER TABLE public.pilot_learning_dossiers
+      ADD CONSTRAINT pilot_learning_dossiers_route_interest_check
+      CHECK (route_interest IN ('exitscan', 'retentiescan', 'teamscan', 'combinatie', 'nog-onzeker'));
+  END IF;
+END $$;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -441,7 +441,7 @@ create table if not exists public.pilot_learning_dossiers (
   campaign_id             uuid references public.campaigns(id) on delete cascade,
   contact_request_id      uuid references public.contact_requests(id) on delete set null,
   title                   text not null,
-  route_interest          text not null default 'exitscan' check (route_interest in ('exitscan', 'retentiescan', 'combinatie', 'nog-onzeker')),
+  route_interest          text not null default 'exitscan' check (route_interest in ('exitscan', 'retentiescan', 'teamscan', 'combinatie', 'nog-onzeker')),
   scan_type               text check (scan_type is null or scan_type in ('exit', 'retention', 'pulse', 'team', 'onboarding', 'leadership')),
   delivery_mode           text check (delivery_mode in ('baseline', 'live')),
   triage_status           text not null default 'nieuw' check (triage_status in ('nieuw', 'bevestigd', 'geparkeerd', 'uitgevoerd', 'verworpen')),

--- a/tests/test_action_center_shared_core.py
+++ b/tests/test_action_center_shared_core.py
@@ -7,7 +7,13 @@ from backend.products.shared.action_center_core import (
     build_permission_envelope,
     summarize_workspace,
 )
-from backend.products.shared.action_center_mto import MtoDesignInput, describe_mto_design_input
+from backend.products.shared.action_center_mto import (
+    MtoDesignInput,
+    MtoDossierInput,
+    build_mto_action_center_workspace,
+    describe_mto_design_input,
+    get_mto_action_center_carrier,
+)
 
 
 def test_action_center_summary_stays_follow_through_bounded():
@@ -74,7 +80,7 @@ def test_permission_envelope_stays_within_follow_through_surface():
     assert owner_envelope.can_open_product_adapters is False
 
 
-def test_mto_and_future_adapters_stay_explicitly_separate():
+def test_mto_becomes_the_first_active_action_center_carrier_while_future_adapters_stay_inactive():
     design_input = describe_mto_design_input(
         MtoDesignInput(
             source="mto",
@@ -82,10 +88,63 @@ def test_mto_and_future_adapters_stay_explicitly_separate():
             notes="Gebruik alleen als ontwerpinspiratie voor dossiervelden.",
         )
     )
+    carrier = get_mto_action_center_carrier()
     exit_adapter = get_future_action_center_adapter("exit")
 
-    assert design_input.mode == "design_input_only"
-    assert design_input.can_create_assignments is False
-    assert design_input.can_open_carrier is False
+    assert carrier.status == "active"
+    assert carrier.workspace_kind == "follow_through"
+    assert carrier.owner_model == "hr_central"
+    assert carrier.manager_scope == "department_only"
+    assert carrier.review_pressure_visible is True
+    assert carrier.dossier_first is True
+    assert carrier.can_open_other_product_adapters is False
+    assert design_input.mode == "active_follow_through"
+    assert design_input.can_create_assignments is True
+    assert design_input.can_open_carrier is True
     assert exit_adapter.status == "inactive"
     assert exit_adapter.live_entry_enabled is False
+
+
+def test_mto_workspace_projects_dossiers_reviews_and_hr_central_guardrails_onto_shared_core():
+    workspace = build_mto_action_center_workspace(
+        role="owner",
+        dossiers=[
+            MtoDossierInput(
+                id="dos-1",
+                title="Werkdruk - Support",
+                triage_status="bevestigd",
+                department_label="Support",
+                manager_label="Sanne",
+                first_action_taken="Roosterdruk binnen 2 weken herverdelen",
+                review_moment="Herlees over 30 dagen",
+                management_action_outcome=None,
+                next_route=None,
+                stop_reason=None,
+            ),
+            MtoDossierInput(
+                id="dos-2",
+                title="Rolhelderheid - Sales",
+                triage_status="nieuw",
+                department_label="Sales",
+                manager_label=None,
+                first_action_taken=None,
+                review_moment=None,
+                management_action_outcome=None,
+                next_route=None,
+                stop_reason=None,
+            ),
+        ],
+    )
+
+    assert workspace.carrier.owner_model == "hr_central"
+    assert workspace.carrier.manager_scope == "department_only"
+    assert workspace.summary.workspace_kind == "follow_through"
+    assert workspace.summary.open_dossier_count == 2
+    assert workspace.summary.blocked_count == 1
+    assert workspace.summary.review_due_count == 2
+    assert workspace.summary.escalation_count == 1
+    assert workspace.manager_departments == ("Sales", "Support")
+    assert workspace.assignments[0].state == "active"
+    assert workspace.assignments[1].state == "blocked"
+    assert any(signal.kind == "owner_missing" for signal in workspace.follow_up_signals)
+    assert any(signal.kind == "decision_due" for signal in workspace.follow_up_signals)

--- a/tests/test_pilot_learning_system.py
+++ b/tests/test_pilot_learning_system.py
@@ -5,6 +5,10 @@ from backend.models import (
     PilotLearningCheckpoint,
     PilotLearningDossier,
 )
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_learning_dossier_persists_with_checkpoint_defaults(db_session):
@@ -116,3 +120,14 @@ def test_learning_checkpoint_can_store_confirmed_lesson_and_destinations(db_sess
     assert stored_dossier is not None
     assert stored_dossier.case_permission_status == "anonymous_case_only"
     assert stored_dossier.case_outcome_quality == "stevig"
+
+
+def test_learning_route_contract_includes_teamscan_for_persisted_dossiers():
+    schema = (ROOT / "supabase/schema.sql").read_text(encoding="utf-8").lower()
+    migration = (
+        ROOT / "migrations/2026_04_25_add_teamscan_learning_route.sql"
+    ).read_text(encoding="utf-8").lower()
+
+    assert "route_interest in ('exitscan', 'retentiescan', 'teamscan', 'combinatie', 'nog-onzeker')" in schema
+    assert "pilot_learning_dossiers_route_interest_check" in migration
+    assert "teamscan" in migration


### PR DESCRIPTION
## Summary
- activate MTO as the first Action Center carrier on the shared follow-through core
- add an MTO Action Center landing inside the existing klantlearnings route with review pressure, dossier-first follow-through, and HR-central guardrails
- keep the change narrow by only adding the TeamScan/MTO-specific route support needed for this carrier

## Why
The shared Action Center contracts existed, but MTO still lived in a design-only state and TeamScan campaigns could not land as their own dossier route. This change lets the existing MTO cockpit/dossier/review flow land on the shared core without opening live links to other products or broadening the redesign outside the Action Center boundary.

## Impact
- `/beheer/klantlearnings` now exposes a shared-core MTO Action Center summary above the existing workbench
- TeamScan/MTO dossiers now keep their own carrier identity instead of collapsing into retention routing
- shared core tests now lock HR-central ownership, department-bound manager scope, visible review pressure, and dossier-first follow-through

## Validation
- `pytest tests/test_action_center_shared_core.py -q`
- `npm test -- "lib/action-center-shared-core.test.ts" "lib/pilot-learning.test.ts" "app/(dashboard)/dashboard/page.test.ts" "app/(dashboard)/beheer/klantlearnings/page.test.ts"`
- `npm run lint -- "lib/action-center-mto.ts" "lib/pilot-learning.ts" "components/dashboard/pilot-learning-workbench.tsx" "app/(dashboard)/beheer/klantlearnings/page.tsx" "app/(dashboard)/dashboard/page.tsx"`

## Notes
- `gh` was not available in this environment, so the PR was opened through the GitHub connector.
