### PR TITLE
[codex] canonize action center layer

### DIFF
--- a/docs/DOCUMENT_INDEX.md
+++ b/docs/DOCUMENT_INDEX.md
@@ -69,6 +69,7 @@ Voor de huidige fix-tranche:
 - [RETENTIESCAN_LIVE_TEST_PLAN.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/RETENTIESCAN_LIVE_TEST_PLAN.md)
 - [SCHEMA_DB_SEMANTIC_MIGRATION_PLAN.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/SCHEMA_DB_SEMANTIC_MIGRATION_PLAN.md)
 - [METRIC_HARDENING_SIGNOFF.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/METRIC_HARDENING_SIGNOFF.md)
+- [ACTION_CENTER_CANON.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/ACTION_CENTER_CANON.md)
 
 ## Reference
 
@@ -115,6 +116,7 @@ Voor de huidige fix-tranche:
 - [SCALABILITY_IMPROVEMENT_WAVES.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/SCALABILITY_IMPROVEMENT_WAVES.md)
 - [SCALABILITY_REVIEW_WORKBOOK.xlsx](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/SCALABILITY_REVIEW_WORKBOOK.xlsx)
 - [SOURCE_OF_TRUTH_CHARTER.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/SOURCE_OF_TRUTH_CHARTER.md)
+- [ACTION_CENTER_OPERATING_MODEL.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/ACTION_CENTER_OPERATING_MODEL.md)
 - [SUPABASE_LIVE_HARDENING_CHECKLIST.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/SUPABASE_LIVE_HARDENING_CHECKLIST.md)
 - [RETENTION_V11_VALIDATION_WORKFLOW.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/RETENTION_V11_VALIDATION_WORKFLOW.md)
 

