### PR TITLE
[codex] add ExitScan action center adapter

### DIFF
--- a/backend/products/shared/action_center_adapters.py
+++ b/backend/products/shared/action_center_adapters.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 
-FutureActionCenterAdapterKey = Literal["exit", "retention", "onboarding", "pulse", "leadership"]
+FutureActionCenterAdapterKey = Literal["retention", "onboarding", "pulse", "leadership"]
 FutureActionCenterAdapterStatus = Literal["inactive"]
 
 
@@ -17,12 +17,6 @@ class FutureActionCenterAdapter:
 
 
 _FUTURE_ADAPTERS: dict[FutureActionCenterAdapterKey, FutureActionCenterAdapter] = {
-    "exit": FutureActionCenterAdapter(
-        key="exit",
-        label="ExitScan-adapter",
-        status="inactive",
-        live_entry_enabled=False,
-    ),
     "retention": FutureActionCenterAdapter(
         key="retention",
         label="RetentieScan-adapter",

--- a/backend/products/shared/action_center_exit.py
+++ b/backend/products/shared/action_center_exit.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from .action_center_core import (
+    ActionAssignment,
+    ActionDossier,
+    ActionFollowUpSignal,
+    ActionReviewMoment,
+    ActionWorkspaceSummary,
+    MemberRole,
+    build_permission_envelope,
+    summarize_workspace,
+)
+
+
+ExitCarrierStatus = Literal["active"]
+ExitCarrierRouteScope = Literal["exit_only"]
+ExitCarrierOwnerModel = Literal["explicit_named_owner"]
+ExitCarrierReviewDiscipline = Literal["follow_up_review_required"]
+ExitTriageStatus = Literal["nieuw", "bevestigd", "geparkeerd", "uitgevoerd", "verworpen"]
+ExitDeliveryMode = Literal["baseline", "live"]
+
+_OPEN_TRIAGE_STATUSES = {"nieuw", "bevestigd"}
+
+
+@dataclass(frozen=True)
+class ExitActionCenterCarrier:
+    key: Literal["exit"]
+    label: str
+    status: ExitCarrierStatus
+    workspace_kind: Literal["follow_through"]
+    route_scope: ExitCarrierRouteScope
+    owner_model: ExitCarrierOwnerModel
+    review_discipline: ExitCarrierReviewDiscipline
+    can_open_other_product_adapters: Literal[False]
+
+
+@dataclass(frozen=True)
+class ExitDossierInput:
+    id: str
+    title: str
+    triage_status: ExitTriageStatus
+    delivery_mode: ExitDeliveryMode | None
+    management_owner_label: str | None
+    review_owner_label: str | None
+    first_action_taken: str | None
+    review_moment: str | None
+    management_action_outcome: str | None
+    next_route: str | None
+    stop_reason: str | None
+
+
+@dataclass(frozen=True)
+class ExitActionCenterWorkspace:
+    carrier: ExitActionCenterCarrier
+    summary: ActionWorkspaceSummary
+    dossiers: list[ActionDossier]
+    assignments: list[ActionAssignment]
+    review_moments: list[ActionReviewMoment]
+    follow_up_signals: list[ActionFollowUpSignal]
+    active_delivery_modes: tuple[ExitDeliveryMode, ...]
+
+
+_EXIT_ACTION_CENTER_CARRIER = ExitActionCenterCarrier(
+    key="exit",
+    label="ExitScan-adapter",
+    status="active",
+    workspace_kind="follow_through",
+    route_scope="exit_only",
+    owner_model="explicit_named_owner",
+    review_discipline="follow_up_review_required",
+    can_open_other_product_adapters=False,
+)
+
+
+def _build_actor_id(prefix: str, value: str | None) -> str | None:
+    if not value:
+        return None
+    normalized = "-".join(value.strip().lower().split())
+    return f"{prefix}:{normalized}" if normalized else None
+
+
+def _is_open(triage_status: ExitTriageStatus) -> bool:
+    return triage_status in _OPEN_TRIAGE_STATUSES
+
+
+def get_exit_action_center_carrier() -> ExitActionCenterCarrier:
+    return _EXIT_ACTION_CENTER_CARRIER
+
+
+def build_exit_action_center_workspace(
+    *,
+    role: MemberRole | None,
+    dossiers: list[ExitDossierInput],
+) -> ExitActionCenterWorkspace:
+    shared_dossiers: list[ActionDossier] = []
+    assignments: list[ActionAssignment] = []
+    review_moments: list[ActionReviewMoment] = []
+    follow_up_signals: list[ActionFollowUpSignal] = []
+    active_delivery_modes = tuple(
+        sorted(
+            {
+                dossier.delivery_mode
+                for dossier in dossiers
+                if dossier.delivery_mode in {"baseline", "live"}
+            }
+        )
+    )
+
+    for dossier in dossiers:
+        permission_envelope = build_permission_envelope(role)
+        is_open = _is_open(dossier.triage_status)
+        has_follow_through_decision = bool(
+            dossier.management_action_outcome or dossier.next_route or dossier.stop_reason
+        )
+        management_owner_id = _build_actor_id("manager", dossier.management_owner_label)
+        review_owner_id = _build_actor_id("review", dossier.review_owner_label)
+        owner_id = management_owner_id or review_owner_id
+
+        shared_dossiers.append(
+            ActionDossier(
+                id=dossier.id,
+                title=dossier.title,
+                status="open" if is_open else "closed",
+                owner_id=owner_id,
+                permission_envelope=permission_envelope,
+            )
+        )
+
+        assignment_state = (
+            "completed"
+            if dossier.triage_status == "uitgevoerd"
+            else "cancelled"
+            if dossier.triage_status == "verworpen"
+            else "waiting"
+            if dossier.triage_status == "geparkeerd"
+            else "active"
+            if dossier.first_action_taken
+            else "blocked"
+        )
+        assignment_kind = (
+            "handoff"
+            if has_follow_through_decision
+            else "follow_up"
+            if dossier.first_action_taken
+            else "review_prep"
+        )
+        assignments.append(
+            ActionAssignment(
+                id=f"asg-{dossier.id}",
+                dossier_id=dossier.id,
+                title=dossier.first_action_taken or "Leg eerste ExitScan follow-up stap vast",
+                state=assignment_state,
+                kind=assignment_kind,
+                owner_id=owner_id,
+            )
+        )
+
+        review_state = (
+            "completed"
+            if dossier.triage_status == "uitgevoerd"
+            else "cancelled"
+            if dossier.triage_status in {"geparkeerd", "verworpen"}
+            else "due"
+        )
+        review_moments.append(
+            ActionReviewMoment(
+                id=f"rev-{dossier.id}",
+                dossier_id=dossier.id,
+                scheduled_for=dossier.review_moment or "Exit reviewmoment nog vastleggen",
+                state=review_state,
+            )
+        )
+
+        if is_open and not owner_id:
+            follow_up_signals.append(
+                ActionFollowUpSignal(
+                    id=f"sig-owner-{dossier.id}",
+                    dossier_id=dossier.id,
+                    kind="owner_missing",
+                    severity="warning",
+                    state="open",
+                )
+            )
+
+        if is_open and not dossier.first_action_taken:
+            follow_up_signals.append(
+                ActionFollowUpSignal(
+                    id=f"sig-step-{dossier.id}",
+                    dossier_id=dossier.id,
+                    kind="blocked_assignment",
+                    severity="critical",
+                    state="open",
+                )
+            )
+
+        if is_open:
+            follow_up_signals.append(
+                ActionFollowUpSignal(
+                    id=f"sig-review-{dossier.id}",
+                    dossier_id=dossier.id,
+                    kind="review_due",
+                    severity="warning",
+                    state="open",
+                )
+            )
+
+        if is_open and not has_follow_through_decision:
+            follow_up_signals.append(
+                ActionFollowUpSignal(
+                    id=f"sig-decision-{dossier.id}",
+                    dossier_id=dossier.id,
+                    kind="decision_due",
+                    severity="warning",
+                    state="open",
+                )
+            )
+
+    summary = summarize_workspace(
+        dossiers=shared_dossiers,
+        assignments=assignments,
+        review_moments=review_moments,
+        follow_up_signals=follow_up_signals,
+    )
+
+    return ExitActionCenterWorkspace(
+        carrier=_EXIT_ACTION_CENTER_CARRIER,
+        summary=summary,
+        dossiers=shared_dossiers,
+        assignments=assignments,
+        review_moments=review_moments,
+        follow_up_signals=follow_up_signals,
+        active_delivery_modes=active_delivery_modes,
+    )

--- a/frontend/lib/action-center-adapters.ts
+++ b/frontend/lib/action-center-adapters.ts
@@ -1,5 +1,4 @@
 export type FutureActionCenterAdapterKey =
-  | 'exit'
   | 'retention'
   | 'onboarding'
   | 'pulse'
@@ -15,7 +14,6 @@ export interface FutureActionCenterAdapter {
 }
 
 const FUTURE_ADAPTERS: Record<FutureActionCenterAdapterKey, FutureActionCenterAdapter> = {
-  exit: { key: 'exit', label: 'ExitScan-adapter', status: 'inactive', liveEntryEnabled: false },
   retention: { key: 'retention', label: 'RetentieScan-adapter', status: 'inactive', liveEntryEnabled: false },
   onboarding: { key: 'onboarding', label: 'Onboarding-adapter', status: 'inactive', liveEntryEnabled: false },
   pulse: { key: 'pulse', label: 'Pulse-adapter', status: 'inactive', liveEntryEnabled: false },

--- a/frontend/lib/action-center-exit.ts
+++ b/frontend/lib/action-center-exit.ts
@@ -1,0 +1,206 @@
+import {
+  buildActionCenterPermissionEnvelope,
+  buildActionCenterWorkspaceSummary,
+  type ActionCenterAssignment,
+  type ActionCenterDossier,
+  type ActionCenterFollowUpSignal,
+  type ActionCenterReviewMoment,
+  type ActionCenterWorkspaceSummary,
+} from '@/lib/action-center-shared-core'
+import type { MemberRole } from '@/lib/types'
+
+export type ExitCarrierStatus = 'active'
+export type ExitCarrierRouteScope = 'exit_only'
+export type ExitCarrierOwnerModel = 'explicit_named_owner'
+export type ExitCarrierReviewDiscipline = 'follow_up_review_required'
+export type ExitTriageStatus = 'nieuw' | 'bevestigd' | 'geparkeerd' | 'uitgevoerd' | 'verworpen'
+export type ExitDeliveryMode = 'baseline' | 'live'
+
+const OPEN_TRIAGE_STATUSES = new Set<ExitTriageStatus>(['nieuw', 'bevestigd'])
+
+export interface ExitActionCenterCarrier {
+  key: 'exit'
+  label: string
+  status: ExitCarrierStatus
+  workspaceKind: 'follow_through'
+  routeScope: ExitCarrierRouteScope
+  ownerModel: ExitCarrierOwnerModel
+  reviewDiscipline: ExitCarrierReviewDiscipline
+  canOpenOtherProductAdapters: false
+}
+
+export interface ExitDossierInput {
+  id: string
+  title: string
+  triageStatus: ExitTriageStatus
+  deliveryMode: ExitDeliveryMode | null
+  managementOwnerLabel: string | null
+  reviewOwnerLabel: string | null
+  firstActionTaken: string | null
+  reviewMoment: string | null
+  managementActionOutcome: string | null
+  nextRoute: string | null
+  stopReason: string | null
+}
+
+export interface ExitActionCenterWorkspace {
+  carrier: ExitActionCenterCarrier
+  summary: ActionCenterWorkspaceSummary
+  dossiers: ActionCenterDossier[]
+  assignments: ActionCenterAssignment[]
+  reviewMoments: ActionCenterReviewMoment[]
+  followUpSignals: ActionCenterFollowUpSignal[]
+  activeDeliveryModes: ExitDeliveryMode[]
+}
+
+const EXIT_ACTION_CENTER_CARRIER: ExitActionCenterCarrier = {
+  key: 'exit',
+  label: 'ExitScan-adapter',
+  status: 'active',
+  workspaceKind: 'follow_through',
+  routeScope: 'exit_only',
+  ownerModel: 'explicit_named_owner',
+  reviewDiscipline: 'follow_up_review_required',
+  canOpenOtherProductAdapters: false,
+}
+
+function buildActorId(prefix: string, value: string | null) {
+  if (!value) return null
+  const normalized = value.trim().toLowerCase().split(/\s+/).join('-')
+  return normalized ? `${prefix}:${normalized}` : null
+}
+
+function isOpen(triageStatus: ExitTriageStatus) {
+  return OPEN_TRIAGE_STATUSES.has(triageStatus)
+}
+
+function isExitDeliveryMode(value: ExitDeliveryMode | null): value is ExitDeliveryMode {
+  return value === 'baseline' || value === 'live'
+}
+
+export function getExitActionCenterCarrier() {
+  return EXIT_ACTION_CENTER_CARRIER
+}
+
+export function buildExitActionCenterWorkspace(args: {
+  role: MemberRole | null | undefined
+  dossiers: ExitDossierInput[]
+}): ExitActionCenterWorkspace {
+  const dossiers: ActionCenterDossier[] = []
+  const assignments: ActionCenterAssignment[] = []
+  const reviewMoments: ActionCenterReviewMoment[] = []
+  const followUpSignals: ActionCenterFollowUpSignal[] = []
+  const activeDeliveryModes = Array.from(
+    new Set(args.dossiers.map((dossier) => dossier.deliveryMode).filter(isExitDeliveryMode)),
+  ).sort((left, right) => left.localeCompare(right))
+
+  for (const dossier of args.dossiers) {
+    const permissionEnvelope = buildActionCenterPermissionEnvelope({ role: args.role })
+    const open = isOpen(dossier.triageStatus)
+    const hasFollowThroughDecision = Boolean(
+      dossier.managementActionOutcome || dossier.nextRoute || dossier.stopReason,
+    )
+    const managementOwnerId = buildActorId('manager', dossier.managementOwnerLabel)
+    const reviewOwnerId = buildActorId('review', dossier.reviewOwnerLabel)
+    const ownerId = managementOwnerId ?? reviewOwnerId
+
+    dossiers.push({
+      id: dossier.id,
+      title: dossier.title,
+      status: open ? 'open' : 'closed',
+      ownerId,
+      permissionEnvelope,
+    })
+
+    const assignmentState =
+      dossier.triageStatus === 'uitgevoerd'
+        ? 'completed'
+        : dossier.triageStatus === 'verworpen'
+          ? 'cancelled'
+          : dossier.triageStatus === 'geparkeerd'
+            ? 'waiting'
+            : dossier.firstActionTaken
+              ? 'active'
+              : 'blocked'
+    const assignmentKind =
+      hasFollowThroughDecision ? 'handoff' : dossier.firstActionTaken ? 'follow_up' : 'review_prep'
+
+    assignments.push({
+      id: `asg-${dossier.id}`,
+      dossierId: dossier.id,
+      title: dossier.firstActionTaken ?? 'Leg eerste ExitScan follow-up stap vast',
+      state: assignmentState,
+      kind: assignmentKind,
+      ownerId,
+    })
+
+    const reviewState =
+      dossier.triageStatus === 'uitgevoerd'
+        ? 'completed'
+        : dossier.triageStatus === 'geparkeerd' || dossier.triageStatus === 'verworpen'
+          ? 'cancelled'
+          : 'due'
+
+    reviewMoments.push({
+      id: `rev-${dossier.id}`,
+      dossierId: dossier.id,
+      scheduledFor: dossier.reviewMoment ?? 'Exit reviewmoment nog vastleggen',
+      state: reviewState,
+    })
+
+    if (open && !ownerId) {
+      followUpSignals.push({
+        id: `sig-owner-${dossier.id}`,
+        dossierId: dossier.id,
+        kind: 'owner_missing',
+        severity: 'warning',
+        state: 'open',
+      })
+    }
+
+    if (open && !dossier.firstActionTaken) {
+      followUpSignals.push({
+        id: `sig-step-${dossier.id}`,
+        dossierId: dossier.id,
+        kind: 'blocked_assignment',
+        severity: 'critical',
+        state: 'open',
+      })
+    }
+
+    if (open) {
+      followUpSignals.push({
+        id: `sig-review-${dossier.id}`,
+        dossierId: dossier.id,
+        kind: 'review_due',
+        severity: 'warning',
+        state: 'open',
+      })
+    }
+
+    if (open && !hasFollowThroughDecision) {
+      followUpSignals.push({
+        id: `sig-decision-${dossier.id}`,
+        dossierId: dossier.id,
+        kind: 'decision_due',
+        severity: 'warning',
+        state: 'open',
+      })
+    }
+  }
+
+  return {
+    carrier: EXIT_ACTION_CENTER_CARRIER,
+    summary: buildActionCenterWorkspaceSummary({
+      dossiers,
+      assignments,
+      reviewMoments,
+      followUpSignals,
+    }),
+    dossiers,
+    assignments,
+    reviewMoments,
+    followUpSignals,
+    activeDeliveryModes,
+  }
+}

--- a/frontend/lib/action-center-shared-core.test.ts
+++ b/frontend/lib/action-center-shared-core.test.ts
@@ -6,6 +6,10 @@ import {
   getFutureActionCenterAdapter,
 } from '@/lib/action-center-shared-core'
 import {
+  buildExitActionCenterWorkspace,
+  getExitActionCenterCarrier,
+} from '@/lib/action-center-exit'
+import {
   buildMtoActionCenterWorkspace,
   describeMtoDesignInput,
   getMtoActionCenterCarrier,
@@ -78,14 +82,14 @@ describe('action center shared core', () => {
     expect(ownerEnvelope.canOpenProductAdapters).toBe(false)
   })
 
-  it('activates MTO as the first action center carrier while future adapters stay inactive', () => {
+  it('keeps MTO active while future product adapters stay inactive by default', () => {
     const mtoDesignInput = describeMtoDesignInput({
       source: 'mto',
       themes: ['werkdruk', 'rolhelderheid'],
       notes: 'Gebruik alleen als ontwerpinspiratie voor dossiervelden.',
     })
     const carrier = getMtoActionCenterCarrier()
-    const exitAdapter = getFutureActionCenterAdapter('exit')
+    const retentionAdapter = getFutureActionCenterAdapter('retention')
 
     expect(carrier.status).toBe('active')
     expect(carrier.workspaceKind).toBe('follow_through')
@@ -97,8 +101,8 @@ describe('action center shared core', () => {
     expect(mtoDesignInput.mode).toBe('active_follow_through')
     expect(mtoDesignInput.canCreateAssignments).toBe(true)
     expect(mtoDesignInput.canOpenCarrier).toBe(true)
-    expect(exitAdapter.status).toBe('inactive')
-    expect(exitAdapter.liveEntryEnabled).toBe(false)
+    expect(retentionAdapter.status).toBe('inactive')
+    expect(retentionAdapter.liveEntryEnabled).toBe(false)
   })
 
   it('projects MTO dossiers and review pressure onto the shared follow-through core', () => {
@@ -140,6 +144,67 @@ describe('action center shared core', () => {
     expect(workspace.summary.reviewDueCount).toBe(2)
     expect(workspace.summary.escalationCount).toBe(1)
     expect(workspace.managerDepartmentLabels).toEqual(['Sales', 'Support'])
+    expect(workspace.assignments[0]?.state).toBe('active')
+    expect(workspace.assignments[1]?.state).toBe('blocked')
+    expect(workspace.followUpSignals.some((signal) => signal.kind === 'owner_missing')).toBe(true)
+    expect(workspace.followUpSignals.some((signal) => signal.kind === 'decision_due')).toBe(true)
+  })
+
+  it('activates ExitScan as a bounded action center adapter without opening the suite', () => {
+    const carrier = getExitActionCenterCarrier()
+    const retentionAdapter = getFutureActionCenterAdapter('retention')
+
+    expect(carrier.label).toBe('ExitScan-adapter')
+    expect(carrier.status).toBe('active')
+    expect(carrier.workspaceKind).toBe('follow_through')
+    expect(carrier.routeScope).toBe('exit_only')
+    expect(carrier.ownerModel).toBe('explicit_named_owner')
+    expect(carrier.reviewDiscipline).toBe('follow_up_review_required')
+    expect(carrier.canOpenOtherProductAdapters).toBe(false)
+    expect(retentionAdapter.status).toBe('inactive')
+    expect(retentionAdapter.liveEntryEnabled).toBe(false)
+  })
+
+  it('projects ExitScan dossiers onto the shared core with explicit owner and review guardrails', () => {
+    const workspace = buildExitActionCenterWorkspace({
+      role: 'owner',
+      dossiers: [
+        {
+          id: 'dos-1',
+          title: 'ExitScan - Support closeout',
+          triageStatus: 'bevestigd',
+          deliveryMode: 'live',
+          managementOwnerLabel: 'Sanne',
+          reviewOwnerLabel: 'Verisight',
+          firstActionTaken: 'Plan exit-closeout met HR en teamlead',
+          reviewMoment: 'Herlees over 30 dagen',
+          managementActionOutcome: null,
+          nextRoute: null,
+          stopReason: null,
+        },
+        {
+          id: 'dos-2',
+          title: 'ExitScan - Sales learned route',
+          triageStatus: 'nieuw',
+          deliveryMode: 'baseline',
+          managementOwnerLabel: null,
+          reviewOwnerLabel: null,
+          firstActionTaken: null,
+          reviewMoment: null,
+          managementActionOutcome: null,
+          nextRoute: null,
+          stopReason: null,
+        },
+      ],
+    })
+
+    expect(workspace.carrier.routeScope).toBe('exit_only')
+    expect(workspace.summary.workspaceKind).toBe('follow_through')
+    expect(workspace.summary.openDossierCount).toBe(2)
+    expect(workspace.summary.blockedCount).toBe(1)
+    expect(workspace.summary.reviewDueCount).toBe(2)
+    expect(workspace.summary.escalationCount).toBe(1)
+    expect(workspace.activeDeliveryModes).toEqual(['baseline', 'live'])
     expect(workspace.assignments[0]?.state).toBe('active')
     expect(workspace.assignments[1]?.state).toBe('blocked')
     expect(workspace.followUpSignals.some((signal) => signal.kind === 'owner_missing')).toBe(true)

--- a/tests/test_action_center_shared_core.py
+++ b/tests/test_action_center_shared_core.py
@@ -1,4 +1,9 @@
 from backend.products.shared.action_center_adapters import get_future_action_center_adapter
+from backend.products.shared.action_center_exit import (
+    ExitDossierInput,
+    build_exit_action_center_workspace,
+    get_exit_action_center_carrier,
+)
 from backend.products.shared.action_center_core import (
     ActionAssignment,
     ActionDossier,
@@ -80,7 +85,7 @@ def test_permission_envelope_stays_within_follow_through_surface():
     assert owner_envelope.can_open_product_adapters is False
 
 
-def test_mto_becomes_the_first_active_action_center_carrier_while_future_adapters_stay_inactive():
+def test_mto_stays_active_while_future_product_adapters_remain_inactive_by_default():
     design_input = describe_mto_design_input(
         MtoDesignInput(
             source="mto",
@@ -89,7 +94,7 @@ def test_mto_becomes_the_first_active_action_center_carrier_while_future_adapter
         )
     )
     carrier = get_mto_action_center_carrier()
-    exit_adapter = get_future_action_center_adapter("exit")
+    retention_adapter = get_future_action_center_adapter("retention")
 
     assert carrier.status == "active"
     assert carrier.workspace_kind == "follow_through"
@@ -101,8 +106,8 @@ def test_mto_becomes_the_first_active_action_center_carrier_while_future_adapter
     assert design_input.mode == "active_follow_through"
     assert design_input.can_create_assignments is True
     assert design_input.can_open_carrier is True
-    assert exit_adapter.status == "inactive"
-    assert exit_adapter.live_entry_enabled is False
+    assert retention_adapter.status == "inactive"
+    assert retention_adapter.live_entry_enabled is False
 
 
 def test_mto_workspace_projects_dossiers_reviews_and_hr_central_guardrails_onto_shared_core():
@@ -144,6 +149,67 @@ def test_mto_workspace_projects_dossiers_reviews_and_hr_central_guardrails_onto_
     assert workspace.summary.review_due_count == 2
     assert workspace.summary.escalation_count == 1
     assert workspace.manager_departments == ("Sales", "Support")
+    assert workspace.assignments[0].state == "active"
+    assert workspace.assignments[1].state == "blocked"
+    assert any(signal.kind == "owner_missing" for signal in workspace.follow_up_signals)
+    assert any(signal.kind == "decision_due" for signal in workspace.follow_up_signals)
+
+
+def test_exit_adapter_becomes_active_without_opening_other_products():
+    carrier = get_exit_action_center_carrier()
+    retention_adapter = get_future_action_center_adapter("retention")
+
+    assert carrier.label == "ExitScan-adapter"
+    assert carrier.status == "active"
+    assert carrier.workspace_kind == "follow_through"
+    assert carrier.route_scope == "exit_only"
+    assert carrier.owner_model == "explicit_named_owner"
+    assert carrier.review_discipline == "follow_up_review_required"
+    assert carrier.can_open_other_product_adapters is False
+    assert retention_adapter.status == "inactive"
+    assert retention_adapter.live_entry_enabled is False
+
+
+def test_exit_workspace_projects_dossiers_with_explicit_owner_and_review_guardrails():
+    workspace = build_exit_action_center_workspace(
+        role="owner",
+        dossiers=[
+            ExitDossierInput(
+                id="dos-1",
+                title="ExitScan - Support closeout",
+                triage_status="bevestigd",
+                delivery_mode="live",
+                management_owner_label="Sanne",
+                review_owner_label="Verisight",
+                first_action_taken="Plan exit-closeout met HR en teamlead",
+                review_moment="Herlees over 30 dagen",
+                management_action_outcome=None,
+                next_route=None,
+                stop_reason=None,
+            ),
+            ExitDossierInput(
+                id="dos-2",
+                title="ExitScan - Sales learned route",
+                triage_status="nieuw",
+                delivery_mode="baseline",
+                management_owner_label=None,
+                review_owner_label=None,
+                first_action_taken=None,
+                review_moment=None,
+                management_action_outcome=None,
+                next_route=None,
+                stop_reason=None,
+            ),
+        ],
+    )
+
+    assert workspace.carrier.route_scope == "exit_only"
+    assert workspace.summary.workspace_kind == "follow_through"
+    assert workspace.summary.open_dossier_count == 2
+    assert workspace.summary.blocked_count == 1
+    assert workspace.summary.review_due_count == 2
+    assert workspace.summary.escalation_count == 1
+    assert workspace.active_delivery_modes == ("baseline", "live")
     assert workspace.assignments[0].state == "active"
     assert workspace.assignments[1].state == "blocked"
     assert any(signal.kind == "owner_missing" for signal in workspace.follow_up_signals)


### PR DESCRIPTION
## What changed
- adds a mirrored ExitScan Action Center adapter in frontend and backend
- keeps the adapter bounded to the existing `follow_through` core with explicit owner, review, and decision guardrails
- extends the shared Action Center tests in Vitest and pytest to cover the new ExitScan adapter while leaving other product placeholders inactive

## Why this changed
The shared Action Center core already had one active carrier plus inactive product placeholders. ExitScan needed a narrow adapter layer so its learning-dossier follow-through can project onto the existing core without opening a broader suite rollout.

## Impact
- ExitScan now has a dedicated adapter contract on both sides of the stack
- ownership stays explicit instead of inferred from broader suite state
- review pressure and bounded follow-through decisions stay visible through the shared core primitives
- other product adapters remain inactive in this slice

## Validation
- `python -m py_compile backend/products/shared/action_center_exit.py tests/test_action_center_shared_core.py`
- `python -m pytest tests/test_action_center_shared_core.py`
- `npm run lint -- lib/action-center-exit.ts lib/action-center-shared-core.test.ts`
- `npm run test -- lib/action-center-shared-core.test.ts`