### PR TITLE
[codex] Align action center strategy and packaging truth

### DIFF
--- a/docs/active/COMMERCIAL_AND_ONBOARDING_SIGNOFF.md
+++ b/docs/active/COMMERCIAL_AND_ONBOARDING_SIGNOFF.md
@@ -10,7 +10,7 @@ Commercial Architecture And Onboarding Flow Refinement - Signoff
 
 ## Korte samenvatting
 
-Deze signoff bevestigt dat de commerciele kernstructuur, packaginglogica en operationele onboardingflows nu op elkaar aansluiten zonder de producttruth te overschrijven. Dual-core is hiermee bruikbaar als commerciele default, terwijl bounded routes begrensd blijven.
+Deze signoff bevestigt dat de commerciele kernstructuur, packaginglogica en operationele onboardingflows nu op elkaar aansluiten zonder de producttruth te overschrijven. Dual-core is hiermee bruikbaar als commerciele default, terwijl bounded routes begrensd blijven en Action Center alleen als embedded follow-through laag op de bestaande adminsurface meegelezen mag worden.
 
 ## Wat is geaudit
 
@@ -28,17 +28,20 @@ Deze signoff bevestigt dat de commerciele kernstructuur, packaginglogica en oper
 - De eerste route-, first-value- en report-to-actionlogica vormen nu een doorlopende keten.
 - Dual-core werkt commercieel als default zolang bounded en parity-build routes niet als gelijkwaardige hoofdproposities worden behandeld.
 - De flowdocs maken operator-overdracht eenvoudiger zonder nieuwe product- of pricingbesluiten af te dwingen.
+- Action Center sluit op die keten aan als bounded follow-through laag voor MTO en ExitScan, zonder nieuw route- of pricingverhaal te openen.
 
 ## Belangrijkste inconsistenties of risico's
 
 - Buyer-facing mirrors kunnen nog steeds vooruitlopen als marketingstatus of detailcopy niet later op deze signoff wordt getoetst.
 - `Combinatie` blijft gevoelig voor suite- en bundeldrift als portfoliokader en first-buy verhaal door elkaar gaan lopen.
+- Als de follow-through laag buiten deze signoff blijft, kan Action Center alsnog onbedoeld als losse module, cockpit of derde product gaan voelen.
 
 ## Beslissingen / canonvoorstellen
 
 - `First buy -> first value -> first management use` is nu de canonieke commerciele en operationele hoofdroute.
 - `ExitScan` en `RetentieScan` blijven de enige standaard first-buy routes.
 - `TeamScan`, `Onboarding 30-60-90`, `Pulse` en `Leadership Scan` blijven vervolg-, bounded of parity-build routes volgens de vastgelegde routevormen.
+- Bounded follow-through via Action Center volgt pas na eerste management use, blijft beperkt tot de huidige MTO- en ExitScan-consumers en is geen extra routekeuze of prijslaag.
 - Working maturity labels blijven intern en worden door deze signoff niet gepromoveerd tot publieke statuslaag.
 
 ## Concrete wijzigingen
@@ -54,6 +57,7 @@ Deze signoff bevestigt dat de commerciele kernstructuur, packaginglogica en oper
 - Alle nieuwe documenten volgen dezelfde dual-core, bounded-route en report-to-action guardrails.
 - Geen van de documenten heropent of wijzigt de vaste ExitScan-report-architectuur.
 - Er is geen pricing- of productstatuspromotie vastgelegd.
+- Er is geen standalone Action Center pricing, modulepositionering of adapterverbreding vastgelegd.
 
 ## Assumptions / defaults
 

--- a/docs/active/PACKAGING_AND_ROUTE_LOGIC.md
+++ b/docs/active/PACKAGING_AND_ROUTE_LOGIC.md
@@ -10,7 +10,7 @@ Commercial Architecture And Onboarding Flow Refinement - Packaging and route log
 
 ## Korte samenvatting
 
-Dit document zet de commerciele routearchitectuur om in expliciete packaging- en routebeslisregels. De kern is dat Verisight voorlopig een dual-core instap kent, terwijl de rest alleen als verdieping, bounded vervolg, embedded follow-through laag of portfolioroute mag worden gelezen.
+Dit document zet de commerciele routearchitectuur om in expliciete packaging- en routebeslisregels. De kern is dat Verisight voorlopig een dual-core instap kent, terwijl de rest alleen als verdieping, bounded vervolg, embedded follow-through laag op de bestaande adminsurface of portfolioroute mag worden gelezen.
 
 ## Wat is geaudit
 
@@ -31,6 +31,7 @@ Dit document zet de commerciele routearchitectuur om in expliciete packaging- en
 - `Pulse` en `Leadership Scan` werken alleen veilig als bounded support routes na een eerste managementvraag of eerste managementactie.
 - `Combinatie` is alleen logisch als portfolioverbindende route boven reeds bestaande managementvragen, niet als zelfstandig instappakket.
 - Action Center is nu een echte interne productlaag, maar alleen als embedded follow-through voor bounded live consumers en niet als extra routevorm of pricinglaag.
+- Die Action Center-laag betekent nu concreet een `follow_through`-workspace voor dossiers, assignments, reviewmomenten en follow-upsignalen; MTO en ExitScan zijn live, terwijl RetentieScan, Onboarding, Pulse en Leadership adaptermatig nog inactive zijn.
 
 ## Belangrijkste inconsistenties of risico's
 
@@ -46,6 +47,7 @@ Dit document zet de commerciele routearchitectuur om in expliciete packaging- en
 - `Vervolg` betekent: ritme, review of herhaalmeting nadat first value en first action al zijn geland.
 - `Bounded support` betekent: smaller use case, begrensde claim en geen zelfstandige suite- of statuspromotie.
 - `Embedded follow-through layer` betekent: een interne gedeelde productlaag die dossiers, eigenaarschap, reviewmomenten en signalen bundelt onder guided execution zonder buyer-facing pricing, losse moduleclaim of open adapterverhaal.
+- Action Center betekent in deze fase concreet: bounded `follow_through`, geen project-plan/advisory-scope en geen live entry buiten MTO en ExitScan.
 - `Portfolio route` betekent: verbindende route tussen meerdere echte managementvragen, niet een derde productkern.
 - De commerciele default is `dual-core`, maar die default herdefinieert de vaste ExitScan-report-architectuur of de productmaturitylabels niet.
 - Action Center valt nu expliciet onder `embedded follow-through layer` en niet onder `instap`, `verdieping`, `vervolg`, `bounded support` of `portfolio route`.