--- a/docs/active/ACTION_CENTER_CANON.md
+++ b/docs/active/ACTION_CENTER_CANON.md
@@ -1,0 +1,189 @@
+# ACTION_CENTER_CANON
+
+Last updated: 2026-04-26  
+Status: active  
+Source of truth: live `/beheer/klantlearnings` runtime, shared Action Center carrier contracts, dashboard boundary docs and follow-up ops cadence.
+
+## Titel
+
+Action Center Product Layer Canon
+
+## Korte samenvatting
+
+Deze canon legt Action Center vast als zelfstandige suiteproductlaag voor bounded follow-through. Action Center is geen buyer-facing dashboard, geen generieke customer-ops cockpit en geen nieuw commercieel productverhaal. Het is de admin-first laag waarin dossierstatus, assignment, reviewmoment en follow-upbesluit per live route expliciet blijven totdat een bounded uitkomst of bewuste stop zichtbaar is.
+
+## Wat is geaudit
+
+- [SOURCE_OF_TRUTH_CHARTER.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/SOURCE_OF_TRUTH_CHARTER.md)
+- [CLIENT_OWNERSHIP_AND_FOLLOW_UP_CADENCE.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/CLIENT_OWNERSHIP_AND_FOLLOW_UP_CADENCE.md)
+- [CLIENT_ONBOARDING_FLOW_SYSTEM.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/CLIENT_ONBOARDING_FLOW_SYSTEM.md)
+- [PILOT_LEARNING_PLAYBOOK.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/PILOT_LEARNING_PLAYBOOK.md)
+- [DASHBOARD_HOME_DECISION_LAUNCHER.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/dashboard/DASHBOARD_HOME_DECISION_LAUNCHER.md)
+- [PRODUCT_LANGUAGE_CANON.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/PRODUCT_LANGUAGE_CANON.md)
+- [page.tsx](/C:/Users/larsh/Desktop/Business/Verisight/frontend/app/(dashboard)/beheer/klantlearnings/page.tsx)
+- [page.tsx](/C:/Users/larsh/Desktop/Business/Verisight/frontend/app/(dashboard)/dashboard/page.tsx)
+- [action-center-shared-core.ts](/C:/Users/larsh/Desktop/Business/Verisight/frontend/lib/action-center-shared-core.ts)
+- [action-center-mto.ts](/C:/Users/larsh/Desktop/Business/Verisight/frontend/lib/action-center-mto.ts)
+- [action-center-exit.ts](/C:/Users/larsh/Desktop/Business/Verisight/frontend/lib/action-center-exit.ts)
+- [action-center-shared-core.test.ts](/C:/Users/larsh/Desktop/Business/Verisight/frontend/lib/action-center-shared-core.test.ts)
+
+## Belangrijkste bevindingen
+
+- Action Center bestaat nu al als live gedeelde follow-through-laag op `/beheer/klantlearnings`.
+- De gedeelde core is bewust smal: `follow_through`, dossier-first, reviewdruk zichtbaar, geen projectplanlaag en geen advisorylaag.
+- Er zijn nu precies twee live consumers op deze laag: `MTO` en `ExitScan`.
+- Dashboard en customer ops hebben al een andere, scherpere rol: dashboard is decision-first campaignread; customer ops is setup, activatie en deliverycontrole.
+
+## Belangrijkste inconsistenties of risico's
+
+- Zonder expliciete canon kan `/beheer/klantlearnings` te makkelijk alleen als learninglog of juist als brede ops-cockpit gelezen worden.
+- Zonder grens met dashboard kan Action Center gaan lijken op een tweede managementdashboard.
+- Zonder grens met customer ops kan follow-through vervagen in setup, activation of checkpointwerk.
+- Zonder bounded consumer-regel kan elke nieuwe route impliciet als live adapter gaan gelden zonder governance of producttruth-signoff.
+
+## Beslissingen / canonvoorstellen
+
+### Wat Action Center is
+
+Action Center is:
+
+- een zelfstandige suiteproductlaag binnen de admin-first productstack
+- de gedeelde follow-through- en closeoutlaag voor live routes met expliciete dossiersturing
+- de plek waar `assignment`, `reviewmoment`, `owner`, `follow-upsignaal` en `bounded vervolgbesluit` bij elkaar blijven
+- een multi-consumer surface met route-specifieke carriers boven dezelfde gedeelde core
+
+Action Center opent pas echt zodra een traject niet alleen setup of eerste read vraagt, maar expliciete follow-through nodig heeft rond eigenaar, eerste stap, reviewdruk of closeoutbesluit.
+
+### Wat Action Center niet is
+
+Action Center is niet:
+
+- het buyer-facing dashboard
+- de primaire customer-ops setup- en activatielaag
+- een generieke projectmanagementtool
+- een brede advisory workspace
+- een sales-, pricing- of suitepositioneringslaag
+- een plek om nieuwe productclaims of maturityclaims te introduceren
+
+### Verhouding tot dashboard
+
+Dashboard blijft canoniek voor:
+
+- campaignkeuze
+- eerste managementread
+- portfolio-overzicht
+- rapport- en dashboardgebruik als managementinstrument
+
+Action Center blijft canoniek voor:
+
+- interne follow-through na of rond die read
+- dossierstatus en reviewdruk
+- bounded handoff naar vervolgrichting of closeout
+
+Boundaryregel:
+
+- dashboard toont wat nu gelezen of geopend moet worden
+- Action Center toont wat intern nog vastgelegd, beoordeeld of gesloten moet worden
+- dashboard mag Action Center niet vervangen als eigenaar-, review- of closurelaag
+- Action Center mag dashboard niet vervangen als buyer- of managementread
+
+### Verhouding tot customer ops
+
+Customer ops blijft canoniek voor:
+
+- organisatie- en campaignsetup
+- respondentimport en activatie
+- delivery exceptions en checkpointbevestigingen
+- operator next steps tijdens assisted uitvoering
+
+Action Center blijft canoniek voor:
+
+- learningdossiers met expliciete follow-through
+- first action, reviewmoment en follow-upbesluit
+- routegebonden closeout en learning handoff
+
+Beslisregel:
+
+- gaat het om setup, launch, activation of delivery checkpoint? Gebruik customer ops
+- gaat het om dossier, eigenaar, reviewdruk of bounded vervolgbesluit? Gebruik Action Center
+
+### Live consumers en governance
+
+De huidige live consumers zijn:
+
+- `MTO` als carrier met `hr_central`, `department_only` en zichtbare reviewdruk
+- `ExitScan` als carrier met `exit_only`, `explicit_named_owner` en verplichte follow-upreview
+
+Governanceregel:
+
+- nieuwe live consumers zijn pas toegestaan zodra de route al echt live is
+- de route een expliciete carriercontractlaag heeft
+- de gedeelde core bounded blijft tot `follow_through`
+- andere toekomstige adapters expliciet inactief blijven tot aparte canon- en runtimebeslissing
+
+`RetentieScan` en andere toekomstige adapters zijn dus niet impliciet live doordat Action Center nu bestaat.
+
+### Assignments, reviews en follow-up moeten bounded blijven
+
+Action Center-assignments zijn:
+
+- klein
+- expliciet eigenaar-gebonden
+- direct gekoppeld aan een dossier
+- bedoeld voor eerste stap, reviewvoorbereiding, handoff of closure
+
+Action Center-reviewmomenten zijn:
+
+- expliciet per dossier
+- standaard binnen 10 werkdagen of eerder in bestaand managementoverleg
+- een follow-throughcontrole, geen nieuw analysetraject
+
+Action Center-follow-up blijft open totdat ten minste een van deze bounded uitkomsten expliciet is vastgelegd:
+
+- managementactie-uitkomst
+- bounded next route
+- bewuste stopreden
+
+Een open dossier zonder eigenaar, eerste stap of reviewmoment moet zichtbaar blijven als signaal en mag niet stilzwijgend verdwijnen in notities, mail of losse meetings.
+
+### Commerciele en taalgrens
+
+Action Center-taal blijft internal-first:
+
+- `shared follow-through`
+- `dossier-first`
+- `reviewdruk`
+- `bounded vervolg`
+- `closeout`
+
+Niet canoniseren in deze fase:
+
+- nieuwe suiteclaims
+- pricinglogica
+- salescopy
+- sitecopy
+- buyer-facing value-framing voor Action Center als commercieel product
+
+## Concrete wijzigingen
+
+- Nieuw bestand aangemaakt: [ACTION_CENTER_CANON.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/ACTION_CENTER_CANON.md)
+- Action Center expliciet vastgelegd als zelfstandige suiteproductlaag in plaats van impliciete learningpagina
+- De boundary met dashboard en customer ops expliciet gemaakt
+- Governance voor live consumers, assignments, reviews en follow-up bounded vastgezet
+
+## Validatie
+
+- De canon volgt de huidige live runtime in `frontend/lib/action-center-*.ts` en `/beheer/klantlearnings`.
+- De canon introduceert geen nieuwe route, geen nieuwe adapter en geen nieuwe buyer-facing claim.
+- De dashboardgrens volgt de bestaande decision-launcher waarheid.
+- De opsgrens volgt de bestaande onboarding-, delivery- en follow-upcadence.
+
+## Assumptions / defaults
+
+- `/beheer/klantlearnings` blijft de huidige Action Center-surface totdat een latere repo-beslissing het pad of label wijzigt.
+- `MTO` en `ExitScan` zijn de enige live consumers die nu canoniek benoemd mogen worden.
+- Action Center blijft admin-first totdat latere canon expliciet een andere audience of permissionlaag opent.
+
+## Next gate
+
+Ops- en boundarydocumenten laten aansluiten op deze canon en daarna pas overwegen of extra live consumers dezelfde productlaag mogen gebruiken.

