### PR TITLE
[codex] Revalidate dashboard redesign v2 readiness

### DIFF
--- a/frontend/app/(dashboard)/campaigns/[id]/page.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.test.ts
@@ -95,4 +95,18 @@ describe('campaign detail review guardrails', () => {
     expect(pageSource).toContain("'border-slate-200 bg-slate-50'")
     expect(chartSource).toContain('<Bar dataKey="count" fill="#94A3B8" radius={[2, 2, 0, 0]} />')
   })
+
+  it('keeps deeper operational copy in Dutch so management and admin layers read consistently', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+
+    expect(source).toContain('← Terug naar dashboardoverzicht')
+    expect(source).toContain('Operatie, respondenten en uitvoering')
+    expect(source).toContain('Beheer en operatie')
+    expect(source).toContain('leerwerkbank')
+    expect(source).toContain('responsen')
+    expect(source).not.toContain('Terug naar campaignoverzicht')
+    expect(source).not.toContain('Admin en operations')
+    expect(source).not.toContain('learning-workbench')
+    expect(source).not.toContain('Campaign is al opgenomen in de learninglus')
+  })
 })

--- a/frontend/app/(dashboard)/campaigns/[id]/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.tsx
@@ -15,6 +15,9 @@ import {
   DashboardSection,
   DashboardSummaryBar,
   DashboardTimeline,
+  FocusPanel,
+  InsightStatCard,
+  SignalStatCard,
 } from '@/components/dashboard/dashboard-primitives'
 import { DashboardTabs } from '@/components/dashboard/dashboard-tabs'
 import { FactorTable } from '@/components/dashboard/factor-table'
@@ -62,6 +65,7 @@ import {
   SegmentPlaybookList,
   SdtGauge,
 } from './page-helpers'
+import { getRiskBandFromScore } from '@/lib/management-language'
 import { buildCampaignReadinessState, getDeliveryModeLabel } from '@/lib/implementation-readiness'
 import { getFirstNextStepGuidance } from '@/lib/client-onboarding'
 import { type CampaignAuditEventRecord } from '@/lib/campaign-audit'
@@ -1474,8 +1478,29 @@ export default async function CampaignPage({ params }: Props) {
       </>
     ) : null
 
+  const dominantBand = (['HOOG', 'MIDDEN', 'LAAG'] as const).reduce((a, b) =>
+    riskDistribution[a] >= riskDistribution[b] ? a : b
+  )
+  const totalRiskResponses = riskDistribution.HOOG + riskDistribution.MIDDEN + riskDistribution.LAAG
+  const dominantPct = totalRiskResponses > 0
+    ? Math.round((riskDistribution[dominantBand] / totalRiskResponses) * 100)
+    : 0
+  const BAND_LABELS_SHORT = { HOOG: 'Direct prioriteren', MIDDEN: 'Eerst toetsen', LAAG: 'Volgen' }
+
+  const focusPanelItems = showManagementOutput ? [
+    {
+      text: dashboardViewModel.primaryQuestion.title,
+      moduleLabel: scanDefinition.productName,
+    },
+    {
+      text: dashboardViewModel.nextStep.title,
+      moduleLabel: scanDefinition.productName,
+    },
+  ] : []
+
   return (
-    <div className="space-y-6">
+    <div className="flex gap-8 xl:items-start">
+    <div className="min-w-0 flex-1 space-y-6">
       <Link
         href="/dashboard"
         className="text-sm font-medium text-slate-500 transition-colors hover:text-slate-700"
@@ -1615,6 +1640,33 @@ export default async function CampaignPage({ params }: Props) {
             <p className="mt-1 leading-6">{notice.body}</p>
           </div>
         ))}
+      </div>
+
+      {/* Stat cards row */}
+      <div className="grid grid-cols-2 gap-4 xl:grid-cols-4">
+        <SignalStatCard
+          label="Signaal-index"
+          value={averageRiskScore !== null ? `${averageRiskScore.toFixed(1)}/10` : '—'}
+          subline={averageRiskScore !== null ? BAND_LABELS_SHORT[getRiskBandFromScore(averageRiskScore)] : undefined}
+          band={averageRiskScore !== null ? getRiskBandFromScore(averageRiskScore) : undefined}
+        />
+        <SignalStatCard
+          label="Respons"
+          value={`${stats.completion_rate_pct ?? 0}%`}
+          subline={`${stats.total_completed} van ${stats.total_invited} responses`}
+          band="neutral"
+        />
+        <SignalStatCard
+          label="Risicoband"
+          value={`${dominantPct}%`}
+          subline={`valt nu in ${BAND_LABELS_SHORT[dominantBand].toLowerCase()}`}
+          band={dominantBand}
+        />
+        <InsightStatCard
+          label="Sterkste factor"
+          value={topExitReasonLabel ?? topContributingReasonLabel ?? '—'}
+          subline="vraagt nu als eerste aandacht"
+        />
       </div>
 
       <DashboardSummaryBar
@@ -2334,6 +2386,11 @@ export default async function CampaignPage({ params }: Props) {
             ) : null}
           </div>
         </DashboardSection>
-      ) : null}    </div>
+      ) : null}
+    </div>
+    {focusPanelItems.length > 0 && (
+      <FocusPanel items={focusPanelItems} />
+    )}
+    </div>
   )
 }

