### PR TITLE
Tighten ExitScan Action Center truth claims

### DIFF
--- a/backend/products/shared/action_center_mto.py
+++ b/backend/products/shared/action_center_mto.py
@@ -15,8 +15,8 @@ from .action_center_core import (
 )
 
 
-MtoDesignMode = Literal["active_follow_through"]
-MtoCarrierStatus = Literal["active"]
+MtoDesignMode = Literal["design_input_only"]
+MtoCarrierStatus = Literal["inactive"]
 MtoCarrierOwnerModel = Literal["hr_central"]
 MtoCarrierManagerScope = Literal["department_only"]
 MtoTriageStatus = Literal["nieuw", "bevestigd", "geparkeerd", "uitgevoerd", "verworpen"]
@@ -37,8 +37,8 @@ class MtoDesignInputSummary:
     mode: MtoDesignMode
     theme_count: int
     notes: str | None
-    can_create_assignments: Literal[True]
-    can_open_carrier: Literal[True]
+    can_create_assignments: Literal[False]
+    can_open_carrier: Literal[False]
 
 
 @dataclass(frozen=True)
@@ -81,8 +81,8 @@ class MtoActionCenterWorkspace:
 
 _MTO_ACTION_CENTER_CARRIER = MtoActionCenterCarrier(
     key="mto",
-    label="MTO-carrier",
-    status="active",
+    label="MTO-design-input",
+    status="inactive",
     workspace_kind="follow_through",
     owner_model="hr_central",
     manager_scope="department_only",
@@ -106,11 +106,11 @@ def _is_open(triage_status: MtoTriageStatus) -> bool:
 def describe_mto_design_input(input_data: MtoDesignInput) -> MtoDesignInputSummary:
     return MtoDesignInputSummary(
         source=input_data.source,
-        mode="active_follow_through",
+        mode="design_input_only",
         theme_count=len(input_data.themes),
         notes=input_data.notes,
-        can_create_assignments=True,
-        can_open_carrier=True,
+        can_create_assignments=False,
+        can_open_carrier=False,
     )
 
 

--- a/frontend/app/(dashboard)/beheer/klantlearnings/page.test.ts
+++ b/frontend/app/(dashboard)/beheer/klantlearnings/page.test.ts
@@ -1,18 +1,20 @@
 import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
-describe('klantlearnings action center landing', () => {
-  it('wires ExitScan onto the live action center surface without reopening the wider adapter suite', () => {
+describe('klantlearnings action center truth pass', () => {
+  it('keeps the live ExitScan surface bounded and read-only for the admin route', () => {
     const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
 
     expect(source).toContain("buildExitActionCenterWorkspace")
+    expect(source).toContain("isExitActionCenterCandidate")
+    expect(source).toContain("role: 'member'")
     expect(source).toContain('Action Center voor ExitScan-follow-through')
-    expect(source).toContain('Operations Action Center')
-    expect(source).toContain('ExitScan follow-through als zelfstandige productlaag')
-    expect(source).toContain('Expliciete eigenaar')
-    expect(source).toContain('Reviewdruk')
-    expect(source).toContain('Dossier-first')
-    expect(source).toContain('Nog geen open ExitScan-dossiers')
+    expect(source).toContain('Surface-rechten')
+    expect(source).toContain('Read-only')
+    expect(source).toContain('Ownerduiding')
+    expect(source).toContain('Exit-only filter')
+    expect(source).toContain('Reviewstatus')
+    expect(source).toContain('Nog niet gepland')
     expect(source).not.toContain("buildMtoActionCenterWorkspace")
     expect(source).not.toContain('Action Center voor MTO-follow-through')
   })

--- a/frontend/app/(dashboard)/beheer/klantlearnings/page.tsx
+++ b/frontend/app/(dashboard)/beheer/klantlearnings/page.tsx
@@ -1,7 +1,10 @@
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { PilotLearningWorkbench } from '@/components/dashboard/pilot-learning-workbench'
-import { buildExitActionCenterWorkspace } from '@/lib/action-center-exit'
+import {
+  buildExitActionCenterWorkspace,
+  isExitActionCenterCandidate,
+} from '@/lib/action-center-exit'
 import {
   DashboardChip,
   DashboardHero,
@@ -24,6 +27,8 @@ interface Props {
   searchParams?: Promise<SearchParams>
 }
 
+const REVIEW_MOMENT_PENDING_LABEL = 'Exit reviewmoment nog vastleggen'
+
 function getSingleValue(value: string | string[] | undefined) {
   return typeof value === 'string' ? value : null
 }
@@ -39,6 +44,10 @@ function filterCountsByOrgIds(source: Record<string, number>, orgIds: Set<string
     }
     return acc
   }, {})
+}
+
+function isReviewMomentPlanned(value: string) {
+  return value !== REVIEW_MOMENT_PENDING_LABEL
 }
 
 export default async function KlantLearningsPage({ searchParams }: Props) {
@@ -144,19 +153,28 @@ export default async function KlantLearningsPage({ searchParams }: Props) {
   const exitCampaignStats = campaignStats.filter(
     (stats) => stats.scan_type === 'exit' || exitCampaignIds.has(stats.campaign_id),
   )
-  const exitDossiers = dossiers.filter(
-    (dossier) =>
-      dossier.scan_type === 'exit' ||
-      dossier.route_interest === 'exitscan' ||
-      (dossier.campaign_id ? exitCampaignIds.has(dossier.campaign_id) : false),
+  const exitDossiers = dossiers.filter((dossier) =>
+    isExitActionCenterCandidate({
+      dossier: {
+        scanType: dossier.scan_type,
+        routeInterest: dossier.route_interest,
+        campaignId: dossier.campaign_id,
+      },
+      exitCampaignIds,
+    }),
   )
   const exitDossierIds = new Set(exitDossiers.map((dossier) => dossier.id))
   const exitCheckpoints = checkpoints.filter((checkpoint) => exitDossierIds.has(checkpoint.dossier_id))
+  const exitLeadIdsFromDossiers = new Set(
+    exitDossiers
+      .map((dossier) => dossier.contact_request_id)
+      .filter((value): value is string => Boolean(value)),
+  )
   const exitLeads = leads.filter(
     (lead) =>
       isExitRouteInterest(lead.route_interest) ||
       isExitRouteInterest(lead.qualified_route) ||
-      exitDossiers.some((dossier) => dossier.contact_request_id === lead.id),
+      exitLeadIdsFromDossiers.has(lead.id),
   )
   const exitOrgIds = new Set<string>([
     ...exitCampaigns.map((campaign) => campaign.organization_id),
@@ -179,7 +197,7 @@ export default async function KlantLearningsPage({ searchParams }: Props) {
   }, {})
 
   const exitWorkspace = buildExitActionCenterWorkspace({
-    role: 'owner',
+    role: 'member',
     dossiers: exitDossiers.map((dossier) => {
       const dossierCheckpoints = checkpointsByDossier[dossier.id] ?? []
       const firstManagementCheckpoint =
@@ -206,6 +224,11 @@ export default async function KlantLearningsPage({ searchParams }: Props) {
   const openExitDossiers = exitWorkspace.dossiers.filter((dossier) => dossier.status === 'open')
   const reviewPressureItems = exitWorkspace.reviewMoments.filter((reviewMoment) => reviewMoment.state === 'due')
   const openSignals = exitWorkspace.followUpSignals.filter((signal) => signal.state === 'open')
+  const explicitOwnerCount = exitWorkspace.dossiers.filter((dossier) => dossier.ownerId).length
+  const explicitOwnerOpenCount = openExitDossiers.filter((dossier) => dossier.ownerId).length
+  const scheduledReviewCount = reviewPressureItems.filter((reviewMoment) =>
+    isReviewMomentPlanned(reviewMoment.scheduledFor),
+  ).length
   const activeClientAccessCount = Object.values(exitActiveClientAccessByOrg).reduce((sum, count) => sum + count, 0)
   const initialExitLeadId = exitLeads.some((lead) => lead.id === initialLeadId) ? initialLeadId : null
   const initialExitCampaignId = exitCampaigns.some((campaign) => campaign.id === initialCampaignId)
@@ -311,7 +334,7 @@ export default async function KlantLearningsPage({ searchParams }: Props) {
         surface="ops"
         eyebrow="ExitScan live consumer"
         title="Shared follow-through voor ExitScan-dossiers, reviews en workbench"
-        description="Deze live consumer leest een echte ExitScan-stroom uit de huidige learningdossiers, houdt assignment-, review- en follow-through-logica bounded en laat Action Center voor het eerst als zelfstandige productlaag landen op een bestaand runtime-oppervlak."
+        description="Deze live consumer blijft read-only voor de adminroute, leest alleen bounded ExitScan-dossiers in en toont eigenaar- en reviewstatus zonder extra claims over permissions of andere productsporen."
         aside={
           <DashboardChip
             surface="ops"
@@ -323,38 +346,44 @@ export default async function KlantLearningsPage({ searchParams }: Props) {
         <div className="grid gap-4 xl:grid-cols-4">
           <DashboardPanel
             surface="ops"
-            eyebrow="Expliciete eigenaar"
-            title="Shared eigenaar"
-            value={exitWorkspace.dossiers.some((dossier) => dossier.ownerId) ? 'Named owner' : 'Nog te expliciteren'}
-            body="De live consumer leest management- of revieweigenaars direct uit ExitScan-checkpoints. Zonder expliciete eigenaar opent alleen het bounded waarschuwingssignaal, niet een nieuw permissiemodel."
+            eyebrow="Ownerduiding"
+            title="Expliciete dossierhouders"
+            value={
+              openExitDossiers.length > 0
+                ? `${explicitOwnerOpenCount}/${openExitDossiers.length} expliciet`
+                : explicitOwnerCount > 0
+                  ? `${explicitOwnerCount}/${exitWorkspace.dossiers.length} expliciet`
+                  : 'Nog niet expliciet'
+            }
+            body="Deze admin-surface neemt eigenaarschap niet over. Hij leest alleen expliciete manager- of reviewhouders uit ExitScan-checkpoints."
             tone="slate"
           />
           <DashboardPanel
             surface="ops"
-            eyebrow="Reviewdruk"
-            title="Actieve reviewqueue"
-            value={`${exitWorkspace.summary.reviewDueCount}`}
-            body="Elke open ExitScan-dossierregel blijft zichtbaar in de reviewdruk tot reviewmoment, uitkomst of stopbesluit expliciet zijn vastgelegd."
-            tone={exitWorkspace.summary.reviewDueCount > 0 ? 'amber' : 'slate'}
+            eyebrow="Permissions"
+            title="Surface-rechten"
+            value={exitWorkspace.dossiers.some((dossier) => dossier.permissionEnvelope.canUpdateAssignments) ? 'Bewerkbaar' : 'Read-only'}
+            body="De huidige adminroute kijkt mee als shared-core member. Assignment-, permission- en close-acties blijven dus buiten deze surface totdat een echte product-owner ze opent."
+            tone="slate"
           />
           <DashboardPanel
             surface="ops"
-            eyebrow="Dossier-first"
-            title="Open follow-through"
-            value={`${exitWorkspace.summary.openDossierCount}`}
-            body="Besluiten, eerste stap en vervolgrichting blijven dossier-first gegroepeerd in plaats van te verspreiden over losse campaignnotities of een designpreview."
-            tone={exitWorkspace.summary.openDossierCount > 0 ? 'slate' : 'amber'}
-          />
-          <DashboardPanel
-            surface="ops"
-            eyebrow="Delivery"
-            title="Actieve routes"
-            value={exitWorkspace.activeDeliveryModes.length > 0 ? exitWorkspace.activeDeliveryModes.join(' / ') : 'Nog niet expliciet'}
-            body={
-              exitWorkspace.activeDeliveryModes.length > 0
-                ? `Actieve ExitScan-routes in deze surface: ${exitWorkspace.activeDeliveryModes.join(', ')}.`
-                : 'Maak deliverymode expliciet in het dossier zodra ExitScan-follow-through echt in baseline of live delivery landt.'
+            eyebrow="Reviewstatus"
+            title="Open reviewdruk"
+            value={
+              reviewPressureItems.length > 0
+                ? `${scheduledReviewCount}/${reviewPressureItems.length} gepland`
+                : 'Geen open reviews'
             }
+            body="Open dossiers blijven in reviewdruk; zonder expliciet reviewmoment leest deze surface dat ook zo, in plaats van alsof review al gepland is."
+            tone={reviewPressureItems.length > 0 ? 'amber' : 'slate'}
+          />
+          <DashboardPanel
+            surface="ops"
+            eyebrow="Bounded scope"
+            title="Exit-only filter"
+            value={exitWorkspace.carrier.routeScope}
+            body="Dossiers blijven alleen binnen deze surface als scan_type exit is, een exit-campaign is gekoppeld, of de intake nog ongebonden ExitScan-route is."
             tone="slate"
           />
         </div>
@@ -388,7 +417,10 @@ export default async function KlantLearningsPage({ searchParams }: Props) {
                         Eerste stap: {assignment?.title ?? 'Nog niet vastgelegd'}.
                       </p>
                       <p className="mt-1 text-xs text-slate-500">
-                        Status {assignment?.state ?? 'onbekend'} - Permission shared-core: {dossier.permissionEnvelope.canUpdateAssignments ? 'bewerkbaar' : 'read-only'}
+                        Dossierhouder: {dossier.ownerId ?? 'Nog niet expliciet'}.
+                      </p>
+                      <p className="mt-1 text-xs text-slate-500">
+                        Status {assignment?.state ?? 'onbekend'} - Surface: {dossier.permissionEnvelope.canUpdateAssignments ? 'bewerkbaar' : 'read-only'}
                       </p>
                     </div>
                   )
@@ -423,6 +455,9 @@ export default async function KlantLearningsPage({ searchParams }: Props) {
                     <div key={reviewMoment.id} className="rounded-2xl border border-slate-200 bg-slate-50/70 px-4 py-4">
                       <p className="text-sm font-semibold text-slate-950">{dossier?.title ?? reviewMoment.dossierId}</p>
                       <p className="mt-2 text-sm leading-6 text-slate-600">{reviewMoment.scheduledFor}</p>
+                      <p className="mt-1 text-xs text-slate-500">
+                        Reviewstatus: {isReviewMomentPlanned(reviewMoment.scheduledFor) ? 'Gepland' : 'Nog niet gepland'}
+                      </p>
                       <p className="mt-1 text-xs text-slate-500">
                         Open signalen: {signals.map((signal) => signal.kind).join(', ') || 'geen'}
                       </p>

--- a/frontend/lib/action-center-exit.ts
+++ b/frontend/lib/action-center-exit.ts
@@ -53,6 +53,12 @@ export interface ExitActionCenterWorkspace {
   activeDeliveryModes: ExitDeliveryMode[]
 }
 
+export interface ExitActionCenterCandidateDossier {
+  scanType: string | null
+  routeInterest: string | null
+  campaignId: string | null
+}
+
 const EXIT_ACTION_CENTER_CARRIER: ExitActionCenterCarrier = {
   key: 'exit',
   label: 'ExitScan-adapter',
@@ -80,6 +86,23 @@ function isExitDeliveryMode(value: ExitDeliveryMode | null): value is ExitDelive
 
 export function getExitActionCenterCarrier() {
   return EXIT_ACTION_CENTER_CARRIER
+}
+
+export function isExitActionCenterCandidate(args: {
+  dossier: ExitActionCenterCandidateDossier
+  exitCampaignIds: ReadonlySet<string>
+}) {
+  const { dossier, exitCampaignIds } = args
+
+  if (dossier.scanType === 'exit') {
+    return true
+  }
+
+  if (dossier.campaignId) {
+    return exitCampaignIds.has(dossier.campaignId)
+  }
+
+  return dossier.scanType === null && dossier.routeInterest === 'exitscan'
 }
 
 export function buildExitActionCenterWorkspace(args: {

--- a/frontend/lib/action-center-mto.ts
+++ b/frontend/lib/action-center-mto.ts
@@ -9,8 +9,8 @@ import {
 } from '@/lib/action-center-shared-core'
 import type { MemberRole } from '@/lib/types'
 
-export type MtoDesignMode = 'active_follow_through'
-export type MtoCarrierStatus = 'active'
+export type MtoDesignMode = 'design_input_only'
+export type MtoCarrierStatus = 'inactive'
 export type MtoCarrierOwnerModel = 'hr_central'
 export type MtoCarrierManagerScope = 'department_only'
 export type MtoTriageStatus = 'nieuw' | 'bevestigd' | 'geparkeerd' | 'uitgevoerd' | 'verworpen'
@@ -69,8 +69,8 @@ export interface MtoActionCenterWorkspace {
 
 const MTO_ACTION_CENTER_CARRIER: MtoActionCenterCarrier = {
   key: 'mto',
-  label: 'MTO-carrier',
-  status: 'active',
+  label: 'MTO-design-input',
+  status: 'inactive',
   workspaceKind: 'follow_through',
   ownerModel: 'hr_central',
   managerScope: 'department_only',
@@ -92,11 +92,11 @@ function isOpen(triageStatus: MtoTriageStatus) {
 export function describeMtoDesignInput(input: MtoDesignInput): MtoDesignInputSummary {
   return {
     source: input.source,
-    mode: 'active_follow_through',
+    mode: 'design_input_only',
     themeCount: input.themes.length,
     notes: input.notes,
-    canCreateAssignments: true,
-    canOpenCarrier: true,
+    canCreateAssignments: false,
+    canOpenCarrier: false,
   }
 }
 

--- a/frontend/lib/action-center-shared-core.test.ts
+++ b/frontend/lib/action-center-shared-core.test.ts
@@ -8,12 +8,9 @@ import {
 import {
   buildExitActionCenterWorkspace,
   getExitActionCenterCarrier,
+  isExitActionCenterCandidate,
 } from '@/lib/action-center-exit'
-import {
-  buildMtoActionCenterWorkspace,
-  describeMtoDesignInput,
-  getMtoActionCenterCarrier,
-} from '@/lib/action-center-mto'
+import { describeMtoDesignInput } from '@/lib/action-center-mto'
 
 describe('action center shared core', () => {
   it('keeps the workspace bounded to follow-through signals instead of generic project planning', () => {
@@ -82,75 +79,22 @@ describe('action center shared core', () => {
     expect(ownerEnvelope.canOpenProductAdapters).toBe(false)
   })
 
-  it('keeps MTO available as a bounded carrier while future product adapters exclude live ExitScan', () => {
+  it('keeps MTO design-only while future product adapters stay inactive', () => {
     const mtoDesignInput = describeMtoDesignInput({
       source: 'mto',
       themes: ['werkdruk', 'rolhelderheid'],
       notes: 'Gebruik alleen als ontwerpinspiratie voor dossiervelden.',
     })
-    const carrier = getMtoActionCenterCarrier()
     const retentionAdapter = getFutureActionCenterAdapter('retention')
 
-    expect(carrier.status).toBe('active')
-    expect(carrier.workspaceKind).toBe('follow_through')
-    expect(carrier.ownerModel).toBe('hr_central')
-    expect(carrier.managerScope).toBe('department_only')
-    expect(carrier.reviewPressureVisible).toBe(true)
-    expect(carrier.dossierFirst).toBe(true)
-    expect(carrier.canOpenOtherProductAdapters).toBe(false)
-    expect(mtoDesignInput.mode).toBe('active_follow_through')
-    expect(mtoDesignInput.canCreateAssignments).toBe(true)
-    expect(mtoDesignInput.canOpenCarrier).toBe(true)
+    expect(mtoDesignInput.mode).toBe('design_input_only')
+    expect(mtoDesignInput.canCreateAssignments).toBe(false)
+    expect(mtoDesignInput.canOpenCarrier).toBe(false)
     expect(retentionAdapter.status).toBe('inactive')
     expect(retentionAdapter.liveEntryEnabled).toBe(false)
   })
 
-  it('projects MTO dossiers and review pressure onto the shared follow-through core', () => {
-    const workspace = buildMtoActionCenterWorkspace({
-      role: 'owner',
-      dossiers: [
-        {
-          id: 'dos-1',
-          title: 'Werkdruk - Support',
-          triageStatus: 'bevestigd',
-          departmentLabel: 'Support',
-          managerLabel: 'Sanne',
-          firstActionTaken: 'Roosterdruk binnen 2 weken herverdelen',
-          reviewMoment: 'Herlees over 30 dagen',
-          managementActionOutcome: null,
-          nextRoute: null,
-          stopReason: null,
-        },
-        {
-          id: 'dos-2',
-          title: 'Rolhelderheid - Sales',
-          triageStatus: 'nieuw',
-          departmentLabel: 'Sales',
-          managerLabel: null,
-          firstActionTaken: null,
-          reviewMoment: null,
-          managementActionOutcome: null,
-          nextRoute: null,
-          stopReason: null,
-        },
-      ],
-    })
-
-    expect(workspace.carrier.ownerModel).toBe('hr_central')
-    expect(workspace.carrier.managerScope).toBe('department_only')
-    expect(workspace.summary.workspaceKind).toBe('follow_through')
-    expect(workspace.summary.openDossierCount).toBe(2)
-    expect(workspace.summary.blockedCount).toBe(1)
-    expect(workspace.summary.reviewDueCount).toBe(2)
-    expect(workspace.summary.escalationCount).toBe(1)
-    expect(workspace.managerDepartmentLabels).toEqual(['Sales', 'Support'])
-    expect(workspace.assignments[0]?.state).toBe('active')
-    expect(workspace.assignments[1]?.state).toBe('blocked')
-    expect(workspace.followUpSignals.some((signal) => signal.kind === 'owner_missing')).toBe(true)
-    expect(workspace.followUpSignals.some((signal) => signal.kind === 'decision_due')).toBe(true)
-  })
-
-  it('activates ExitScan as the first live product consumer without opening the other adapters', () => {
+  it('keeps ExitScan as the only live action center consumer in this slice', () => {
     const carrier = getExitActionCenterCarrier()
     const retentionAdapter = getFutureActionCenterAdapter('retention')
 
@@ -165,9 +109,54 @@ describe('action center shared core', () => {
     expect(retentionAdapter.liveEntryEnabled).toBe(false)
   })
 
-  it('projects ExitScan dossiers onto the shared core with explicit owner and bounded review logic', () => {
+  it('keeps route-only intake bounded once another product binding exists', () => {
+    const exitCampaignIds = new Set(['camp-exit'])
+
+    expect(
+      isExitActionCenterCandidate({
+        dossier: {
+          scanType: 'exit',
+          routeInterest: 'retentiescan',
+          campaignId: 'camp-retention',
+        },
+        exitCampaignIds,
+      }),
+    ).toBe(true)
+    expect(
+      isExitActionCenterCandidate({
+        dossier: {
+          scanType: null,
+          routeInterest: 'exitscan',
+          campaignId: null,
+        },
+        exitCampaignIds,
+      }),
+    ).toBe(true)
+    expect(
+      isExitActionCenterCandidate({
+        dossier: {
+          scanType: 'retention',
+          routeInterest: 'exitscan',
+          campaignId: null,
+        },
+        exitCampaignIds,
+      }),
+    ).toBe(false)
+    expect(
+      isExitActionCenterCandidate({
+        dossier: {
+          scanType: null,
+          routeInterest: 'exitscan',
+          campaignId: 'camp-retention',
+        },
+        exitCampaignIds,
+      }),
+    ).toBe(false)
+  })
+
+  it('keeps the admin surface read-only while explicit dossier owners stay visible', () => {
     const workspace = buildExitActionCenterWorkspace({
-      role: 'owner',
+      role: 'member',
       dossiers: [
         {
           id: 'dos-1',
@@ -177,19 +166,6 @@ describe('action center shared core', () => {
           managementOwnerLabel: 'Sanne',
           reviewOwnerLabel: 'Verisight',
           firstActionTaken: 'Plan exit-closeout met HR en teamlead',
-          reviewMoment: 'Herlees over 30 dagen',
-          managementActionOutcome: null,
-          nextRoute: null,
-          stopReason: null,
-        },
-        {
-          id: 'dos-2',
-          title: 'ExitScan - Sales closeout',
-          triageStatus: 'nieuw',
-          deliveryMode: 'baseline',
-          managementOwnerLabel: null,
-          reviewOwnerLabel: null,
-          firstActionTaken: null,
           reviewMoment: null,
           managementActionOutcome: null,
           nextRoute: null,
@@ -198,16 +174,10 @@ describe('action center shared core', () => {
       ],
     })
 
-    expect(workspace.carrier.routeScope).toBe('exit_only')
-    expect(workspace.summary.workspaceKind).toBe('follow_through')
-    expect(workspace.summary.openDossierCount).toBe(2)
-    expect(workspace.summary.blockedCount).toBe(1)
-    expect(workspace.summary.reviewDueCount).toBe(2)
-    expect(workspace.summary.escalationCount).toBe(1)
-    expect(workspace.activeDeliveryModes).toEqual(['baseline', 'live'])
-    expect(workspace.assignments[0]?.state).toBe('active')
-    expect(workspace.assignments[1]?.state).toBe('blocked')
-    expect(workspace.followUpSignals.some((signal) => signal.kind === 'owner_missing')).toBe(true)
-    expect(workspace.followUpSignals.some((signal) => signal.kind === 'decision_due')).toBe(true)
+    expect(workspace.dossiers[0]?.ownerId).toBe('manager:sanne')
+    expect(workspace.assignments[0]?.ownerId).toBe('manager:sanne')
+    expect(workspace.dossiers[0]?.permissionEnvelope.canUpdateAssignments).toBe(false)
+    expect(workspace.dossiers[0]?.permissionEnvelope.canManagePermissions).toBe(false)
+    expect(workspace.reviewMoments[0]?.scheduledFor).toBe('Exit reviewmoment nog vastleggen')
   })
 })

--- a/frontend/lib/action-center-shared-core.test.ts
+++ b/frontend/lib/action-center-shared-core.test.ts
@@ -10,7 +10,7 @@ import {
   getExitActionCenterCarrier,
   isExitActionCenterCandidate,
 } from '@/lib/action-center-exit'
-import { describeMtoDesignInput } from '@/lib/action-center-mto'
+import { describeMtoDesignInput, getMtoActionCenterCarrier } from '@/lib/action-center-mto'
 
 describe('action center shared core', () => {
   it('keeps the workspace bounded to follow-through signals instead of generic project planning', () => {
@@ -85,11 +85,14 @@ describe('action center shared core', () => {
       themes: ['werkdruk', 'rolhelderheid'],
       notes: 'Gebruik alleen als ontwerpinspiratie voor dossiervelden.',
     })
+    const mtoCarrier = getMtoActionCenterCarrier()
     const retentionAdapter = getFutureActionCenterAdapter('retention')
 
     expect(mtoDesignInput.mode).toBe('design_input_only')
     expect(mtoDesignInput.canCreateAssignments).toBe(false)
     expect(mtoDesignInput.canOpenCarrier).toBe(false)
+    expect(mtoCarrier.label).toBe('MTO-design-input')
+    expect(mtoCarrier.status).toBe('inactive')
     expect(retentionAdapter.status).toBe('inactive')
     expect(retentionAdapter.liveEntryEnabled).toBe(false)
   })

--- a/tests/test_action_center_shared_core.py
+++ b/tests/test_action_center_shared_core.py
@@ -12,13 +12,7 @@ from backend.products.shared.action_center_core import (
     build_permission_envelope,
     summarize_workspace,
 )
-from backend.products.shared.action_center_mto import (
-    MtoDesignInput,
-    MtoDossierInput,
-    build_mto_action_center_workspace,
-    describe_mto_design_input,
-    get_mto_action_center_carrier,
-)
+from backend.products.shared.action_center_mto import MtoDesignInput, describe_mto_design_input
 
 
 def test_action_center_summary_stays_follow_through_bounded():
@@ -85,7 +79,7 @@ def test_permission_envelope_stays_within_follow_through_surface():
     assert owner_envelope.can_open_product_adapters is False
 
 
-def test_mto_stays_available_while_future_product_adapters_exclude_live_exit():
+def test_mto_stays_design_only_while_future_product_adapters_stay_inactive():
     design_input = describe_mto_design_input(
         MtoDesignInput(
             source="mto",
@@ -93,69 +87,16 @@ def test_mto_stays_available_while_future_product_adapters_exclude_live_exit():
             notes="Gebruik alleen als ontwerpinspiratie voor dossiervelden.",
         )
     )
-    carrier = get_mto_action_center_carrier()
     retention_adapter = get_future_action_center_adapter("retention")
 
-    assert carrier.status == "active"
-    assert carrier.workspace_kind == "follow_through"
-    assert carrier.owner_model == "hr_central"
-    assert carrier.manager_scope == "department_only"
-    assert carrier.review_pressure_visible is True
-    assert carrier.dossier_first is True
-    assert carrier.can_open_other_product_adapters is False
-    assert design_input.mode == "active_follow_through"
-    assert design_input.can_create_assignments is True
-    assert design_input.can_open_carrier is True
+    assert design_input.mode == "design_input_only"
+    assert design_input.can_create_assignments is False
+    assert design_input.can_open_carrier is False
     assert retention_adapter.status == "inactive"
     assert retention_adapter.live_entry_enabled is False
 
 
-def test_mto_workspace_projects_dossiers_reviews_and_hr_central_guardrails_onto_shared_core():
-    workspace = build_mto_action_center_workspace(
-        role="owner",
-        dossiers=[
-            MtoDossierInput(
-                id="dos-1",
-                title="Werkdruk - Support",
-                triage_status="bevestigd",
-                department_label="Support",
-                manager_label="Sanne",
-                first_action_taken="Roosterdruk binnen 2 weken herverdelen",
-                review_moment="Herlees over 30 dagen",
-                management_action_outcome=None,
-                next_route=None,
-                stop_reason=None,
-            ),
-            MtoDossierInput(
-                id="dos-2",
-                title="Rolhelderheid - Sales",
-                triage_status="nieuw",
-                department_label="Sales",
-                manager_label=None,
-                first_action_taken=None,
-                review_moment=None,
-                management_action_outcome=None,
-                next_route=None,
-                stop_reason=None,
-            ),
-        ],
-    )
-
-    assert workspace.carrier.owner_model == "hr_central"
-    assert workspace.carrier.manager_scope == "department_only"
-    assert workspace.summary.workspace_kind == "follow_through"
-    assert workspace.summary.open_dossier_count == 2
-    assert workspace.summary.blocked_count == 1
-    assert workspace.summary.review_due_count == 2
-    assert workspace.summary.escalation_count == 1
-    assert workspace.manager_departments == ("Sales", "Support")
-    assert workspace.assignments[0].state == "active"
-    assert workspace.assignments[1].state == "blocked"
-    assert any(signal.kind == "owner_missing" for signal in workspace.follow_up_signals)
-    assert any(signal.kind == "decision_due" for signal in workspace.follow_up_signals)
-
-
-def test_exit_becomes_the_first_live_product_consumer_without_opening_other_adapters():
+def test_exit_becomes_the_only_live_action_center_consumer_in_this_slice():
     carrier = get_exit_action_center_carrier()
     retention_adapter = get_future_action_center_adapter("retention")
 
@@ -170,9 +111,9 @@ def test_exit_becomes_the_first_live_product_consumer_without_opening_other_adap
     assert retention_adapter.live_entry_enabled is False
 
 
-def test_exit_workspace_projects_dossiers_with_explicit_owner_and_bounded_review_logic():
+def test_exit_workspace_keeps_admin_surface_read_only_while_owner_ids_stay_explicit():
     workspace = build_exit_action_center_workspace(
-        role="owner",
+        role="member",
         dossiers=[
             ExitDossierInput(
                 id="dos-1",
@@ -182,19 +123,6 @@ def test_exit_workspace_projects_dossiers_with_explicit_owner_and_bounded_review
                 management_owner_label="Sanne",
                 review_owner_label="Verisight",
                 first_action_taken="Plan exit-closeout met HR en teamlead",
-                review_moment="Herlees over 30 dagen",
-                management_action_outcome=None,
-                next_route=None,
-                stop_reason=None,
-            ),
-            ExitDossierInput(
-                id="dos-2",
-                title="ExitScan - Sales closeout",
-                triage_status="nieuw",
-                delivery_mode="baseline",
-                management_owner_label=None,
-                review_owner_label=None,
-                first_action_taken=None,
                 review_moment=None,
                 management_action_outcome=None,
                 next_route=None,
@@ -203,14 +131,8 @@ def test_exit_workspace_projects_dossiers_with_explicit_owner_and_bounded_review
         ],
     )
 
-    assert workspace.carrier.route_scope == "exit_only"
-    assert workspace.summary.workspace_kind == "follow_through"
-    assert workspace.summary.open_dossier_count == 2
-    assert workspace.summary.blocked_count == 1
-    assert workspace.summary.review_due_count == 2
-    assert workspace.summary.escalation_count == 1
-    assert workspace.active_delivery_modes == ("baseline", "live")
-    assert workspace.assignments[0].state == "active"
-    assert workspace.assignments[1].state == "blocked"
-    assert any(signal.kind == "owner_missing" for signal in workspace.follow_up_signals)
-    assert any(signal.kind == "decision_due" for signal in workspace.follow_up_signals)
+    assert workspace.dossiers[0].owner_id == "manager:sanne"
+    assert workspace.assignments[0].owner_id == "manager:sanne"
+    assert workspace.dossiers[0].permission_envelope.can_update_assignments is False
+    assert workspace.dossiers[0].permission_envelope.can_manage_permissions is False
+    assert workspace.review_moments[0].scheduled_for == "Exit reviewmoment nog vastleggen"

--- a/tests/test_action_center_shared_core.py
+++ b/tests/test_action_center_shared_core.py
@@ -12,7 +12,11 @@ from backend.products.shared.action_center_core import (
     build_permission_envelope,
     summarize_workspace,
 )
-from backend.products.shared.action_center_mto import MtoDesignInput, describe_mto_design_input
+from backend.products.shared.action_center_mto import (
+    MtoDesignInput,
+    describe_mto_design_input,
+    get_mto_action_center_carrier,
+)
 
 
 def test_action_center_summary_stays_follow_through_bounded():
@@ -87,11 +91,14 @@ def test_mto_stays_design_only_while_future_product_adapters_stay_inactive():
             notes="Gebruik alleen als ontwerpinspiratie voor dossiervelden.",
         )
     )
+    mto_carrier = get_mto_action_center_carrier()
     retention_adapter = get_future_action_center_adapter("retention")
 
     assert design_input.mode == "design_input_only"
     assert design_input.can_create_assignments is False
     assert design_input.can_open_carrier is False
+    assert mto_carrier.label == "MTO-design-input"
+    assert mto_carrier.status == "inactive"
     assert retention_adapter.status == "inactive"
     assert retention_adapter.live_entry_enabled is False
 


### PR DESCRIPTION
## Summary
- tighten the first live ExitScan Action Center slice around boundedness, owner wording, permission claims, and review-status truth
- keep the same live consumer and same `klantlearnings` surface without opening any new product path
- preserve the bounded adapter setup while closing the remaining truth gaps called out in review

## Truth gaps corrected
- keep route-only ExitScan intake bounded: route-interest-only dossiers now stay in scope only while they are still unbound to another product or campaign
- change the live admin surface to shared-core `member` instead of `owner`, so the surface reads truthfully as read-only
- tighten owner wording so the page reflects explicit dossier holders from checkpoints instead of implying the surface itself owns the work
- tighten review wording so missing review moments read as not yet planned instead of implicitly scheduled
- restore MTO helper semantics to design-only and inactive, so this stacked truth-pass does not reintroduce MTO-first carrier claims outside the live ExitScan path

## Out of scope
- no new consumer
- no new Action Center surface
- no dashboard expansion beyond the existing utility-card wording
- no MTO-first framing
- no broad adapter wave

## Verification
- `python -m py_compile backend/products/shared/action_center_adapters.py backend/products/shared/action_center_exit.py backend/products/shared/action_center_mto.py tests/test_action_center_shared_core.py`
- `python -m pytest tests/test_action_center_shared_core.py`
- `npm run test -- lib/action-center-shared-core.test.ts app/(dashboard)/beheer/klantlearnings/page.test.ts app/(dashboard)/dashboard/page.test.ts`
- `npm run lint -- lib/action-center-adapters.ts lib/action-center-exit.ts lib/action-center-mto.ts lib/action-center-shared-core.test.ts app/(dashboard)/beheer/klantlearnings/page.tsx app/(dashboard)/beheer/klantlearnings/page.test.ts app/(dashboard)/dashboard/page.tsx app/(dashboard)/dashboard/page.test.ts`

## Chosen live consumer
- ExitScan only
- fed Action Center surface: `frontend/app/(dashboard)/beheer/klantlearnings/page.tsx`