--- a/docs/active/ACTION_CENTER_CANON.md
+++ b/docs/active/ACTION_CENTER_CANON.md
@@ -1,7 +1,7 @@
 # ACTION_CENTER_CANON
 
-Last updated: 2026-04-26  
-Status: active  
+Last updated: 2026-04-26
+Status: active
 Source of truth: live `/beheer/klantlearnings` runtime, shared Action Center carrier contracts, dashboard boundary docs and follow-up ops cadence.
 
 ## Titel

--- a/docs/dashboard/DASHBOARD_HOME_DECISION_LAUNCHER.md
+++ b/docs/dashboard/DASHBOARD_HOME_DECISION_LAUNCHER.md
@@ -77,6 +77,18 @@ De volgende zaken zijn expres lager in de hierarchie geplaatst:
 - supportverwachting
 - beheer- en operationele taken
 
+## Relatie tot Action Center
+
+Deze homepage blijft bewust gescheiden van Action Center:
+
+- dashboard = campaignkeuze, eerste managementread en portfolio-context
+- Action Center = admin-first follow-through, dossierstatus, reviewdruk en bounded closeout
+
+Boundaryregel:
+
+- open eerst de juiste campaign via dashboard
+- gebruik Action Center pas zodra interne follow-through, eigenaar of reviewdiscipline expliciet bewaakt moet worden
+
 Deze content blijft beschikbaar via secundaire blocks en disclosures, maar concurreert niet meer met de hoofdvraag: welke campaign open je nu?
 
 ## Visuele hierarchie