@@ -62,7 +64,7 @@ Dit document zet de commerciele routearchitectuur om in expliciete packaging- en
 | Verdieping | er al een gekozen eerste route is en extra duiding of segmentwerk logisch volgt | vervanging van een first-buy beslissing | segment deep dive, extra managementsessie |
 | Vervolg | first value en first action al zijn geland | los add-on verhaal zonder managementdoel | vervolgmeting, ritmeroute |
 | Bounded support | de vraag smaller is dan een kernroute en de begrenzing expliciet blijft | nieuwe kernpropositie of brede statusclaim | Pulse, Leadership Scan |
-| Embedded follow-through layer | de laag intern dossiers, reviewdruk en eigenaarschap bundelt onder guided execution voor al actieve carriers | publiek prijsanker, derde product, buyer-facing module of bewijs van brede adapterdekking | Action Center |
+| Embedded follow-through layer | de laag intern dossiers, reviewdruk, assignments en eigenaarschap bundelt onder guided execution voor al actieve carriers | publiek prijsanker, derde product, buyer-facing module of bewijs van brede adapterdekking | Action Center (MTO + ExitScan live; RetentieScan/Onboarding/Pulse/Leadership inactive) |
 | Lokale verificatie | er een bestaande hoofdvraag is die lokaal of per team getoetst moet worden | generieke teamsuite als eerste verkoopverhaal | TeamScan |
 | Lifecycle-check | er een specifieke onboardingvraag ligt na of naast de eerste kernroute | algemeen HR operating system | Onboarding 30-60-90 |
 | Portfolio route | meerdere echte managementvragen tegelijk bestuurlijk spelen | bundel als hoofdverhaal of prijsanker | Combinatie |
@@ -73,13 +75,14 @@ Dit document zet de commerciele routearchitectuur om in expliciete packaging- en
 - Er wordt geen nieuwe pricingstructuur of portfolioverbreding vastgezet.
 - De indeling beschermt expliciet tegen buyer-facing overspraak van parity-build en bounded routes.
 - Action Center is nu expliciet geclassificeerd zonder nieuwe commerciële scope te openen.
+- De indeling botst niet met de gedeelde Action Center-core: geen adapteropening, geen project-plan/advisory-scope en geen routeclaim buiten de twee live consumers.
 
 ## Assumptions / defaults
 
 - `Instap` is een commerciele routecategorie en geen repo-brede productstatus.
 - `Bounded support` beschrijft routegebruik, niet waardeloosheid of afwijzing.
 - Producten zonder volledige formele report parity mogen nog steeds intern of bounded worden gebruikt, zolang de claimlaag beperkt blijft.
-- Action Center beschrijft nu een bestaande interne productlaag met twee bounded live consumers, niet een publieke route of apart pakket.
+- Action Center beschrijft nu een bestaande interne productlaag met twee bounded live consumers, niet een publieke route, apart pakket of brede adaptershell.
 
 ## Next gate
 

--- a/docs/active/PACKAGING_AND_ROUTE_LOGIC.md
+++ b/docs/active/PACKAGING_AND_ROUTE_LOGIC.md
@@ -1,6 +1,6 @@
 # PACKAGING_AND_ROUTE_LOGIC
 
-Last updated: 2026-04-18  
+Last updated: 2026-04-26
 Status: active  
 Source of truth: commercial architecture canon, product line status board and client onboarding flow system.
 
@@ -10,7 +10,7 @@ Commercial Architecture And Onboarding Flow Refinement - Packaging and route log
 
 ## Korte samenvatting
 
-Dit document zet de commerciele routearchitectuur om in expliciete packaging- en routebeslisregels. De kern is dat Verisight voorlopig een dual-core instap kent, terwijl de rest alleen als verdieping, bounded vervolg of portfolioroute mag worden gelezen.
+Dit document zet de commerciele routearchitectuur om in expliciete packaging- en routebeslisregels. De kern is dat Verisight voorlopig een dual-core instap kent, terwijl de rest alleen als verdieping, bounded vervolg, embedded follow-through laag of portfolioroute mag worden gelezen.
 
 ## Wat is geaudit
 
@@ -20,6 +20,8 @@ Dit document zet de commerciele routearchitectuur om in expliciete packaging- en
 - [PRODUCT_LINE_STATUS_BOARD.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/PRODUCT_LINE_STATUS_BOARD.md)
 - [PRODUCT_LANGUAGE_CANON.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/PRODUCT_LANGUAGE_CANON.md)
 - [REPORT_TO_ACTION_PROGRAM_PLAN.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/REPORT_TO_ACTION_PROGRAM_PLAN.md)
+- [STRATEGY.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/strategy/STRATEGY.md)
+- [2026-04-25-action-center-second-live-consumer.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/superpowers/plans/2026-04-25-action-center-second-live-consumer.md)
 - [marketing-products.ts](/C:/Users/larsh/Desktop/Business/Verisight/frontend/lib/marketing-products.ts)
 
 ## Belangrijkste bevindingen
@@ -28,12 +30,14 @@ Dit document zet de commerciele routearchitectuur om in expliciete packaging- en
 - `TeamScan` en `Onboarding 30-60-90` zijn geloofwaardige vervolgroutes, maar nog geen gelijkwaardige first-buy proposities.
 - `Pulse` en `Leadership Scan` werken alleen veilig als bounded support routes na een eerste managementvraag of eerste managementactie.
 - `Combinatie` is alleen logisch als portfolioverbindende route boven reeds bestaande managementvragen, niet als zelfstandig instappakket.
+- Action Center is nu een echte interne productlaag, maar alleen als embedded follow-through voor bounded live consumers en niet als extra routevorm of pricinglaag.
 
 ## Belangrijkste inconsistenties of risico's
 
 - Buyer-facing overzichten die follow-on routes als `live` of volwaardige hoofdroutes framen, lopen voor op parity en formele outputvolwassenheid.
 - Zonder routebeslisregels kan dual-core verschuiven naar suite-chaos of naar opportunistische upsellvolgorde.
 - Packagingtaal kan te snel productstatus suggereren als instap, vervolg en bounded support niet expliciet gescheiden blijven.
+- Zodra Action Center nergens expliciet is geclassificeerd, kan het onbedoeld gaan voelen als derde product, cockpitmodule of suite-shell terwijl de huidige laag alleen bounded follow-through draagt.
 
 ## Beslissingen / canonvoorstellen
 
@@ -41,14 +45,16 @@ Dit document zet de commerciele routearchitectuur om in expliciete packaging- en
 - `Verdieping` betekent: extra duiding, segmentwerk of managementsessie bovenop een gekozen eerste route.
 - `Vervolg` betekent: ritme, review of herhaalmeting nadat first value en first action al zijn geland.
 - `Bounded support` betekent: smaller use case, begrensde claim en geen zelfstandige suite- of statuspromotie.
