### PR TITLE
[codex] Refine dashboard redesign visual shell

### DIFF
--- a/frontend/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/page.tsx
@@ -187,11 +187,11 @@ export default async function DashboardHomePage({
             {bucket.groups.map((group) => (
               <section key={group.key} className="space-y-3">
                 {bucket.groups.length > 1 ? (
-                  <div className="rounded-[22px] border border-[color:var(--border)] bg-[color:var(--bg)] px-4 py-4">
+                  <div className="rounded-[var(--dashboard-radius-card)] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)] px-4 py-3.5">
                     <div className="flex flex-wrap items-start justify-between gap-3">
                       <div>
-                        <p className="text-sm font-semibold text-[color:var(--ink)]">{group.title}</p>
-                        <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">{group.description}</p>
+                        <p className="text-sm font-semibold tracking-[-0.01em] text-[color:var(--dashboard-ink)]">{group.title}</p>
+                        <p className="mt-1.5 text-sm leading-[1.65] text-[color:var(--dashboard-text)]">{group.description}</p>
                       </div>
                       <DashboardChip label={getHomeStateMeta(group.key).label} tone={getHomeStateMeta(group.key).tone} />
                     </div>
@@ -264,13 +264,13 @@ export default async function DashboardHomePage({
           )
         }
         aside={
-          <div className="space-y-4">
+          <div className="space-y-3.5">
             <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">Hoofdsignaal</p>
-              <p className="mt-2 text-base font-semibold text-[color:var(--ink)]">
-                {primaryOverviewDefinition ? primaryOverviewDefinition.productName : 'Nog geen actieve campaign'}
+              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--dashboard-muted)]">Hoofdsignaal</p>
+              <p className="mt-1.5 text-sm font-semibold text-[color:var(--dashboard-ink)]">
+                {primaryOverviewDefinition ? primaryOverviewDefinition.productName : 'Nog geen actieve campagne'}
               </p>
-              <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">
+              <p className="mt-1.5 text-sm leading-[1.65] text-[color:var(--dashboard-text)]">
                 {primaryOverviewCampaign
                   ? getOverviewHeadline({
                       campaign: primaryOverviewCampaign,
@@ -278,10 +278,10 @@ export default async function DashboardHomePage({
                       isAdmin,
                       avgSignal,
                     })
-                  : 'Zodra de eerste campaign live of leesbaar wordt, verschijnt hier automatisch de eerste buyer- of operationsread.'}
+                  : 'Zodra de eerste campagne live of leesbaar wordt, verschijnt hier automatisch de eerste managementread.'}
               </p>
             </div>
-            <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
+            <div className="grid gap-2.5 sm:grid-cols-2 xl:grid-cols-1">
               <StatCell label="Management-ready" value={`${managementReadyCount}`} />
               <StatCell label="Setup of launch" value={`${setupCount}`} />
             </div>
@@ -289,68 +289,68 @@ export default async function DashboardHomePage({
         }
       />
 
-      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.15fr),minmax(340px,0.85fr)]">
-        <section className="rounded-[24px] border border-[color:var(--border)] bg-white p-5 shadow-[0_8px_24px_rgba(19,32,51,0.04)]">
-          <div className="flex flex-col gap-3 border-b border-[color:var(--border)]/80 pb-4 lg:flex-row lg:items-end lg:justify-between">
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.15fr),minmax(320px,0.85fr)]">
+        <section className="rounded-[var(--dashboard-radius-card)] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)] p-5 shadow-[var(--dashboard-shadow-soft)]">
+          <div className="flex flex-col gap-3 border-b border-[color:var(--dashboard-frame-border)] pb-4 lg:flex-row lg:items-end lg:justify-between">
             <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">Trend in portfolio</p>
-              <h2 className="mt-2 text-lg font-semibold text-[color:var(--ink)]">Waar veranderde de aandacht in de portfolio?</h2>
-              <p className="mt-2 max-w-3xl text-sm leading-6 text-[color:var(--text)]">
-                Lees eerst wat al managementduiding draagt, wat nog slechts deels zichtbaar is en waar uitvoering of rapportdiscipline nog leidend blijft.
+              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">Trend in portfolio</p>
+              <h2 className="mt-1.5 text-base font-semibold tracking-[-0.02em] text-[color:var(--dashboard-ink)]">Waar veranderde de aandacht?</h2>
+              <p className="mt-1.5 max-w-2xl text-sm leading-[1.65] text-[color:var(--dashboard-text)]">
+                Lees eerst wat managementduiding draagt, wat deels zichtbaar is en waar uitvoering nog leidend blijft.
               </p>
             </div>
-            <DashboardChip label="Compact trendbeeld" tone="slate" />
+            <DashboardChip label="Portfoliotrend" tone="slate" />
           </div>
-          <div className="mt-5 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
             <DashboardPanel
               eyebrow="Managementduiding gereed"
               title={`${fullCount}`}
-              body="Campagnes met genoeg respons en zichtbaarheid om dashboard, aanbevelingen en rapport echt als managementinstrument te gebruiken."
+              body="Campagnes met genoeg respons om dashboard en rapport als managementinstrument te gebruiken."
               tone="emerald"
             />
             <DashboardPanel
               eyebrow="Deels zichtbaar"
               title={`${partialCount}`}
-              body="Campagnes waar de eerste veilige read open is, maar waar drivers of diepere patroonduiding nog bewust begrensd blijven."
+              body="Eerste read open, maar verdiepingslaag nog bewust begrensd."
               tone={partialCount > 0 ? 'amber' : 'slate'}
             />
             <DashboardPanel
               eyebrow="Uitvoering actief"
               title={`${activeExecutionCount}`}
-              body="Campagnes in setup, launch, running of sparse responsopbouw. Hier ligt de nadruk nog op uitvoerdiscipline."
+              body="In setup, launch, running of sparse opbouw — nadruk op uitvoerdiscipline."
               tone={activeExecutionCount > 0 ? 'amber' : 'slate'}
             />
             <DashboardPanel
               eyebrow="Gesloten / rapport eerst"
-              title={avgSignal ? `${avgSignal}/10` : closedCount > 0 ? `${closedCount}` : 'Nog leeg'}
+              title={avgSignal ? `${avgSignal}/10` : closedCount > 0 ? `${closedCount}` : '—'}
               body={
                 avgSignal
-                  ? `Gemiddeld groepssignaal over campagnes met leesbare output. Gesloten campagnes: ${closedCount}. Gemiddelde respons: ${avgResponse}%.`
+                  ? `Gem. groepssignaal. Gesloten: ${closedCount}. Respons: ${avgResponse}%.`
                   : campaigns.length === 0
-                    ? 'Nog geen leesbare campaign in de omgeving.'
-                    : `Campagnes waar rapport nu voorop staat: ${closedCount}. Gemiddelde respons: ${avgResponse}%.`
+                    ? 'Nog geen leesbare campagne.'
+                    : `Rapport voorop: ${closedCount}. Gem. respons: ${avgResponse}%.`
               }
               tone={avgSignal ? 'emerald' : 'slate'}
             />
           </div>
         </section>
 
-        <section className="rounded-[24px] border border-[color:var(--border)] bg-[color:var(--surface)] p-5 shadow-[0_8px_24px_rgba(19,32,51,0.04)]">
+        <section className="rounded-[var(--dashboard-radius-card)] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)] p-5 shadow-[var(--dashboard-shadow-soft)]">
           <div className="flex flex-col gap-4">
             <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">Waar eerst kijken</p>
-              <h2 className="mt-2 text-lg font-semibold text-[color:var(--ink)]">Kies eerst de hoofdread, pas daarna de verdieping</h2>
-              <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">
-                Home blijft compact: eerst signaleren wat nu telt, daarna openen via menu, tabs of campaignroute.
+              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">Waar eerst kijken</p>
+              <h2 className="mt-1.5 text-base font-semibold tracking-[-0.02em] text-[color:var(--dashboard-ink)]">Kies eerst de hoofdread</h2>
+              <p className="mt-1.5 text-sm leading-[1.65] text-[color:var(--dashboard-text)]">
+                Eerst signaleren wat nu telt, daarna verdiepen via menu, tabs of campagneroute.
               </p>
             </div>
 
             {!isAdmin && primaryGuideCampaign && primaryExecutionState && primaryGuideScanDefinition ? (
-              <div className="rounded-[22px] border border-[color:var(--border)] bg-[color:var(--bg)] p-4">
+              <div className="rounded-[var(--dashboard-radius-card)] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)] p-4">
                 <div className="flex flex-wrap items-center justify-between gap-3">
                   <div>
-                    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">Jouw uitvoerstatus</p>
-                    <p className="mt-2 text-base font-semibold text-[color:var(--ink)]">{primaryExecutionState.currentStateLabel}</p>
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--dashboard-muted)]">Uitvoerstatus</p>
+                    <p className="mt-1.5 text-sm font-semibold text-[color:var(--dashboard-ink)]">{primaryExecutionState.currentStateLabel}</p>
                   </div>
                   <DashboardChip
                     label={primaryGuideStateMeta?.label ?? primaryExecutionState.currentStateLabel}
@@ -528,45 +528,45 @@ function CampaignRow({
   const ctaLabel = isAdmin && state === 'setup' ? 'Naar setup' : stateMeta.viewerCta
 
   return (
-    <div className="rounded-[28px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)] px-4 py-4 shadow-[0_18px_40px_rgba(17,24,39,0.07)]">
+    <div className="rounded-[var(--dashboard-radius-card)] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)] px-5 py-5 shadow-[var(--dashboard-shadow-soft)] transition-shadow hover:shadow-[var(--dashboard-shadow-strong)]">
       <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between xl:gap-6">
         <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="flex flex-wrap items-center gap-1.5">
             <DashboardChip label={scanDefinition.productName} tone="slate" />
             <DashboardChip label={campaign.is_active ? 'Actief' : 'Gesloten'} tone={campaign.is_active ? 'emerald' : 'slate'} />
             <DashboardChip label={stateMeta.label} tone={stateMeta.tone} />
           </div>
-          <h2 className="mt-3 text-lg font-semibold text-[color:var(--ink)]">{campaign.campaign_name}</h2>
-          <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">{stateMeta.body}</p>
-          <p className="mt-2 text-sm leading-6 text-[color:var(--muted)]">{stateMeta.trust}</p>
+          <h2 className="mt-3 text-base font-semibold tracking-[-0.02em] text-[color:var(--dashboard-ink)]">{campaign.campaign_name}</h2>
+          <p className="mt-1.5 text-sm leading-[1.65] text-[color:var(--dashboard-text)]">{stateMeta.body}</p>
+          <p className="mt-1 text-xs leading-5 text-[color:var(--dashboard-muted)]">{stateMeta.trust}</p>
         </div>
 
-        <div className="grid gap-3 sm:grid-cols-2 xl:min-w-[420px] xl:grid-cols-2 2xl:min-w-[560px] 2xl:grid-cols-4">
+        <div className="grid gap-2.5 sm:grid-cols-2 xl:min-w-[380px] xl:grid-cols-2 2xl:min-w-[520px] 2xl:grid-cols-4">
           <StatCell label="Respons" value={`${campaign.completion_rate_pct ?? 0}%`} />
           <StatCell label="Ingevuld" value={`${campaign.total_completed}`} />
           <StatCell label="Uitgenodigd" value={`${campaign.total_invited}`} />
           <StatCell
             label={`Gem. ${scanDefinition.signalLabelLower}`}
-            value={campaign.avg_risk_score !== null ? `${campaign.avg_risk_score.toFixed(1)}/10` : '-'}
+            value={campaign.avg_risk_score !== null ? `${campaign.avg_risk_score.toFixed(1)}/10` : '—'}
           />
         </div>
       </div>
 
-      <div className="mt-4 flex flex-col gap-3 border-t border-[color:var(--border)]/80 pt-4 lg:flex-row lg:items-center lg:justify-between">
-        <div className="flex flex-wrap items-center gap-2 text-sm">
-          <span className="rounded-full bg-[color:var(--dashboard-soft)] px-3 py-1 font-medium text-[color:var(--dashboard-text)]">
+      <div className="mt-4 flex flex-col gap-3 border-t border-[color:var(--dashboard-frame-border)] pt-4 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex flex-wrap items-center gap-2 text-xs text-[color:var(--dashboard-text)]">
+          <span className="rounded-full border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)] px-2.5 py-1 font-semibold text-[color:var(--dashboard-muted)]">
             {stateMeta.nextStepLabel}
           </span>
-          <span className="text-[color:var(--muted)]">•</span>
-          <span className="text-[color:var(--text)]">
-            Uitnodigingen {campaign.total_invited} • Banden hoog/midden/laag: {campaign.band_high}/{campaign.band_medium}/{campaign.band_low}
+          <span className="text-[color:var(--dashboard-muted)] select-none">·</span>
+          <span>
+            {campaign.total_invited} uitnodigingen · {campaign.band_high}/{campaign.band_medium}/{campaign.band_low} hoog/midden/laag
           </span>
         </div>
-        <div className="flex flex-wrap items-center gap-3">
+        <div className="flex flex-wrap items-center gap-2.5">
           {isAdmin && state === 'setup' ? (
             <Link
               href="/beheer"
-              className="inline-flex rounded-full border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)] px-4 py-2 text-sm font-semibold text-[color:var(--dashboard-ink)] transition-colors hover:border-[color:var(--dashboard-accent-soft-border)] hover:text-[color:var(--dashboard-accent-strong)]"
+              className="inline-flex rounded-full border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)] px-4 py-1.5 text-sm font-semibold text-[color:var(--dashboard-ink)] transition-colors hover:border-[color:var(--dashboard-accent-soft-border)] hover:text-[color:var(--dashboard-accent-strong)]"
             >
               Naar setup
             </Link>
@@ -575,7 +575,7 @@ function CampaignRow({
             {showOnboarding ? <OnboardingBalloon step={1} label="Open je campagne" align="left" /> : null}
             <Link
               href={`/campaigns/${campaign.campaign_id}`}
-              className="inline-flex rounded-full border border-[color:var(--dashboard-accent-soft-border)] bg-[color:var(--dashboard-accent-soft)] px-4 py-2 text-sm font-semibold text-[color:var(--dashboard-accent-strong)] transition-colors hover:brightness-[0.98]"
+              className="inline-flex rounded-full border border-[color:var(--dashboard-accent-soft-border)] bg-[color:var(--dashboard-accent-soft)] px-4 py-1.5 text-sm font-semibold text-[color:var(--dashboard-accent-strong)] transition-colors hover:brightness-[0.97]"
             >
               {ctaLabel}
             </Link>
@@ -603,13 +603,13 @@ function UtilityCard({
   cta: string
 }) {
   return (
-    <div className="rounded-[28px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)] p-5 shadow-[0_18px_40px_rgba(17,24,39,0.07)]">
-      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">{eyebrow}</p>
-      <p className="mt-2 text-base font-semibold text-[color:var(--ink)]">{title}</p>
-      <p className="mt-3 text-sm leading-6 text-[color:var(--text)]">{body}</p>
+    <div className="rounded-[var(--dashboard-radius-card)] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)] p-5 shadow-[var(--dashboard-shadow-card)]">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--dashboard-muted)]">{eyebrow}</p>
+      <p className="mt-2 text-sm font-semibold tracking-[-0.01em] text-[color:var(--dashboard-ink)]">{title}</p>
+      <p className="mt-2 text-sm leading-[1.65] text-[color:var(--dashboard-text)]">{body}</p>
       <Link
         href={href}
-        className="mt-4 inline-flex rounded-full border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)] px-4 py-2 text-sm font-semibold text-[color:var(--dashboard-ink)] transition-colors hover:border-[color:var(--dashboard-accent-soft-border)] hover:text-[color:var(--dashboard-accent-strong)]"
+        className="mt-4 inline-flex rounded-full border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)] px-4 py-1.5 text-sm font-semibold text-[color:var(--dashboard-ink)] transition-colors hover:border-[color:var(--dashboard-accent-soft-border)] hover:text-[color:var(--dashboard-accent-strong)]"
       >
         {cta}
       </Link>
@@ -630,12 +630,12 @@ function StatCell({ label, value }: { label: string; value: string }) {
             : null
 
   return (
-    <div className="rounded-[22px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)] px-4 py-3">
+    <div className="rounded-[var(--dashboard-radius-card)] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)] px-4 py-3.5">
       <div className="flex items-center gap-1.5">
-        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">{label}</p>
+        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--dashboard-muted)]">{label}</p>
         {helpText ? <InfoTooltip text={helpText} /> : null}
       </div>
-      <p className="mt-2 text-lg font-semibold text-[color:var(--ink)]">{value}</p>
+      <p className="dash-number mt-2 text-[1.5rem] text-[color:var(--dashboard-ink)]">{value}</p>
     </div>
   )
 }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -25,8 +25,29 @@
   /* Shadows */
   --marketing-shadow-soft: 0 20px 48px rgba(19, 32, 51, 0.06);
   --marketing-shadow-strong: 0 28px 72px rgba(19, 32, 51, 0.11);
-  --dashboard-shadow-soft: 0 16px 42px rgba(19, 32, 51, 0.06);
-  --dashboard-shadow-strong: 0 18px 44px rgba(19, 32, 51, 0.1);
+  --dashboard-shadow-soft: 0 4px 24px rgba(19, 32, 51, 0.06), 0 1px 4px rgba(19, 32, 51, 0.04);
+  --dashboard-shadow-strong: 0 8px 32px rgba(19, 32, 51, 0.09), 0 2px 8px rgba(19, 32, 51, 0.05);
+  --dashboard-shadow-card: 0 2px 12px rgba(19, 32, 51, 0.05);
+
+  /* Dashboard tokens — alle --dashboard-* vars die in components gebruikt worden */
+  --dashboard-ink: #132033;
+  --dashboard-surface: #FFFFFF;
+  --dashboard-soft: #F7F5F1;
+  --dashboard-frame-border: #E5E0D6;
+  --dashboard-text: #4A5563;
+  --dashboard-muted: #9CA3AF;
+  --dashboard-accent-soft: #EAF4F3;
+  --dashboard-accent-soft-border: #B8D8D4;
+  --dashboard-accent-strong: #25605C;
+  --dashboard-blue-soft: #F0F5F8;
+  --dashboard-amber-soft: #FEF9F1;
+  --dashboard-topbar-strong: rgba(255, 255, 255, 0.97);
+
+  /* Dashboard layout */
+  --dashboard-sidebar-width: 260px;
+  --dashboard-radius-card: 1.25rem;
+  --dashboard-radius-hero: 1.75rem;
+  --dashboard-radius-chip: 9999px;
 }
 
 @theme inline {
@@ -482,24 +503,24 @@ details > summary::-webkit-details-marker {
   }
 
   .dashboard-surface {
-    border: 1px solid var(--border);
-    background: var(--surface);
+    border: 1px solid var(--dashboard-frame-border);
+    background: var(--dashboard-surface);
     box-shadow: var(--dashboard-shadow-soft);
-    border-radius: 1.5rem;
+    border-radius: var(--dashboard-radius-card);
   }
 
   .dashboard-surface-soft {
-    border: 1px solid var(--border);
-    background: var(--bg);
-    box-shadow: var(--dashboard-shadow-soft);
-    border-radius: 1.5rem;
+    border: 1px solid var(--dashboard-frame-border);
+    background: var(--dashboard-soft);
+    box-shadow: var(--dashboard-shadow-card);
+    border-radius: var(--dashboard-radius-card);
   }
 
   .dashboard-surface-accent {
-    border: 1px solid rgba(35, 75, 87, 0.14);
-    background: #f3f8f8;
-    box-shadow: var(--dashboard-shadow-soft);
-    border-radius: 1.5rem;
+    border: 1px solid var(--dashboard-accent-soft-border);
+    background: var(--dashboard-accent-soft);
+    box-shadow: var(--dashboard-shadow-card);
+    border-radius: var(--dashboard-radius-card);
   }
 
   .dashboard-hierarchy-label {
@@ -507,6 +528,73 @@ details > summary::-webkit-details-marker {
     font-weight: 700;
     letter-spacing: 0.2em;
     text-transform: uppercase;
+    color: var(--dashboard-muted);
+  }
+
+  /* Sidebar nav item states */
+  .dash-nav-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    border-radius: 0.625rem;
+    padding: 0.5rem 0.625rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    transition: background-color 160ms ease, color 160ms ease;
+    cursor: pointer;
+    text-decoration: none;
+  }
+
+  .dash-nav-item-active {
+    background: rgba(60, 141, 138, 0.14);
+    color: var(--teal-light);
+  }
+
+  .dash-nav-item-active:hover {
+    background: rgba(60, 141, 138, 0.18);
+  }
+
+  .dash-nav-item-inactive {
+    color: rgba(247, 245, 241, 0.72);
+  }
+
+  .dash-nav-item-inactive:hover {
+    background: rgba(255, 255, 255, 0.06);
+    color: rgba(247, 245, 241, 0.95);
+  }
+
+  .dash-nav-item-disabled {
+    color: rgba(247, 245, 241, 0.28);
+    cursor: default;
+  }
+
+  .dash-nav-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.25rem;
+    height: 1.25rem;
+    padding-inline: 0.375rem;
+    border-radius: 9999px;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    background: rgba(255, 255, 255, 0.1);
+    color: rgba(247, 245, 241, 0.6);
+    flex-shrink: 0;
+  }
+
+  .dash-nav-badge-active {
+    background: rgba(60, 141, 138, 0.3);
+    color: var(--teal-light);
+  }
+
+  /* Fraunces number display */
+  .dash-number {
+    font-family: var(--font-fraunces), Georgia, serif;
+    font-weight: 300;
+    letter-spacing: -0.02em;
+    font-variation-settings: "opsz" 32;
   }
 
   .marketing-flow-stack > * {

--- a/frontend/components/dashboard/dashboard-primitives.tsx
+++ b/frontend/components/dashboard/dashboard-primitives.tsx
@@ -4,35 +4,35 @@ type Tone = 'slate' | 'blue' | 'emerald' | 'amber'
 type Surface = 'default' | 'ops'
 
 const TONE_SURFACES: Record<Tone, string> = {
-  slate: 'border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)]',
-  blue: 'border-[#c8d7df] bg-[color:var(--dashboard-blue-soft)]',
+  slate:   'border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)]',
+  blue:    'border-[#c4d4dc] bg-[color:var(--dashboard-blue-soft)]',
   emerald: 'border-[color:var(--dashboard-accent-soft-border)] bg-[color:var(--dashboard-accent-soft)]',
-  amber: 'border-[#e6d6af] bg-[color:var(--dashboard-amber-soft)]',
+  amber:   'border-[#e2d3a8] bg-[color:var(--dashboard-amber-soft)]',
 }
 
 const OPS_TONE_SURFACES: Record<Tone, string> = {
-  slate: 'border-[color:var(--border)] bg-white',
-  blue: 'border-[#dfe6ea] bg-[#fbfcfd]',
-  emerald: 'border-[#d8e4df] bg-[#f8fbf9]',
-  amber: 'border-[#e7e0d1] bg-[#fcfbf7]',
+  slate:   'border-[color:var(--dashboard-frame-border)] bg-white',
+  blue:    'border-[#d8e4ea] bg-[#f8fbfd]',
+  emerald: 'border-[color:var(--dashboard-accent-soft-border)] bg-[color:var(--dashboard-accent-soft)]',
+  amber:   'border-[#e5dcc8] bg-[#fdfaf4]',
 }
 
 const TONE_LABELS: Record<Tone, string> = {
-  slate: 'text-[color:var(--dashboard-text)]',
-  blue: 'text-[#204655]',
+  slate:   'text-[color:var(--dashboard-muted)]',
+  blue:    'text-[#1f4455]',
   emerald: 'text-[color:var(--dashboard-accent-strong)]',
-  amber: 'text-[#7a5b18]',
+  amber:   'text-[#7a5918]',
 }
 
 const OPS_TONE_LABELS: Record<Tone, string> = {
-  slate: 'text-[color:var(--text)]',
-  blue: 'text-[color:var(--text)]',
-  emerald: 'text-[#3C8D8A]',
-  amber: 'text-[#8C6B1F]',
+  slate:   'text-[color:var(--dashboard-muted)]',
+  blue:    'text-[color:var(--dashboard-text)]',
+  emerald: 'text-[color:var(--dashboard-accent-strong)]',
+  amber:   'text-[#8a651c]',
 }
 
-const CARD_SHADOW = 'shadow-[0_18px_40px_rgba(17,24,39,0.07)]'
-const PANEL_GLOW = 'before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-white/72'
+const CARD_SHADOW = 'shadow-[var(--dashboard-shadow-soft)]'
+const PANEL_GLOW = 'before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-white/60'
 
 function joinClasses(...classes: Array<string | false | null | undefined>) {
   return classes.filter(Boolean).join(' ')
@@ -67,8 +67,7 @@ function DashboardSectionHeader({
         {eyebrow ? (
           <p
             className={joinClasses(
-              surface === 'ops' ? 'text-xs tracking-[0.22em]' : 'text-[11px] tracking-[0.24em]',
-              'font-semibold uppercase',
+              'text-[11px] font-semibold uppercase tracking-[0.2em]',
               getToneLabel(tone, surface),
             )}
           >
@@ -78,9 +77,9 @@ function DashboardSectionHeader({
         <h2
           className={joinClasses(
             surface === 'ops'
-              ? 'mt-1 text-lg text-[color:var(--ink)]'
-              : 'mt-2 max-w-4xl text-[1.65rem] text-[color:var(--dashboard-ink)] sm:text-[1.85rem]',
-            'font-semibold tracking-[-0.04em]',
+              ? 'mt-1.5 text-[1.1rem] text-[color:var(--ink)]'
+              : 'mt-2 max-w-4xl text-[1.5rem] text-[color:var(--dashboard-ink)] sm:text-[1.65rem]',
+            'font-semibold tracking-[-0.035em]',
           )}
         >
           {title}
@@ -89,8 +88,8 @@ function DashboardSectionHeader({
           <p
             className={joinClasses(
               surface === 'ops'
-                ? 'mt-2 max-w-3xl text-sm leading-6 text-[color:var(--text)]'
-                : 'mt-3 max-w-4xl text-sm leading-7 text-[color:var(--dashboard-text)] sm:text-[0.95rem]',
+                ? 'mt-2 max-w-3xl text-sm leading-6 text-[color:var(--dashboard-text)]'
+                : 'mt-2.5 max-w-3xl text-sm leading-[1.7] text-[color:var(--dashboard-text)]',
             )}
           >
             {description}
@@ -128,28 +127,27 @@ export function DashboardHero({
       data-dashboard-primitive="hero"
       className={joinClasses(
         surface === 'ops'
-          ? 'overflow-visible rounded-[24px] border p-5 shadow-[0_10px_28px_rgba(19,32,51,0.05)] sm:p-6'
-          : 'relative overflow-hidden rounded-[34px] border px-6 py-6 sm:px-7 sm:py-7',
+          ? 'overflow-visible rounded-[var(--dashboard-radius-card)] border p-5 shadow-[var(--dashboard-shadow-card)] sm:p-6'
+          : 'relative overflow-hidden rounded-[var(--dashboard-radius-hero)] border px-6 py-6 sm:px-7 sm:py-7',
         surface === 'default' && CARD_SHADOW,
         surface === 'default' && PANEL_GLOW,
         toneSurface,
       )}
     >
       {surface === 'default' ? (
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(255,255,255,0.86),transparent_36%)]" />
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_80%_-10%,rgba(255,255,255,0.9),transparent_48%)]" />
       ) : null}
       <div
         className={joinClasses(
           surface === 'ops'
-            ? 'grid gap-6 xl:grid-cols-[minmax(0,1.5fr),minmax(320px,0.9fr)]'
-            : 'relative grid gap-5 xl:grid-cols-[minmax(0,1.4fr),minmax(280px,0.6fr)] xl:items-start',
+            ? 'grid gap-6 xl:grid-cols-[minmax(0,1.5fr),minmax(300px,0.85fr)]'
+            : 'relative grid gap-5 xl:grid-cols-[minmax(0,1.4fr),minmax(260px,0.6fr)] xl:items-start',
         )}
       >
         <div className={surface === 'default' ? 'min-w-0' : undefined}>
           <p
             className={joinClasses(
-              surface === 'ops' ? 'text-xs tracking-[0.22em]' : 'text-[11px] tracking-[0.24em]',
-              'font-semibold uppercase',
+              'text-[11px] font-semibold uppercase tracking-[0.22em]',
               getToneLabel(tone, surface),
             )}
           >
@@ -158,8 +156,8 @@ export function DashboardHero({
           <h1
             className={joinClasses(
               surface === 'ops'
-                ? 'mt-3 text-[1.75rem] font-bold tracking-tight text-[color:var(--ink)] sm:text-[2rem]'
-                : 'mt-3 max-w-4xl text-[2rem] font-semibold tracking-[-0.05em] text-[color:var(--dashboard-ink)] sm:text-[2.45rem]',
+                ? 'mt-2.5 text-[1.65rem] font-semibold tracking-[-0.03em] text-[color:var(--ink)] sm:text-[1.85rem]'
+                : 'mt-2.5 max-w-4xl text-[1.9rem] font-semibold tracking-[-0.04em] text-[color:var(--dashboard-ink)] sm:text-[2.25rem]',
             )}
           >
             {title}
@@ -167,21 +165,21 @@ export function DashboardHero({
           <p
             className={joinClasses(
               surface === 'ops'
-                ? 'mt-3 max-w-3xl text-sm leading-6 text-[color:var(--text)]'
-                : 'mt-4 max-w-4xl text-sm leading-7 text-[color:var(--dashboard-text)] sm:text-[0.97rem]',
+                ? 'mt-3 max-w-3xl text-sm leading-6 text-[color:var(--dashboard-text)]'
+                : 'mt-3 max-w-3xl text-sm leading-7 text-[color:var(--dashboard-text)] sm:text-[0.95rem]',
             )}
           >
             {description}
           </p>
-          {meta ? <div className="mt-5 flex flex-wrap gap-2">{meta}</div> : null}
-          {actions ? <div className={surface === 'ops' ? 'mt-5 flex flex-wrap items-center gap-3' : 'mt-6 flex flex-wrap items-center gap-3'}>{actions}</div> : null}
+          {meta ? <div className="mt-4 flex flex-wrap gap-2">{meta}</div> : null}
+          {actions ? <div className="mt-5 flex flex-wrap items-center gap-2.5">{actions}</div> : null}
         </div>
         {aside ? (
           <div
             className={joinClasses(
               surface === 'ops'
-                ? 'rounded-[22px] border border-slate-200 bg-white p-4 shadow-[0_8px_24px_rgba(19,32,51,0.04)]'
-                : 'rounded-[28px] border border-white/75 bg-white/84 p-5 shadow-[0_20px_40px_rgba(17,24,39,0.07)] backdrop-blur',
+                ? 'rounded-[var(--dashboard-radius-card)] border border-[color:var(--dashboard-frame-border)] bg-white p-4 shadow-[var(--dashboard-shadow-card)]'
+                : 'rounded-[var(--dashboard-radius-card)] border border-white/70 bg-white/88 p-5 shadow-[var(--dashboard-shadow-card)] backdrop-blur',
             )}
           >
             {aside}
@@ -217,8 +215,8 @@ export function DashboardSection({
       data-dashboard-primitive="section"
       className={joinClasses(
         surface === 'ops'
-          ? 'scroll-mt-36 rounded-[24px] border p-5 shadow-[0_10px_28px_rgba(19,32,51,0.05)]'
-          : 'relative scroll-mt-40 overflow-hidden rounded-[32px] border px-5 py-5 sm:px-6 sm:py-6',
+          ? 'scroll-mt-36 rounded-[var(--dashboard-radius-card)] border p-5 shadow-[var(--dashboard-shadow-card)]'
+          : 'relative scroll-mt-40 overflow-hidden rounded-[var(--dashboard-radius-hero)] border px-5 py-5 sm:px-6 sm:py-6',
         surface === 'default' && CARD_SHADOW,
         surface === 'default' && PANEL_GLOW,
         getToneSurface(tone, surface),
@@ -235,8 +233,8 @@ export function DashboardSection({
       <div
         className={joinClasses(
           surface === 'ops'
-            ? 'mt-5 border-t border-[color:var(--border)]/80 pt-5'
-            : 'mt-5 border-t border-white/72 pt-5',
+            ? 'mt-5 border-t border-[color:var(--dashboard-frame-border)]/70 pt-5'
+            : 'mt-5 border-t border-[color:var(--dashboard-frame-border)]/60 pt-5',
         )}
       >
         {children}
@@ -333,8 +331,8 @@ export function DashboardStatCard({
       data-dashboard-primitive="stat-card"
       className={joinClasses(
         surface === 'ops'
-          ? 'rounded-[20px] border p-4 shadow-[0_6px_18px_rgba(19,32,51,0.035)] sm:p-5'
-          : 'relative overflow-hidden rounded-[28px] border px-4 py-4 sm:px-5 sm:py-5',
+          ? 'rounded-[var(--dashboard-radius-card)] border p-4 shadow-[var(--dashboard-shadow-card)] sm:p-5'
+          : 'relative overflow-hidden rounded-[var(--dashboard-radius-card)] border px-4 py-4 sm:px-5 sm:py-5',
         surface === 'default' && CARD_SHADOW,
         surface === 'default' && PANEL_GLOW,
         getToneSurface(tone, surface),
@@ -343,27 +341,38 @@ export function DashboardStatCard({
       {eyebrow ? (
         <p
           className={joinClasses(
-            surface === 'ops' ? 'text-xs tracking-[0.18em]' : 'text-[11px] tracking-[0.22em]',
-            'font-semibold uppercase',
+            'text-[11px] font-semibold uppercase tracking-[0.2em]',
             getToneLabel(tone, surface),
           )}
         >
           {eyebrow}
         </p>
       ) : null}
-      <p className={joinClasses(surface === 'ops' ? 'mt-1 text-[color:var(--ink)]' : 'mt-2 text-[color:var(--dashboard-ink)]', 'text-sm font-semibold')}>{title}</p>
+      <p className={joinClasses(
+        surface === 'ops' ? 'text-[color:var(--ink)]' : 'text-[color:var(--dashboard-ink)]',
+        eyebrow ? 'mt-1.5' : 'mt-0',
+        'text-sm font-semibold',
+      )}>
+        {title}
+      </p>
       {value ? (
         <p
           className={joinClasses(
+            'dash-number',
             surface === 'ops'
-              ? 'mt-3 text-[1.7rem] font-bold tracking-tight text-[color:var(--ink)]'
-              : 'mt-4 text-[2.15rem] font-semibold tracking-[-0.06em] text-[color:var(--dashboard-ink)]',
+              ? 'mt-3 text-[1.9rem] text-[color:var(--ink)]'
+              : 'mt-3 text-[2.2rem] text-[color:var(--dashboard-ink)]',
           )}
         >
           {value}
         </p>
       ) : null}
-      <p className={joinClasses(surface === 'ops' ? 'text-[color:var(--text)]' : 'text-[color:var(--dashboard-text)]', 'mt-3 text-sm leading-6')}>{body}</p>
+      <p className={joinClasses(
+        surface === 'ops' ? 'text-[color:var(--dashboard-text)]' : 'text-[color:var(--dashboard-text)]',
+        'mt-3 text-sm leading-[1.65]',
+      )}>
+        {body}
+      </p>
     </div>
   )
 }
@@ -466,8 +475,7 @@ export function DashboardChip({
   return (
     <span
       className={joinClasses(
-        surface === 'ops' ? 'px-3 py-1 text-xs' : 'px-3 py-1.5 text-xs',
-        'inline-flex items-center rounded-full border font-semibold',
+        'inline-flex items-center rounded-full border px-2.5 py-1 text-[11px] font-semibold tracking-[0.01em]',
         getToneSurface(tone, surface),
         getToneLabel(tone, surface),
       )}
@@ -493,26 +501,18 @@ export function DashboardKeyValue({
   return (
     <div
       className={joinClasses(
-        surface === 'ops'
-          ? 'rounded-[18px] border border-[color:var(--border)] bg-[color:var(--bg)] px-4 py-3'
-          : 'rounded-[24px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)] px-4 py-3',
+        'rounded-[var(--dashboard-radius-card)] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)] px-4 py-3',
       )}
     >
       <div className="flex items-center gap-1.5">
-        <p
-          className={joinClasses(
-            surface === 'ops' ? 'text-[color:var(--muted)]' : 'text-[color:var(--dashboard-muted)]',
-            'text-[11px] font-semibold uppercase tracking-[0.22em]',
-          )}
-        >
+        <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
           {label}
         </p>
         {helpText ? <InfoTooltip text={helpText} /> : null}
       </div>
       <p
         className={joinClasses(
-          surface === 'ops' ? 'text-[color:var(--ink)]' : 'text-[color:var(--dashboard-ink)]',
-          'mt-2 text-lg font-semibold',
+          'mt-2 dash-number text-[1.5rem] text-[color:var(--dashboard-ink)]',
           accent,
         )}
       >

--- a/frontend/components/dashboard/dashboard-primitives.tsx
+++ b/frontend/components/dashboard/dashboard-primitives.tsx
@@ -501,18 +501,27 @@ export function DashboardKeyValue({
   return (
     <div
       className={joinClasses(
-        'rounded-[var(--dashboard-radius-card)] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)] px-4 py-3',
+        'rounded-[var(--dashboard-radius-card)] border px-4 py-3',
+        surface === 'ops'
+          ? 'border-[color:var(--border)] bg-[color:var(--bg)]'
+          : 'border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)]',
       )}
     >
       <div className="flex items-center gap-1.5">
-        <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
+        <p
+          className={joinClasses(
+            'text-[11px] font-semibold uppercase tracking-[0.2em]',
+            surface === 'ops' ? 'text-[color:var(--muted)]' : 'text-[color:var(--dashboard-muted)]',
+          )}
+        >
           {label}
         </p>
         {helpText ? <InfoTooltip text={helpText} /> : null}
       </div>
       <p
         className={joinClasses(
-          'mt-2 dash-number text-[1.5rem] text-[color:var(--dashboard-ink)]',
+          'mt-2 dash-number text-[1.5rem]',
+          surface === 'ops' ? 'text-[color:var(--ink)]' : 'text-[color:var(--dashboard-ink)]',
           accent,
         )}
       >

--- a/frontend/components/dashboard/dashboard-shell.tsx
+++ b/frontend/components/dashboard/dashboard-shell.tsx
@@ -44,121 +44,136 @@ export function DashboardShellFrame({
   return (
     <div className="dashboard-shell min-h-screen bg-[color:var(--bg)] text-[color:var(--ink)]">
       <div className="mx-auto flex min-h-screen w-full max-w-[1600px]">
-        <aside className="hidden w-[280px] shrink-0 border-r border-[color:var(--border)] bg-[color:var(--ink)] text-[color:var(--bg)] lg:flex">
-          <div className="sticky top-0 flex h-screen w-full flex-col px-6 py-7">
+
+        {/* ── Desktop Sidebar ── */}
+        <aside className="hidden w-[var(--dashboard-sidebar-width)] shrink-0 border-r border-white/[0.06] bg-[color:var(--ink)] lg:flex">
+          <div className="sticky top-0 flex h-screen w-full flex-col overflow-y-auto py-5">
+
+            {/* Brand */}
             <Link
               href="/dashboard"
-              className="rounded-[26px] border border-white/10 bg-white/[0.04] px-5 py-5 transition-colors hover:bg-white/[0.07]"
+              className="mx-4 mb-6 flex items-center gap-3 rounded-xl px-2 py-2 transition-colors hover:bg-white/[0.05]"
             >
-              <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-white/60">Verisight dashboard</p>
-              <p className="mt-3 text-2xl font-semibold tracking-[-0.04em] text-white">Overview-first</p>
-              <p className="mt-3 text-sm leading-6 text-white/72">
-                De rail geeft richting. Home leest eerst als overzicht, daarna pas als verdieping.
-              </p>
+              <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[color:var(--teal)]">
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                  <path d="M3 4h10M3 8h7M3 12h4" stroke="white" strokeWidth="1.75" strokeLinecap="round" />
+                </svg>
+              </div>
+              <div className="min-w-0">
+                <p className="text-sm font-semibold tracking-[-0.02em] text-white">Verisight</p>
+                <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-white/45">Dashboard</p>
+              </div>
             </Link>
 
-            <nav className="mt-8 flex-1 space-y-8">
-              <DashboardShellSection
+            {/* Nav */}
+            <nav className="flex-1 px-3 space-y-6">
+              <SidebarSection
                 title="Navigatie"
                 items={navigation.primary}
                 pathname={pathname}
                 activePortfolioView={activePortfolioView}
-                onNavigate={() => setMobileNavOpen(false)}
+                onNavigate={() => {}}
               />
-              <DashboardShellSection
-                title="Portfolio-navigatie"
+              <SidebarSection
+                title="Portfolio"
                 items={navigation.portfolio}
                 pathname={pathname}
                 activePortfolioView={activePortfolioView}
-                onNavigate={() => setMobileNavOpen(false)}
+                onNavigate={() => {}}
+                showBadge
               />
               {navigation.admin.length > 0 ? (
-                <DashboardShellSection
+                <SidebarSection
                   title="Beheer"
                   items={navigation.admin}
                   pathname={pathname}
                   activePortfolioView={activePortfolioView}
-                  onNavigate={() => setMobileNavOpen(false)}
+                  onNavigate={() => {}}
                 />
               ) : null}
             </nav>
 
-            <div className="rounded-[24px] border border-white/10 bg-white/[0.05] px-5 py-4">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-white/60">Account</p>
-              <p className="mt-2 truncate text-sm text-white">{userEmail}</p>
-              <p className="mt-1 text-xs text-white/62">{isAdmin ? 'Verisight beheer' : 'Klantdashboard'}</p>
-              <div className="mt-4">
-                <LogoutButton className="w-full justify-center rounded-full border border-white/12 bg-white/8 px-4 py-2 text-sm font-semibold text-white hover:bg-white/14 hover:text-white" />
+            {/* Account */}
+            <div className="mx-3 mt-4 rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-3">
+              <p className="truncate text-[13px] font-medium text-white/80">{userEmail}</p>
+              <p className="mt-0.5 text-xs text-white/38">
+                {isAdmin ? 'Verisight beheer' : 'Klantdashboard'}
+              </p>
+              <div className="mt-3">
+                <LogoutButton className="w-full justify-center rounded-lg border border-white/[0.1] bg-white/[0.05] px-3 py-1.5 text-xs font-semibold text-white/70 transition-colors hover:bg-white/[0.09] hover:text-white/90" />
               </div>
             </div>
           </div>
         </aside>
 
+        {/* ── Content Column ── */}
         <div className="flex min-w-0 flex-1 flex-col">
-          <header className="sticky top-0 z-40 border-b border-[color:var(--border)] bg-[color:var(--surface)]/95 backdrop-blur">
-            <div className="mx-auto flex w-full max-w-7xl items-center gap-3 px-4 py-4 sm:px-6">
+
+          {/* Topbar */}
+          <header className="sticky top-0 z-40 border-b border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-topbar-strong)] backdrop-blur-sm">
+            <div className="mx-auto flex w-full max-w-7xl items-center gap-3 px-4 py-3.5 sm:px-6">
+
+              {/* Mobile hamburger */}
               <button
                 type="button"
                 onClick={() => setMobileNavOpen((open) => !open)}
-                className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-[color:var(--border)] bg-[color:var(--surface)] text-[color:var(--ink)] transition-colors hover:border-[#d6e4e8] hover:text-[#234B57] lg:hidden"
+                className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-[color:var(--dashboard-frame-border)] bg-white text-[color:var(--ink)] transition-colors hover:border-[color:var(--dashboard-accent-soft-border)] hover:text-[color:var(--teal)] lg:hidden"
                 aria-label="Navigatie openen"
               >
-                <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   {mobileNavOpen ? (
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M6 6l12 12M18 6L6 18" />
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 6l12 12M18 6L6 18" />
                   ) : (
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M4 7h16M4 12h16M4 17h16" />
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 7h16M4 12h16M4 17h16" />
                   )}
                 </svg>
               </button>
 
+              {/* Page title */}
               <div className="min-w-0 flex-1">
-                <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[color:var(--muted)]">
-                  {isAdmin ? 'Verisight beheer' : 'Klantdashboard'}
-                </p>
-                <div className="mt-1 flex flex-wrap items-center gap-2">
-                  <h1 className="text-xl font-semibold tracking-[-0.03em] text-[color:var(--ink)]">
+                <div className="flex flex-wrap items-center gap-2">
+                  <h1 className="text-base font-semibold tracking-[-0.025em] text-[color:var(--ink)]">
                     {getDashboardShellCurrentLabel(pathname)}
                   </h1>
-                  <span className="hidden rounded-full border border-[color:var(--border)] bg-[color:var(--bg)] px-3 py-1 text-xs font-semibold text-[color:var(--text)] sm:inline-flex">
-                    {pathname.startsWith('/campaigns/') ? 'Verdieping via tabs' : 'Overview-first'}
+                  <span className="hidden rounded-full border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)] px-2.5 py-0.5 text-xs font-semibold text-[color:var(--dashboard-muted)] sm:inline-flex">
+                    {pathname.startsWith('/campaigns/') ? 'Verdieping' : 'Overview-first'}
                   </span>
                 </div>
               </div>
 
+              {/* Desktop account */}
               <div className="hidden items-center gap-3 lg:flex">
-                <span className="max-w-[220px] truncate text-sm text-[color:var(--text)]">{userEmail}</span>
-                <LogoutButton className="rounded-full border border-[color:var(--border)] bg-[color:var(--surface)] px-4 py-2 text-sm font-semibold text-[color:var(--ink)] hover:border-[#d6e4e8] hover:text-[#234B57]" />
+                <span className="max-w-[200px] truncate text-sm text-[color:var(--dashboard-muted)]">{userEmail}</span>
+                <LogoutButton className="rounded-full border border-[color:var(--dashboard-frame-border)] bg-white px-3.5 py-1.5 text-sm font-semibold text-[color:var(--ink)] transition-colors hover:border-[color:var(--dashboard-accent-soft-border)] hover:text-[color:var(--teal)]" />
               </div>
             </div>
 
+            {/* Mobile nav drawer */}
             {mobileNavOpen ? (
-              <div className="border-t border-[color:var(--border)] px-4 py-4 sm:px-6 lg:hidden">
-                <div className="space-y-6 rounded-[24px] border border-[color:var(--border)] bg-[color:var(--surface)] p-4 shadow-[0_18px_40px_rgba(19,32,51,0.08)]">
-                  <DashboardShellSection
+              <div className="border-t border-[color:var(--dashboard-frame-border)] bg-[color:var(--ink)] px-3 py-4 lg:hidden">
+                <div className="space-y-5">
+                  <SidebarSection
                     title="Navigatie"
                     items={navigation.primary}
                     pathname={pathname}
                     activePortfolioView={activePortfolioView}
                     onNavigate={() => setMobileNavOpen(false)}
-                    mobile
                   />
-                  <DashboardShellSection
-                    title="Portfolio-navigatie"
+                  <SidebarSection
+                    title="Portfolio"
                     items={navigation.portfolio}
                     pathname={pathname}
                     activePortfolioView={activePortfolioView}
                     onNavigate={() => setMobileNavOpen(false)}
-                    mobile
+                    showBadge
                   />
                   {navigation.admin.length > 0 ? (
-                    <DashboardShellSection
+                    <SidebarSection
                       title="Beheer"
                       items={navigation.admin}
                       pathname={pathname}
                       activePortfolioView={activePortfolioView}
                       onNavigate={() => setMobileNavOpen(false)}
-                      mobile
                     />
                   ) : null}
                 </div>
@@ -166,18 +181,19 @@ export function DashboardShellFrame({
             ) : null}
           </header>
 
-          <main className="mx-auto flex-1 w-full max-w-7xl px-4 py-6 sm:px-6">
+          {/* Main content */}
+          <main className="mx-auto w-full max-w-7xl flex-1 px-4 py-6 sm:px-6">
             {acceptedCount > 0 ? (
-              <div className="mb-6 rounded-[20px] border border-[#d2e6e0] bg-[#eef7f4] px-4 py-3 text-sm text-[#234B57]">
-                Jouw account is gekoppeld aan {acceptedCount} organisatie{acceptedCount === 1 ? '' : 's'}.
-                Je ziet nu automatisch het juiste klantdashboard en de bijbehorende rapportages.
+              <div className="mb-5 rounded-xl border border-[color:var(--dashboard-accent-soft-border)] bg-[color:var(--dashboard-accent-soft)] px-4 py-3 text-sm text-[color:var(--dashboard-accent-strong)]">
+                Uw account is gekoppeld aan {acceptedCount} organisatie{acceptedCount === 1 ? '' : 's'}.
+                Het juiste klantdashboard en de bijbehorende rapportages zijn automatisch geladen.
               </div>
             ) : null}
             {children}
           </main>
 
-          <footer className="border-t border-[color:var(--border)] px-4 py-4 text-xs text-[color:var(--muted)] sm:px-6">
-            Verisight dashboard · vaste rail, centrale overview, bounded verdieping
+          <footer className="border-t border-[color:var(--dashboard-frame-border)] px-4 py-3 text-xs text-[color:var(--dashboard-muted)] sm:px-6">
+            Verisight · Overview-first dashboard
           </footer>
         </div>
       </div>
@@ -185,84 +201,43 @@ export function DashboardShellFrame({
   )
 }
 
-function DashboardShellSection({
+function SidebarSection({
   title,
   items,
   pathname,
   activePortfolioView,
   onNavigate,
-  mobile = false,
+  showBadge = false,
 }: {
   title: string
   items: Array<{ label: string; detail: string; href: string | null; disabled: boolean; key?: DashboardPortfolioView }>
   pathname: string
   activePortfolioView: DashboardPortfolioView
   onNavigate: () => void
-  mobile?: boolean
+  showBadge?: boolean
 }) {
   if (items.length === 0) return null
 
   return (
     <div>
-      <p
-        className={`text-[11px] font-semibold uppercase tracking-[0.24em] ${mobile ? 'text-[color:var(--muted)]' : 'text-white/58'}`}
-      >
+      <p className="mb-1.5 px-2 text-[10px] font-semibold uppercase tracking-[0.2em] text-white/35">
         {title}
       </p>
-      <div className="mt-3 space-y-2">
+      <div className="space-y-0.5">
         {items.map((item) => {
-          const active = isActiveShellItem({
-            pathname,
-            activePortfolioView,
-            item,
-          })
-          const classes = mobile
-            ? active
-              ? 'border-[#d6e4e8] bg-[#f3f8f8] text-[#234B57]'
-              : item.disabled
-                ? 'border-dashed border-[color:var(--border)] bg-[color:var(--bg)] text-[color:var(--muted)]'
-                : 'border-transparent bg-[color:var(--bg)] text-[color:var(--text)] hover:border-[color:var(--border)] hover:text-[color:var(--ink)]'
-            : active
-              ? 'border-white/10 bg-white text-[color:var(--ink)]'
-              : item.disabled
-                ? 'border-white/8 border-dashed bg-white/[0.02] text-white/42'
-                : 'border-transparent bg-transparent text-white/78 hover:border-white/8 hover:bg-white/8'
-
-          const labelClasses = mobile
-            ? active
-              ? 'text-[#234B57]'
-              : item.disabled
-                ? 'text-[color:var(--muted)]'
-                : 'text-[color:var(--ink)]'
-            : active
-              ? 'text-[#234B57]'
-              : item.disabled
-                ? 'text-white/42'
-                : 'text-white/50'
-
-          const detailClasses = mobile
-            ? active
-              ? 'text-[#234B57]'
-              : item.disabled
-                ? 'text-[color:var(--muted)]'
-                : 'text-[color:var(--text)]'
-            : active
-              ? 'text-[color:var(--text)]'
-              : item.disabled
-                ? 'text-white/42'
-                : 'text-white/66'
-
-          const content = (
-            <>
-              <p className={`text-xs font-semibold uppercase tracking-[0.18em] ${labelClasses}`}>{item.label}</p>
-              <p className={`mt-2 text-sm leading-6 ${detailClasses}`}>{item.detail}</p>
-            </>
-          )
+          const active = isActiveShellItem({ pathname, activePortfolioView, item })
+          const count = showBadge ? extractCountFromDetail(item.detail) : null
 
           if (!item.href || item.disabled) {
             return (
-              <div key={`${title}-${item.label}`} className={`rounded-[20px] border px-4 py-3 ${classes}`}>
-                {content}
+              <div
+                key={`${title}-${item.label}`}
+                className="dash-nav-item dash-nav-item-disabled"
+              >
+                <span className="truncate">{item.label}</span>
+                {count !== null ? (
+                  <span className="dash-nav-badge opacity-40">{count}</span>
+                ) : null}
               </div>
             )
           }
@@ -272,15 +247,25 @@ function DashboardShellSection({
               key={`${title}-${item.label}`}
               href={item.href}
               onClick={onNavigate}
-              className={`block rounded-[20px] border px-4 py-3 transition-colors ${classes}`}
+              className={`dash-nav-item ${active ? 'dash-nav-item-active' : 'dash-nav-item-inactive'}`}
             >
-              {content}
+              <span className="truncate">{item.label}</span>
+              {count !== null ? (
+                <span className={`dash-nav-badge ${active ? 'dash-nav-badge-active' : ''}`}>
+                  {count}
+                </span>
+              ) : null}
             </Link>
           )
         })}
       </div>
     </div>
   )
+}
+
+function extractCountFromDetail(detail: string): number | null {
+  const match = detail.match(/^(\d+)\s+campagne/)
+  return match ? parseInt(match[1], 10) : null
 }
 
 function isActiveShellItem({


### PR DESCRIPTION
## Summary
- tighten the dashboard shell, primitives, and overview home into a more compact overview-first visual system
- add the missing dashboard design tokens and number/nav utilities so the redesign renders consistently instead of depending on undeclared CSS vars
- preserve `DashboardKeyValue` surface-specific ops styling so the visual refresh does not blur admin/ops treatment into the default dashboard surface

## Guardrails kept
- no new consumers or wiring
- no runtime expansion
- no direct commercial or site-copy changes
- branch remains visual/presentation-only and stays separate from dashboard/customer ops behavior changes

## Review focus
- admin-first framing remains explicit through beheer/setup routing and shell sections
- dossier-first and bounded follow-through language stays in the existing campaign/detail routes rather than opening new home-level flows
- Action Center separation is preserved by not introducing new cross-surface navigation or operational logic in this slice

## Validation
- `git diff --check HEAD^ HEAD`
- `npx eslint "app/(dashboard)/dashboard/page.tsx" components/dashboard/dashboard-primitives.tsx components/dashboard/dashboard-shell.tsx`
- `npm run build` reaches Next.js compile/type/lint successfully, then stops on existing missing Supabase env for auth prerender pages (`/forgot-password` in the latest run)

## Notes
- `npm run lint` is not a stable repo-wide signal after build in this workspace because generated `.next-preview/types` files are linted; targeted eslint on the touched dashboard files passed cleanly.
- there are still pre-existing unused-variable warnings in `components/marketing/vertrouwen-content.tsx`, outside this branch scope.