--- a/docs/ops/ACTION_CENTER_OPERATING_MODEL.md
+++ b/docs/ops/ACTION_CENTER_OPERATING_MODEL.md
@@ -1,0 +1,139 @@
+# Action Center Operating Model
+
+Last updated: 2026-04-26
+Status: active
+
+## Purpose
+
+Dit document legt vast hoe Verisight Action Center operationeel gebruikt als bounded follow-throughlaag naast dashboard en customer ops.
+
+Gebruik altijd samen met:
+
+- [ACTION_CENTER_CANON.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/ACTION_CENTER_CANON.md)
+- [SOURCE_OF_TRUTH_CHARTER.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/SOURCE_OF_TRUTH_CHARTER.md)
+- [CLIENT_OWNERSHIP_AND_FOLLOW_UP_CADENCE.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/CLIENT_OWNERSHIP_AND_FOLLOW_UP_CADENCE.md)
+- [CLIENT_ONBOARDING_FLOW_SYSTEM.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/CLIENT_ONBOARDING_FLOW_SYSTEM.md)
+- [PILOT_LEARNING_PLAYBOOK.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/PILOT_LEARNING_PLAYBOOK.md)
+
+## Core operating rule
+
+Gebruik Action Center zodra een live route een expliciet dossier nodig heeft voor:
+
+- eerste bounded stap
+- expliciete eigenaar
+- reviewmoment
+- follow-upbesluit
+- closeout of handoff
+
+Gebruik Action Center niet voor:
+
+- setup
+- launch
+- respondentimport
+- klantactivatie
+- generieke takenbakken
+- brede projectsturing
+
+## Welke laag gebruik je wanneer?
+
+### Dashboard
+
+Gebruik dashboard voor:
+
+- campaignkeuze
+- eerste managementread
+- portfolio-overzicht
+- rapport- en dashboardgebruik door klant of management
+
+### Customer ops
+
+Gebruik customer ops voor:
+
+- organisatie- en campaignsetup
+- delivery lifecycle en exceptions
+- import-QA
+- activatie en toegangsbevestiging
+- operator next steps in uitvoering
+
+### Action Center
+
+Gebruik Action Center voor:
+
+- dossier-first follow-through
+- eigenaar-, review- en closurediscipline
+- bounded vervolg per route
+- learning handoff zodra een traject managementgebruik heeft geraakt
+
+## Dossier opening triggers
+
+Open of houd een Action Center-dossier actief als minimaal een van deze situaties geldt:
+
+- first management use heeft een eerste stap opgeleverd
+- er is reviewdruk zonder geplande reviewdatum
+- er ontbreekt een expliciete eigenaar
+- een bounded vervolgroute moet worden vastgelegd
+- een closeoutbesluit ontbreekt nog
+- een confirmed learning anders in losse notities zou blijven hangen
+
+## Assignment rules
+
+- Elk open dossier heeft maximaal een eerstvolgende bounded assignment als hoofdactie.
+- Een assignmenttitel beschrijft een kleine, concrete vervolgstap en geen breed project.
+- Zonder eerste stap blijft het dossier zichtbaar als `blocked_assignment`.
+- Assignments horen alleen de states `queued`, `active`, `blocked`, `waiting`, `completed` of `cancelled` te gebruiken.
+- Een assignment wordt `handoff` of `closure` zodra het dossier niet meer om analyse vraagt maar om expliciete afronding of routekeuze.
+
+## Review rules
+
+- Elk open dossier krijgt een expliciet reviewmoment.
+- Default: binnen 10 werkdagen of eerder in een bestaand managementoverleg.
+- Zonder reviewmoment blijft `review_due` open.
+- Geparkeerde of verworpen dossiers annuleren reviewdruk expliciet; review verdwijnt niet stilzwijgend.
+- De 30-90 dagen review blijft een aparte learninglaag en vervangt de eerste follow-upreview niet.
+
+## Follow-up and closure rules
+
+Een dossier mag pas dicht wanneer:
+
+- managementactie-uitkomst, bounded next route of stopreden expliciet is vastgelegd
+- learning handoff is bijgewerkt
+- open eigenaar- of reviewsignalen zijn opgelost of bewust gesloten
+
+Follow-up blijft dus open zolang:
+
+- geen eigenaar vastligt
+- geen eerste stap vastligt
+- geen reviewmoment vastligt
+- geen vervolguitkomst vastligt
+
+## Governance and permissions
+
+- Action Center blijft admin-first en owner-governed.
+- `owner` mag assignments, reviewmomenten, signalen en closure bijwerken.
+- `member` of `viewer` mag de follow-through lezen maar opent geen nieuwe productadapter.
+- De permission envelope blijft bounded: geen generic planning, geen advisoryrechten en geen adapter-opening vanuit deze laag.
+
+Nieuwe live consumers zijn alleen toegestaan wanneer:
+
+1. de route al echt live in de runtime bestaat
+2. de route een expliciete carriercontractlaag heeft
+3. dit document en de canon bewust zijn bijgewerkt
+4. andere toekomstige adapters expliciet inactief blijven
+
+## Weekly cadence
+
+Toets Action Center minimaal wekelijks op:
+
+- `owner_missing`
+- `blocked_assignment`
+- `review_due`
+- `decision_due`
+- dossiers die al follow-up hebben maar nog geen closeout tonen
+
+Werk daarna alleen de samenvatting door naar week- of maandreview. De Action Center-surface blijft primair.
+
+## Cross-document handoff
+
+- Trek terugkerende patronen door naar [MONTHLY_PHASE_REVIEW.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/MONTHLY_PHASE_REVIEW.md).
+- Trek casewaardige output pas door naar [CASE_PROOF_CAPTURE_PLAYBOOK.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/CASE_PROOF_CAPTURE_PLAYBOOK.md) als bewijsruimte echt hard genoeg is.
+- Gebruik dashboard of customer ops niet als vervanging voor open Action Center-follow-through.