+- `Embedded follow-through layer` betekent: een interne gedeelde productlaag die dossiers, eigenaarschap, reviewmomenten en signalen bundelt onder guided execution zonder buyer-facing pricing, losse moduleclaim of open adapterverhaal.
 - `Portfolio route` betekent: verbindende route tussen meerdere echte managementvragen, niet een derde productkern.
 - De commerciele default is `dual-core`, maar die default herdefinieert de vaste ExitScan-report-architectuur of de productmaturitylabels niet.
+- Action Center valt nu expliciet onder `embedded follow-through layer` en niet onder `instap`, `verdieping`, `vervolg`, `bounded support` of `portfolio route`.
 
 ## Concrete wijzigingen
 
 - Nieuw bestand aangemaakt: [PACKAGING_AND_ROUTE_LOGIC.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/PACKAGING_AND_ROUTE_LOGIC.md)
 
-## Route logic
+## Route and layer logic
 
 | Routevorm | Mag buyer-facing worden gebruikt als | Mag niet worden gebruikt als | Huidige producten |
 | --- | --- | --- | --- |
@@ -56,6 +62,7 @@ Dit document zet de commerciele routearchitectuur om in expliciete packaging- en
 | Verdieping | er al een gekozen eerste route is en extra duiding of segmentwerk logisch volgt | vervanging van een first-buy beslissing | segment deep dive, extra managementsessie |
 | Vervolg | first value en first action al zijn geland | los add-on verhaal zonder managementdoel | vervolgmeting, ritmeroute |
 | Bounded support | de vraag smaller is dan een kernroute en de begrenzing expliciet blijft | nieuwe kernpropositie of brede statusclaim | Pulse, Leadership Scan |
+| Embedded follow-through layer | de laag intern dossiers, reviewdruk en eigenaarschap bundelt onder guided execution voor al actieve carriers | publiek prijsanker, derde product, buyer-facing module of bewijs van brede adapterdekking | Action Center |
 | Lokale verificatie | er een bestaande hoofdvraag is die lokaal of per team getoetst moet worden | generieke teamsuite als eerste verkoopverhaal | TeamScan |
 | Lifecycle-check | er een specifieke onboardingvraag ligt na of naast de eerste kernroute | algemeen HR operating system | Onboarding 30-60-90 |
 | Portfolio route | meerdere echte managementvragen tegelijk bestuurlijk spelen | bundel als hoofdverhaal of prijsanker | Combinatie |
@@ -65,12 +72,14 @@ Dit document zet de commerciele routearchitectuur om in expliciete packaging- en
 - De route-indeling volgt de huidige statusboard- en commercial-canonlogica.
 - Er wordt geen nieuwe pricingstructuur of portfolioverbreding vastgezet.
 - De indeling beschermt expliciet tegen buyer-facing overspraak van parity-build en bounded routes.
+- Action Center is nu expliciet geclassificeerd zonder nieuwe commerciële scope te openen.
 
 ## Assumptions / defaults
 
 - `Instap` is een commerciele routecategorie en geen repo-brede productstatus.
 - `Bounded support` beschrijft routegebruik, niet waardeloosheid of afwijzing.
 - Producten zonder volledige formele report parity mogen nog steeds intern of bounded worden gebruikt, zolang de claimlaag beperkt blijft.
+- Action Center beschrijft nu een bestaande interne productlaag met twee bounded live consumers, niet een publieke route of apart pakket.
 
 ## Next gate
 

--- a/docs/active/PRICING_AND_PACKAGING_PROGRAM_PLAN.md
+++ b/docs/active/PRICING_AND_PACKAGING_PROGRAM_PLAN.md
@@ -4,7 +4,7 @@
 
 Dit traject heeft van de bestaande prijsankers, package-vormen en commerciële uitleg van Verisight één strakke, verkoopbare en repo-consistente pricing- en packaginglaag gemaakt. De strategische alignment in deze reviewronde trekt dat verhaal opnieuw gelijk met de huidige productwaarheid: guided execution, assisted self-service discipline, twee eerlijke first-buy routes en een bewust bounded portfolio.
 
-Sinds 2026-04-26 hoort daar ook expliciet bij dat de inmiddels echte Action Center-productlaag niet meer onzichtbaar onder de commerciële taal mag blijven hangen. Die laag is wél productwaarheid, maar nog niet verkoopbaar als derde product, losse module, add-on of prijsanker. Pricing en packaging moeten dus ruimte laten voor Action Center als embedded follow-through laag zonder daar commerciële fantasie omheen te bouwen.
+Sinds 2026-04-26 hoort daar ook expliciet bij dat de inmiddels echte Action Center-productlaag niet meer onzichtbaar onder de commerciële taal mag blijven hangen. Die laag is wél productwaarheid, maar nog niet verkoopbaar als derde product, losse module, add-on of prijsanker. Pricing en packaging moeten dus ruimte laten voor Action Center als embedded follow-through laag zonder daar commerciële fantasie omheen te bouwen. Concreet draagt de huidige laag dossier-, assignment-, review- en signaalopvolging voor precies twee live consumers (MTO en ExitScan); andere adapters bestaan alleen nog als inactive placeholder en mogen dus niet in pricing worden meegelezen.
 
 De uitgevoerde richting in deze tranche:
 
@@ -28,6 +28,7 @@ Belangrijkste repo-observaties waarop deze uitvoering is gebaseerd:
 - RetentieScan had commercieel meer package-varianten dan ExitScan, waardoor package-uitleg sneller diffuus kon worden
 - frontend-, funnel- en dashboardlagen stuurden inmiddels al op question-first eerste routekeuze en guided self-service discipline
 - de echte Action Center-core bestaat nu als interne follow-through laag met precies twee bounded live consumers, maar nog zonder buyer-facing package- of modulecontract
+- future adapters voor RetentieScan, Onboarding, Pulse en Leadership bestaan alleen als inactive placeholder en mogen niet als commerciële dekking of vervolglijn worden verkocht
 - portfolio-architectuur en producttaal maakten duidelijk dat bounded vervolgroutes niet als extra kernproducten of brede pricinglaag mogen worden geframed
 - strategie, trust en roadmap maakten expliciet dat pricing assisted/productized moest blijven en niet mocht doorschieten naar plans, seats, subscriptions of Stripe-logica
 
@@ -63,9 +64,10 @@ Status 2026-04-26:
   - geen self-service checkout of publieke planmatrix
   - geen nieuwe technische campaign-entiteiten voor elke commerciële vervolgroute
   - geen groot website-redesign buiten package- en pricingalignment