--- a/frontend/app/(dashboard)/campaigns/[id]/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.tsx
@@ -548,7 +548,7 @@ export default async function CampaignPage({ params }: Props) {
       label: 'Nog niet live',
       tone: 'amber' as const,
       trust:
-        'Deze campaign blijft in setup. Toon hier nog geen managementlaag of rapport-first gedrag.',
+        'Dit traject blijft in setup. Toon hier nog geen managementlaag of rapport-first gedrag.',
     },
     ready_to_launch: {
       label: 'Launch klaar',
@@ -566,7 +566,7 @@ export default async function CampaignPage({ params }: Props) {
       label: 'Indicatief, nog dun',
       tone: 'amber' as const,
       trust:
-        'Er zijn eerste responses, maar het beeld is nog te dun voor een veilige dashboardread of aanbevelingslaag.',
+        'Er is eerste respons, maar het beeld is nog te dun voor een veilige dashboardread of aanbevelingslaag.',
     },
     partial: {
       label: 'Deels zichtbaar',
@@ -584,7 +584,7 @@ export default async function CampaignPage({ params }: Props) {
       label: 'Rapport eerst',
       tone: 'slate' as const,
       trust:
-        'Deze campaign is gesloten. Gebruik dashboard en rapport nu voor terugblik, context en bestuurlijke opvolging.',
+        'Dit traject is gesloten. Gebruik dashboard en rapport nu voor terugblik, context en bestuurlijke opvolging.',
     },
   }[compositionState]
   const utilitySectionVisible = canExecuteCampaign || respondents.length > 0 || isVerisightAdmin
@@ -1505,7 +1505,7 @@ export default async function CampaignPage({ params }: Props) {
         href="/dashboard"
         className="text-sm font-medium text-slate-500 transition-colors hover:text-slate-700"
       >
-        ← Terug naar campaignoverzicht
+        ← Terug naar dashboardoverzicht
       </Link>
 
       <div id="samenvatting" className="scroll-mt-36 space-y-4">
@@ -1612,7 +1612,7 @@ export default async function CampaignPage({ params }: Props) {
                     : 'Alle uitgenodigde respondenten hebben afgerond.'}
                 </p>
                 <p className="mt-2 text-xs leading-5 text-slate-500">
-                  State: {compositionStateMeta.label}. {compositionStateMeta.trust}
+                  Status: {compositionStateMeta.label}. {compositionStateMeta.trust}
                 </p>
                 <p className="mt-2 text-xs leading-5 text-slate-500">{activationState.statusDetail}</p>
               </div>
@@ -1653,7 +1653,7 @@ export default async function CampaignPage({ params }: Props) {
         <SignalStatCard
           label="Respons"
           value={`${stats.completion_rate_pct ?? 0}%`}
-          subline={`${stats.total_completed} van ${stats.total_invited} responses`}
+          subline={`${stats.total_completed} van ${stats.total_invited} responsen`}
           band="neutral"
         />
         <SignalStatCard
@@ -1767,7 +1767,7 @@ export default async function CampaignPage({ params }: Props) {
           id="handoff"
           eyebrow="Bestuurlijke handoff"
           title="Eerste compacte managementduiding"
-          description="De eerste veilige dashboardlaag is zichtbaar, maar deze campaign blijft nog bewust compact tot thresholds en scorecompleetheid een vollediger beeld dragen."
+          description="De eerste veilige dashboardlaag is zichtbaar, maar dit traject blijft nog bewust compact tot thresholds en scorecompleetheid een vollediger beeld dragen."
           aside={<DashboardChip label={compositionStateMeta.label} tone={compositionStateMeta.tone} />}
           tone="slate"
         >
@@ -1788,7 +1788,7 @@ export default async function CampaignPage({ params }: Props) {
                 <DashboardPanel
                   eyebrow="Wat bewust nog wacht"
                   title="Nog geen volle aanbevelingslaag"
-                  body="Drivers, aanbevelingen en 30–90-dagenroute gaan pas open zodra minstens 10 complete responses beschikbaar zijn en privacygrenzen niet meer onnodig veel verbergen."
+                  body="Drivers, aanbevelingen en 30–90-dagenroute gaan pas open zodra minstens 10 complete responsen beschikbaar zijn en privacygrenzen niet meer onnodig veel verbergen."
                   tone="amber"
                 />
               </div>
@@ -1974,7 +1974,7 @@ export default async function CampaignPage({ params }: Props) {
           </div>
         ) : (
           <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-4 text-sm leading-6 text-slate-600">
-            Verdiepende analyse wordt zichtbaar vanaf {MIN_N_PATTERNS} ingevulde responses. Tot die tijd blijft het dashboard bewust compact en voorzichtig.
+            Verdiepende analyse wordt zichtbaar vanaf {MIN_N_PATTERNS} ingevulde responsen. Tot die tijd blijft het dashboard bewust compact en voorzichtig.
           </div>
           )}
       </DashboardSection>
@@ -2055,7 +2055,7 @@ export default async function CampaignPage({ params }: Props) {
           </div>
         ) : (
           <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-4 text-sm leading-6 text-slate-600">
-            Focusvragen en route-uitvoer worden betekenisvoller zodra het dashboard minstens {MIN_N_PATTERNS} responses heeft.
+            Focusvragen en route-uitvoer worden betekenisvoller zodra het dashboard minstens {MIN_N_PATTERNS} responsen heeft.
           </div>
           )}
       </DashboardSection>
@@ -2192,13 +2192,13 @@ export default async function CampaignPage({ params }: Props) {
         <DashboardSection
           id="operatie"
           eyebrow={showClientExecutionFlow ? 'Uitvoering' : 'Utilitylaag'}
-          title={showClientExecutionFlow ? 'Responsmonitoring en begrensde uitvoerlaag' : 'Operatie, respondenten en delivery'}
+          title={showClientExecutionFlow ? 'Responsmonitoring en begrensde uitvoerlaag' : 'Operatie, respondenten en uitvoering'}
           description={
             showClientExecutionFlow
-              ? 'Gebruik deze laag om deelnemers, uitnodigingen en respons netjes te volgen. Productsetup, campaignarchitectuur en deliveryrecords blijven bewust bij Verisight.'
+              ? 'Gebruik deze laag om deelnemers, uitnodigingen en respons netjes te volgen. Productinrichting, trajectarchitectuur en uitvoerregistratie blijven bewust bij Verisight.'
               : 'Alles onder deze lijn ondersteunt uitvoering en beheer. De managementhoofdlijn blijft hierboven compact en bestuurlijk.'
           }
-          aside={<DashboardChip label={showClientExecutionFlow ? 'Begeleide uitvoering' : 'Admin en operations'} tone="slate" />}
+          aside={<DashboardChip label={showClientExecutionFlow ? 'Begeleide uitvoering' : 'Beheer en operatie'} tone="slate" />}
         >
           <div className="space-y-4">
             {canManageCampaign ? (
@@ -2312,16 +2312,16 @@ export default async function CampaignPage({ params }: Props) {
             {profile?.is_verisight_admin ? (
               <DashboardDisclosure
                 defaultOpen={false}
-                title="Pilot- en early-customer-learning"
-                description="Gebruik de learning-workbench om buyer-signalen, implementationlessen, eerste managementduiding en de gekozen repeat- of expansionrichting expliciet vast te leggen voor deze campaign."
+                title="Pilot- en vroege-klantlessen"
+                description="Gebruik de leerwerkbank om koopsignalen, implementatielessen, eerste managementduiding en de gekozen vervolg- of uitbreidingsrichting expliciet vast te leggen voor dit traject."
                 badge={
                   <DashboardChip
                     label={
                       learningDossiers.length === 0
                         ? 'Nog geen dossier'
                         : learningCloseoutEvidenceCount > 0
-                          ? `${learningCloseoutEvidenceCount} closeout-signaal`
-                          : `${learningDossiers.length} gekoppeld, closeout open`
+                          ? `${learningCloseoutEvidenceCount} afrondingssignaal`
+                          : `${learningDossiers.length} gekoppeld, afronding open`
                     }
                     tone={learningDossiers.length > 0 && learningCloseoutEvidenceCount > 0 ? 'emerald' : 'amber'}
                   />
@@ -2330,29 +2330,29 @@ export default async function CampaignPage({ params }: Props) {
                 <div className="grid gap-4 xl:grid-cols-[minmax(0,1.1fr),minmax(320px,0.9fr)]">
                   <DashboardPanel
                     eyebrow="Waarom nu"
-                    title={learningDossiers.length > 0 ? 'Campaign is al opgenomen in de learninglus' : 'Koppel deze campaign aan een learningdossier'}
+                    title={learningDossiers.length > 0 ? 'Dit traject zit al in de leerlus' : 'Koppel dit traject aan een leerdossier'}
                     body={
                       learningDossiers.length > 0
-                        ? 'Gebruik gekoppelde dossiers om implementationfrictie, launchsignalen, managementgebruik en gekozen vervolgroutes expliciet terug te laten landen in product, report, onboarding, sales en operations.'
-                        : 'Zodra deze campaign leerwaarde geeft, koppel je hem aan een dossier in de learning-workbench. Zo blijven echte deliverylessen en vervolgkeuzes niet hangen in losse handover-notes.'
+                        ? 'Gebruik gekoppelde dossiers om implementatiefrictie, launchsignalen, managementgebruik en gekozen vervolgroutes expliciet terug te laten landen in product, rapport, onboarding, sales en operatie.'
+                        : 'Zodra dit traject leerwaarde geeft, koppel je het aan een dossier in de leerwerkbank. Zo blijven echte uitvoerlessen en vervolgkeuzes niet hangen in losse overdrachtsnotities.'
                     }
                     tone={learningDossiers.length > 0 ? 'slate' : 'amber'}
                   />
                   <DashboardPanel
-                    eyebrow="Closeoutdiscipline"
+                    eyebrow="Afrondingsdiscipline"
                     title={
                       learningCloseoutEvidenceCount > 0
-                        ? 'Learning kan naar formele closeout toewerken'
+                        ? 'De leerlus kan naar formele afronding toewerken'
                         : learningDossiers.length > 0
-                          ? 'Learning bestaat, maar closeout-evidence mist nog'
-                          : 'Nog geen learning-closeout mogelijk'
+                          ? 'De leerlus loopt, maar afrondingsbewijs mist nog'
+                          : 'Nog geen formele leerafronding mogelijk'
                     }
                     body={
                       learningCloseoutEvidenceCount > 0
-                        ? 'Er is al minstens één expliciete review-, vervolg- of stopuitkomst vastgelegd. Daarmee kan delivery later eerlijker naar follow-up of learning closeout bewegen.'
+                        ? 'Er is al minstens één expliciete review-, vervolg- of stopuitkomst vastgelegd. Daarmee kan de uitvoering later eerlijker naar opvolging of formele leerafronding bewegen.'
                         : learningDossiers.length > 0
-                          ? 'Er zijn al gekoppelde dossiers, maar nog geen expliciete review-, vervolg- of stopuitkomst. Houd delivery dus bewust open tot die follow-through echt is vastgelegd.'
-                          : 'Zonder gekoppeld learningdossier hoort delivery-closeout nog niet als afgerond te voelen.'
+                          ? 'Er zijn al gekoppelde dossiers, maar nog geen expliciete review-, vervolg- of stopuitkomst. Houd de uitvoering dus bewust open tot die vervolgstap echt is vastgelegd.'
+                          : 'Zonder gekoppeld leerdossier hoort de uitvoerafronding nog niet als afgerond te voelen.'
                     }
                     tone={learningCloseoutEvidenceCount > 0 ? 'emerald' : 'amber'}
                   />
@@ -2360,7 +2360,7 @@ export default async function CampaignPage({ params }: Props) {
                     <p className="text-sm font-semibold text-slate-950">Gekoppelde dossiers</p>
                     {learningDossiers.length === 0 ? (
                       <p className="mt-2 text-sm leading-6 text-slate-600">
-                        Er is nog geen dossier gekoppeld aan deze campaign.
+                        Er is nog geen dossier gekoppeld aan dit traject.
                       </p>
                     ) : (
                       <div className="mt-3 space-y-3">
@@ -2378,7 +2378,7 @@ export default async function CampaignPage({ params }: Props) {
                       href={`/beheer/klantlearnings?campaign=${id}`}
                       className="mt-4 inline-flex items-center rounded-full border border-slate-200 bg-white px-4 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:text-slate-900"
                     >
-                      Open learning-workbench
+                      Open leerwerkbank
                     </Link>
                   </div>
                 </div>

--- a/frontend/app/(dashboard)/campaigns/[id]/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.tsx
@@ -260,7 +260,7 @@ export default async function CampaignPage({ params }: Props) {
           href="/dashboard"
           className="text-sm font-medium text-slate-500 transition-colors hover:text-slate-700"
         >
-          ← Terug naar campaignoverzicht
+          ← Terug naar dashboardoverzicht
         </Link>
 
         <div id="samenvatting" className="scroll-mt-36 space-y-4">

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -25,22 +25,29 @@
   /* Shadows */
   --marketing-shadow-soft: 0 20px 48px rgba(19, 32, 51, 0.06);
   --marketing-shadow-strong: 0 28px 72px rgba(19, 32, 51, 0.11);
-  --dashboard-shadow-soft: 0 4px 24px rgba(19, 32, 51, 0.06), 0 1px 4px rgba(19, 32, 51, 0.04);
-  --dashboard-shadow-strong: 0 8px 32px rgba(19, 32, 51, 0.09), 0 2px 8px rgba(19, 32, 51, 0.05);
+  --dashboard-shadow-soft: 0 16px 42px rgba(19, 32, 51, 0.06);
+  --dashboard-shadow-strong: 0 18px 44px rgba(19, 32, 51, 0.1);
   --dashboard-shadow-card: 0 2px 12px rgba(19, 32, 51, 0.05);
 
-  /* Dashboard tokens — alle --dashboard-* vars die in components gebruikt worden */
-  --dashboard-ink: #132033;
-  --dashboard-surface: #FFFFFF;
-  --dashboard-soft: #F7F5F1;
-  --dashboard-frame-border: #E5E0D6;
-  --dashboard-text: #4A5563;
-  --dashboard-muted: #9CA3AF;
-  --dashboard-accent-soft: #EAF4F3;
+  /* Brand accent — warm amber/copper (homepage-aligned) */
+  --brand-accent-deep:  oklch(0.42 0.18 52);
+  --brand-accent-mid:   oklch(0.78 0.133 55);
+  --brand-accent-soft:  oklch(0.95 0.055 52);
+
+  /* Dashboard canvas & surfaces */
+  --dashboard-canvas:        #F8F4EE;
+  --dashboard-surface:       #FFFCF8;
+  --dashboard-soft:          #F0EBE1;
+  --dashboard-rail:          #0f1923;
+  --dashboard-frame-border:  rgba(19, 32, 51, 0.10);
+  --dashboard-ink:           #132033;
+  --dashboard-text:          #4e5b67;
+  --dashboard-muted:         #7c8a95;
+  --dashboard-accent-soft:   #EAF4F3;
   --dashboard-accent-soft-border: #B8D8D4;
   --dashboard-accent-strong: #25605C;
-  --dashboard-blue-soft: #F0F5F8;
-  --dashboard-amber-soft: #FEF9F1;
+  --dashboard-blue-soft:     #F0F5F8;
+  --dashboard-amber-soft:    #FEF9F1;
   --dashboard-topbar-strong: rgba(255, 255, 255, 0.97);
 
   /* Dashboard layout */
@@ -48,6 +55,12 @@
   --dashboard-radius-card: 1.25rem;
   --dashboard-radius-hero: 1.75rem;
   --dashboard-radius-chip: 9999px;
+
+  /* Risk band colors */
+  --risk-high:     #C65B52;
+  --risk-mid:      #C88C20;
+  --risk-low:      #2E7C6D;
+  --risk-neutral:  #8A7D6E;
 }
 
 @theme inline {

--- a/frontend/components/dashboard/dashboard-primitives.tsx
+++ b/frontend/components/dashboard/dashboard-primitives.tsx
@@ -687,6 +687,181 @@ export function DashboardTimeline({
   )
 }
 
+export type RiskBand = 'HOOG' | 'MIDDEN' | 'LAAG'
+
+const RISK_ACCENT_COLORS: Record<RiskBand, string> = {
+  HOOG: '#C65B52',
+  MIDDEN: '#C88C20',
+  LAAG: '#2E7C6D',
+}
+
+export function SignalStatCard({
+  label,
+  value,
+  subline,
+  band,
+}: {
+  label: string
+  value: string
+  subline?: string
+  band?: RiskBand | 'neutral'
+}) {
+  const accentColor = band && band !== 'neutral' ? RISK_ACCENT_COLORS[band] : '#8A7D6E'
+
+  return (
+    <div
+      className="relative flex overflow-hidden rounded-[18px]"
+      style={{
+        background: 'var(--dashboard-surface)',
+        border: '1px solid var(--dashboard-frame-border)',
+        boxShadow: '0 1px 3px rgba(0,0,0,0.04)',
+        padding: '20px 20px 18px',
+      }}
+    >
+      {/* Inset left accent bar */}
+      <div
+        className="absolute left-0 top-[6px] bottom-[6px] w-[3px] rounded-r-full"
+        style={{ backgroundColor: accentColor }}
+      />
+      <div className="min-w-0 pl-4">
+        <p
+          className="text-[0.65rem] font-medium uppercase"
+          style={{ color: 'var(--dashboard-muted)', letterSpacing: '0.18em' }}
+        >
+          {label}
+        </p>
+        <p
+          className="mt-2 font-medium leading-none"
+          style={{ fontSize: '2.0rem', color: 'var(--dashboard-ink)' }}
+        >
+          {value}
+        </p>
+        {subline && (
+          <p className="mt-2 text-[0.80rem]" style={{ color: 'var(--dashboard-muted)' }}>
+            {subline}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function InsightStatCard({
+  label,
+  value,
+  subline,
+}: {
+  label: string
+  value: string
+  subline?: string
+}) {
+  return (
+    <div
+      className="relative flex overflow-hidden rounded-[18px]"
+      style={{
+        background: 'var(--dashboard-surface)',
+        border: '1px solid var(--dashboard-frame-border)',
+        boxShadow: '0 1px 3px rgba(0,0,0,0.04)',
+        padding: '20px 20px 18px',
+      }}
+    >
+      {/* Neutral inset bar */}
+      <div
+        className="absolute left-0 top-[6px] bottom-[6px] w-[3px] rounded-r-full"
+        style={{ backgroundColor: '#8A7D6E' }}
+      />
+      <div className="min-w-0 pl-4">
+        <p
+          className="text-[0.65rem] font-medium uppercase"
+          style={{ color: 'var(--dashboard-muted)', letterSpacing: '0.18em' }}
+        >
+          {label}
+        </p>
+        <p
+          className="mt-2 font-semibold leading-snug"
+          style={{ fontSize: '1.25rem', color: 'var(--dashboard-ink)', letterSpacing: '-0.01em' }}
+        >
+          {value}
+        </p>
+        {subline && (
+          <p className="mt-2 text-[0.80rem]" style={{ color: 'var(--dashboard-muted)' }}>
+            {subline}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function FocusPanel({
+  items,
+}: {
+  items: Array<{ text: string; moduleLabel?: string }>
+}) {
+  return (
+    <aside
+      className="hidden w-[300px] shrink-0 rounded-[18px] xl:block"
+      style={{
+        background: '#132033',
+        padding: '24px',
+        alignSelf: 'start',
+        position: 'sticky',
+        top: '80px',
+      }}
+    >
+      {/* Eyebrow */}
+      <div className="flex items-center gap-2 mb-4">
+        <div className="h-4 w-[2px] rounded-full" style={{ backgroundColor: '#2E7C6D' }} />
+        <p
+          className="text-[0.65rem] font-medium uppercase"
+          style={{ color: 'rgba(246,241,233,0.55)', letterSpacing: '0.18em' }}
+        >
+          Aanbevolen Focus
+        </p>
+      </div>
+
+      {/* Heading */}
+      <p
+        className="font-semibold leading-snug text-white mb-5"
+        style={{ fontSize: '1.2rem' }}
+      >
+        Waar nu aandacht naartoe
+      </p>
+
+      {/* Items */}
+      <ol className="space-y-4">
+        {items.map((item, i) => (
+          <li key={i} className="flex gap-3">
+            <span
+              className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[0.65rem] font-semibold"
+              style={{ background: 'rgba(255,255,255,0.08)', color: 'rgba(246,241,233,0.70)' }}
+            >
+              {i + 1}
+            </span>
+            <div className="min-w-0">
+              <p className="text-[0.875rem] leading-snug" style={{ color: 'rgba(246,241,233,0.85)' }}>
+                {item.text}
+              </p>
+              {item.moduleLabel && (
+                <span
+                  className="mt-1.5 inline-block rounded-full px-2 py-0.5 text-[0.60rem] font-medium uppercase"
+                  style={{
+                    background: 'rgba(255,255,255,0.07)',
+                    color: 'rgba(246,241,233,0.50)',
+                    letterSpacing: '0.12em',
+                  }}
+                >
+                  {item.moduleLabel}
+                </span>
+              )}
+            </div>
+          </li>
+        ))}
+      </ol>
+    </aside>
+  )
+}
+
 export function InfoTooltip({ text }: { text: string }) {
   return (
     <span className="group relative inline-flex items-center">

--- a/frontend/components/dashboard/dashboard-shell.tsx
+++ b/frontend/components/dashboard/dashboard-shell.tsx
@@ -8,7 +8,10 @@ import {
   buildDashboardShellNavigation,
   getDashboardShellCurrentLabel,
   normalizeDashboardPortfolioView,
+  DASHBOARD_MODULE_NAV,
+  getActiveModuleFromPathname,
   type DashboardPortfolioView,
+  type DashboardModuleNavItem,
 } from '@/lib/dashboard/shell-navigation'
 
 type PortfolioCounts = Record<DashboardPortfolioView, number>
@@ -31,6 +34,7 @@ export function DashboardShellFrame({
   const [mobileNavOpen, setMobileNavOpen] = useState(false)
   const currentCampaignPath = pathname.startsWith('/campaigns/') ? pathname : null
   const activePortfolioView = normalizeDashboardPortfolioView(searchParams.get('view') ?? undefined)
+  const activeModule = getActiveModuleFromPathname(pathname)
   const navigation = useMemo(
     () =>
       buildDashboardShellNavigation({
@@ -41,159 +45,181 @@ export function DashboardShellFrame({
     [currentCampaignPath, isAdmin, portfolioCounts],
   )
 
+  const moduleItems = DASHBOARD_MODULE_NAV.filter((m) => m.section === 'modules')
+  const supportItems = DASHBOARD_MODULE_NAV.filter((m) => m.section === 'support')
+
+  const activeModuleLabel = DASHBOARD_MODULE_NAV.find((m) => m.key === activeModule)?.label ?? 'Overview'
+  const orgName = userEmail.split('@')[1]?.split('.')[0] ?? 'Dashboard'
+  const orgDisplay = orgName.charAt(0).toUpperCase() + orgName.slice(1)
+
   return (
-    <div className="dashboard-shell min-h-screen bg-[color:var(--bg)] text-[color:var(--ink)]">
+    <div
+      className="min-h-screen text-[color:var(--ink)]"
+      style={{ backgroundColor: 'var(--dashboard-canvas)' }}
+    >
       <div className="mx-auto flex min-h-screen w-full max-w-[1600px]">
+        {/* Sidebar */}
+        <aside
+          className="hidden w-[280px] shrink-0 lg:flex"
+          style={{ backgroundColor: 'var(--dashboard-rail)', borderRight: '1px solid rgba(255,255,255,0.06)' }}
+        >
+          <div className="sticky top-0 flex h-screen w-full flex-col py-7">
+            {/* Wordmark */}
+            <div className="px-6 pb-6" style={{ borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
+              <Link href="/dashboard" className="block">
+                <span
+                  className="text-[15px] font-semibold tracking-[-0.01em]"
+                  style={{ color: 'rgba(246,241,233,0.95)' }}
+                >
+                  Verisight
+                </span>
+              </Link>
+            </div>
 
-        {/* ── Desktop Sidebar ── */}
-        <aside className="hidden w-[var(--dashboard-sidebar-width)] shrink-0 border-r border-white/[0.06] bg-[color:var(--ink)] lg:flex">
-          <div className="sticky top-0 flex h-screen w-full flex-col overflow-y-auto py-5">
-
-            {/* Brand */}
-            <Link
-              href="/dashboard"
-              className="mx-4 mb-6 flex items-center gap-3 rounded-xl px-2 py-2 transition-colors hover:bg-white/[0.05]"
-            >
-              <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[color:var(--teal)]">
-                <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-                  <path d="M3 4h10M3 8h7M3 12h4" stroke="white" strokeWidth="1.75" strokeLinecap="round" />
-                </svg>
-              </div>
-              <div className="min-w-0">
-                <p className="text-sm font-semibold tracking-[-0.02em] text-white">Verisight</p>
-                <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-white/45">Dashboard</p>
-              </div>
-            </Link>
-
-            {/* Nav */}
-            <nav className="flex-1 px-3 space-y-6">
+            {/* Module navigation */}
+            <nav className="flex-1 overflow-y-auto px-4 pt-6">
+              <SidebarSection label="Modules" items={moduleItems} activeModule={activeModule} onNavigate={() => {}} />
               <SidebarSection
-                title="Navigatie"
-                items={navigation.primary}
-                pathname={pathname}
-                activePortfolioView={activePortfolioView}
+                label="Support"
+                items={supportItems}
+                activeModule={activeModule}
                 onNavigate={() => {}}
+                className="mt-6"
               />
-              <SidebarSection
-                title="Portfolio"
-                items={navigation.portfolio}
-                pathname={pathname}
-                activePortfolioView={activePortfolioView}
-                onNavigate={() => {}}
-                showBadge
-              />
-              {navigation.admin.length > 0 ? (
-                <SidebarSection
-                  title="Beheer"
-                  items={navigation.admin}
-                  pathname={pathname}
-                  activePortfolioView={activePortfolioView}
-                  onNavigate={() => {}}
-                />
-              ) : null}
+              {navigation.admin.length > 0 && (
+                <div className="mt-6">
+                  <p
+                    className="mb-2 px-3 text-[0.60rem] font-medium uppercase"
+                    style={{ color: 'rgba(246,241,233,0.38)', letterSpacing: '0.18em' }}
+                  >
+                    Beheer
+                  </p>
+                  {navigation.admin.map((item) => (
+                    <Link
+                      key={item.label}
+                      href={item.href ?? '/dashboard'}
+                      className="flex w-full items-center justify-between rounded-lg px-3 py-2 text-sm transition-colors"
+                      style={{ color: 'rgba(246,241,233,0.70)' }}
+                    >
+                      {item.label}
+                    </Link>
+                  ))}
+                </div>
+              )}
             </nav>
 
-            {/* Account */}
-            <div className="mx-3 mt-4 rounded-xl border border-white/[0.08] bg-white/[0.04] px-3 py-3">
-              <p className="truncate text-[13px] font-medium text-white/80">{userEmail}</p>
-              <p className="mt-0.5 text-xs text-white/38">
-                {isAdmin ? 'Verisight beheer' : 'Klantdashboard'}
+            {/* Account footer */}
+            <div
+              className="mx-4 rounded-xl px-4 py-3"
+              style={{ borderTop: '1px solid rgba(255,255,255,0.06)', background: 'rgba(255,255,255,0.04)' }}
+            >
+              <p className="truncate text-xs" style={{ color: 'rgba(246,241,233,0.55)' }}>
+                {userEmail}
               </p>
-              <div className="mt-3">
-                <LogoutButton className="w-full justify-center rounded-lg border border-white/[0.1] bg-white/[0.05] px-3 py-1.5 text-xs font-semibold text-white/70 transition-colors hover:bg-white/[0.09] hover:text-white/90" />
+              <div className="mt-2">
+                <LogoutButton className="w-full justify-center rounded-full bg-white/[0.07] px-3 py-1.5 text-xs font-medium text-[rgba(246,241,233,0.80)] transition-colors hover:bg-white/[0.12]" />
               </div>
             </div>
           </div>
         </aside>
 
-        {/* ── Content Column ── */}
         <div className="flex min-w-0 flex-1 flex-col">
-
           {/* Topbar */}
-          <header className="sticky top-0 z-40 border-b border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-topbar-strong)] backdrop-blur-sm">
-            <div className="mx-auto flex w-full max-w-7xl items-center gap-3 px-4 py-3.5 sm:px-6">
-
-              {/* Mobile hamburger */}
+          <header
+            className="sticky top-0 z-40 backdrop-blur-md"
+            style={{
+              background: 'rgba(248,244,238,0.88)',
+              borderBottom: '1px solid rgba(19,32,51,0.08)',
+            }}
+          >
+            <div className="mx-auto flex w-full max-w-7xl items-center gap-3 px-6 py-3">
+              {/* Mobile menu button */}
               <button
                 type="button"
                 onClick={() => setMobileNavOpen((open) => !open)}
-                className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-[color:var(--dashboard-frame-border)] bg-white text-[color:var(--ink)] transition-colors hover:border-[color:var(--dashboard-accent-soft-border)] hover:text-[color:var(--teal)] lg:hidden"
+                className="inline-flex h-9 w-9 items-center justify-center rounded-full transition-colors lg:hidden"
+                style={{ border: '1px solid var(--dashboard-frame-border)', color: 'var(--dashboard-ink)' }}
                 aria-label="Navigatie openen"
               >
                 <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   {mobileNavOpen ? (
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 6l12 12M18 6L6 18" />
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M6 6l12 12M18 6L6 18" />
                   ) : (
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 7h16M4 12h16M4 17h16" />
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M4 7h16M4 12h16M4 17h16" />
                   )}
                 </svg>
               </button>
 
-              {/* Page title */}
+              {/* Context label */}
               <div className="min-w-0 flex-1">
-                <div className="flex flex-wrap items-center gap-2">
-                  <h1 className="text-base font-semibold tracking-[-0.025em] text-[color:var(--ink)]">
-                    {getDashboardShellCurrentLabel(pathname)}
-                  </h1>
-                  <span className="hidden rounded-full border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)] px-2.5 py-0.5 text-xs font-semibold text-[color:var(--dashboard-muted)] sm:inline-flex">
-                    {pathname.startsWith('/campaigns/') ? 'Verdieping' : 'Overview-first'}
-                  </span>
-                </div>
+                <p className="text-sm font-medium" style={{ color: 'var(--dashboard-ink)' }}>
+                  <span style={{ color: 'var(--dashboard-muted)' }}>{orgDisplay}</span>
+                  <span className="mx-1.5" style={{ color: 'var(--dashboard-frame-border)' }}>·</span>
+                  <span>{activeModuleLabel}</span>
+                </p>
               </div>
 
-              {/* Desktop account */}
-              <div className="hidden items-center gap-3 lg:flex">
-                <span className="max-w-[200px] truncate text-sm text-[color:var(--dashboard-muted)]">{userEmail}</span>
-                <LogoutButton className="rounded-full border border-[color:var(--dashboard-frame-border)] bg-white px-3.5 py-1.5 text-sm font-semibold text-[color:var(--ink)] transition-colors hover:border-[color:var(--dashboard-accent-soft-border)] hover:text-[color:var(--teal)]" />
-              </div>
+              {/* Export button */}
+              <button
+                type="button"
+                className="rounded-full px-4 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90"
+                style={{ background: '#161310' }}
+              >
+                Rapport exporteren
+              </button>
             </div>
 
-            {/* Mobile nav drawer */}
-            {mobileNavOpen ? (
-              <div className="border-t border-[color:var(--dashboard-frame-border)] bg-[color:var(--ink)] px-3 py-4 lg:hidden">
-                <div className="space-y-5">
-                  <SidebarSection
-                    title="Navigatie"
-                    items={navigation.primary}
-                    pathname={pathname}
-                    activePortfolioView={activePortfolioView}
-                    onNavigate={() => setMobileNavOpen(false)}
-                  />
-                  <SidebarSection
-                    title="Portfolio"
-                    items={navigation.portfolio}
-                    pathname={pathname}
-                    activePortfolioView={activePortfolioView}
-                    onNavigate={() => setMobileNavOpen(false)}
-                    showBadge
-                  />
-                  {navigation.admin.length > 0 ? (
-                    <SidebarSection
-                      title="Beheer"
-                      items={navigation.admin}
-                      pathname={pathname}
-                      activePortfolioView={activePortfolioView}
-                      onNavigate={() => setMobileNavOpen(false)}
-                    />
-                  ) : null}
+            {/* Mobile nav */}
+            {mobileNavOpen && (
+              <div
+                className="border-t px-4 py-4 lg:hidden"
+                style={{ borderColor: 'var(--dashboard-frame-border)', background: 'var(--dashboard-surface)' }}
+              >
+                <div className="space-y-1">
+                  {DASHBOARD_MODULE_NAV.map((item) => {
+                    const isActive = item.key === activeModule
+                    return (
+                      <Link
+                        key={item.key}
+                        href={item.href}
+                        onClick={() => setMobileNavOpen(false)}
+                        className="block rounded-lg px-4 py-2.5 text-sm font-medium transition-colors"
+                        style={{
+                          background: isActive ? 'rgba(19,32,51,0.06)' : 'transparent',
+                          color: isActive ? 'var(--dashboard-ink)' : 'var(--dashboard-text)',
+                        }}
+                      >
+                        {item.label}
+                      </Link>
+                    )
+                  })}
                 </div>
               </div>
-            ) : null}
+            )}
           </header>
 
-          {/* Main content */}
-          <main className="mx-auto w-full max-w-7xl flex-1 px-4 py-6 sm:px-6">
+          <main className="mx-auto flex-1 w-full max-w-7xl px-6 py-8">
             {acceptedCount > 0 ? (
-              <div className="mb-5 rounded-xl border border-[color:var(--dashboard-accent-soft-border)] bg-[color:var(--dashboard-accent-soft)] px-4 py-3 text-sm text-[color:var(--dashboard-accent-strong)]">
-                Uw account is gekoppeld aan {acceptedCount} organisatie{acceptedCount === 1 ? '' : 's'}.
-                Het juiste klantdashboard en de bijbehorende rapportages zijn automatisch geladen.
+              <div
+                className="mb-6 rounded-[16px] px-4 py-3 text-sm"
+                style={{
+                  background: 'rgba(46,124,109,0.08)',
+                  border: '1px solid rgba(46,124,109,0.18)',
+                  color: '#2E7C6D',
+                }}
+              >
+                Jouw account is gekoppeld aan {acceptedCount} organisatie{acceptedCount === 1 ? '' : 's'}.
+                Je ziet nu automatisch het juiste klantdashboard en de bijbehorende rapportages.
               </div>
             ) : null}
             {children}
           </main>
 
-          <footer className="border-t border-[color:var(--dashboard-frame-border)] px-4 py-3 text-xs text-[color:var(--dashboard-muted)] sm:px-6">
-            Verisight · Overview-first dashboard
+          <footer
+            className="px-6 py-4 text-xs"
+            style={{ borderTop: '1px solid var(--dashboard-frame-border)', color: 'var(--dashboard-muted)' }}
+          >
+            Verisight · {new Date().getFullYear()}
           </footer>
         </div>
       </div>
@@ -202,85 +228,52 @@ export function DashboardShellFrame({
 }
 
 function SidebarSection({
-  title,
+  label,
   items,
-  pathname,
-  activePortfolioView,
+  activeModule,
   onNavigate,
-  showBadge = false,
+  className = '',
 }: {
-  title: string
-  items: Array<{ label: string; detail: string; href: string | null; disabled: boolean; key?: DashboardPortfolioView }>
-  pathname: string
-  activePortfolioView: DashboardPortfolioView
+  label: string
+  items: DashboardModuleNavItem[]
+  activeModule: string
   onNavigate: () => void
-  showBadge?: boolean
+  className?: string
 }) {
-  if (items.length === 0) return null
-
   return (
-    <div>
-      <p className="mb-1.5 px-2 text-[10px] font-semibold uppercase tracking-[0.2em] text-white/35">
-        {title}
+    <div className={className}>
+      <p
+        className="mb-2 px-3 text-[0.60rem] font-medium uppercase"
+        style={{ color: 'rgba(246,241,233,0.38)', letterSpacing: '0.18em' }}
+      >
+        {label}
       </p>
       <div className="space-y-0.5">
         {items.map((item) => {
-          const active = isActiveShellItem({ pathname, activePortfolioView, item })
-          const count = showBadge ? extractCountFromDetail(item.detail) : null
-
-          if (!item.href || item.disabled) {
-            return (
-              <div
-                key={`${title}-${item.label}`}
-                className="dash-nav-item dash-nav-item-disabled"
-              >
-                <span className="truncate">{item.label}</span>
-                {count !== null ? (
-                  <span className="dash-nav-badge opacity-40">{count}</span>
-                ) : null}
-              </div>
-            )
-          }
-
+          const isActive = item.key === activeModule
           return (
             <Link
-              key={`${title}-${item.label}`}
+              key={item.key}
               href={item.href}
               onClick={onNavigate}
-              className={`dash-nav-item ${active ? 'dash-nav-item-active' : 'dash-nav-item-inactive'}`}
+              className="flex w-full items-center justify-between rounded-lg px-3 py-2 text-sm transition-colors"
+              style={{
+                background: isActive ? 'rgba(255,255,255,0.07)' : 'transparent',
+                color: isActive ? 'rgba(246,241,233,1)' : 'rgba(246,241,233,0.70)',
+                fontWeight: isActive ? 500 : 400,
+              }}
             >
-              <span className="truncate">{item.label}</span>
-              {count !== null ? (
-                <span className={`dash-nav-badge ${active ? 'dash-nav-badge-active' : ''}`}>
-                  {count}
-                </span>
-              ) : null}
+              <span>{item.label}</span>
+              {isActive && (
+                <span
+                  className="ml-2 h-1.5 w-1.5 shrink-0 rounded-full"
+                  style={{ backgroundColor: 'var(--brand-accent-mid)' }}
+                />
+              )}
             </Link>
           )
         })}
       </div>
     </div>
   )
-}
-
-function extractCountFromDetail(detail: string): number | null {
-  const match = detail.match(/^(\d+)\s+campagne/)
-  return match ? parseInt(match[1], 10) : null
-}
-
-function isActiveShellItem({
-  pathname,
-  activePortfolioView,
-  item,
-}: {
-  pathname: string
-  activePortfolioView: DashboardPortfolioView
-  item: { href: string | null; key?: DashboardPortfolioView; label: string }
-}) {
-  if (!item.href) return false
-  if (item.label === 'Huidige campagne') return pathname.startsWith('/campaigns/')
-  if (item.label === 'Overview') return pathname === '/dashboard' && !item.key
-  if (item.key) return pathname === '/dashboard' && activePortfolioView === item.key
-
-  return pathname === item.href || pathname.startsWith(`${item.href}/`)
 }

--- a/frontend/components/dashboard/dashboard-shell.tsx
+++ b/frontend/components/dashboard/dashboard-shell.tsx
@@ -41,9 +41,7 @@ export function DashboardShellFrame({
       }),
     [currentCampaignPath, isAdmin, portfolioCounts],
   )
-
-  const moduleItems = DASHBOARD_MODULE_NAV.filter((m) => m.section === 'modules')
-  const supportItems = DASHBOARD_MODULE_NAV.filter((m) => m.section === 'support')
+  const mobileItems = [...navigation.modules, ...navigation.support]
 
   const activeModuleLabel = DASHBOARD_MODULE_NAV.find((m) => m.key === activeModule)?.label ?? 'Overzicht'
   const currentLabel = getDashboardShellCurrentLabel(pathname)
@@ -76,10 +74,10 @@ export function DashboardShellFrame({
 
             {/* Module navigation */}
             <nav className="flex-1 overflow-y-auto px-4 pt-6">
-              <SidebarSection label="Modules" items={moduleItems} activeModule={activeModule} onNavigate={() => {}} />
+              <SidebarSection label="Modules" items={navigation.modules} activeModule={activeModule} onNavigate={() => {}} />
               <SidebarSection
                 label="Support"
-                items={supportItems}
+                items={navigation.support}
                 activeModule={activeModule}
                 onNavigate={() => {}}
                 className="mt-6"
@@ -169,7 +167,7 @@ export function DashboardShellFrame({
                 style={{ borderColor: 'var(--dashboard-frame-border)', background: 'var(--dashboard-surface)' }}
               >
                 <div className="space-y-1">
-                  {DASHBOARD_MODULE_NAV.map((item) => {
+                  {mobileItems.map((item) => {
                     const isActive = item.key === activeModule
                     return (
                       <Link

--- a/frontend/components/dashboard/dashboard-shell.tsx
+++ b/frontend/components/dashboard/dashboard-shell.tsx
@@ -1,13 +1,12 @@
 'use client'
 
 import Link from 'next/link'
-import { usePathname, useSearchParams } from 'next/navigation'
+import { usePathname } from 'next/navigation'
 import { useMemo, useState } from 'react'
 import { LogoutButton } from '@/components/ui/logout-button'
 import {
   buildDashboardShellNavigation,
   getDashboardShellCurrentLabel,
-  normalizeDashboardPortfolioView,
   DASHBOARD_MODULE_NAV,
   getActiveModuleFromPathname,
   type DashboardPortfolioView,
@@ -30,10 +29,8 @@ export function DashboardShellFrame({
   children: React.ReactNode
 }) {
   const pathname = usePathname()
-  const searchParams = useSearchParams()
   const [mobileNavOpen, setMobileNavOpen] = useState(false)
   const currentCampaignPath = pathname.startsWith('/campaigns/') ? pathname : null
-  const activePortfolioView = normalizeDashboardPortfolioView(searchParams.get('view') ?? undefined)
   const activeModule = getActiveModuleFromPathname(pathname)
   const navigation = useMemo(
     () =>
@@ -48,7 +45,8 @@ export function DashboardShellFrame({
   const moduleItems = DASHBOARD_MODULE_NAV.filter((m) => m.section === 'modules')
   const supportItems = DASHBOARD_MODULE_NAV.filter((m) => m.section === 'support')
 
-  const activeModuleLabel = DASHBOARD_MODULE_NAV.find((m) => m.key === activeModule)?.label ?? 'Overview'
+  const activeModuleLabel = DASHBOARD_MODULE_NAV.find((m) => m.key === activeModule)?.label ?? 'Overzicht'
+  const currentLabel = getDashboardShellCurrentLabel(pathname)
   const orgName = userEmail.split('@')[1]?.split('.')[0] ?? 'Dashboard'
   const orgDisplay = orgName.charAt(0).toUpperCase() + orgName.slice(1)
 
@@ -139,7 +137,7 @@ export function DashboardShellFrame({
                 onClick={() => setMobileNavOpen((open) => !open)}
                 className="inline-flex h-9 w-9 items-center justify-center rounded-full transition-colors lg:hidden"
                 style={{ border: '1px solid var(--dashboard-frame-border)', color: 'var(--dashboard-ink)' }}
-                aria-label="Navigatie openen"
+                aria-label={mobileNavOpen ? 'Navigatie sluiten' : 'Navigatie openen'}
               >
                 <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   {mobileNavOpen ? (
@@ -157,16 +155,11 @@ export function DashboardShellFrame({
                   <span className="mx-1.5" style={{ color: 'var(--dashboard-frame-border)' }}>·</span>
                   <span>{activeModuleLabel}</span>
                 </p>
+                <p className="mt-1 text-xs" style={{ color: 'var(--dashboard-muted)' }}>
+                  {currentLabel}
+                </p>
               </div>
 
-              {/* Export button */}
-              <button
-                type="button"
-                className="rounded-full px-4 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90"
-                style={{ background: '#161310' }}
-              >
-                Rapport exporteren
-              </button>
             </div>
 
             {/* Mobile nav */}

--- a/frontend/components/dashboard/factor-table.tsx
+++ b/frontend/components/dashboard/factor-table.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { buildFactorPresentation, getManagementBandBadgeClasses, getRiskBandFromScore } from '@/lib/management-language'
+import { buildFactorPresentation, getRiskBandFromScore, RISK_COLORS, RISK_BG_COLORS } from '@/lib/management-language'
 import { getScanDefinition } from '@/lib/scan-definitions'
 import { FACTOR_LABELS } from '@/lib/types'
 import type { ScanType } from '@/lib/types'
@@ -24,49 +24,73 @@ export function FactorTable({ factorAverages, scanType }: Props) {
       return { factor: f, score, riskVal, band, presentation }
     })
     .sort((a, b) => b.riskVal - a.riskVal)
+
   const introText =
     scanType === 'exit'
-      ? 'De belevingsscore laat zien hoe vertrekkers een thema gemiddeld ervoeren. Het managementlabel vertaalt dat naar wat dit bestuurlijk nu vraagt. De signaallogica blijft ondersteunend en is geen tweede hoofdscore.'
+      ? 'De belevingsscore laat zien hoe vertrekkers een thema gemiddeld ervoeren. Het managementlabel vertaalt dat naar wat dit bestuurlijk nu vraagt.'
       : scanType === 'team'
-        ? `De belevingsscore laat zien hoe medewerkers hun directe werkcontext gemiddeld ervaren. Het managementlabel vertaalt dat naar wat dit lokaal bestuurlijk vraagt. Het ${scanDefinition.signalLabelLower} per factor blijft ondersteunende logica, geen tweede hoofdscore.`
+        ? `De belevingsscore laat zien hoe medewerkers hun directe werkcontext gemiddeld ervaren. Het managementlabel vertaalt dat naar wat dit lokaal bestuurlijk vraagt.`
       : scanType === 'onboarding'
-        ? `De belevingsscore laat zien hoe nieuwe medewerkers dit checkpoint gemiddeld ervaren. Het managementlabel vertaalt dat naar wat dit in de vroege managementread vraagt. Het ${scanDefinition.signalLabelLower} per factor blijft ondersteunende logica, geen tweede hoofdscore.`
-      : `De belevingsscore laat zien hoe medewerkers een thema gemiddeld ervaren. Het managementlabel vertaalt dat naar wat dit bestuurlijk vraagt voor behoud. Het ${scanDefinition.signalLabelLower} per factor blijft ondersteunende logica, geen tweede hoofdscore.`
+        ? `De belevingsscore laat zien hoe nieuwe medewerkers dit checkpoint gemiddeld ervaren. Het managementlabel vertaalt dat naar wat dit in de vroege managementread vraagt.`
+      : `De belevingsscore laat zien hoe medewerkers een thema gemiddeld ervaren. Het managementlabel vertaalt dat naar wat dit bestuurlijk vraagt voor behoud.`
+
+  const BAND_LABELS = { HOOG: 'Direct prioriteren', MIDDEN: 'Eerst toetsen', LAAG: 'Volgen' }
 
   return (
-    <div className="space-y-2">
-      <p className="text-xs leading-5 text-gray-500">
-        {introText} Het is geen extra meting of bewijslaag.
+    <div className="space-y-1">
+      <p className="mb-4 text-[0.85rem] leading-6" style={{ color: 'var(--dashboard-muted)' }}>
+        {introText}
       </p>
-      {rows.map(row => (
-        <div key={row.factor} className="flex items-center gap-3">
-          {/* Naam */}
-          <span className="text-sm text-gray-700 w-44 flex-shrink-0">
+      {rows.map((row, i) => (
+        <div
+          key={row.factor}
+          className="flex items-center gap-4 py-3"
+          style={{
+            borderBottom: i < rows.length - 1 ? '1px solid rgba(19,32,51,0.06)' : undefined,
+          }}
+        >
+          {/* Factor label */}
+          <span
+            className="w-40 shrink-0 text-[0.875rem]"
+            style={{ color: 'var(--dashboard-ink)' }}
+          >
             {FACTOR_LABELS[row.factor]}
           </span>
 
-          {/* Balk */}
-          <div className="flex-1 h-2 bg-gray-100 rounded-full overflow-hidden">
+          {/* Progress bar */}
+          <div
+            className="h-[6px] flex-1 overflow-hidden rounded-[3px]"
+            style={{ background: 'rgba(19,32,51,0.08)' }}
+          >
             <div
-              className="h-full rounded-full"
+              className="h-full rounded-[3px] transition-all"
               style={{
                 width: `${((row.score - 1) / 9) * 100}%`,
-                backgroundColor:
-                  row.band === 'HOOG' ? '#DC2626'
-                  : row.band === 'MIDDEN' ? '#F59E0B'
-                  : '#16A34A',
+                backgroundColor: RISK_COLORS[row.band],
               }}
             />
           </div>
 
           {/* Score */}
-          <span className="text-sm font-semibold text-gray-800 w-20 text-right">
+          <span
+            className="w-16 shrink-0 text-right text-[0.875rem] font-medium"
+            style={{ color: 'var(--dashboard-ink)' }}
+          >
             {row.presentation.scoreDisplay}
           </span>
 
-          {/* Badge */}
-          <span className={`text-xs font-bold px-2 py-0.5 rounded min-w-[124px] text-center ${getManagementBandBadgeClasses(row.band)}`}>
-            {row.presentation.managementLabel}
+          {/* Badge pill */}
+          <span
+            className="shrink-0 rounded-full px-2.5 py-0.5 text-[0.65rem] font-medium uppercase"
+            style={{
+              background: RISK_BG_COLORS[row.band],
+              color: RISK_COLORS[row.band],
+              letterSpacing: '0.04em',
+              minWidth: '7rem',
+              textAlign: 'center',
+            }}
+          >
+            {BAND_LABELS[row.band]}
           </span>
         </div>
       ))}

--- a/frontend/components/dashboard/factor-table.tsx
+++ b/frontend/components/dashboard/factor-table.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { buildFactorPresentation, getRiskBandFromScore, RISK_COLORS, RISK_BG_COLORS } from '@/lib/management-language'
-import { getScanDefinition } from '@/lib/scan-definitions'
 import { FACTOR_LABELS } from '@/lib/types'
 import type { ScanType } from '@/lib/types'
 
@@ -13,7 +12,6 @@ interface Props {
 }
 
 export function FactorTable({ factorAverages, scanType }: Props) {
-  const scanDefinition = getScanDefinition(scanType)
   const rows = ORG_FACTORS
     .filter(f => f in factorAverages)
     .map(f => {

--- a/frontend/components/dashboard/risk-charts.tsx
+++ b/frontend/components/dashboard/risk-charts.tsx
@@ -6,7 +6,6 @@ import {
   type PieLabelRenderProps,
 } from 'recharts'
 import { getManagementBandLabel, RISK_COLORS } from '@/lib/management-language'
-import { getScanDefinition } from '@/lib/scan-definitions'
 import type { ScanType } from '@/lib/types'
 
 interface Props {
@@ -67,7 +66,6 @@ export function StackedRiskBar({
 }
 
 export function RiskCharts({ distribution, histogramBins, averageScore, scanType }: Props) {
-  const scanDefinition = getScanDefinition(scanType)
   const totalResponses = distribution.HOOG + distribution.MIDDEN + distribution.LAAG
   const pieLabels =
     scanType === 'exit'
@@ -101,19 +99,19 @@ export function RiskCharts({ distribution, histogramBins, averageScore, scanType
         ? 'De signaalverdeling laat zien hoe breed het huidige lokale beeld is verdeeld over directe aandachtspunten, aandacht en voorlopige stabiliteit.'
         : scanType === 'onboarding'
           ? 'De signaalverdeling laat zien hoe breed het huidige onboardingcheckpoint is verdeeld over directe aandachtspunten, aandacht en voorlopige stabiliteit.'
-      : 'De signaalverdeling laat zien hoe responses zijn verdeeld over voorlopige stabiliteit, aandacht en directe aandachtspunten.'
+      : 'De signaalverdeling laat zien hoe reacties zijn verdeeld over voorlopige stabiliteit, aandacht en directe aandachtspunten.'
 
   const insightText = scanType === 'exit'
     ? dominantBand.band === 'HOOG'
-      ? `${dominantPercent}% van de exitresponses valt in ${getManagementBandLabel('HOOG').toLowerCase()}. Dat wijst op een breder werkgerelateerd vertrekbeeld dat eerst managementverificatie verdient.`
+      ? `${dominantPercent}% van de exitreacties valt in ${getManagementBandLabel('HOOG').toLowerCase()}. Dat wijst op een breder werkgerelateerd vertrekbeeld dat eerst managementverificatie verdient.`
       : dominantBand.band === 'LAAG'
-        ? `${dominantPercent}% van de exitresponses valt in ${getManagementBandLabel('LAAG').toLowerCase()}. Dat wijst niet op een breed werkpatroon, maar laat nog steeds ruimte voor afwijkende factoren.`
-        : `${dominantPercent}% van de exitresponses valt in ${getManagementBandLabel('MIDDEN').toLowerCase()}. Dat past bij een beeld met terugkerende signalen, maar nog zonder eenduidige managementduiding.`
+        ? `${dominantPercent}% van de exitreacties valt in ${getManagementBandLabel('LAAG').toLowerCase()}. Dat wijst niet op een breed werkpatroon, maar laat nog steeds ruimte voor afwijkende factoren.`
+        : `${dominantPercent}% van de exitreacties valt in ${getManagementBandLabel('MIDDEN').toLowerCase()}. Dat past bij een beeld met terugkerende signalen, maar nog zonder eenduidige managementduiding.`
     : dominantBand.band === 'HOOG'
-      ? `${dominantPercent}% van de responses valt in de hoogste risicoband. Kijk eerst naar de topfactoren en plan snelle verdieping.`
+      ? `${dominantPercent}% van de reacties valt in de hoogste risicoband. Kijk eerst naar de topfactoren en plan snelle verdieping.`
       : dominantBand.band === 'LAAG'
-        ? `${dominantPercent}% van de responses valt in de laagste risicoband. Het blijft zinvol om de opvallendste factoren te controleren.`
-        : `${dominantPercent}% van de responses valt in de middelste risicoband. Gebruik de topfactoren om gericht door te vragen.`
+        ? `${dominantPercent}% van de reacties valt in de laagste risicoband. Het blijft zinvol om de opvallendste factoren te controleren.`
+        : `${dominantPercent}% van de reacties valt in de middelste risicoband. Gebruik de topfactoren om gericht door te vragen.`
 
   return (
     <div className="space-y-6">
@@ -152,8 +150,8 @@ export function RiskCharts({ distribution, histogramBins, averageScore, scanType
               stroke="#7C8A95"
               strokeDasharray="3 3"
             />
-            <Bar dataKey="count" fill="rgba(19,32,51,0.18)" radius={[2, 2, 0, 0]} />
-            <Tooltip formatter={(v) => [`${v} responses`, 'Aantal']} />
+            <Bar dataKey="count" fill="#94A3B8" radius={[2, 2, 0, 0]} />
+            <Tooltip formatter={(v) => [`${v} reacties`, 'Aantal']} />
           </BarChart>
         </ResponsiveContainer>
       )}
@@ -184,7 +182,7 @@ export function RiskCharts({ distribution, histogramBins, averageScore, scanType
                 <Cell key={entry.name} fill={entry.color} />
               ))}
             </Pie>
-            <Tooltip formatter={(v) => [`${v} responses`]} />
+            <Tooltip formatter={(v) => [`${v} reacties`]} />
           </PieChart>
         </ResponsiveContainer>
       </details>

--- a/frontend/components/dashboard/risk-charts.tsx
+++ b/frontend/components/dashboard/risk-charts.tsx
@@ -5,7 +5,7 @@ import {
   BarChart, Bar, XAxis, YAxis, ReferenceLine,
   type PieLabelRenderProps,
 } from 'recharts'
-import { getManagementBandLabel } from '@/lib/management-language'
+import { getManagementBandLabel, RISK_COLORS } from '@/lib/management-language'
 import { getScanDefinition } from '@/lib/scan-definitions'
 import type { ScanType } from '@/lib/types'
 
@@ -16,7 +16,55 @@ interface Props {
   scanType: ScanType
 }
 
-const COLORS = { HOOG: '#B45309', MIDDEN: '#C78924', LAAG: '#2D6F6C' }
+export function StackedRiskBar({
+  distribution,
+}: {
+  distribution: { HOOG: number; MIDDEN: number; LAAG: number }
+}) {
+  const total = distribution.HOOG + distribution.MIDDEN + distribution.LAAG
+  if (total === 0) return null
+
+  const segments = [
+    { key: 'HOOG' as const, label: 'Direct prioriteren', value: distribution.HOOG },
+    { key: 'MIDDEN' as const, label: 'Eerst toetsen', value: distribution.MIDDEN },
+    { key: 'LAAG' as const, label: 'Volgen', value: distribution.LAAG },
+  ].filter((s) => s.value > 0)
+
+  return (
+    <div>
+      {/* Stacked bar */}
+      <div className="flex h-3 w-full overflow-hidden rounded-full">
+        {segments.map((seg) => (
+          <div
+            key={seg.key}
+            style={{
+              width: `${(seg.value / total) * 100}%`,
+              backgroundColor: RISK_COLORS[seg.key],
+            }}
+          />
+        ))}
+      </div>
+
+      {/* Legend */}
+      <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1">
+        {segments.map((seg) => (
+          <div key={seg.key} className="flex items-center gap-1.5">
+            <div
+              className="h-2 w-2 shrink-0 rounded-full"
+              style={{ backgroundColor: RISK_COLORS[seg.key] }}
+            />
+            <span className="text-[0.75rem]" style={{ color: 'var(--dashboard-text)' }}>
+              {seg.label}{' '}
+              <span style={{ color: 'var(--dashboard-ink)', fontWeight: 500 }}>
+                {Math.round((seg.value / total) * 100)}%
+              </span>
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
 
 export function RiskCharts({ distribution, histogramBins, averageScore, scanType }: Props) {
   const scanDefinition = getScanDefinition(scanType)
@@ -29,10 +77,11 @@ export function RiskCharts({ distribution, histogramBins, averageScore, scanType
         : scanType === 'onboarding'
           ? { HOOG: 'Direct checkpoint aandachtspunt', MIDDEN: 'Checkpoint aandacht nodig', LAAG: 'Checkpoint voorlopig stabiel' }
       : { HOOG: getManagementBandLabel('HOOG'), MIDDEN: getManagementBandLabel('MIDDEN'), LAAG: getManagementBandLabel('LAAG') }
+
   const pieData = [
-    { name: pieLabels.HOOG, value: distribution.HOOG, color: COLORS.HOOG },
-    { name: pieLabels.MIDDEN, value: distribution.MIDDEN, color: COLORS.MIDDEN },
-    { name: pieLabels.LAAG, value: distribution.LAAG, color: COLORS.LAAG },
+    { name: pieLabels.HOOG, value: distribution.HOOG, color: RISK_COLORS.HOOG },
+    { name: pieLabels.MIDDEN, value: distribution.MIDDEN, color: RISK_COLORS.MIDDEN },
+    { name: pieLabels.LAAG, value: distribution.LAAG, color: RISK_COLORS.LAAG },
   ].filter((d) => d.value > 0)
 
   const dominantBand = [
@@ -51,37 +100,35 @@ export function RiskCharts({ distribution, histogramBins, averageScore, scanType
       : scanType === 'team'
         ? 'De signaalverdeling laat zien hoe breed het huidige lokale beeld is verdeeld over directe aandachtspunten, aandacht en voorlopige stabiliteit.'
         : scanType === 'onboarding'
-          ? 'De signaalverdeling laat zien hoe breed het huidige onboardingcheckpoint is verdeeld over directe aandachtspunten, aandacht en voorlopige stabiliteit. Dat helpt bepalen of dit meetmoment vooral borging of juist een eerste correctie vraagt.'
-      : 'De signaalverdeling laat zien hoe responses zijn verdeeld over voorlopige stabiliteit, aandacht en directe aandachtspunten. Dit zegt iets over de breedte en intensiteit van signalen in de groep, niet over een bewezen oorzaak.'
+          ? 'De signaalverdeling laat zien hoe breed het huidige onboardingcheckpoint is verdeeld over directe aandachtspunten, aandacht en voorlopige stabiliteit.'
+      : 'De signaalverdeling laat zien hoe responses zijn verdeeld over voorlopige stabiliteit, aandacht en directe aandachtspunten.'
 
   const insightText = scanType === 'exit'
     ? dominantBand.band === 'HOOG'
       ? `${dominantPercent}% van de exitresponses valt in ${getManagementBandLabel('HOOG').toLowerCase()}. Dat wijst op een breder werkgerelateerd vertrekbeeld dat eerst managementverificatie verdient.`
       : dominantBand.band === 'LAAG'
-        ? `${dominantPercent}% van de exitresponses valt in ${getManagementBandLabel('LAAG').toLowerCase()}. Dat wijst niet op een breed werkpatroon, maar laat nog steeds ruimte voor afwijkende factoren, teams of vertrekredenen.`
+        ? `${dominantPercent}% van de exitresponses valt in ${getManagementBandLabel('LAAG').toLowerCase()}. Dat wijst niet op een breed werkpatroon, maar laat nog steeds ruimte voor afwijkende factoren.`
         : `${dominantPercent}% van de exitresponses valt in ${getManagementBandLabel('MIDDEN').toLowerCase()}. Dat past bij een beeld met terugkerende signalen, maar nog zonder eenduidige managementduiding.`
-    : scanType === 'team'
-      ? dominantBand.band === 'HOOG'
-        ? `${dominantPercent}% van de responses valt in direct lokaal aandachtspunt. Voor HR wijst dit op een scherp lokaal spoor: kijk eerst naar afdelingen, topfactoren en veilige lokale context.`
-        : dominantBand.band === 'LAAG'
-          ? `${dominantPercent}% van de responses valt in lokaal voorlopig stabiel. Voor HR wijst dit niet op een breed lokaal probleem, maar afdelingen en topfactoren kunnen nog steeds verificatie vragen.`
-          : `${dominantPercent}% van de responses valt in lokaal aandacht nodig. Voor HR betekent dit meestal dat lokalisatie mogelijk is, maar nog terughoudend gelezen moet worden.`
-      : scanType === 'onboarding'
-        ? dominantBand.band === 'HOOG'
-          ? `${dominantPercent}% van de responses valt in direct checkpoint aandachtspunt. Voor HR wijst dit op een scherp vroeg spoor: kijk eerst naar de topfactoren en kies een kleine, zichtbare correctie voor het volgende checkpoint.`
-          : dominantBand.band === 'LAAG'
-            ? `${dominantPercent}% van de responses valt in checkpoint voorlopig stabiel. Voor HR wijst dit op een overwegend stabiele instroomervaring, maar topfactoren blijven nuttig om te borgen wat werkt.`
-            : `${dominantPercent}% van de responses valt in checkpoint aandacht nodig. Voor HR betekent dit meestal dat de instroomervaring gemengd maar leesbaar is: kies eerst een beperkte managementvraag en houd de volgende check bewust bounded.`
-      : dominantBand.band === 'HOOG'
-      ? `${dominantPercent}% van de responses valt in ${getManagementBandLabel('HOOG').toLowerCase()}. Voor HR wijst dit op een breed en relatief scherp spoor: kijk eerst naar de topfactoren en plan snelle verdieping.`
+    : dominantBand.band === 'HOOG'
+      ? `${dominantPercent}% van de responses valt in de hoogste risicoband. Kijk eerst naar de topfactoren en plan snelle verdieping.`
       : dominantBand.band === 'LAAG'
-        ? `${dominantPercent}% van de responses valt in ${getManagementBandLabel('LAAG').toLowerCase()}. Voor HR wijst dit niet op een breed ${scanDefinition.signalLabelLower}, maar het blijft zinvol om de opvallendste factoren en open antwoorden te controleren.`
-        : `${dominantPercent}% van de responses valt in ${getManagementBandLabel('MIDDEN').toLowerCase()}. Voor HR betekent dit meestal geen eenduidig crisisbeeld, maar wel terugkerende signalering: gebruik de topfactoren en segmenten om gericht door te vragen.`
+        ? `${dominantPercent}% van de responses valt in de laagste risicoband. Het blijft zinvol om de opvallendste factoren te controleren.`
+        : `${dominantPercent}% van de responses valt in de middelste risicoband. Gebruik de topfactoren om gericht door te vragen.`
 
   return (
-    <div className="space-y-4">
-      <div className="rounded-[24px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)] px-4 py-4 text-sm text-[color:var(--dashboard-text)]">
-        <p className="font-medium text-[color:var(--dashboard-ink)]">
+    <div className="space-y-6">
+      {/* Stacked bar — primary visualization */}
+      <StackedRiskBar distribution={distribution} />
+
+      <div
+        className="rounded-[16px] px-4 py-4 text-sm"
+        style={{
+          background: 'var(--dashboard-soft)',
+          border: '1px solid var(--dashboard-frame-border)',
+          color: 'var(--dashboard-text)',
+        }}
+      >
+        <p className="font-medium" style={{ color: 'var(--dashboard-ink)' }}>
           {scanType === 'exit'
             ? 'Wat zegt dit over het vertrekbeeld?'
             : scanType === 'team'
@@ -91,46 +138,56 @@ export function RiskCharts({ distribution, histogramBins, averageScore, scanType
               : 'Wat betekent dit voor behoudsduiding?'}
         </p>
         <p className="mt-1">{introText}</p>
-        <p className="mt-2 text-[color:var(--dashboard-ink)]">{insightText}</p>
+        <p className="mt-2" style={{ color: 'var(--dashboard-ink)' }}>{insightText}</p>
       </div>
 
-      <ResponsiveContainer width="100%" height={160}>
-        <PieChart>
-          <Pie
-            data={pieData}
-            cx="50%"
-            cy="50%"
-            innerRadius={50}
-            outerRadius={70}
-            dataKey="value"
-            label={({ name, percent }: PieLabelRenderProps) =>
-              (percent ?? 0) > 0.05 ? `${name ?? ''} ${((percent ?? 0) * 100).toFixed(0)}%` : ''
-            }
-            labelLine={false}
-          >
-            {pieData.map((entry) => (
-              <Cell key={entry.name} fill={entry.color} />
-            ))}
-          </Pie>
-          <Tooltip formatter={(v) => [`${v} responses`]} />
-        </PieChart>
-      </ResponsiveContainer>
-
+      {/* Histogram */}
       {averageScore !== null && (
         <ResponsiveContainer width="100%" height={100}>
           <BarChart data={histogramBins} margin={{ top: 0, right: 0, left: -20, bottom: 0 }}>
-            <XAxis dataKey="range" tick={{ fontSize: 10 }} />
-            <YAxis tick={{ fontSize: 10 }} allowDecimals={false} />
+            <XAxis dataKey="range" tick={{ fontSize: 10, fill: '#7c8a95' }} />
+            <YAxis tick={{ fontSize: 10, fill: '#7c8a95' }} allowDecimals={false} />
             <ReferenceLine
               x={`${Math.floor(averageScore)}-${Math.ceil(averageScore)}`}
               stroke="#7C8A95"
               strokeDasharray="3 3"
             />
-            <Bar dataKey="count" fill="#94A3B8" radius={[2, 2, 0, 0]} />
+            <Bar dataKey="count" fill="rgba(19,32,51,0.18)" radius={[2, 2, 0, 0]} />
             <Tooltip formatter={(v) => [`${v} responses`, 'Aantal']} />
           </BarChart>
         </ResponsiveContainer>
       )}
+
+      {/* Pie chart — secondary/supplementary */}
+      <details>
+        <summary
+          className="cursor-pointer select-none text-[0.80rem]"
+          style={{ color: 'var(--dashboard-muted)' }}
+        >
+          Toon taartdiagram
+        </summary>
+        <ResponsiveContainer width="100%" height={160}>
+          <PieChart>
+            <Pie
+              data={pieData}
+              cx="50%"
+              cy="50%"
+              innerRadius={50}
+              outerRadius={70}
+              dataKey="value"
+              label={({ name, percent }: PieLabelRenderProps) =>
+                (percent ?? 0) > 0.05 ? `${name ?? ''} ${((percent ?? 0) * 100).toFixed(0)}%` : ''
+              }
+              labelLine={false}
+            >
+              {pieData.map((entry) => (
+                <Cell key={entry.name} fill={entry.color} />
+              ))}
+            </Pie>
+            <Tooltip formatter={(v) => [`${v} responses`]} />
+          </PieChart>
+        </ResponsiveContainer>
+      </details>
     </div>
   )
 }

--- a/frontend/lib/dashboard/risk-charts-copy.test.ts
+++ b/frontend/lib/dashboard/risk-charts-copy.test.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('risk charts copy', () => {
+  it('keeps visible chart copy in Dutch', () => {
+    const source = readFileSync(new URL('../../components/dashboard/risk-charts.tsx', import.meta.url), 'utf8')
+
+    expect(source).not.toContain('responses')
+    expect(source).toContain('reacties')
+  })
+})

--- a/frontend/lib/dashboard/shell-navigation.test.ts
+++ b/frontend/lib/dashboard/shell-navigation.test.ts
@@ -2,13 +2,12 @@ import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 import {
   buildDashboardShellNavigation,
-  DASHBOARD_MODULE_NAV,
   getDashboardShellCurrentLabel,
   normalizeDashboardPortfolioView,
 } from './shell-navigation'
 
 describe('dashboard shell buyer-readiness', () => {
-  it('builds a route-first buyer rail with disabled portfolio slots when no campaigns are available', () => {
+  it('builds the same module and support sections that the shell actually renders', () => {
     const navigation = buildDashboardShellNavigation({
       isAdmin: false,
       currentCampaignPath: '/campaigns/campaign-123',
@@ -20,43 +19,17 @@ describe('dashboard shell buyer-readiness', () => {
       },
     })
 
-    expect(navigation.primary.map((item) => item.label)).toEqual(['Overzicht', 'Huidige campagne'])
-    expect(navigation.primary[1]?.href).toBe('/campaigns/campaign-123')
-
-    expect(navigation.portfolio).toEqual([
-      {
-        key: 'ready',
-        label: 'Management-ready',
-        detail: 'Nog niet actief in deze omgeving',
-        href: null,
-        disabled: true,
-      },
-      {
-        key: 'building',
-        label: 'In opbouw',
-        detail: '2 campagne(s)',
-        href: '/dashboard?view=building#portfolio',
-        disabled: false,
-      },
-      {
-        key: 'setup',
-        label: 'Setup of launch',
-        detail: '1 campagne(s)',
-        href: '/dashboard?view=setup#portfolio',
-        disabled: false,
-      },
-      {
-        key: 'closed',
-        label: 'Afgerond',
-        detail: 'Nog niet actief in deze omgeving',
-        href: null,
-        disabled: true,
-      },
+    expect(navigation.modules.map((item) => item.label)).toEqual([
+      'Overzicht',
+      'ExitScan',
+      'RetentieScan',
+      'Onboarding 30-60-90',
     ])
+    expect(navigation.support.map((item) => item.label)).toEqual(['Pulse', 'Leadership Scan'])
     expect(navigation.admin).toEqual([])
   })
 
-  it('keeps admin links separate from buyer overview navigation', () => {
+  it('keeps admin links separate from the shared buyer rail', () => {
     const navigation = buildDashboardShellNavigation({
       isAdmin: true,
       currentCampaignPath: null,
@@ -68,13 +41,9 @@ describe('dashboard shell buyer-readiness', () => {
       },
     })
 
-    expect(navigation.primary.map((item) => item.label)).toEqual(['Overzicht'])
     expect(navigation.admin.map((item) => item.label)).toEqual(['Rapporten', 'Nieuwe campagne'])
-    expect(navigation.portfolio[2]).toMatchObject({
-      key: 'setup',
-      href: null,
-      disabled: true,
-    })
+    expect(navigation.modules[0]?.href).toBe('/dashboard')
+    expect(navigation.support[1]?.href).toBe('/dashboard/leadership')
   })
 
   it('normalizes unknown portfolio views back to overview-ready tabs', () => {
@@ -85,15 +54,18 @@ describe('dashboard shell buyer-readiness', () => {
   })
 
   it('keeps primary shell labels in Dutch and context-aware', () => {
-    expect(DASHBOARD_MODULE_NAV[0]?.label).toBe('Overzicht')
     expect(getDashboardShellCurrentLabel('/dashboard')).toBe('Dashboardoverzicht')
     expect(getDashboardShellCurrentLabel('/campaigns/demo')).toBe('Campagneread')
   })
 
-  it('does not render a dead global export CTA in the shell header', () => {
+  it('keeps the rendered shell sections aligned with the navigation model and avoids a dead global export CTA', () => {
     const source = readFileSync(new URL('../../components/dashboard/dashboard-shell.tsx', import.meta.url), 'utf8')
 
     expect(source).toContain('getDashboardShellCurrentLabel(pathname)')
+    expect(source).toContain('items={navigation.modules}')
+    expect(source).toContain('items={navigation.support}')
+    expect(source).toContain('{mobileItems.map((item) => {')
+    expect(source).not.toContain('DASHBOARD_MODULE_NAV.filter')
     expect(source).not.toContain('Rapport exporteren')
   })
 })

--- a/frontend/lib/dashboard/shell-navigation.test.ts
+++ b/frontend/lib/dashboard/shell-navigation.test.ts
@@ -1,7 +1,13 @@
+import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
-import { buildDashboardShellNavigation, normalizeDashboardPortfolioView } from './shell-navigation'
+import {
+  buildDashboardShellNavigation,
+  DASHBOARD_MODULE_NAV,
+  getDashboardShellCurrentLabel,
+  normalizeDashboardPortfolioView,
+} from './shell-navigation'
 
-describe('dashboard shell navigation', () => {
+describe('dashboard shell buyer-readiness', () => {
   it('builds a route-first buyer rail with disabled portfolio slots when no campaigns are available', () => {
     const navigation = buildDashboardShellNavigation({
       isAdmin: false,
@@ -14,7 +20,7 @@ describe('dashboard shell navigation', () => {
       },
     })
 
-    expect(navigation.primary.map((item) => item.label)).toEqual(['Overview', 'Huidige campagne'])
+    expect(navigation.primary.map((item) => item.label)).toEqual(['Overzicht', 'Huidige campagne'])
     expect(navigation.primary[1]?.href).toBe('/campaigns/campaign-123')
 
     expect(navigation.portfolio).toEqual([
@@ -62,8 +68,8 @@ describe('dashboard shell navigation', () => {
       },
     })
 
-    expect(navigation.primary.map((item) => item.label)).toEqual(['Overview'])
-    expect(navigation.admin.map((item) => item.label)).toEqual(['Setup', 'Leads', 'Learnings'])
+    expect(navigation.primary.map((item) => item.label)).toEqual(['Overzicht'])
+    expect(navigation.admin.map((item) => item.label)).toEqual(['Rapporten', 'Nieuwe campagne'])
     expect(navigation.portfolio[2]).toMatchObject({
       key: 'setup',
       href: null,
@@ -76,5 +82,18 @@ describe('dashboard shell navigation', () => {
     expect(normalizeDashboardPortfolioView('closed')).toBe('closed')
     expect(normalizeDashboardPortfolioView('unknown')).toBe('ready')
     expect(normalizeDashboardPortfolioView(undefined)).toBe('ready')
+  })
+
+  it('keeps primary shell labels in Dutch and context-aware', () => {
+    expect(DASHBOARD_MODULE_NAV[0]?.label).toBe('Overzicht')
+    expect(getDashboardShellCurrentLabel('/dashboard')).toBe('Dashboardoverzicht')
+    expect(getDashboardShellCurrentLabel('/campaigns/demo')).toBe('Campagneread')
+  })
+
+  it('does not render a dead global export CTA in the shell header', () => {
+    const source = readFileSync(new URL('../../components/dashboard/dashboard-shell.tsx', import.meta.url), 'utf8')
+
+    expect(source).toContain('getDashboardShellCurrentLabel(pathname)')
+    expect(source).not.toContain('Rapport exporteren')
   })
 })

--- a/frontend/lib/dashboard/shell-navigation.ts
+++ b/frontend/lib/dashboard/shell-navigation.ts
@@ -13,6 +13,33 @@ type DashboardShellPortfolioItem = DashboardShellNavItem & {
   key: DashboardPortfolioView
 }
 
+export type DashboardModuleKey = 'overview' | 'exitscan' | 'retentiescan' | 'onboarding' | 'pulse' | 'leadership'
+
+export type DashboardModuleNavItem = {
+  key: DashboardModuleKey
+  label: string
+  href: string
+  section: 'modules' | 'support'
+}
+
+export const DASHBOARD_MODULE_NAV: DashboardModuleNavItem[] = [
+  { key: 'overview',     label: 'Overview',            href: '/dashboard',              section: 'modules' },
+  { key: 'exitscan',    label: 'ExitScan',             href: '/dashboard/exitscan',     section: 'modules' },
+  { key: 'retentiescan', label: 'RetentieScan',        href: '/dashboard/retentiescan', section: 'modules' },
+  { key: 'onboarding',  label: 'Onboarding 30-60-90',  href: '/dashboard/onboarding',   section: 'modules' },
+  { key: 'pulse',       label: 'Pulse',                href: '/dashboard/pulse',        section: 'support' },
+  { key: 'leadership',  label: 'Leadership Scan',      href: '/dashboard/leadership',   section: 'support' },
+]
+
+export function getActiveModuleFromPathname(pathname: string): DashboardModuleKey {
+  if (pathname.startsWith('/dashboard/exitscan') || pathname.startsWith('/campaigns/')) return 'exitscan'
+  if (pathname.startsWith('/dashboard/retentiescan')) return 'retentiescan'
+  if (pathname.startsWith('/dashboard/onboarding')) return 'onboarding'
+  if (pathname.startsWith('/dashboard/pulse')) return 'pulse'
+  if (pathname.startsWith('/dashboard/leadership')) return 'leadership'
+  return 'overview'
+}
+
 export type DashboardShellNavigation = {
   primary: DashboardShellNavItem[]
   portfolio: DashboardShellPortfolioItem[]
@@ -78,21 +105,15 @@ export function buildDashboardShellNavigation({
   const admin: DashboardShellNavItem[] = isAdmin
     ? [
         {
-          label: 'Setup',
+          label: 'Rapporten',
           detail: 'Organisaties, campaignsetup en launchdiscipline.',
           href: '/beheer',
           disabled: false,
         },
         {
-          label: 'Leads',
+          label: 'Nieuwe campagne',
           detail: 'Sales-to-delivery context en contactaanvragen.',
           href: '/beheer/contact-aanvragen',
-          disabled: false,
-        },
-        {
-          label: 'Learnings',
-          detail: 'Klantlearnings en bounded closeoutdiscipline.',
-          href: '/beheer/klantlearnings',
           disabled: false,
         },
       ]

--- a/frontend/lib/dashboard/shell-navigation.ts
+++ b/frontend/lib/dashboard/shell-navigation.ts
@@ -9,10 +9,6 @@ type DashboardShellNavItem = {
   disabled: boolean
 }
 
-type DashboardShellPortfolioItem = DashboardShellNavItem & {
-  key: DashboardPortfolioView
-}
-
 export type DashboardModuleKey = 'overview' | 'exitscan' | 'retentiescan' | 'onboarding' | 'pulse' | 'leadership'
 
 export type DashboardModuleNavItem = {
@@ -41,16 +37,9 @@ export function getActiveModuleFromPathname(pathname: string): DashboardModuleKe
 }
 
 export type DashboardShellNavigation = {
-  primary: DashboardShellNavItem[]
-  portfolio: DashboardShellPortfolioItem[]
+  modules: DashboardModuleNavItem[]
+  support: DashboardModuleNavItem[]
   admin: DashboardShellNavItem[]
-}
-
-const PORTFOLIO_ITEM_LABELS: Record<DashboardPortfolioView, string> = {
-  ready: 'Management-ready',
-  building: 'In opbouw',
-  setup: 'Setup of launch',
-  closed: 'Afgerond',
 }
 
 export function normalizeDashboardPortfolioView(view: string | undefined): DashboardPortfolioView {
@@ -70,37 +59,11 @@ export function buildDashboardShellNavigation({
   currentCampaignPath: string | null
   portfolioCounts: PortfolioCounts
 }): DashboardShellNavigation {
-  const primary: DashboardShellNavItem[] = [
-    {
-      label: 'Overzicht',
-      detail: 'Kerncijfers, trend en waar eerst kijken.',
-      href: '/dashboard',
-      disabled: false,
-    },
-  ]
+  void currentCampaignPath
+  void portfolioCounts
 
-  if (currentCampaignPath) {
-    primary.push({
-      label: 'Huidige campagne',
-      detail: 'Verdieping via tabs en bounded uitvoer.',
-      href: currentCampaignPath,
-      disabled: false,
-    })
-  }
-
-  const portfolio: DashboardShellPortfolioItem[] = (Object.keys(PORTFOLIO_ITEM_LABELS) as DashboardPortfolioView[]).map(
-    (key) => {
-      const count = portfolioCounts[key]
-
-      return {
-        key,
-        label: PORTFOLIO_ITEM_LABELS[key],
-        detail: count > 0 ? `${count} campagne(s)` : 'Nog niet actief in deze omgeving',
-        href: count > 0 ? `/dashboard?view=${key}#portfolio` : null,
-        disabled: count === 0,
-      }
-    },
-  )
+  const modules = DASHBOARD_MODULE_NAV.filter((item) => item.section === 'modules')
+  const support = DASHBOARD_MODULE_NAV.filter((item) => item.section === 'support')
 
   const admin: DashboardShellNavItem[] = isAdmin
     ? [
@@ -120,8 +83,8 @@ export function buildDashboardShellNavigation({
     : []
 
   return {
-    primary,
-    portfolio,
+    modules,
+    support,
     admin,
   }
 }

--- a/frontend/lib/dashboard/shell-navigation.ts
+++ b/frontend/lib/dashboard/shell-navigation.ts
@@ -23,7 +23,7 @@ export type DashboardModuleNavItem = {
 }
 
 export const DASHBOARD_MODULE_NAV: DashboardModuleNavItem[] = [
-  { key: 'overview',     label: 'Overview',            href: '/dashboard',              section: 'modules' },
+  { key: 'overview',     label: 'Overzicht',           href: '/dashboard',              section: 'modules' },
   { key: 'exitscan',    label: 'ExitScan',             href: '/dashboard/exitscan',     section: 'modules' },
   { key: 'retentiescan', label: 'RetentieScan',        href: '/dashboard/retentiescan', section: 'modules' },
   { key: 'onboarding',  label: 'Onboarding 30-60-90',  href: '/dashboard/onboarding',   section: 'modules' },
@@ -72,7 +72,7 @@ export function buildDashboardShellNavigation({
 }): DashboardShellNavigation {
   const primary: DashboardShellNavItem[] = [
     {
-      label: 'Overview',
+      label: 'Overzicht',
       detail: 'Kerncijfers, trend en waar eerst kijken.',
       href: '/dashboard',
       disabled: false,
@@ -127,10 +127,10 @@ export function buildDashboardShellNavigation({
 }
 
 export function getDashboardShellCurrentLabel(pathname: string) {
-  if (pathname.startsWith('/campaigns/')) return 'Campaign detail'
+  if (pathname.startsWith('/campaigns/')) return 'Campagneread'
   if (pathname.startsWith('/beheer/contact-aanvragen')) return 'Leadcontext'
-  if (pathname.startsWith('/beheer/klantlearnings')) return 'Learning workbench'
+  if (pathname.startsWith('/beheer/klantlearnings')) return 'Learningdossiers'
   if (pathname.startsWith('/beheer')) return 'Setup en beheer'
 
-  return 'Dashboard overview'
+  return 'Dashboardoverzicht'
 }

--- a/frontend/lib/management-language.ts
+++ b/frontend/lib/management-language.ts
@@ -29,12 +29,29 @@ export function getManagementBandLabel(input: RiskBand | number): string {
   return MANAGEMENT_BAND_LABELS[band]
 }
 
+export const RISK_COLORS: Record<RiskBand, string> = {
+  HOOG:   '#C65B52',
+  MIDDEN: '#C88C20',
+  LAAG:   '#2E7C6D',
+}
+
+export const RISK_BG_COLORS: Record<RiskBand, string> = {
+  HOOG:   'rgba(198,91,82,0.12)',
+  MIDDEN: 'rgba(200,140,32,0.12)',
+  LAAG:   'rgba(46,124,109,0.12)',
+}
+
+export function getRiskColor(input: RiskBand | number): string {
+  const band = typeof input === 'number' ? getRiskBandFromScore(input) : input
+  return RISK_COLORS[band]
+}
+
 export function getManagementBandBadgeClasses(input: RiskBand | number): string {
   const band = typeof input === 'number' ? getRiskBandFromScore(input) : input
   return {
-    HOOG: 'bg-red-100 text-red-700',
+    HOOG:   'bg-red-100 text-red-700',
     MIDDEN: 'bg-amber-100 text-amber-700',
-    LAAG: 'bg-emerald-100 text-emerald-700',
+    LAAG:   'bg-emerald-100 text-emerald-700',
   }[band]
 }
 


### PR DESCRIPTION
## Summary
- resolved the mixed deeper terminology in `app/(dashboard)/campaigns/[id]/page.tsx` by standardizing visible operational copy to Dutch trajectory, execution, and learning-workbench equivalents
- aligned the dashboard shell navigation model with the rail and mobile menu the shell actually renders, and tightened regression coverage around that contract
- reran the focused dashboard review suite, lint checks, and a full production build after the blocker pass

## Why
PR #48 had two explicit review blockers left in the draft description:
- mixed deeper campaign/admin terminology in the campaign detail page
- a mismatch between the rail/menu model and the hierarchy the dashboard shell actually renders

This pass only addresses those two blockers and keeps the rest of the redesign branch out of scope.

## Review status
- the two blockers called out above are addressed in `0d441e2`
- the PR is still left in draft state for now, but this blocker pass itself is review-ready unless you want the draft flag cleared immediately

## Validation
- `npx vitest run "app/(dashboard)/campaigns/[id]/dashboard-architecture.test.ts" "app/(dashboard)/campaigns/[id]/page.route-shell.test.ts" "app/(dashboard)/campaigns/[id]/page.test.ts" "lib/dashboard/shell-navigation.test.ts" "lib/dashboard/risk-charts-copy.test.ts"`
- `npx eslint "components/dashboard/dashboard-shell.tsx" "components/dashboard/factor-table.tsx" "components/dashboard/risk-charts.tsx" "lib/dashboard/shell-navigation.ts" "lib/dashboard/shell-navigation.test.ts" "lib/dashboard/risk-charts-copy.test.ts" "app/(dashboard)/campaigns/[id]/page.tsx" "app/(dashboard)/campaigns/[id]/page.test.ts"`
- `npm run build`