--- a/docs/ops/CLIENT_OWNERSHIP_AND_FOLLOW_UP_CADENCE.md
+++ b/docs/ops/CLIENT_OWNERSHIP_AND_FOLLOW_UP_CADENCE.md
@@ -9,6 +9,7 @@ Dit document maakt de operating cadence expliciet rond klantactivatie, first man
 
 Gebruik altijd samen met:
 
+- [ACTION_CENTER_OPERATING_MODEL.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/ACTION_CENTER_OPERATING_MODEL.md)
 - [CLIENT_ONBOARDING_PLAYBOOK.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/CLIENT_ONBOARDING_PLAYBOOK.md)
 - [CLIENT_ONBOARDING_FLOW_SYSTEM.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/CLIENT_ONBOARDING_FLOW_SYSTEM.md)
 - [CLIENT_REPORT_TO_ACTION_FLOW.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/CLIENT_REPORT_TO_ACTION_FLOW.md)
@@ -43,11 +44,13 @@ Een actief klanttraject blijft operationeel open totdat vier gates expliciet bev
 - Tijdens first management use worden eerste eigenaar, eerste actie en reviewmoment vastgelegd.
 - Default: reviewmoment binnen 10 werkdagen of eerder in het eerstvolgende bestaande managementoverleg.
 - Zonder reviewdatum blijft follow-up operationeel open.