-  - geen admin/dashboardcopy-wijziging, omdat de huidige interne termen de publieke packagecopy nu niet blokkeren
-  - geen standalone Action Center pricing, modulepositionering of buyer-facing upsellcopy
-  - geen nieuwe pricinglaag voor bounded vervolgroutes of portfolioverbreding zonder apart besluit
+- geen admin/dashboardcopy-wijziging, omdat de huidige interne termen de publieke packagecopy nu niet blokkeren
+- geen standalone Action Center pricing, modulepositionering of buyer-facing upsellcopy
+- geen pricingcopy die inactive future adapters, brede orchestration of open adaptertoegang suggereert
+- geen nieuwe pricinglaag voor bounded vervolgroutes of portfolioverbreding zonder apart besluit
 
 ## 2. Milestones
 
@@ -179,6 +181,7 @@ Dependency: Milestone 3
 - [x] Pricing gekoppeld gehouden aan echte voorbeeldoutput en report-structuur.
 - [x] Pricing expliciet gekoppeld gehouden aan guided execution, assisted self-service discipline en bounded portfolio guardrails uit de actuele productlaag.
 - [x] Pricing expliciet gekoppeld gehouden aan de huidige Action Center-truth: dossier-first follow-through, reviewdruk, expliciete eigenaar en slechts twee bounded live consumers.
+- [x] Vastgelegd dat inactive future adapters onder Action Center geen buyer-facing pricingdekking, vervolglijn of routeverbreding rechtvaardigen.
 - [x] Vastgelegd welke packageclaims niet mogen: always-on live monitoring alsof dit al product-led standaard is, benchmark- of ROI-claims zonder basis en SaaS-planframing.
 - [x] Vastgelegd welke Action Center-claims nu niet mogen: losse moduleframing, cross-product orchestration alsof alle adapters al live zijn en buyer-facing pricing alsof follow-through al productized self-serve is.
 - [x] Interne admin/dashboardcopy beoordeeld; geen directe wijziging nodig geacht in deze tranche.
@@ -188,6 +191,7 @@ Dependency: Milestone 3
 - [x] Pricing belooft niet meer dan dashboard, report, preview en campaignmodel waarmaken.
 - [x] De packagearchitectuur blijft assisted/productized in plaats van pseudo-SaaS.
 - [x] Action Center wordt commercieel niet zwaarder gelezen dan de huidige bounded ops- en follow-upcapaciteit draagt.
+- [x] Geen pricinglaag suggereert live entry of buyer-facing dekking voor inactive future adapters.
 
 #### Validation
 - [x] `backend/report.py`, previewcopy, dashboard/admin-context en voorbeeld-PDF's ondersteunen de packageclaims.

--- a/docs/active/PRICING_AND_PACKAGING_PROGRAM_PLAN.md
+++ b/docs/active/PRICING_AND_PACKAGING_PROGRAM_PLAN.md
@@ -4,6 +4,8 @@
 
 Dit traject heeft van de bestaande prijsankers, package-vormen en commerciële uitleg van Verisight één strakke, verkoopbare en repo-consistente pricing- en packaginglaag gemaakt. De strategische alignment in deze reviewronde trekt dat verhaal opnieuw gelijk met de huidige productwaarheid: guided execution, assisted self-service discipline, twee eerlijke first-buy routes en een bewust bounded portfolio.
 
+Sinds 2026-04-26 hoort daar ook expliciet bij dat de inmiddels echte Action Center-productlaag niet meer onzichtbaar onder de commerciële taal mag blijven hangen. Die laag is wél productwaarheid, maar nog niet verkoopbaar als derde product, losse module, add-on of prijsanker. Pricing en packaging moeten dus ruimte laten voor Action Center als embedded follow-through laag zonder daar commerciële fantasie omheen te bouwen.
+
 De uitgevoerde richting in deze tranche:
 
 - één canonieke pricing- en packagingarchitectuur vastgelegd rond twee first-buy routes, guided vervolgvormen, add-ons en een bounded portfolioroute
@@ -25,10 +27,11 @@ Belangrijkste repo-observaties waarop deze uitvoering is gebaseerd:
 - `delivery_mode` bestond backendmatig, maar droeg `ExitScan ritmeroute` nog niet als volwaardige publieke productmodus
 - RetentieScan had commercieel meer package-varianten dan ExitScan, waardoor package-uitleg sneller diffuus kon worden
 - frontend-, funnel- en dashboardlagen stuurden inmiddels al op question-first eerste routekeuze en guided self-service discipline
+- de echte Action Center-core bestaat nu als interne follow-through laag met precies twee bounded live consumers, maar nog zonder buyer-facing package- of modulecontract
 - portfolio-architectuur en producttaal maakten duidelijk dat bounded vervolgroutes niet als extra kernproducten of brede pricinglaag mogen worden geframed
 - strategie, trust en roadmap maakten expliciet dat pricing assisted/productized moest blijven en niet mocht doorschieten naar plans, seats, subscriptions of Stripe-logica
 
-Status 2026-04-24:
+Status 2026-04-26:
 
 - Oorspronkelijk uitgevoerd op 2026-04-15:
   - `docs/active/PRICING_AND_PACKAGING_PROGRAM_PLAN.md`
@@ -50,12 +53,18 @@ Status 2026-04-24:
   - `docs/active/PRICING_AND_PACKAGING_PROGRAM_PLAN.md`
   - `docs/strategy/STRATEGY.md`
   - first-buy logica opnieuw gelijkgetrokken met guided execution, assisted self-service en bounded portfolio guardrails
+- Action Center-alignment toegevoegd op 2026-04-26:
+  - `docs/active/PRICING_AND_PACKAGING_PROGRAM_PLAN.md`
+  - `docs/active/PACKAGING_AND_ROUTE_LOGIC.md`
+  - `docs/strategy/STRATEGY.md`
+  - expliciet vastgelegd dat Action Center een embedded follow-through laag is en geen publiek prijsanker, add-on of derde productverhaal
 - Bewust niet uitgevoerd in deze ronde:
   - geen Stripe, billing, subscription- of seatlogica
   - geen self-service checkout of publieke planmatrix
   - geen nieuwe technische campaign-entiteiten voor elke commerciële vervolgroute
   - geen groot website-redesign buiten package- en pricingalignment
   - geen admin/dashboardcopy-wijziging, omdat de huidige interne termen de publieke packagecopy nu niet blokkeren
+  - geen standalone Action Center pricing, modulepositionering of buyer-facing upsellcopy
   - geen nieuwe pricinglaag voor bounded vervolgroutes of portfolioverbreding zonder apart besluit
 
 ## 2. Milestones
@@ -71,10 +80,12 @@ Dependency: none
 - [x] Vastgelegd welke package-elementen technisch echt ondersteund zijn: `segment_deep_dive`, `delivery_mode` en RetentieScan trend-/ritme-output.
 - [x] Vastgelegd waar pricing inhoudelijk rust op echte output en waar pricing vooral een commerciële constructie was.
 - [x] De belangrijkste verwarringspunten gedocumenteerd: ExitScan Baseline versus ExitScan ritmeroute, RetentieScan ritmeroute versus compacte vervolgmeting, combinatie als route versus pakket en add-on versus productvorm.
