### PR TITLE
[codex] Add ExitScan as second Action Center live consumer

### DIFF
--- a/backend/products/shared/action_center_adapters.py
+++ b/backend/products/shared/action_center_adapters.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 
-FutureActionCenterAdapterKey = Literal["exit", "retention", "onboarding", "pulse", "leadership"]
+FutureActionCenterAdapterKey = Literal["retention", "onboarding", "pulse", "leadership"]
 FutureActionCenterAdapterStatus = Literal["inactive"]
 
 
@@ -17,12 +17,6 @@ class FutureActionCenterAdapter:
 
 
 _FUTURE_ADAPTERS: dict[FutureActionCenterAdapterKey, FutureActionCenterAdapter] = {
-    "exit": FutureActionCenterAdapter(
-        key="exit",
-        label="ExitScan-adapter",
-        status="inactive",
-        live_entry_enabled=False,
-    ),
     "retention": FutureActionCenterAdapter(
         key="retention",
         label="RetentieScan-adapter",

--- a/backend/products/shared/action_center_exit.py
+++ b/backend/products/shared/action_center_exit.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from .action_center_core import (
+    ActionAssignment,
+    ActionDossier,
+    ActionFollowUpSignal,
+    ActionReviewMoment,
+    ActionWorkspaceSummary,
+    MemberRole,
+    build_permission_envelope,
+    summarize_workspace,
+)
+
+
+ExitCarrierStatus = Literal["active"]
+ExitCarrierRouteScope = Literal["exit_only"]
+ExitCarrierOwnerModel = Literal["explicit_named_owner"]
+ExitCarrierReviewDiscipline = Literal["follow_up_review_required"]
+ExitTriageStatus = Literal["nieuw", "bevestigd", "geparkeerd", "uitgevoerd", "verworpen"]
+ExitDeliveryMode = Literal["baseline", "live"]
+
+_OPEN_TRIAGE_STATUSES = {"nieuw", "bevestigd"}
+
+
+@dataclass(frozen=True)
+class ExitActionCenterCarrier:
+    key: Literal["exit"]
+    label: str
+    status: ExitCarrierStatus
+    workspace_kind: Literal["follow_through"]
+    route_scope: ExitCarrierRouteScope
+    owner_model: ExitCarrierOwnerModel
+    review_discipline: ExitCarrierReviewDiscipline
+    can_open_other_product_adapters: Literal[False]
+
+
+@dataclass(frozen=True)
+class ExitDossierInput:
+    id: str
+    title: str
+    triage_status: ExitTriageStatus
+    delivery_mode: ExitDeliveryMode | None
+    management_owner_label: str | None
+    review_owner_label: str | None
+    first_action_taken: str | None
+    review_moment: str | None
+    management_action_outcome: str | None
+    next_route: str | None
+    stop_reason: str | None
+
+
+@dataclass(frozen=True)
+class ExitActionCenterWorkspace:
+    carrier: ExitActionCenterCarrier
+    summary: ActionWorkspaceSummary
+    dossiers: list[ActionDossier]
+    assignments: list[ActionAssignment]
+    review_moments: list[ActionReviewMoment]
+    follow_up_signals: list[ActionFollowUpSignal]
+    active_delivery_modes: tuple[ExitDeliveryMode, ...]
+
+
+_EXIT_ACTION_CENTER_CARRIER = ExitActionCenterCarrier(
+    key="exit",
+    label="ExitScan-adapter",
+    status="active",
+    workspace_kind="follow_through",
+    route_scope="exit_only",
+    owner_model="explicit_named_owner",
+    review_discipline="follow_up_review_required",
+    can_open_other_product_adapters=False,
+)
+
+
+def _build_actor_id(prefix: str, value: str | None) -> str | None:
+    if not value:
+        return None
+    normalized = "-".join(value.strip().lower().split())
+    return f"{prefix}:{normalized}" if normalized else None
+
+
+def _is_open(triage_status: ExitTriageStatus) -> bool:
+    return triage_status in _OPEN_TRIAGE_STATUSES
+
+
+def get_exit_action_center_carrier() -> ExitActionCenterCarrier:
+    return _EXIT_ACTION_CENTER_CARRIER
+
+
+def build_exit_action_center_workspace(
+    *,
+    role: MemberRole | None,
+    dossiers: list[ExitDossierInput],
+) -> ExitActionCenterWorkspace:
+    shared_dossiers: list[ActionDossier] = []
+    assignments: list[ActionAssignment] = []
+    review_moments: list[ActionReviewMoment] = []
+    follow_up_signals: list[ActionFollowUpSignal] = []
+    active_delivery_modes = tuple(
+        sorted({dossier.delivery_mode for dossier in dossiers if dossier.delivery_mode in {"baseline", "live"}})
+    )
+
+    for dossier in dossiers:
+        permission_envelope = build_permission_envelope(role)
+        is_open = _is_open(dossier.triage_status)
+        has_follow_through_decision = bool(
+            dossier.management_action_outcome or dossier.next_route or dossier.stop_reason
+        )
+        management_owner_id = _build_actor_id("manager", dossier.management_owner_label)
+        review_owner_id = _build_actor_id("review", dossier.review_owner_label)
+        owner_id = management_owner_id or review_owner_id
+
+        shared_dossiers.append(
+            ActionDossier(
+                id=dossier.id,
+                title=dossier.title,
+                status="open" if is_open else "closed",
+                owner_id=owner_id,
+                permission_envelope=permission_envelope,
+            )
+        )
+
+        assignment_state = (
+            "completed"
+            if dossier.triage_status == "uitgevoerd"
+            else "cancelled"
+            if dossier.triage_status == "verworpen"
+            else "waiting"
+            if dossier.triage_status == "geparkeerd"
+            else "active"
+            if dossier.first_action_taken
+            else "blocked"
+        )
+        assignment_kind = (
+            "handoff"
+            if has_follow_through_decision
+            else "follow_up"
+            if dossier.first_action_taken
+            else "review_prep"
+        )
+        assignments.append(
+            ActionAssignment(
+                id=f"asg-{dossier.id}",
+                dossier_id=dossier.id,
+                title=dossier.first_action_taken or "Leg eerste ExitScan follow-up stap vast",
+                state=assignment_state,
+                kind=assignment_kind,
+                owner_id=owner_id,
+            )
+        )
+
+        review_state = (
+            "completed"
+            if dossier.triage_status == "uitgevoerd"
+            else "cancelled"
+            if dossier.triage_status in {"geparkeerd", "verworpen"}
+            else "due"
+        )
+        review_moments.append(
+            ActionReviewMoment(
+                id=f"rev-{dossier.id}",
+                dossier_id=dossier.id,
+                scheduled_for=dossier.review_moment or "Exit reviewmoment nog vastleggen",
+                state=review_state,
+            )
+        )
+
+        if is_open and not owner_id:
+            follow_up_signals.append(
+                ActionFollowUpSignal(
+                    id=f"sig-owner-{dossier.id}",
+                    dossier_id=dossier.id,
+                    kind="owner_missing",
+                    severity="warning",
+                    state="open",
+                )
+            )
+
+        if is_open and not dossier.first_action_taken:
+            follow_up_signals.append(
+                ActionFollowUpSignal(
+                    id=f"sig-step-{dossier.id}",
+                    dossier_id=dossier.id,
+                    kind="blocked_assignment",
+                    severity="critical",
+                    state="open",
+                )
+            )
+
+        if is_open:
+            follow_up_signals.append(
+                ActionFollowUpSignal(
+                    id=f"sig-review-{dossier.id}",
+                    dossier_id=dossier.id,
+                    kind="review_due",
+                    severity="warning",
+                    state="open",
+                )
+            )
+
+        if is_open and not has_follow_through_decision:
+            follow_up_signals.append(
+                ActionFollowUpSignal(
+                    id=f"sig-decision-{dossier.id}",
+                    dossier_id=dossier.id,
+                    kind="decision_due",
+                    severity="warning",
+                    state="open",
+                )
+            )
+
+    summary = summarize_workspace(
+        dossiers=shared_dossiers,
+        assignments=assignments,
+        review_moments=review_moments,
+        follow_up_signals=follow_up_signals,
+    )
+
+    return ExitActionCenterWorkspace(
+        carrier=_EXIT_ACTION_CENTER_CARRIER,
+        summary=summary,
+        dossiers=shared_dossiers,
+        assignments=assignments,
+        review_moments=review_moments,
+        follow_up_signals=follow_up_signals,
+        active_delivery_modes=active_delivery_modes,
+    )

--- a/backend/products/shared/action_center_exit.py
+++ b/backend/products/shared/action_center_exit.py
@@ -86,6 +86,10 @@ def _is_open(triage_status: ExitTriageStatus) -> bool:
     return triage_status in _OPEN_TRIAGE_STATUSES
 
 
+def _has_bounded_text(value: str | None) -> bool:
+    return bool(value and value.strip())
+
+
 def get_exit_action_center_carrier() -> ExitActionCenterCarrier:
     return _EXIT_ACTION_CENTER_CARRIER
 
@@ -109,6 +113,7 @@ def build_exit_action_center_workspace(
         has_follow_through_decision = bool(
             dossier.management_action_outcome or dossier.next_route or dossier.stop_reason
         )
+        has_review_moment = _has_bounded_text(dossier.review_moment)
         management_owner_id = _build_actor_id("manager", dossier.management_owner_label)
         review_owner_id = _build_actor_id("review", dossier.review_owner_label)
         owner_id = management_owner_id or review_owner_id
@@ -157,6 +162,8 @@ def build_exit_action_center_workspace(
             if dossier.triage_status == "uitgevoerd"
             else "cancelled"
             if dossier.triage_status in {"geparkeerd", "verworpen"}
+            else "scheduled"
+            if has_review_moment
             else "due"
         )
         review_moments.append(
@@ -190,7 +197,7 @@ def build_exit_action_center_workspace(
                 )
             )
 
-        if is_open:
+        if is_open and not has_review_moment:
             follow_up_signals.append(
                 ActionFollowUpSignal(
                     id=f"sig-review-{dossier.id}",

--- a/docs/superpowers/plans/2026-04-25-action-center-second-live-consumer.md
+++ b/docs/superpowers/plans/2026-04-25-action-center-second-live-consumer.md
@@ -1,0 +1,57 @@
+# Action Center Second Live Consumer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Connect exactly one additional live current product stream, ExitScan, to the existing Action Center product layer without opening any broader adapter, dashboard, public, or commercial scope.
+
+**Architecture:** Keep the existing shared Action Center core and current MTO carrier intact. Add one bounded ExitScan carrier contract in backend and frontend, then surface that contract on the existing `/beheer/klantlearnings` Action Center page as a second live consumer fed only by current ExitScan learning dossiers, checkpoints, leads, and campaigns.
+
+**Tech Stack:** Python dataclasses and pytest for backend shared-core contracts; Next.js/TypeScript/Vitest for frontend carrier and surface checks; Supabase-backed learning dossier runtime already present in the page.
+
+---
+
+### Task 1: Lock the second-consumer contract in tests
+
+**Files:**
+- Modify: `tests/test_action_center_shared_core.py`
+- Modify: `frontend/lib/action-center-shared-core.test.ts`
+- Modify: `frontend/app/(dashboard)/beheer/klantlearnings/page.test.ts`
+
+- [ ] Add backend expectations that ExitScan can become one additional active product consumer while non-selected future adapters stay inactive.
+- [ ] Add frontend expectations for the mirrored ExitScan carrier contract and shared-core projection.
+- [ ] Add a source-level Action Center surface test that requires both the existing MTO carrier and the new ExitScan section to coexist on the page.
+- [ ] Run the targeted backend and frontend tests and confirm they fail for the missing ExitScan implementation or surface strings.
+
+### Task 2: Implement the bounded ExitScan carrier
+
+**Files:**
+- Create: `backend/products/shared/action_center_exit.py`
+- Modify: `backend/products/shared/action_center_adapters.py`
+- Create: `frontend/lib/action-center-exit.ts`
+- Modify: `frontend/lib/action-center-adapters.ts`
+
+- [ ] Add the smallest shared-core projection for ExitScan with explicit owner binding, follow-up review discipline, and no cross-product adapter opening.
+- [ ] Keep every non-Exit future adapter inactive and unchanged apart from removing ExitScan from the future-adapter list.
+- [ ] Mirror the same bounded contract in TypeScript so frontend and backend stay truthy to the same shape.
+- [ ] Re-run the targeted shared-core tests until both backend and frontend carrier tests pass.
+
+### Task 3: Wire one real Action Center surface
+
+**Files:**
+- Modify: `frontend/app/(dashboard)/beheer/klantlearnings/page.tsx`
+
+- [ ] Derive a live ExitScan slice from existing learning workbench inputs only: ExitScan campaigns, dossiers, leads, checkpoints, and related org access counts.
+- [ ] Keep the current MTO Action Center section intact and add one clearly bounded ExitScan section to the same page.
+- [ ] Reuse existing dashboard primitives and workbench components; do not open a new route, dashboard, or buyer-facing surface.
+- [ ] Re-run the page source test until it passes.
+
+### Task 4: Verify, ship, and publish
+
+**Files:**
+- No planned source changes unless verification reveals a focused defect.
+
+- [ ] Run targeted backend tests: `C:\Users\larsh\Desktop\Business\Verisight\.venv\Scripts\python.exe -m pytest tests/test_action_center_shared_core.py -q`
+- [ ] Install frontend dependencies in the worktree with `npm ci` if needed, then run targeted frontend tests.
+- [ ] Run a frontend build check with `npm run build`.
+- [ ] Start a narrow runtime check for `/beheer/klantlearnings`, confirm the new ExitScan section renders on the existing Action Center surface, then stop the dev server.
+- [ ] Commit with a focused message, push `codex/action-center-second-live-consumer`, and open a draft PR.

--- a/frontend/app/(dashboard)/beheer/klantlearnings/page.test.ts
+++ b/frontend/app/(dashboard)/beheer/klantlearnings/page.test.ts
@@ -2,14 +2,19 @@ import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
 describe('klantlearnings action center landing', () => {
-  it('keeps MTO on the shared action center core without opening other carriers', () => {
+  it('keeps MTO live and adds ExitScan as exactly one additional consumer on the same action center surface', () => {
     const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
 
     expect(source).toContain("buildMtoActionCenterWorkspace")
+    expect(source).toContain('buildExitActionCenterWorkspace')
     expect(source).toContain('Action Center voor MTO-follow-through')
     expect(source).toContain('Operations Action Center')
     expect(source).toContain('Shared follow-through voor cockpit, dossiers en reviews')
     expect(source).toContain('HR blijft de centrale eigenaar')
+    expect(source).toContain('ExitScan live consumer')
+    expect(source).toContain('Shared follow-through voor ExitScan-dossiers, reviews en workbench')
+    expect(source).toContain('Open ExitScan follow-through')
+    expect(source).toContain('Nog geen open ExitScan-dossiers')
     expect(source).toContain('Reviewdruk')
     expect(source).toContain('Dossier-first')
     expect(source).toContain('Nog geen open MTO-dossiers')

--- a/frontend/app/(dashboard)/beheer/klantlearnings/page.tsx
+++ b/frontend/app/(dashboard)/beheer/klantlearnings/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { PilotLearningWorkbench } from '@/components/dashboard/pilot-learning-workbench'
+import { buildExitActionCenterWorkspace } from '@/lib/action-center-exit'
 import {
   buildMtoActionCenterWorkspace,
   normalizeMtoManagerLabel,
@@ -34,6 +35,19 @@ interface Props {
 
 function getSingleValue(value: string | string[] | undefined) {
   return typeof value === 'string' ? value : null
+}
+
+function isExitRouteInterest(value: ContactRequestRecord['route_interest'] | ContactRequestRecord['qualified_route']) {
+  return value === 'exitscan'
+}
+
+function filterCountsByOrgIds(source: Record<string, number>, orgIds: Set<string>) {
+  return Object.entries(source).reduce<Record<string, number>>((acc, [orgId, count]) => {
+    if (orgIds.has(orgId)) {
+      acc[orgId] = count
+    }
+    return acc
+  }, {})
 }
 
 const ACTION_ASSIGNMENT_STATE_LABELS: Record<ActionCenterAssignmentState, string> = {
@@ -165,6 +179,35 @@ export default async function KlantLearningsPage({ searchParams }: Props) {
     acc[checkpoint.dossier_id].push(checkpoint)
     return acc
   }, {})
+  const exitCampaigns = campaigns.filter((campaign) => campaign.scan_type === 'exit')
+  const exitCampaignIds = new Set(exitCampaigns.map((campaign) => campaign.id))
+  const exitCampaignStats = campaignStats.filter(
+    (stats) => stats.scan_type === 'exit' || exitCampaignIds.has(stats.campaign_id),
+  )
+  const exitDossiers = dossiers.filter(
+    (dossier) =>
+      dossier.scan_type === 'exit' ||
+      dossier.route_interest === 'exitscan' ||
+      (dossier.campaign_id ? exitCampaignIds.has(dossier.campaign_id) : false),
+  )
+  const exitDossierIds = new Set(exitDossiers.map((dossier) => dossier.id))
+  const exitCheckpoints = checkpoints.filter((checkpoint) => exitDossierIds.has(checkpoint.dossier_id))
+  const exitLeads = leads.filter(
+    (lead) =>
+      isExitRouteInterest(lead.route_interest) ||
+      isExitRouteInterest(lead.qualified_route) ||
+      exitDossiers.some((dossier) => dossier.contact_request_id === lead.id),
+  )
+  const exitOrgIds = new Set<string>([
+    ...exitCampaigns.map((campaign) => campaign.organization_id),
+    ...exitDossiers
+      .map((dossier) => dossier.organization_id)
+      .filter((value): value is string => Boolean(value)),
+  ])
+  const exitOrgs = activeOrgs.filter((org) => exitOrgIds.has(org.id))
+  const exitActiveClientAccessByOrg = filterCountsByOrgIds(activeClientAccessByOrg, exitOrgIds)
+  const exitPendingClientInvitesByOrg = filterCountsByOrgIds(pendingClientInvitesByOrg, exitOrgIds)
+
   const mtoWorkspace = buildMtoActionCenterWorkspace({
     role: 'owner',
     dossiers: dossiers
@@ -189,8 +232,43 @@ export default async function KlantLearningsPage({ searchParams }: Props) {
       }),
   })
   const openMtoDossiers = mtoWorkspace.dossiers.filter((dossier) => dossier.status === 'open')
-  const reviewPressureItems = mtoWorkspace.reviewMoments.filter((reviewMoment) => reviewMoment.state === 'due')
-  const openSignals = mtoWorkspace.followUpSignals.filter((signal) => signal.state === 'open')
+  const mtoReviewPressureItems = mtoWorkspace.reviewMoments.filter((reviewMoment) => reviewMoment.state === 'due')
+  const mtoOpenSignals = mtoWorkspace.followUpSignals.filter((signal) => signal.state === 'open')
+  const exitWorkspace = buildExitActionCenterWorkspace({
+    role: 'owner',
+    dossiers: exitDossiers.map((dossier) => {
+      const dossierCheckpoints = checkpointsByDossier[dossier.id] ?? []
+      const firstManagementCheckpoint =
+        dossierCheckpoints.find((checkpoint) => checkpoint.checkpoint_key === 'first_management_use') ?? null
+      const followUpReviewCheckpoint =
+        dossierCheckpoints.find((checkpoint) => checkpoint.checkpoint_key === 'follow_up_review') ?? null
+
+      return {
+        id: dossier.id,
+        title: dossier.title,
+        triageStatus: dossier.triage_status,
+        deliveryMode: dossier.delivery_mode,
+        managementOwnerLabel: firstManagementCheckpoint?.owner_label ?? null,
+        reviewOwnerLabel: followUpReviewCheckpoint?.owner_label ?? null,
+        firstActionTaken: dossier.first_action_taken,
+        reviewMoment: dossier.review_moment,
+        managementActionOutcome: dossier.management_action_outcome,
+        nextRoute: dossier.next_route,
+        stopReason: dossier.stop_reason,
+      }
+    }),
+  })
+  const openExitDossiers = exitWorkspace.dossiers.filter((dossier) => dossier.status === 'open')
+  const exitReviewPressureItems = exitWorkspace.reviewMoments.filter((reviewMoment) => reviewMoment.state === 'due')
+  const exitOpenSignals = exitWorkspace.followUpSignals.filter((signal) => signal.state === 'open')
+  const exitOpenLessons = exitCheckpoints.filter((checkpoint) => checkpoint.status === 'nieuw').length
+  const exitConfirmedLessons = exitCheckpoints.filter((checkpoint) => checkpoint.status === 'bevestigd').length
+  const exitCampaignLinkedDossiers = exitDossiers.filter((dossier) => dossier.campaign_id).length
+  const exitLeadLinkedDossiers = exitDossiers.filter((dossier) => dossier.contact_request_id).length
+  const initialExitLeadId = exitLeads.some((lead) => lead.id === initialLeadId) ? initialLeadId : null
+  const initialExitCampaignId = exitCampaigns.some((campaign) => campaign.id === initialCampaignId)
+    ? initialCampaignId
+    : null
 
   return (
     <div className="space-y-6">
@@ -276,6 +354,7 @@ export default async function KlantLearningsPage({ searchParams }: Props) {
         ]}
         anchors={[
           { id: 'action-center', label: 'Action Center' },
+          { id: 'exit-consumer', label: 'ExitScan' },
           { id: 'dekking', label: 'Dekking' },
           { id: 'issues', label: 'Issues' },
           { id: 'workbench', label: 'Workbench' },
@@ -385,19 +464,138 @@ export default async function KlantLearningsPage({ searchParams }: Props) {
               </div>
               <DashboardChip
                 surface="ops"
-                label={`${reviewPressureItems.length} review${reviewPressureItems.length === 1 ? '' : 's'}`}
-                tone={reviewPressureItems.length > 0 ? 'amber' : 'slate'}
+                label={`${mtoReviewPressureItems.length} review${mtoReviewPressureItems.length === 1 ? '' : 's'}`}
+                tone={mtoReviewPressureItems.length > 0 ? 'amber' : 'slate'}
               />
             </div>
             <div className="mt-4 space-y-3">
-              {reviewPressureItems.length === 0 ? (
+              {mtoReviewPressureItems.length === 0 ? (
                 <p className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-3 text-sm leading-6 text-slate-600">
                   Geen actieve reviewdruk. De shared core houdt deze lijst leeg zodra dossiers geparkeerd, uitgevoerd of bewust gestopt zijn.
                 </p>
               ) : (
-                reviewPressureItems.slice(0, 5).map((reviewMoment) => {
+                mtoReviewPressureItems.slice(0, 5).map((reviewMoment) => {
                   const dossier = mtoWorkspace.dossiers.find((item) => item.id === reviewMoment.dossierId)
-                  const signals = openSignals.filter((signal) => signal.dossierId === reviewMoment.dossierId)
+                  const signals = mtoOpenSignals.filter((signal) => signal.dossierId === reviewMoment.dossierId)
+
+                  return (
+                    <div key={reviewMoment.id} className="rounded-2xl border border-slate-200 bg-slate-50/70 px-4 py-4">
+                      <p className="text-sm font-semibold text-slate-950">{dossier?.title ?? reviewMoment.dossierId}</p>
+                      <p className="mt-2 text-sm leading-6 text-slate-600">{reviewMoment.scheduledFor}</p>
+                      <p className="mt-1 text-xs text-slate-500">
+                        Open signalen: {signals.map((signal) => ACTION_SIGNAL_KIND_LABELS[signal.kind]).join(', ') || 'geen'}
+                      </p>
+                    </div>
+                  )
+                })
+              )}
+            </div>
+          </div>
+        </div>
+      </DashboardSection>
+
+      <DashboardSection
+        id="exit-consumer"
+        surface="ops"
+        eyebrow="ExitScan live consumer"
+        title="Shared follow-through voor ExitScan-dossiers, reviews en workbench"
+        description="Deze tweede live consumer leest alleen de huidige ExitScan-stroom uit learningdossiers, checkpoints, leads en campaigncontext. De bounded carrier houdt reviewdruk, eigenaar en follow-through dossier-first zonder andere productlagen te openen."
+        aside={<DashboardChip surface="ops" label={`${exitWorkspace.carrier.label} · actief`} tone="slate" />}
+      >
+        <div className="grid gap-4 xl:grid-cols-4">
+          <DashboardPanel
+            surface="ops"
+            eyebrow="Expliciete eigenaar"
+            title="Owner-model"
+            value={exitWorkspace.dossiers.some((dossier) => dossier.ownerId) ? 'Named owner' : 'Nog open'}
+            body="ExitScan bindt alleen expliciete management- of revieweigenaars uit bestaande checkpoints. Zonder eigenaar blijft alleen het bounded signaal zichtbaar."
+            tone="slate"
+          />
+          <DashboardPanel
+            surface="ops"
+            eyebrow="Reviewdruk"
+            title="Actieve reviewqueue"
+            value={`${exitWorkspace.summary.reviewDueCount}`}
+            body="Open ExitScan-dossiers blijven zichtbaar tot reviewmoment, uitkomst of stopbesluit expliciet is vastgelegd."
+            tone={exitWorkspace.summary.reviewDueCount > 0 ? 'amber' : 'slate'}
+          />
+          <DashboardPanel
+            surface="ops"
+            eyebrow="Dossier-first"
+            title="Open ExitScan follow-through"
+            value={`${exitWorkspace.summary.openDossierCount}`}
+            body="Besluit, eerste stap en vervolgrichting blijven gegroepeerd per ExitScan-dossier in plaats van te verdwijnen in losse workbenchnotities."
+            tone={exitWorkspace.summary.openDossierCount > 0 ? 'slate' : 'amber'}
+          />
+          <DashboardPanel
+            surface="ops"
+            eyebrow="Delivery"
+            title="Actieve routes"
+            value={exitWorkspace.activeDeliveryModes.length > 0 ? exitWorkspace.activeDeliveryModes.join(' / ') : 'Nog open'}
+            body="Alleen bestaande ExitScan deliverymodes tellen mee. Geen nieuwe suiteverbreding, geen extra productroutes."
+            tone="slate"
+          />
+        </div>
+
+        <div className="mt-4 grid gap-4 xl:grid-cols-2">
+          <div className="rounded-[24px] border border-slate-200 bg-white p-5 shadow-sm">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Dossiers</p>
+                <h3 className="mt-2 text-lg font-semibold text-slate-950">Open ExitScan follow-through</h3>
+              </div>
+              <DashboardChip
+                surface="ops"
+                label={`${openExitDossiers.length} open`}
+                tone={openExitDossiers.length > 0 ? 'amber' : 'slate'}
+              />
+            </div>
+            <div className="mt-4 space-y-3">
+              {openExitDossiers.length === 0 ? (
+                <p className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-3 text-sm leading-6 text-slate-600">
+                  Nog geen open ExitScan-dossiers. Zodra ExitScan follow-through leerwaarde geeft, verschijnt de dossierqueue hier automatisch.
+                </p>
+              ) : (
+                openExitDossiers.slice(0, 5).map((dossier) => {
+                  const assignment = exitWorkspace.assignments.find((item) => item.dossierId === dossier.id)
+                  return (
+                    <div key={dossier.id} className="rounded-2xl border border-slate-200 bg-slate-50/70 px-4 py-4">
+                      <p className="text-sm font-semibold text-slate-950">{dossier.title}</p>
+                      <p className="mt-2 text-sm leading-6 text-slate-600">
+                        Eerste stap: {assignment?.title ?? 'Nog niet vastgelegd'}.
+                      </p>
+                      <p className="mt-1 text-xs text-slate-500">
+                        Status {assignment ? ACTION_ASSIGNMENT_STATE_LABELS[assignment.state] : 'Onbekend'} · Bewerkbaarheid:{' '}
+                        {dossier.permissionEnvelope.canUpdateAssignments ? 'Bewerkbaar' : 'Alleen lezen'}
+                      </p>
+                    </div>
+                  )
+                })
+              )}
+            </div>
+          </div>
+
+          <div className="rounded-[24px] border border-slate-200 bg-white p-5 shadow-sm">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Reviews</p>
+                <h3 className="mt-2 text-lg font-semibold text-slate-950">Exit reviewdruk en open signalen</h3>
+              </div>
+              <DashboardChip
+                surface="ops"
+                label={`${exitReviewPressureItems.length} review${exitReviewPressureItems.length === 1 ? '' : 's'}`}
+                tone={exitReviewPressureItems.length > 0 ? 'amber' : 'slate'}
+              />
+            </div>
+            <div className="mt-4 space-y-3">
+              {exitReviewPressureItems.length === 0 ? (
+                <p className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-3 text-sm leading-6 text-slate-600">
+                  Geen actieve Exit reviewdruk. De shared core houdt deze lijst leeg zodra dossiers geparkeerd, uitgevoerd of bewust gestopt zijn.
+                </p>
+              ) : (
+                exitReviewPressureItems.slice(0, 5).map((reviewMoment) => {
+                  const dossier = exitWorkspace.dossiers.find((item) => item.id === reviewMoment.dossierId)
+                  const signals = exitOpenSignals.filter((signal) => signal.dossierId === reviewMoment.dossierId)
 
                   return (
                     <div key={reviewMoment.id} className="rounded-2xl border border-slate-200 bg-slate-50/70 px-4 py-4">
@@ -494,6 +692,64 @@ export default async function KlantLearningsPage({ searchParams }: Props) {
           initialLeadId={initialLeadId}
           initialCampaignId={initialCampaignId}
         />
+      </DashboardSection>
+
+      <DashboardSection
+        surface="ops"
+        eyebrow="ExitScan workbench"
+        title="ExitScan learninglog en dossiers"
+        description="Deze bounded workbench laat alleen de huidige ExitScan-route zien: echte leads, campagnes, dossiers en checkpoints die al in de runtime bestaan."
+        aside={<DashboardChip surface="ops" label={`${exitOrgs.length} actieve organisatie${exitOrgs.length === 1 ? '' : 's'}`} tone="slate" />}
+      >
+        <div className="grid gap-4 xl:grid-cols-4">
+          <DashboardPanel
+            surface="ops"
+            eyebrow="Coverage"
+            title="Open checkpoints"
+            value={`${exitOpenLessons}`}
+            body="Alleen ExitScan-checkpoints tellen mee in deze workbenchslice."
+            tone={exitOpenLessons > 0 ? 'amber' : 'slate'}
+          />
+          <DashboardPanel
+            surface="ops"
+            eyebrow="Bevestigd"
+            title="Bevestigde lessen"
+            value={`${exitConfirmedLessons}`}
+            body="Bevestigde ExitScan-lessen blijven binnen deze consumer, niet in een brede suitebak."
+            tone={exitConfirmedLessons > 0 ? 'emerald' : 'slate'}
+          />
+          <DashboardPanel
+            surface="ops"
+            eyebrow="Leadkoppeling"
+            title="Leadbinding"
+            value={`${exitLeadLinkedDossiers}/${exitDossiers.length || 0}`}
+            body="Exit-intake hoort gekoppeld te blijven aan de follow-through van dezelfde route."
+            tone="slate"
+          />
+          <DashboardPanel
+            surface="ops"
+            eyebrow="Campaignkoppeling"
+            title="Deliverybinding"
+            value={`${exitCampaignLinkedDossiers}/${exitDossiers.length || 0}`}
+            body="Koppel alleen echte ExitScan-campaigns terug in deze consumer."
+            tone="slate"
+          />
+        </div>
+
+        <div className="mt-4">
+          <PilotLearningWorkbench
+            orgs={exitOrgs}
+            campaigns={exitCampaigns}
+            campaignStats={exitCampaignStats}
+            leads={exitLeads as ContactRequestRecord[]}
+            dossiers={exitDossiers}
+            checkpoints={exitCheckpoints}
+            activeClientAccessByOrg={exitActiveClientAccessByOrg}
+            pendingClientInvitesByOrg={exitPendingClientInvitesByOrg}
+            initialLeadId={initialExitLeadId}
+            initialCampaignId={initialExitCampaignId}
+          />
+        </div>
       </DashboardSection>
     </div>
   )

--- a/frontend/lib/action-center-adapters.ts
+++ b/frontend/lib/action-center-adapters.ts
@@ -1,5 +1,4 @@
 export type FutureActionCenterAdapterKey =
-  | 'exit'
   | 'retention'
   | 'onboarding'
   | 'pulse'
@@ -15,7 +14,6 @@ export interface FutureActionCenterAdapter {
 }
 
 const FUTURE_ADAPTERS: Record<FutureActionCenterAdapterKey, FutureActionCenterAdapter> = {
-  exit: { key: 'exit', label: 'ExitScan-adapter', status: 'inactive', liveEntryEnabled: false },
   retention: { key: 'retention', label: 'RetentieScan-adapter', status: 'inactive', liveEntryEnabled: false },
   onboarding: { key: 'onboarding', label: 'Onboarding-adapter', status: 'inactive', liveEntryEnabled: false },
   pulse: { key: 'pulse', label: 'Pulse-adapter', status: 'inactive', liveEntryEnabled: false },

--- a/frontend/lib/action-center-exit.ts
+++ b/frontend/lib/action-center-exit.ts
@@ -74,6 +74,10 @@ function isOpen(triageStatus: ExitTriageStatus) {
   return OPEN_TRIAGE_STATUSES.has(triageStatus)
 }
 
+function hasBoundedText(value: string | null) {
+  return Boolean(value?.trim())
+}
+
 function isExitDeliveryMode(value: ExitDeliveryMode | null): value is ExitDeliveryMode {
   return value === 'baseline' || value === 'live'
 }
@@ -100,6 +104,7 @@ export function buildExitActionCenterWorkspace(args: {
     const hasFollowThroughDecision = Boolean(
       dossier.managementActionOutcome || dossier.nextRoute || dossier.stopReason,
     )
+    const hasReviewMoment = hasBoundedText(dossier.reviewMoment)
     const managementOwnerId = buildActorId('manager', dossier.managementOwnerLabel)
     const reviewOwnerId = buildActorId('review', dossier.reviewOwnerLabel)
     const ownerId = managementOwnerId ?? reviewOwnerId
@@ -139,6 +144,8 @@ export function buildExitActionCenterWorkspace(args: {
         ? 'completed'
         : dossier.triageStatus === 'geparkeerd' || dossier.triageStatus === 'verworpen'
           ? 'cancelled'
+          : hasReviewMoment
+            ? 'scheduled'
           : 'due'
 
     reviewMoments.push({
@@ -168,7 +175,7 @@ export function buildExitActionCenterWorkspace(args: {
       })
     }
 
-    if (open) {
+    if (open && !hasReviewMoment) {
       followUpSignals.push({
         id: `sig-review-${dossier.id}`,
         dossierId: dossier.id,

--- a/frontend/lib/action-center-exit.ts
+++ b/frontend/lib/action-center-exit.ts
@@ -1,0 +1,206 @@
+import {
+  buildActionCenterPermissionEnvelope,
+  buildActionCenterWorkspaceSummary,
+  type ActionCenterAssignment,
+  type ActionCenterDossier,
+  type ActionCenterFollowUpSignal,
+  type ActionCenterReviewMoment,
+  type ActionCenterWorkspaceSummary,
+} from '@/lib/action-center-shared-core'
+import type { MemberRole } from '@/lib/types'
+
+export type ExitCarrierStatus = 'active'
+export type ExitCarrierRouteScope = 'exit_only'
+export type ExitCarrierOwnerModel = 'explicit_named_owner'
+export type ExitCarrierReviewDiscipline = 'follow_up_review_required'
+export type ExitTriageStatus = 'nieuw' | 'bevestigd' | 'geparkeerd' | 'uitgevoerd' | 'verworpen'
+export type ExitDeliveryMode = 'baseline' | 'live'
+
+const OPEN_TRIAGE_STATUSES = new Set<ExitTriageStatus>(['nieuw', 'bevestigd'])
+
+export interface ExitActionCenterCarrier {
+  key: 'exit'
+  label: string
+  status: ExitCarrierStatus
+  workspaceKind: 'follow_through'
+  routeScope: ExitCarrierRouteScope
+  ownerModel: ExitCarrierOwnerModel
+  reviewDiscipline: ExitCarrierReviewDiscipline
+  canOpenOtherProductAdapters: false
+}
+
+export interface ExitDossierInput {
+  id: string
+  title: string
+  triageStatus: ExitTriageStatus
+  deliveryMode: ExitDeliveryMode | null
+  managementOwnerLabel: string | null
+  reviewOwnerLabel: string | null
+  firstActionTaken: string | null
+  reviewMoment: string | null
+  managementActionOutcome: string | null
+  nextRoute: string | null
+  stopReason: string | null
+}
+
+export interface ExitActionCenterWorkspace {
+  carrier: ExitActionCenterCarrier
+  summary: ActionCenterWorkspaceSummary
+  dossiers: ActionCenterDossier[]
+  assignments: ActionCenterAssignment[]
+  reviewMoments: ActionCenterReviewMoment[]
+  followUpSignals: ActionCenterFollowUpSignal[]
+  activeDeliveryModes: ExitDeliveryMode[]
+}
+
+const EXIT_ACTION_CENTER_CARRIER: ExitActionCenterCarrier = {
+  key: 'exit',
+  label: 'ExitScan-adapter',
+  status: 'active',
+  workspaceKind: 'follow_through',
+  routeScope: 'exit_only',
+  ownerModel: 'explicit_named_owner',
+  reviewDiscipline: 'follow_up_review_required',
+  canOpenOtherProductAdapters: false,
+}
+
+function buildActorId(prefix: string, value: string | null) {
+  if (!value) return null
+  const normalized = value.trim().toLowerCase().split(/\s+/).join('-')
+  return normalized ? `${prefix}:${normalized}` : null
+}
+
+function isOpen(triageStatus: ExitTriageStatus) {
+  return OPEN_TRIAGE_STATUSES.has(triageStatus)
+}
+
+function isExitDeliveryMode(value: ExitDeliveryMode | null): value is ExitDeliveryMode {
+  return value === 'baseline' || value === 'live'
+}
+
+export function getExitActionCenterCarrier() {
+  return EXIT_ACTION_CENTER_CARRIER
+}
+
+export function buildExitActionCenterWorkspace(args: {
+  role: MemberRole | null | undefined
+  dossiers: ExitDossierInput[]
+}): ExitActionCenterWorkspace {
+  const dossiers: ActionCenterDossier[] = []
+  const assignments: ActionCenterAssignment[] = []
+  const reviewMoments: ActionCenterReviewMoment[] = []
+  const followUpSignals: ActionCenterFollowUpSignal[] = []
+  const activeDeliveryModes = Array.from(
+    new Set(args.dossiers.map((dossier) => dossier.deliveryMode).filter(isExitDeliveryMode)),
+  ).sort((left, right) => left.localeCompare(right))
+
+  for (const dossier of args.dossiers) {
+    const permissionEnvelope = buildActionCenterPermissionEnvelope({ role: args.role })
+    const open = isOpen(dossier.triageStatus)
+    const hasFollowThroughDecision = Boolean(
+      dossier.managementActionOutcome || dossier.nextRoute || dossier.stopReason,
+    )
+    const managementOwnerId = buildActorId('manager', dossier.managementOwnerLabel)
+    const reviewOwnerId = buildActorId('review', dossier.reviewOwnerLabel)
+    const ownerId = managementOwnerId ?? reviewOwnerId
+
+    dossiers.push({
+      id: dossier.id,
+      title: dossier.title,
+      status: open ? 'open' : 'closed',
+      ownerId,
+      permissionEnvelope,
+    })
+
+    const assignmentState =
+      dossier.triageStatus === 'uitgevoerd'
+        ? 'completed'
+        : dossier.triageStatus === 'verworpen'
+          ? 'cancelled'
+          : dossier.triageStatus === 'geparkeerd'
+            ? 'waiting'
+            : dossier.firstActionTaken
+              ? 'active'
+              : 'blocked'
+    const assignmentKind =
+      hasFollowThroughDecision ? 'handoff' : dossier.firstActionTaken ? 'follow_up' : 'review_prep'
+
+    assignments.push({
+      id: `asg-${dossier.id}`,
+      dossierId: dossier.id,
+      title: dossier.firstActionTaken ?? 'Leg eerste ExitScan follow-up stap vast',
+      state: assignmentState,
+      kind: assignmentKind,
+      ownerId,
+    })
+
+    const reviewState =
+      dossier.triageStatus === 'uitgevoerd'
+        ? 'completed'
+        : dossier.triageStatus === 'geparkeerd' || dossier.triageStatus === 'verworpen'
+          ? 'cancelled'
+          : 'due'
+
+    reviewMoments.push({
+      id: `rev-${dossier.id}`,
+      dossierId: dossier.id,
+      scheduledFor: dossier.reviewMoment ?? 'Exit reviewmoment nog vastleggen',
+      state: reviewState,
+    })
+
+    if (open && !ownerId) {
+      followUpSignals.push({
+        id: `sig-owner-${dossier.id}`,
+        dossierId: dossier.id,
+        kind: 'owner_missing',
+        severity: 'warning',
+        state: 'open',
+      })
+    }
+
+    if (open && !dossier.firstActionTaken) {
+      followUpSignals.push({
+        id: `sig-step-${dossier.id}`,
+        dossierId: dossier.id,
+        kind: 'blocked_assignment',
+        severity: 'critical',
+        state: 'open',
+      })
+    }
+
+    if (open) {
+      followUpSignals.push({
+        id: `sig-review-${dossier.id}`,
+        dossierId: dossier.id,
+        kind: 'review_due',
+        severity: 'warning',
+        state: 'open',
+      })
+    }
+
+    if (open && !hasFollowThroughDecision) {
+      followUpSignals.push({
+        id: `sig-decision-${dossier.id}`,
+        dossierId: dossier.id,
+        kind: 'decision_due',
+        severity: 'warning',
+        state: 'open',
+      })
+    }
+  }
+
+  return {
+    carrier: EXIT_ACTION_CENTER_CARRIER,
+    summary: buildActionCenterWorkspaceSummary({
+      dossiers,
+      assignments,
+      reviewMoments,
+      followUpSignals,
+    }),
+    dossiers,
+    assignments,
+    reviewMoments,
+    followUpSignals,
+    activeDeliveryModes,
+  }
+}

--- a/frontend/lib/action-center-shared-core.test.ts
+++ b/frontend/lib/action-center-shared-core.test.ts
@@ -5,6 +5,7 @@ import {
   buildActionCenterWorkspaceSummary,
   getFutureActionCenterAdapter,
 } from '@/lib/action-center-shared-core'
+import { buildExitActionCenterWorkspace, getExitActionCenterCarrier } from '@/lib/action-center-exit'
 import {
   buildMtoActionCenterWorkspace,
   describeMtoDesignInput,
@@ -79,14 +80,14 @@ describe('action center shared core', () => {
     expect(ownerEnvelope.canOpenProductAdapters).toBe(false)
   })
 
-  it('activates MTO as the first action center carrier while future adapters stay inactive', () => {
+  it('keeps MTO active while non-selected future adapters stay inactive', () => {
     const mtoDesignInput = describeMtoDesignInput({
       source: 'mto',
       themes: ['werkdruk', 'rolhelderheid'],
       notes: 'Gebruik alleen als ontwerpinspiratie voor dossiervelden.',
     })
     const carrier = getMtoActionCenterCarrier()
-    const exitAdapter = getFutureActionCenterAdapter('exit')
+    const retentionAdapter = getFutureActionCenterAdapter('retention')
 
     expect(carrier.status).toBe('active')
     expect(carrier.workspaceKind).toBe('follow_through')
@@ -98,8 +99,8 @@ describe('action center shared core', () => {
     expect(mtoDesignInput.mode).toBe('active_follow_through')
     expect(mtoDesignInput.canCreateAssignments).toBe(true)
     expect(mtoDesignInput.canOpenCarrier).toBe(true)
-    expect(exitAdapter.status).toBe('inactive')
-    expect(exitAdapter.liveEntryEnabled).toBe(false)
+    expect(retentionAdapter.status).toBe('inactive')
+    expect(retentionAdapter.liveEntryEnabled).toBe(false)
   })
 
   it('projects MTO dossiers and review pressure onto the shared follow-through core', () => {
@@ -148,6 +149,67 @@ describe('action center shared core', () => {
     expect(workspace.followUpSignals.some((signal) => signal.kind === 'owner_missing')).toBe(true)
     expect(workspace.followUpSignals.some((signal) => signal.kind === 'decision_due')).toBe(true)
     expect(workspace.followUpSignals.filter((signal) => signal.kind === 'review_due')).toHaveLength(1)
+  })
+
+  it('adds ExitScan as one additional live consumer without opening other adapters', () => {
+    const carrier = getExitActionCenterCarrier()
+    const retentionAdapter = getFutureActionCenterAdapter('retention')
+
+    expect(carrier.label).toBe('ExitScan-adapter')
+    expect(carrier.status).toBe('active')
+    expect(carrier.workspaceKind).toBe('follow_through')
+    expect(carrier.routeScope).toBe('exit_only')
+    expect(carrier.ownerModel).toBe('explicit_named_owner')
+    expect(carrier.reviewDiscipline).toBe('follow_up_review_required')
+    expect(carrier.canOpenOtherProductAdapters).toBe(false)
+    expect(retentionAdapter.status).toBe('inactive')
+    expect(retentionAdapter.liveEntryEnabled).toBe(false)
+  })
+
+  it('projects ExitScan dossiers and review pressure onto the shared follow-through core', () => {
+    const workspace = buildExitActionCenterWorkspace({
+      role: 'owner',
+      dossiers: [
+        {
+          id: 'dos-1',
+          title: 'ExitScan - Support closeout',
+          triageStatus: 'bevestigd',
+          deliveryMode: 'live',
+          managementOwnerLabel: 'Sanne',
+          reviewOwnerLabel: 'Verisight',
+          firstActionTaken: 'Plan exit-closeout met HR en teamlead',
+          reviewMoment: 'Herlees over 30 dagen',
+          managementActionOutcome: null,
+          nextRoute: null,
+          stopReason: null,
+        },
+        {
+          id: 'dos-2',
+          title: 'ExitScan - Sales closeout',
+          triageStatus: 'nieuw',
+          deliveryMode: 'baseline',
+          managementOwnerLabel: null,
+          reviewOwnerLabel: null,
+          firstActionTaken: null,
+          reviewMoment: null,
+          managementActionOutcome: null,
+          nextRoute: null,
+          stopReason: null,
+        },
+      ],
+    })
+
+    expect(workspace.carrier.routeScope).toBe('exit_only')
+    expect(workspace.summary.workspaceKind).toBe('follow_through')
+    expect(workspace.summary.openDossierCount).toBe(2)
+    expect(workspace.summary.blockedCount).toBe(1)
+    expect(workspace.summary.reviewDueCount).toBe(2)
+    expect(workspace.summary.escalationCount).toBe(1)
+    expect(workspace.activeDeliveryModes).toEqual(['baseline', 'live'])
+    expect(workspace.assignments[0]?.state).toBe('active')
+    expect(workspace.assignments[1]?.state).toBe('blocked')
+    expect(workspace.followUpSignals.some((signal) => signal.kind === 'owner_missing')).toBe(true)
+    expect(workspace.followUpSignals.some((signal) => signal.kind === 'decision_due')).toBe(true)
   })
 
   it('keeps generic shared checkpoint owners out of manager binding', () => {

--- a/frontend/lib/action-center-shared-core.test.ts
+++ b/frontend/lib/action-center-shared-core.test.ts
@@ -203,13 +203,16 @@ describe('action center shared core', () => {
     expect(workspace.summary.workspaceKind).toBe('follow_through')
     expect(workspace.summary.openDossierCount).toBe(2)
     expect(workspace.summary.blockedCount).toBe(1)
-    expect(workspace.summary.reviewDueCount).toBe(2)
+    expect(workspace.summary.reviewDueCount).toBe(1)
     expect(workspace.summary.escalationCount).toBe(1)
     expect(workspace.activeDeliveryModes).toEqual(['baseline', 'live'])
     expect(workspace.assignments[0]?.state).toBe('active')
     expect(workspace.assignments[1]?.state).toBe('blocked')
+    expect(workspace.reviewMoments[0]?.state).toBe('scheduled')
+    expect(workspace.reviewMoments[1]?.state).toBe('due')
     expect(workspace.followUpSignals.some((signal) => signal.kind === 'owner_missing')).toBe(true)
     expect(workspace.followUpSignals.some((signal) => signal.kind === 'decision_due')).toBe(true)
+    expect(workspace.followUpSignals.filter((signal) => signal.kind === 'review_due')).toHaveLength(1)
   })
 
   it('keeps generic shared checkpoint owners out of manager binding', () => {

--- a/tests/test_action_center_shared_core.py
+++ b/tests/test_action_center_shared_core.py
@@ -1,4 +1,9 @@
 from backend.products.shared.action_center_adapters import get_future_action_center_adapter
+from backend.products.shared.action_center_exit import (
+    ExitDossierInput,
+    build_exit_action_center_workspace,
+    get_exit_action_center_carrier,
+)
 from backend.products.shared.action_center_core import (
     ActionAssignment,
     ActionDossier,
@@ -80,7 +85,7 @@ def test_permission_envelope_stays_within_follow_through_surface():
     assert owner_envelope.can_open_product_adapters is False
 
 
-def test_mto_becomes_the_first_active_action_center_carrier_while_future_adapters_stay_inactive():
+def test_mto_stays_active_while_non_selected_future_adapters_remain_inactive():
     design_input = describe_mto_design_input(
         MtoDesignInput(
             source="mto",
@@ -89,7 +94,7 @@ def test_mto_becomes_the_first_active_action_center_carrier_while_future_adapter
         )
     )
     carrier = get_mto_action_center_carrier()
-    exit_adapter = get_future_action_center_adapter("exit")
+    retention_adapter = get_future_action_center_adapter("retention")
 
     assert carrier.status == "active"
     assert carrier.workspace_kind == "follow_through"
@@ -101,8 +106,8 @@ def test_mto_becomes_the_first_active_action_center_carrier_while_future_adapter
     assert design_input.mode == "active_follow_through"
     assert design_input.can_create_assignments is True
     assert design_input.can_open_carrier is True
-    assert exit_adapter.status == "inactive"
-    assert exit_adapter.live_entry_enabled is False
+    assert retention_adapter.status == "inactive"
+    assert retention_adapter.live_entry_enabled is False
 
 
 def test_mto_workspace_projects_dossiers_reviews_and_hr_central_guardrails_onto_shared_core():
@@ -151,3 +156,64 @@ def test_mto_workspace_projects_dossiers_reviews_and_hr_central_guardrails_onto_
     assert any(signal.kind == "owner_missing" for signal in workspace.follow_up_signals)
     assert any(signal.kind == "decision_due" for signal in workspace.follow_up_signals)
     assert sum(1 for signal in workspace.follow_up_signals if signal.kind == "review_due") == 1
+
+
+def test_exit_becomes_one_additional_live_action_center_consumer_without_opening_other_adapters():
+    carrier = get_exit_action_center_carrier()
+    retention_adapter = get_future_action_center_adapter("retention")
+
+    assert carrier.label == "ExitScan-adapter"
+    assert carrier.status == "active"
+    assert carrier.workspace_kind == "follow_through"
+    assert carrier.route_scope == "exit_only"
+    assert carrier.owner_model == "explicit_named_owner"
+    assert carrier.review_discipline == "follow_up_review_required"
+    assert carrier.can_open_other_product_adapters is False
+    assert retention_adapter.status == "inactive"
+    assert retention_adapter.live_entry_enabled is False
+
+
+def test_exit_workspace_projects_real_follow_through_pressure_onto_shared_core():
+    workspace = build_exit_action_center_workspace(
+        role="owner",
+        dossiers=[
+            ExitDossierInput(
+                id="dos-1",
+                title="ExitScan - Support closeout",
+                triage_status="bevestigd",
+                delivery_mode="live",
+                management_owner_label="Sanne",
+                review_owner_label="Verisight",
+                first_action_taken="Plan exit-closeout met HR en teamlead",
+                review_moment="Herlees over 30 dagen",
+                management_action_outcome=None,
+                next_route=None,
+                stop_reason=None,
+            ),
+            ExitDossierInput(
+                id="dos-2",
+                title="ExitScan - Sales closeout",
+                triage_status="nieuw",
+                delivery_mode="baseline",
+                management_owner_label=None,
+                review_owner_label=None,
+                first_action_taken=None,
+                review_moment=None,
+                management_action_outcome=None,
+                next_route=None,
+                stop_reason=None,
+            ),
+        ],
+    )
+
+    assert workspace.carrier.route_scope == "exit_only"
+    assert workspace.summary.workspace_kind == "follow_through"
+    assert workspace.summary.open_dossier_count == 2
+    assert workspace.summary.blocked_count == 1
+    assert workspace.summary.review_due_count == 2
+    assert workspace.summary.escalation_count == 1
+    assert workspace.active_delivery_modes == ("baseline", "live")
+    assert workspace.assignments[0].state == "active"
+    assert workspace.assignments[1].state == "blocked"
+    assert any(signal.kind == "owner_missing" for signal in workspace.follow_up_signals)
+    assert any(signal.kind == "decision_due" for signal in workspace.follow_up_signals)

--- a/tests/test_action_center_shared_core.py
+++ b/tests/test_action_center_shared_core.py
@@ -210,10 +210,13 @@ def test_exit_workspace_projects_real_follow_through_pressure_onto_shared_core()
     assert workspace.summary.workspace_kind == "follow_through"
     assert workspace.summary.open_dossier_count == 2
     assert workspace.summary.blocked_count == 1
-    assert workspace.summary.review_due_count == 2
+    assert workspace.summary.review_due_count == 1
     assert workspace.summary.escalation_count == 1
     assert workspace.active_delivery_modes == ("baseline", "live")
     assert workspace.assignments[0].state == "active"
     assert workspace.assignments[1].state == "blocked"
+    assert workspace.review_moments[0].state == "scheduled"
+    assert workspace.review_moments[1].state == "due"
     assert any(signal.kind == "owner_missing" for signal in workspace.follow_up_signals)
     assert any(signal.kind == "decision_due" for signal in workspace.follow_up_signals)
+    assert sum(1 for signal in workspace.follow_up_signals if signal.kind == "review_due") == 1


### PR DESCRIPTION
## What changed
- added a bounded `ExitScan` Action Center carrier contract in backend and frontend shared-core layers
- removed `exit` from the future-adapter list so it is no longer modeled as both future and live
- wired `ExitScan` into the existing `/beheer/klantlearnings` Action Center surface as exactly one additional live consumer while keeping the existing MTO carrier intact
- added focused backend, frontend shared-core, and page-surface tests plus a small implementation plan artifact

## Why this changed
The goal of this slice is to connect exactly one second current product stream to the existing Action Center product layer without opening an adapter wave, dashboard expansion, or broader suite scope. ExitScan was the best bounded choice because current learning dossiers, checkpoints, lead routing, and campaign context already exist live in the runtime.

## User and developer impact
- Operations now has a real second Action Center consumer for ExitScan on the current Action Center surface
- MTO remains live and unchanged as the first consumer
- Other products remain explicitly out of scope and inactive as Action Center adapters

## Validation
- `C:\Users\larsh\Desktop\Business\Verisight\.venv\Scripts\python.exe -m pytest tests/test_action_center_shared_core.py -q`
- `npx vitest run lib/action-center-shared-core.test.ts "app/(dashboard)/beheer/klantlearnings/page.test.ts"`
- `npm run build` with temporary local Supabase env injection for the worktree
- runtime smoke: frontend server booted successfully; `/login` returned `200` and protected `/beheer/klantlearnings` returned `307` as expected behind auth