+- Action Center is de primaire plek waar deze follow-through zichtbaar en bijwerkbaar blijft.
 
 ### Gate 4 - Follow-up decided
 
 - Na het reviewmoment kiest de klant expliciet tussen bounded vervolg, bredere duiding of bewust niet opschalen.
 - Verisight werkt lifecycle-status, next step en learninglog binnen 1 werkdag bij.
+- Verisight werkt owner, assignment, reviewdruk en closeout tegelijk bij in Action Center.
 - De 30-90 dagen review blijft een aparte learninglaag en vervangt de eerste follow-up niet.
 
 ## Product

--- a/docs/ops/PILOT_LEARNING_PLAYBOOK.md
+++ b/docs/ops/PILOT_LEARNING_PLAYBOOK.md
@@ -11,7 +11,7 @@ Belangrijke defaults:
 
 - ExitScan blijft de primaire eerste route.
 - RetentieScan blijft complementair en verification-first.
-- De learninglaag is internal-only en admin-first.
+- Action Center is de internal-only en admin-first follow-throughlaag.
 - Manual-first is acceptabel, zolang de les persistente capture krijgt.
 - Een lesson sluit pas wanneer repo-bestemming of bewuste afwijzing expliciet is.
 - Case-proof groeit vanuit learningdossiers, nooit vanuit sample-output of losse anekdotes.
@@ -21,7 +21,7 @@ Belangrijke defaults:
 ### 1. Start vanuit lead of campaign
 
 - Gebruik `/beheer/contact-aanvragen` voor nieuwe buyer-signalen.
-- Gebruik `/beheer/klantlearnings` om direct een dossier te starten.
+- Gebruik `/beheer/klantlearnings` als Action Center om direct een dossier te starten.
 - Koppel een campaign zodra implementation, launch of managementgebruik al in de echte route zitten.
 
 ### 2. Leg de vaste dossierbasis vast
@@ -69,6 +69,12 @@ Leg daarnaast op dossierniveau vast zodra dat kan:
 - claimbare observaties
 - supporting artifacts
 
+Deze dossierlaag blijft bounded:
+
+- geen generieke projectplanning
+- geen setupvervanging
+- geen buyer-facing dashboardcopy
+
 ### 4. Gebruik triage expliciet
 
 - `nieuw`: net vastgelegd, nog niet bevestigd
@@ -79,7 +85,7 @@ Leg daarnaast op dossierniveau vast zodra dat kan:
 
 ### 5. Dwing bestemming af
 
-Elke confirmed lesson hoort minimaal één bestemming te krijgen:
+Elke confirmed lesson hoort minimaal een bestemming te krijgen:
 
 - `product`
 - `report`

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -55,6 +55,13 @@ Voor het huidige fix-programma gebruik je deze volgorde:
 - [OPS_DELIVERY_FAILURE_MATRIX.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/OPS_DELIVERY_FAILURE_MATRIX.md)
   - recovery- en uitzonderingslogica
 