+- [x] Vastgelegd dat de nieuwe Action Center-productlaag wel echt bestaat, maar nog geen eigen package-type, prijsanker of los moduleverhaal heeft.
 
 #### Definition of done
 - [x] Er lag één controleerbaar startbeeld van de huidige pricing- en packaginglaag.
 - [x] Het verschil tussen verkocht, ondersteund en voorbereid was expliciet.
+- [x] Het verschil tussen buyer-facing packages en de onderliggende Action Center-productlaag is expliciet.
 - [x] De grootste spanningen tussen site, sales en productrealiteit waren benoemd.
 
 #### Validation
@@ -94,10 +105,12 @@ Dependency: Milestone 0
 - [x] Vastgelegd welke prijsankers publiek blijven en welke bewust quote-only zijn.
 - [x] Vaste buyer-facing package-termen vastgelegd: product, eerste traject, vervolgvorm, add-on en portfolioroute.
 - [x] Vastgelegd dat pricing in deze fase guided execution ondersteunt, assisted/productized blijft en geen billingmodel is.
+- [x] Vastgelegd dat Action Center onder pricing hoort als embedded follow-through laag en daarom buiten de buyer-facing packageboom blijft.
 
 #### Definition of done
 - [x] Verisight heeft één decision-complete pricing- en packagingarchitectuur.
 - [x] Elk package-element heeft een vaste plaats in de commerciële boom.
+- [x] Action Center heeft expliciet geen plaats als los publiek package-element.
 - [x] De architectuur ondersteunt question-first first-buy routes zonder RetentieScan te degraderen tot afgeleide feature.
 
 #### Validation
@@ -165,13 +178,16 @@ Dependency: Milestone 3
 - [x] Expliciet vastgelegd dat `segment_deep_dive` de enige repo-breed echte add-on is en dat andere commerciële vervolgvormen geen technisch add-on-contract hoeven te zijn.
 - [x] Pricing gekoppeld gehouden aan echte voorbeeldoutput en report-structuur.
 - [x] Pricing expliciet gekoppeld gehouden aan guided execution, assisted self-service discipline en bounded portfolio guardrails uit de actuele productlaag.
+- [x] Pricing expliciet gekoppeld gehouden aan de huidige Action Center-truth: dossier-first follow-through, reviewdruk, expliciete eigenaar en slechts twee bounded live consumers.
 - [x] Vastgelegd welke packageclaims niet mogen: always-on live monitoring alsof dit al product-led standaard is, benchmark- of ROI-claims zonder basis en SaaS-planframing.
+- [x] Vastgelegd welke Action Center-claims nu niet mogen: losse moduleframing, cross-product orchestration alsof alle adapters al live zijn en buyer-facing pricing alsof follow-through al productized self-serve is.
 - [x] Interne admin/dashboardcopy beoordeeld; geen directe wijziging nodig geacht in deze tranche.
 
 #### Definition of done
 - [x] Elke package-vorm is inhoudelijk gekoppeld aan bestaande product- en outputrealiteit.
 - [x] Pricing belooft niet meer dan dashboard, report, preview en campaignmodel waarmaken.
 - [x] De packagearchitectuur blijft assisted/productized in plaats van pseudo-SaaS.
+- [x] Action Center wordt commercieel niet zwaarder gelezen dan de huidige bounded ops- en follow-upcapaciteit draagt.
 
 #### Validation
 - [x] `backend/report.py`, previewcopy, dashboard/admin-context en voorbeeld-PDF's ondersteunen de packageclaims.
@@ -234,6 +250,7 @@ Dependency: Milestone 4
 - [x] `ExitScan ritmeroute` blijft afhankelijk van begeleide delivery en voldoende volume; de quote-only framing verkleint hier het risico op overselling.
 - [x] Alleen `segment_deep_dive` is repo-breed een echte add-on; dit blijft expliciet bewaakt in copy en tests.
 - [x] Oude ExitScan-first taal kan nog steeds terugkeren en de vraaggestuurde first-buy logica onnodig vernauwen.
+- [x] Action Center kan te snel als module, cockpitproduct of suite-shell worden geframed nu de productlaag technisch echter is geworden dan de commerciële docs nog lieten zien.
 - [x] Premature SaaS-logica is in deze tranche bewust buiten scope gehouden.
 - [x] Trust-erosie door te harde packageclaims is verkleind via alignment met preview, trustdocs en paritytests.
 
@@ -241,6 +258,7 @@ Dependency: Milestone 4
 
 - [ ] Willen we `Compacte retentie vervolgmeting` later publiek blijven tonen als aparte vervolgcomponent, of alleen nog als sales-/proposalterm binnen `RetentieScan ritmeroute`?
 - [ ] Willen we `ExitScan ritmeroute` later publiek prominenter maken zodra `delivery_mode` ook frontend- en admin-breed verder is uitgewerkt?
+- [ ] Vanaf welk moment is de Action Center-laag volwassen genoeg om publiek als werkwijze te worden benoemd zonder hem pricingmatig als module of derde product te laten voelen?
 - [ ] Willen we later een compactere executive pricing-view naast de huidige tariefpagina?
 - [ ] Willen we combinatie later semi-gestandaardiseerd tonen als portfolio-opbouw, of structureel `op aanvraag` houden?
 - [ ] Willen we bounded vervolgroutes later publiek/commercieel explicieter maken, of blijven die pas na aparte sign-off zichtbaar buiten de huidige kernpricing?
@@ -260,6 +278,7 @@ Dependency: Milestone 4
 - [x] Geen plan-, seat- of usage-architectuur.
 - [x] Geen herbouw van productmethodiek, scoring of report-engine buiten pricingpariteit.
 - [x] Geen nieuwe productfamilies buiten ExitScan, RetentieScan en combinatie.
+- [x] Geen standalone Action Center pricing, Action Center-module of publieke Action Center-upsell.
 - [x] Geen heropening van bounded vervolgroutes als nieuwe publieke pricinglaag zonder apart besluit.
 - [x] Geen groot website-redesign buiten wat nodig is om pricing- en packagecopy te alignen.
 - [x] Geen verzonnen ROI-, benchmark- of klantproofclaims.
@@ -275,5 +294,6 @@ Dependency: Milestone 4
 - [x] `Compacte retentie vervolgmeting` blijft een compact vervolg binnen de RetentieScan-ritmeroute en niet een parallelle hoofdpackage.
 - [x] `Segment deep dive` blijft de enige expliciete add-on die repo-breed technisch en commercieel herkenbaar is.
 - [x] Combinatie blijft een portfolioroute op aanvraag, geen bundel, korting of standaard upsell.