+### Action Center en bounded follow-through
+
+- [ACTION_CENTER_OPERATING_MODEL.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/ACTION_CENTER_OPERATING_MODEL.md)
+  - primaire usage rules voor dossier-first assignments, reviewmomenten en closeout
+- [SOURCE_OF_TRUTH_CHARTER.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/SOURCE_OF_TRUTH_CHARTER.md)
+  - legt expliciet vast dat customer ops en Action Center twee verschillende primaire app-lagen zijn
+
 ### Product truth en rapportcanon
 
 - [PRODUCT_TRUTH_HARDENING_PROGRAM_PLAN.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/PRODUCT_TRUTH_HARDENING_PROGRAM_PLAN.md)
@@ -63,6 +70,8 @@ Voor het huidige fix-programma gebruik je deze volgorde:
   - inventaris van embedded truth, shared grammar en buyer-facing mirror drift
 - [PRODUCT_LANGUAGE_CANON.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/PRODUCT_LANGUAGE_CANON.md)
   - canonieke producttaal en parityregels voor rapport, dashboard, onboarding en buyer-facing copy
+- [ACTION_CENTER_CANON.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/ACTION_CENTER_CANON.md)
+  - canonieke afbakening van Action Center als zelfstandige suiteproductlaag
 - [REPORT_STRUCTURE_CANON.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/REPORT_STRUCTURE_CANON.md)
   - gedeelde rapportgrammar, met ExitScan expliciet vastgezet op de vaste `P1-P10 + Appendix` architectuur
 - [REPORT_GENERATOR_RUNTIME_BOUNDARY.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/REPORT_GENERATOR_RUNTIME_BOUNDARY.md)

--- a/docs/ops/SOURCE_OF_TRUTH_CHARTER.md
+++ b/docs/ops/SOURCE_OF_TRUTH_CHARTER.md
@@ -18,8 +18,8 @@ Kernregel:
 Voor wave 1 van het fix-programma werkt Verisight hybride:
 
 - leadpipeline primair in `Verisight_CRM.xlsx`
-- delivery primair in de app-surfaces
-- learning primair in `/beheer/klantlearnings`
+- customer ops primair in `/beheer` en `/campaigns/[id]`
+- Action Center primair in `/beheer/klantlearnings`
 - governance primair in scorecard, maandreview, decision log en capacity map
 - evidence primair in `SCALABILITY_REVIEW_WORKBOOK.xlsx`
 
@@ -29,9 +29,9 @@ Voor wave 1 van het fix-programma werkt Verisight hybride:
 | --- | --- | --- | --- |
 | Actieve leads en deals | `Docs_External/.../Verisight_CRM.xlsx` | `CEO_WEEKLY_SCORECARD.xlsx` tab `Deals` | prospectlijst, losse notities, maandreview |
 | Seed prospects en outbound-voorraad | `Verisight_Prospectlijst_2026-04-10.xlsx` | geen vaste mirror nodig | CRM-pipeline zodra een prospect nog niet actief is |
-| Actieve klanttrajecten | `/beheer` en `/campaigns/[id]` | `CEO_WEEKLY_SCORECARD.xlsx` tab `Clients` | onboardingflow-workbooks, losse checklists |
-| Delivery exceptions en checkpoints | `/beheer` en `/campaigns/[id]` | weekreview en maandreview | losse e-mails of operatorgeheugen |
-| Learning en vroege proof | `/beheer/klantlearnings` | maandreview en case-proof docs | losse notities |
+| Actieve klanttrajecten en setup | `/beheer` en `/campaigns/[id]` | `CEO_WEEKLY_SCORECARD.xlsx` tab `Clients` | onboardingflow-workbooks, losse checklists |
+| Delivery exceptions en checkpoints | `/beheer` en `/campaigns/[id]` | weekreview en maandreview | losse e-mails, operatorgeheugen of `/beheer/klantlearnings` als vervanging |
+| Learning, dossier-follow-through en reviewdruk | `/beheer/klantlearnings` | maandreview en case-proof docs | losse notities, setup-surfaces of scorecard-only |
 | Wekelijkse prioriteiten en stopregels | `CEO_WEEKLY_SCORECARD.xlsx` | `DECISION_LOG.md` waar nodig | CRM of deliverysurfaces |
 | Maandelijkse gates en wave-overgangen | `MONTHLY_PHASE_REVIEW.md` | `DECISION_LOG.md`, `SCALABILITY_REVIEW_WORKBOOK.xlsx` | roadmap of losse statusupdates |
 | Capaciteitsgrenzen | `FOUNDER_CAPACITY_MAP.md` | scorecard cash and capacity | impliciet gevoel |
@@ -55,13 +55,14 @@ Werk in deze volgorde:
 2. zet alleen de wekelijkse samenvatting in `CEO_WEEKLY_SCORECARD.xlsx`
 3. gebruik `MONTHLY_PHASE_REVIEW.md` voor terugkerende fricties of gates
 
-### 3. Learning and proof updates
+### 3. Action Center, learning and proof updates
 
 Werk in deze volgorde:
 
 1. update `/beheer/klantlearnings`
-2. trek relevante patroonlessen door naar maandreview
-3. gebruik case-proof docs pas als bewijs of claimruimte echt hard genoeg is
+2. leg eigenaar, eerste stap, reviewmoment en follow-upbesluit eerst daar vast
+3. trek relevante patroonlessen door naar maandreview
+4. gebruik case-proof docs pas als bewijs of claimruimte echt hard genoeg is
 
 ### 4. Governance updates
 
@@ -76,6 +77,7 @@ Werk in deze volgorde:
 
 - `Deals` in `CEO_WEEKLY_SCORECARD.xlsx` is een weekmirror van de CRM-pipeline.
 - `Clients` in `CEO_WEEKLY_SCORECARD.xlsx` is een weekmirror van de app-deliverylaag.
+- `/beheer/klantlearnings` is de primaire Action Center-laag voor learning, bounded follow-through en closeoutdiscipline.
 - `SCALABILITY_REVIEW_WORKBOOK.xlsx` is geen dagelijkse operatie, maar een gate- en evidenceregister.
 - `ROADMAP.md` en `ROADMAP_WORKBOOK.xlsx` blijven fase- en auditlaag, niet de live fix-werklaag.
 - `Docs_External` mag referentie of assetlaag zijn, maar geen autonome prioriteitenlaag.
@@ -86,6 +88,7 @@ Niet doen:
 
 - actieve leads alleen in de prospectlijst laten staan
 - deliverystatus alleen in scorecard of losse notities bijhouden
+- Action Center-follow-through verplaatsen naar setupnotities, maandreview of dashboardcopy zonder de primaire surface bij te werken
 - maandreview invullen zonder terug te wijzen naar echte CRM-, app- of workbookevidence
 - externe workbooks of documenten laten afwijken van de actieve repo-playbooks zonder expliciete sync
 - een mirror gebruiken om het primaire systeem te overrulen


### PR DESCRIPTION
## Summary
- add a dedicated Action Center canon that defines the layer as admin-first, dossier-first, and bounded to follow-through
- add an Action Center operating model for assignments, review moments, closure rules, and consumer governance
- align source-of-truth, dashboard, and ops docs so Action Center stays distinct from dashboard and customer ops

## Why
The product layer is now live with real consumers, but the repo still described `/beheer/klantlearnings` mostly as a learning surface. This PR makes the current truth explicit without opening strategy, pricing, site copy, or new product claims.

## Impact
- clarifies what Action Center is and is not
- fixes the boundary between dashboard, customer ops, and Action Center
- keeps assignments, reviews, and follow-up explicitly bounded
- limits live consumers to the current MTO and ExitScan reality

## Validation
- `git diff --check`
- non-ASCII scan on the newly added canon and operating-model docs
- repo consistency review of the edited docs against the live Action Center and dashboard runtime files