+- [x] Action Center blijft embedded in guided execution, dossier-first en review-first, zonder eigen publiek prijsanker.
 - [x] Pricing blijft guided execution ondersteunen, assisted/productized en boardroom-geschikt, zonder premature SaaS-billinglogica.
 - [x] Claims mogen commercieel scherp zijn, maar nooit verder gaan dan huidige output, trustgrenzen en productrealiteit dragen.

--- a/docs/active/PRODUCT_LANGUAGE_CANON.md
+++ b/docs/active/PRODUCT_LANGUAGE_CANON.md
@@ -38,6 +38,7 @@ Deze canon legt vast welke producttaal leidend is over rapport, dashboard, onboa
 - De sterkste taalbasis zit al in de embedded definities van ExitScan en RetentieScan.
 - Shared grammar is vooral een rapport- en handofftaal en moet daarom breed worden gebruikt, maar niet verward worden met productspecifieke inhoudsblokken.
 - Buyer-facing mirrors mogen vereenvoudigen, maar niet verschuiven van `duiding` naar `diagnose`, van `vroegsignalering` naar `voorspelling`, of van `bounded route` naar impliciete suiteclaim.
+- Follow-through taal rond Action Center moet intern scherp genoeg blijven om geen cockpit-, module- of orchestrationclaim te suggereren.
 - Working maturity labels helpen intern met hardening, maar zijn nu nog te prematuur voor brede publieke of technische canonisering.
 
 ## Belangrijkste inconsistenties of risico's
@@ -45,6 +46,7 @@ Deze canon legt vast welke producttaal leidend is over rapport, dashboard, onboa
 - Zonder expliciete taalhiërarchie blijven oudere landingpagekoppen en voorbeeldrapporten concurreren met embedded truth.
 - Leveringsvormen zoals `live`, `momentopname` en `retrospectief` zijn nuttig, maar worden te snel ingezet als identiteitstaal.
 - Follow-on routes kunnen onbedoeld te groot of te volwassen klinken wanneer begrenzende taal wegvalt.
+- Action Center kan zonder expliciete follow-through canon te snel gaan voelen als buyer-facing module, brede adaptershell of derde productlijn.
 
 ## Beslissingen / canonvoorstellen
 
@@ -185,6 +187,37 @@ Portfolio- en verbredingstaal moet de huidige grenzen bewaken:
 - `Pulse` is een compacte reviewroute, geen derde brede instaproute naast ExitScan en RetentieScan.
 - `Leadership Scan` is een bounded management read, geen 360-tool en geen named leader assessment.
 
+### Action Center follow-through canon
+
+Hoofdpositionering:
+
+`Action Center is de gedeelde bounded follow-through laag op de bestaande adminsurface voor MTO en ExitScan.`
+
+Hoofdtermen:
+
+- `follow-through`
+- `dossier`
+- `assignment`
+- `reviewmoment`
+- `follow-upsignaal`
+- `eerste eigenaar`
+- `closure`
+
+Verboden of te harde termen als hoofdterm:
+
+- `module`
+- `cockpitproduct`
+- `suite-shell`
+- `cross-product orchestration`
+- `open adapterlaag`
+- `self-serve actieplatform`
+
+Canonregels:
+
+- buyer-facing mirrors mogen Action Center alleen indirect benoemen als onderdeel van guided execution en follow-through, nooit als zelfstandige route, package of prijsanker
+- MTO en ExitScan zijn de enige live consumers; adapters voor RetentieScan, Onboarding 30-60-90, Pulse en Leadership Scan blijven nu `inactive`
+- Action Center-taal mag geen brede project-plan-, advisory- of open-adapter-scope suggereren zolang de gedeelde core expliciet `follow_through` bounded blijft
+
 ### Working maturity labels
 
 De volgende labels zijn toegestaan binnen dit hardening-programma:
@@ -203,6 +236,7 @@ Deze labels zijn intern en mogen nog niet verschijnen als buyer-facing status, d
 - Nieuw bestand aangemaakt: [PRODUCT_LANGUAGE_CANON.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/PRODUCT_LANGUAGE_CANON.md)
 - Taalhiërarchie expliciet gemaakt zodat toekomstige fixes, contentupdates en paritykeuzes aan dezelfde bronvolgorde kunnen worden getoetst
 - Producttaal per kernroute en per follow-on route begrensd om drift naar diagnose-, suite- of statusclaimtaal te voorkomen
+- Action Center-taal begrensd tot bounded follow-through zodat strategy-, pricing- en onboardingdocs dezelfde interne productlaag benoemen zonder commerciële drift
 
 ## Validatie
 

--- a/docs/reference/PRICING_AND_PACKAGING_ACCEPTANCE_CHECKLIST.md
+++ b/docs/reference/PRICING_AND_PACKAGING_ACCEPTANCE_CHECKLIST.md
@@ -1,7 +1,7 @@
 # Pricing And Packaging Acceptance Checklist
 
 Handmatige acceptance voor publieke pricing, sales parity en package-governance.
-Laatste update: 2026-04-15
+Laatste update: 2026-04-26
 
 ## Buyer begrip
 
@@ -24,6 +24,7 @@ Laatste update: 2026-04-15
 - [ ] Geen packageclaim gaat verder dan preview, reportoutput en trustdocs dragen.
 - [ ] RetentieScan blijft verification-first en niet voorspellend.
 - [ ] ExitScan blijft vertrekduiding en niet diagnostisch.
+- [ ] Geen pricingcopy leest Action Center als derde product, add-on, module, suite-shell of brede adapterdekking buiten MTO en ExitScan.
 
 ## Sales parity
 

--- a/docs/strategy/STRATEGY.md
+++ b/docs/strategy/STRATEGY.md
@@ -23,8 +23,10 @@ Verisight is nu geen brede people-suite en ook nog geen full self-service SaaS. 
 
 - **Action Center-productlaag**
   - gedeelde follow-through laag onder guided execution en delivery
-  - houdt dossiers, eerste eigenaar, reviewmoment en open follow-upsignalen bij elkaar op de bestaande adminsurface
+  - houdt dossiers, assignments, reviewmomenten en open follow-upsignalen bij elkaar op de bestaande adminsurface
+  - deelt alleen bounded follow-through permissies; productadapters blijven op deze laag gesloten
   - is nu bewust bounded tot twee live consumers: de bestaande MTO/team follow-through en ExitScan follow-through
+  - RetentieScan-, Onboarding-, Pulse- en Leadership-adapters staan nog inactive en openen geen nieuwe commerciële route
   - is geen buyer-facing route, geen losse pricingmodule en geen open adapterlaag
 
 - **Bounded portfoliolaag**
@@ -112,6 +114,7 @@ Wat nu niet te hard geclaimd mag worden:
 - RetentieScan wordt niet lager gezet dan de productrealiteit draagt; het is een eigen eerste kooproute wanneer de managementvraag daarom vraagt
 - Baseline, live, ritme en compacte vervolgmetingen zijn leverings- of vervolgvormen en geen losse productfamilies
 - Action Center mag niet commercieel worden herlezen als derde kernroute, add-on, module upsell of suite-shell
+- inactive future adapters onder Action Center mogen niet impliciet als live route-, pricing- of orchestrationdekking worden verkocht
 - combinatie en andere bounded vervolgroutes blijven portfolio-keuzes na een eerste route, niet nieuwe kernproducten of nieuwe standaardinstappen
 - publieke pricing blijft gericht op wat delivery en ops nu echt kunnen dragen; geen verbreding zonder expliciet besluit
 
@@ -139,7 +142,7 @@ Verisight beweegt wel richting een SaaS-model, maar zit nu nog in een assisted/p
 - productfundament met scans, dashboards, rapportage en organisatie-/campagnestructuur
 - beveiligde appflows met auth, login, invites en beheer
 - guided self-service discipline rond intake, importcontrole, launch, dashboardactivatie en eerste vervolgstap
-- gedeelde Action Center follow-through core voor dossiers, reviewdruk en expliciete eigenaar/opvolgdiscipline binnen bounded live consumers
+- gedeelde Action Center follow-through core voor dossiers, assignments, reviewdruk en expliciete eigenaar/opvolgdiscipline binnen bounded live consumers, zonder open productadaptertoegang
 - demo- en sample-infrastructuur voor assisted verkoop, validatie en showcase
 
 ### Deels aanwezig

--- a/docs/strategy/STRATEGY.md
+++ b/docs/strategy/STRATEGY.md
@@ -1,7 +1,7 @@
 # Verisight - Strategie En Beslissingen
 
 Levend document. Dit is de strategische samenvatting van wat Verisight nu verkoopt, hoe we het positioneren en welke guardrails gelden.
-Laatste update: 2026-04-24
+Laatste update: 2026-04-26
 
 ## Wat we nu bouwen en verkopen
 
@@ -21,6 +21,12 @@ Verisight is nu geen brede people-suite en ook nog geen full self-service SaaS. 
   - begeleidt intake, launchdiscipline, dashboardactivatie en eerste vervolgstap
   - laat de klant zelf werken binnen begrensde product- en deliveryrails
 
+- **Action Center-productlaag**
+  - gedeelde follow-through laag onder guided execution en delivery
+  - houdt dossiers, eerste eigenaar, reviewmoment en open follow-upsignalen bij elkaar op de bestaande adminsurface
+  - is nu bewust bounded tot twee live consumers: de bestaande MTO/team follow-through en ExitScan follow-through
+  - is geen buyer-facing route, geen losse pricingmodule en geen open adapterlaag
+
 - **Bounded portfoliolaag**
   - houdt combinatie en andere bounded vervolgroutes ondergeschikt aan de kernroutes
   - mag pas zichtbaarder worden nadat een eerste route echte managementwaarde heeft opgeleverd
@@ -30,6 +36,7 @@ De commerciele default in deze fase is:
 - first-buy logica is vraaggestuurd: ExitScan is de default, RetentieScan is de eerlijke eerste route bij een expliciete actieve behoudsvraag
 - Baseline blijft de standaard eerste vorm; ritme en live blijven guided vervolg- of deliveryvormen en geen losse hoofdproducten
 - bounded portfolioroutes worden niet als standaard eerste pitch gebruikt en openen de kernhierarchie niet opnieuw
+- Action Center blijft onder deze commerciële laag een interne follow-through productlaag en geen derde publiek aanbod
 
 ## Huidige fase
 
@@ -100,9 +107,11 @@ Wat nu niet te hard geclaimd mag worden:
 ### Product-, route- en portfoliovolgorde
 
 - guided execution is nu een deel van de productwaarheid en niet alleen een deliveryvoetnoot
+- Action Center is nu ook deel van de productwaarheid, maar alleen als embedded follow-through laag binnen guided execution en delivery
 - ExitScan en RetentieScan zijn de twee buyer-facing kernroutes; ExitScan blijft de default, maar niet de enige legitieme first-buy route
 - RetentieScan wordt niet lager gezet dan de productrealiteit draagt; het is een eigen eerste kooproute wanneer de managementvraag daarom vraagt
 - Baseline, live, ritme en compacte vervolgmetingen zijn leverings- of vervolgvormen en geen losse productfamilies
+- Action Center mag niet commercieel worden herlezen als derde kernroute, add-on, module upsell of suite-shell
 - combinatie en andere bounded vervolgroutes blijven portfolio-keuzes na een eerste route, niet nieuwe kernproducten of nieuwe standaardinstappen
 - publieke pricing blijft gericht op wat delivery en ops nu echt kunnen dragen; geen verbreding zonder expliciet besluit
 
@@ -130,6 +139,7 @@ Verisight beweegt wel richting een SaaS-model, maar zit nu nog in een assisted/p
 - productfundament met scans, dashboards, rapportage en organisatie-/campagnestructuur
 - beveiligde appflows met auth, login, invites en beheer
 - guided self-service discipline rond intake, importcontrole, launch, dashboardactivatie en eerste vervolgstap
+- gedeelde Action Center follow-through core voor dossiers, reviewdruk en expliciete eigenaar/opvolgdiscipline binnen bounded live consumers
 - demo- en sample-infrastructuur voor assisted verkoop, validatie en showcase
 
 ### Deels aanwezig
@@ -143,6 +153,7 @@ Verisight beweegt wel richting een SaaS-model, maar zit nu nog in een assisted/p
 - billing/subscription-logica als kern van het model
 - echte self-service onboarding en provisioning als standaardpad
 - volwassen lifecycle-logica rond plans, seats, usage en automated customer operations
+- brede cross-product orchestrationlaag buiten de huidige bounded Action Center consumers
 
 ### Strategische conclusie
 
@@ -196,6 +207,7 @@ Niet alles wat nu belangrijk is, zit in code. Deze afhankelijkheden tellen mee i
 - grote self-service onboarding
 - Stripe en brede billing-automatisering
 - nieuwe productfamilies buiten ExitScan/RetentieScan
+- een buyer-facing Action Center-module, publieke Action Center pricing of brede adapteropening zonder apart besluit
 - portfolioverbreding of bounded route-promotie zonder expliciet besluit
 - publiek API-werk
 - brede contentmachine zonder stabiele kernpropositie
@@ -211,4 +223,5 @@ Niet alles wat nu belangrijk is, zit in code. Deze afhankelijkheden tellen mee i
 - ExitScan blijft de default eerste route in generieke gesprekken, maar niet de enige eerlijke first-buy route
 - RetentieScan blijft een kernroute en wordt niet kunstmatig lager gezet wanneer de actieve behoudsvraag primair is
 - bounded portfolioroutes blijven ondergeschikt aan een scherp gekozen eerste route en openen geen nieuwe pricing- of propositiescope
+- Action Center blijft commercieel onderliggend aan guided execution: wel echte productlaag, geen zelfstandig prijsanker of pitchlijn
 - de eerste commerciële mijlpaal is niet een nieuwe feature, maar een eerste reeks betaalde trajecten via dezelfde truth-aligned routearchitectuur

--- a/tests/test_pricing_packaging_system.py
+++ b/tests/test_pricing_packaging_system.py
@@ -23,9 +23,9 @@ def test_active_pricing_plan_tracks_outputs_and_prompt_closure():
 
 def test_public_pricing_copy_keeps_package_hierarchy_explicit():
     site_content = _read("frontend/components/marketing/site-content.ts")
-    tarieven_page = _read("frontend/app/tarieven/page.tsx")
-    aanpak_page = _read("frontend/app/aanpak/page.tsx")
-    homepage = _read("frontend/app/page.tsx")
+    tarieven_content = _read("frontend/components/marketing/tarieven-content.tsx")
+    aanpak_content = _read("frontend/components/marketing/aanpak-content.tsx")
+    homepage_content = _read("frontend/components/marketing/home-page-content.tsx")
 
     assert "exitscan baseline" in site_content
     assert "retentiescan baseline" in site_content
@@ -34,11 +34,12 @@ def test_public_pricing_copy_keeps_package_hierarchy_explicit():
     assert "retentiescan ritme" in site_content
     assert "compacte retentie vervolgmeting" in site_content
     assert "combinatieroute" in site_content
-    assert "de eerste koop blijft helder." in tarieven_page
-    assert "vervolg en add-ons" in tarieven_page
-    assert "prijs in context" in tarieven_page
-    assert "welke route past nu?" in homepage
-    assert "rapport, bestuurlijke handoff en eerste opvolging" in aanpak_page
+    assert "de eerste koop blijft helder." in tarieven_content
+    assert "vervolg en add-ons" in tarieven_content
+    assert "prijs in context" in tarieven_content
+    assert "kies de route" in homepage_content
+    assert "die past bij uw vraagstuk." in homepage_content
+    assert "rapport, bestuurlijke handoff en eerste opvolging" in aanpak_content
 
 
 def test_sales_docs_keep_same_package_architecture_as_public_site():
@@ -80,3 +81,17 @@ def test_pricing_claims_stay_inside_trust_and_output_boundaries():
     assert "geen individuele signalen naar management" in site_content
     assert "geen brede mto" in retention_one_pager
     assert "geen individuele predictor" in retention_one_pager
+
+
+def test_action_center_stays_documented_as_embedded_non_priced_follow_through_layer():
+    strategy = _read("docs/strategy/STRATEGY.md")
+    pricing_plan = _read("docs/active/PRICING_AND_PACKAGING_PROGRAM_PLAN.md")
+    route_logic = _read("docs/active/PACKAGING_AND_ROUTE_LOGIC.md")
+
+    assert "action center-productlaag" in strategy
+    assert "twee live consumers" in strategy
+    assert "geen buyer-facing route, geen losse pricingmodule" in strategy
+    assert "embedded follow-through laag" in pricing_plan
+    assert "geen standalone action center pricing" in pricing_plan
+    assert "embedded follow-through layer" in route_logic
+    assert "publiek prijsanker, derde product, buyer-facing module" in route_logic

--- a/tests/test_pricing_packaging_system.py
+++ b/tests/test_pricing_packaging_system.py
@@ -87,11 +87,24 @@ def test_action_center_stays_documented_as_embedded_non_priced_follow_through_la
     strategy = _read("docs/strategy/STRATEGY.md")
     pricing_plan = _read("docs/active/PRICING_AND_PACKAGING_PROGRAM_PLAN.md")
     route_logic = _read("docs/active/PACKAGING_AND_ROUTE_LOGIC.md")
+    language_canon = _read("docs/active/PRODUCT_LANGUAGE_CANON.md")
+    signoff = _read("docs/active/COMMERCIAL_AND_ONBOARDING_SIGNOFF.md")
+    acceptance = _read("docs/reference/PRICING_AND_PACKAGING_ACCEPTANCE_CHECKLIST.md")
 
     assert "action center-productlaag" in strategy
     assert "twee live consumers" in strategy
+    assert "productadapters blijven op deze laag gesloten" in strategy
+    assert "retentiescan-, onboarding-, pulse- en leadership-adapters staan nog inactive" in strategy
     assert "geen buyer-facing route, geen losse pricingmodule" in strategy
     assert "embedded follow-through laag" in pricing_plan
     assert "geen standalone action center pricing" in pricing_plan
+    assert "inactive placeholder" in pricing_plan
     assert "embedded follow-through layer" in route_logic
+    assert "mto + exitscan live" in route_logic
+    assert "geen project-plan/advisory-scope" in route_logic
+    assert "action center is de gedeelde bounded follow-through laag" in language_canon
+    assert "nooit als zelfstandige route, package of prijsanker" in language_canon
+    assert "geen extra routekeuze of prijslaag" in signoff
+    assert "geen standalone action center pricing, modulepositionering of adapterverbreding" in signoff
+    assert "geen pricingcopy leest action center als derde product" in acceptance
     assert "publiek prijsanker, derde product, buyer-facing module" in route_logic


### PR DESCRIPTION
## Summary
- tighten the Action Center strategy and pricing canon around the real `follow_through` product layer
- keep Action Center explicitly bounded to the current admin surface, two live consumers, and closed adapters
- extend pricing governance coverage so future doc drift cannot reframe Action Center as a priced module or third route

## What changed
- updated the core strategy, pricing, route-logic, commercial signoff, and product-language docs
- added explicit guardrails that only MTO and ExitScan are live Action Center consumers today
- added acceptance/test coverage for no standalone Action Center pricing, module framing, or broad adapter claims

## Guardrails held
- no site copy changes
- no runtime changes
- no new consumers
- no dashboard scope
- no AC-SITE scope

## Why
AC-CANON is now on `main` and the visual layer is stable, so the remaining gap was strategic/commercial truth. The repo has a real Action Center layer, but only as a bounded embedded follow-through surface. This PR makes the canon say exactly that and blocks commercial drift toward module, suite-shell, or orchestration overclaiming.

## Validation
- `python -m pytest tests/test_pricing_packaging_system.py tests/test_action_center_shared_core.py`