### PR TITLE
[codex] split issue 30 commercial doc cleanup

### DIFF
--- a/docs/DOCUMENT_INDEX.md
+++ b/docs/DOCUMENT_INDEX.md
@@ -19,6 +19,17 @@ Source-of-truth volgorde:
 4. `docs/strategy/STRATEGY.md`
 5. `Docs_External` als gesynchroniseerde referentie- en assetlaag
 
+Voor de huidige commerciële/documentaire truth na PR `#28`, PR `#29` en Issue `#30`:
+
+1. `docs/strategy/STRATEGY.md`
+2. `docs/active/PRICING_AND_PACKAGING_PROGRAM_PLAN.md`
+3. `docs/active/COMMERCIAL_AND_ONBOARDING_SIGNOFF.md`
+4. `docs/active/PACKAGING_AND_ROUTE_LOGIC.md`
+5. `docs/active/PRODUCT_LANGUAGE_CANON.md`
+6. `docs/active/COMMERCIAL_LANGUAGE_PARITY_RECHECK.md`
+7. `docs/active/HISTORICAL_CANON_BOUNDARY_REGISTER.md`
+8. downstream systeemdocs in `docs/reference` en oudere trancheplannen in `docs/active`, maar alleen voor hun eigen subsystemen en nooit als zelfstandige first-buy of routecanon
+
 Voor de huidige fix-tranche:
 
 1. `SCALABILITY_FIX_PROGRAM_PLAN.md`
@@ -151,3 +162,4 @@ Voor de huidige fix-tranche:
 - Nieuwe planbestanden horen bij voorkeur in `docs/active`, behalve een repo-breed commandfile zoals `SCALABILITY_FIX_PROGRAM_PLAN.md`.
 - Gebruik het prompt-systeem in `docs/prompts` voor nieuwe analyse-, plan- en uitvoeringstrajecten.
 - Gebruik externe documenten als referentie, assetbron of archief, niet als concurrerende roadmap.
+- Oudere trancheplannen of reference systems mogen subsystemen uitleggen, maar mogen de first-buy waarheid uit de actieve commerciële canon niet overschrijven.

--- a/docs/active/CASE_PROOF_AND_EVIDENCE_PROGRAM_PLAN.md
+++ b/docs/active/CASE_PROOF_AND_EVIDENCE_PROGRAM_PLAN.md
@@ -4,6 +4,12 @@ Status: uitgevoerd in repo
 Last updated: 2026-04-15
 Source of truth: dit bestand is leidend voor deze tranche.
 
+Historical boundary note:
+
+- dit plan blijft leidend voor de bewijsarchitectuur binnen deze tranche, maar niet voor de huidige first-buy hiërarchie of publieke routepromotie
+- lees oudere formuleringen zoals `ExitScan` primair / `RetentieScan` complementair ondergeschikt aan [STRATEGY.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/strategy/STRATEGY.md), [PRICING_AND_PACKAGING_PROGRAM_PLAN.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/PRICING_AND_PACKAGING_PROGRAM_PLAN.md) en [COMMERCIAL_AND_ONBOARDING_SIGNOFF.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/COMMERCIAL_AND_ONBOARDING_SIGNOFF.md)
+- actuele bewijs- en claimtoepassing wint in [CASE_PROOF_AND_EVIDENCE_SYSTEM.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/reference/CASE_PROOF_AND_EVIDENCE_SYSTEM.md), [SAMPLE_OUTPUT_AND_SHOWCASE_SYSTEM.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/reference/SAMPLE_OUTPUT_AND_SHOWCASE_SYSTEM.md) en [TRUST_AND_CLAIMS_MATRIX.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/reference/TRUST_AND_CLAIMS_MATRIX.md)
+
 ## 1. Summary
 
 Deze tranche maakt van case-proof en evidence bij Verisight een expliciet systeem bovenop de bestaande sample-output-, pilot-learning-, trust- en saleslagen.

--- a/docs/active/DEMO_AND_SAMPLE_ENVIRONMENT_PROGRAM_PLAN.md
+++ b/docs/active/DEMO_AND_SAMPLE_ENVIRONMENT_PROGRAM_PLAN.md
@@ -4,6 +4,12 @@ Status: uitgevoerd in repo
 Last updated: 2026-04-15
 Source of truth: dit bestand is leidend voor deze tranche.
 
+Historical boundary note:
+
+- dit plan blijft leidend voor demo-, sample- en showcase-architectuur binnen deze tranche, maar niet voor de zelfstandige commerciële routehiërarchie
+- actuele first-buy truth en buyer-facing routewoorden winnen in [STRATEGY.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/strategy/STRATEGY.md), [PRICING_AND_PACKAGING_PROGRAM_PLAN.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/PRICING_AND_PACKAGING_PROGRAM_PLAN.md) en [COMMERCIAL_AND_ONBOARDING_SIGNOFF.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/COMMERCIAL_AND_ONBOARDING_SIGNOFF.md)
+- sample-, showcase- en bewijsgrenzen winnen in [SAMPLE_OUTPUT_AND_SHOWCASE_SYSTEM.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/reference/SAMPLE_OUTPUT_AND_SHOWCASE_SYSTEM.md) en [CASE_PROOF_AND_EVIDENCE_SYSTEM.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/reference/CASE_PROOF_AND_EVIDENCE_SYSTEM.md)
+
 ## 1. Summary
 
 Dit traject maakt van de losse demo- en samplelagen van Verisight een expliciet systeem met vaste laagindeling, scenario-contracten, seed-orchestratie, playbook en regressiebescherming.

--- a/docs/active/HISTORICAL_CANON_BOUNDARY_REGISTER.md
+++ b/docs/active/HISTORICAL_CANON_BOUNDARY_REGISTER.md
@@ -1,6 +1,6 @@
 # HISTORICAL_CANON_BOUNDARY_REGISTER
 
-Last updated: 2026-04-18  
+Last updated: 2026-04-26
 Status: active  
 Source of truth: product language canon, commercial language parity recheck and current active hardening docs.
 
@@ -17,6 +17,10 @@ Dit register markeert welke oudere reference- of toekomstdocs nog bruikbaar zijn
 - [FOUNDER_LED_SALES_PLAYBOOK.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/reference/FOUNDER_LED_SALES_PLAYBOOK.md)
 - [SALES_PROPOSAL_SPINES.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/reference/SALES_PROPOSAL_SPINES.md)
 - [PLATFORM_BLUEPRINT.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/reference/PLATFORM_BLUEPRINT.md)
+- [CASE_PROOF_AND_EVIDENCE_PROGRAM_PLAN.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/CASE_PROOF_AND_EVIDENCE_PROGRAM_PLAN.md)
+- [DEMO_AND_SAMPLE_ENVIRONMENT_PROGRAM_PLAN.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/DEMO_AND_SAMPLE_ENVIRONMENT_PROGRAM_PLAN.md)
+- [SALES_ENABLEMENT_SYSTEM_PLAN.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/SALES_ENABLEMENT_SYSTEM_PLAN.md)
+- [PRODUCT_TERMINOLOGY_AND_TAXONOMY_SYSTEM_PLAN.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/PRODUCT_TERMINOLOGY_AND_TAXONOMY_SYSTEM_PLAN.md)
 - [PRODUCT_LANGUAGE_CANON.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/PRODUCT_LANGUAGE_CANON.md)
 - [COMMERCIAL_LANGUAGE_PARITY_RECHECK.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/COMMERCIAL_LANGUAGE_PARITY_RECHECK.md)
 
@@ -24,11 +28,13 @@ Dit register markeert welke oudere reference- of toekomstdocs nog bruikbaar zijn
 
 - Meerdere oudere referentiedocs zijn nog nuttig als denkkader of verkoopreferentie, maar dragen oudere labels zoals `ExitScan Live`, `ritme` of een bredere platformsuite-lezing.
 - De meeste actieve drift kan worden opgevangen met duidelijke boundarynotes en een centraal register in plaats van grootschalige herschrijving.
+- Een tweede driftlaag zat in oudere uitgevoerde trancheplannen die nog als zelfstandige commerciële waarheid konden worden gelezen, terwijl de first-buy canon later is aangescherpt in strategy, pricing en signoff-docs.
 
 ## Belangrijkste inconsistenties of risico's
 
 - Zonder expliciete boundary kunnen oudere referentiedocs opnieuw als actieve waarheid worden gelezen.
 - Vooral future-vision documenten kunnen sneller portfolio- of maturitydrift introduceren dan de huidige hardeninglaag draagt.
+- Oudere trancheplannen in `docs/active` ogen extra canoniek door hun `Source of truth` headers en moeten daarom expliciet downstream worden gemaakt aan de huidige commerciële canon.
 
 ## Beslissingen / canonvoorstellen
 
@@ -37,15 +43,25 @@ Dit register markeert welke oudere reference- of toekomstdocs nog bruikbaar zijn
 | `FOUNDER_LED_SALES_PLAYBOOK.md` | historical-but-usable | salesreferentie, maar ondergeschikt aan actieve canon |
 | `SALES_PROPOSAL_SPINES.md` | historical-but-usable | structuurreferentie, maar routewoorden kunnen pre-normalisatie zijn |
 | `PLATFORM_BLUEPRINT.md` | future-vision non-canon | geen actieve productcanon, geen maturity- of routewaarheid |
+| `CASE_PROOF_AND_EVIDENCE_PROGRAM_PLAN.md` | tranche-locked downstream | bewijsarchitectuur blijft bruikbaar, maar first-buy en routehiërarchie volgen de actieve commerciële canon |
+| `DEMO_AND_SAMPLE_ENVIRONMENT_PROGRAM_PLAN.md` | tranche-locked downstream | demo- en showcase-architectuur blijft bruikbaar, maar bepaalt geen zelfstandige commerciële routewaarheid |
+| `SALES_ENABLEMENT_SYSTEM_PLAN.md` | tranche-locked downstream | rolloutplan blijft context; actuele saleswaarheid zit in de playbook/decision-tree laag en de actieve commerciële canon |
+| `PRODUCT_TERMINOLOGY_AND_TAXONOMY_SYSTEM_PLAN.md` | tranche-locked downstream | rolloutplan blijft context; actuele producttaal zit in de huidige canon- en paritydocs |
 
 ## Concrete wijzigingen
 
 - Register aangemaakt: [HISTORICAL_CANON_BOUNDARY_REGISTER.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/HISTORICAL_CANON_BOUNDARY_REGISTER.md)
 - Future-vision boundary aangescherpt in [PLATFORM_BLUEPRINT.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/reference/PLATFORM_BLUEPRINT.md)
+- Boundarynotes toegevoegd aan:
+  - [CASE_PROOF_AND_EVIDENCE_PROGRAM_PLAN.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/CASE_PROOF_AND_EVIDENCE_PROGRAM_PLAN.md)
+  - [DEMO_AND_SAMPLE_ENVIRONMENT_PROGRAM_PLAN.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/DEMO_AND_SAMPLE_ENVIRONMENT_PROGRAM_PLAN.md)
+  - [SALES_ENABLEMENT_SYSTEM_PLAN.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/SALES_ENABLEMENT_SYSTEM_PLAN.md)
+  - [PRODUCT_TERMINOLOGY_AND_TAXONOMY_SYSTEM_PLAN.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/PRODUCT_TERMINOLOGY_AND_TAXONOMY_SYSTEM_PLAN.md)
 
 ## Validatie
 
 - De aangewezen docs hebben nu expliciete boundarycontext of staan in dit register als non-canon bron.
+- De aangewezen trancheplannen kunnen nu niet langer zelfstandig een oudere commerciële hiërarchie terug de live referentielaag in trekken.
 
 ## Assumptions / defaults
 
@@ -53,4 +69,4 @@ Dit register markeert welke oudere reference- of toekomstdocs nog bruikbaar zijn
 
 ## Next gate
 
-Redesign handoff revalidation.
+Verdere cleanup alleen nog als expliciete archive- of move-sweep, niet als stille inhoudelijke herpromotie.

--- a/docs/active/HISTORICAL_DOC_BOUNDARY_SWEEP.md
+++ b/docs/active/HISTORICAL_DOC_BOUNDARY_SWEEP.md
@@ -1,6 +1,6 @@
 # HISTORICAL_DOC_BOUNDARY_SWEEP.md
 
-Last updated: 2026-04-18
+Last updated: 2026-04-26
 Status: active
 Source of truth: dit document begrenst oudere plan-, archive- en referentiedocs die nog pre-hardening taal of routewoorden dragen, zodat ze geen tweede waarheid terug de actieve laag in brengen.
 
@@ -18,6 +18,10 @@ Deze sweep labelt oudere documenten die nog historische termen dragen zoals `Exi
 - [ACCOUNT_AND_BILLING_MODEL_READINESS_PLAN.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/ACCOUNT_AND_BILLING_MODEL_READINESS_PLAN.md)
 - [CLIENT_ONBOARDING_AND_ADOPTION_PROGRAM_PLAN.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/CLIENT_ONBOARDING_AND_ADOPTION_PROGRAM_PLAN.md)
 - [PORTFOLIO_ARCHITECTURE_PROGRAM_PLAN.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/PORTFOLIO_ARCHITECTURE_PROGRAM_PLAN.md)
+- [CASE_PROOF_AND_EVIDENCE_PROGRAM_PLAN.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/CASE_PROOF_AND_EVIDENCE_PROGRAM_PLAN.md)
+- [DEMO_AND_SAMPLE_ENVIRONMENT_PROGRAM_PLAN.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/DEMO_AND_SAMPLE_ENVIRONMENT_PROGRAM_PLAN.md)
+- [SALES_ENABLEMENT_SYSTEM_PLAN.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/SALES_ENABLEMENT_SYSTEM_PLAN.md)
+- [PRODUCT_TERMINOLOGY_AND_TAXONOMY_SYSTEM_PLAN.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/PRODUCT_TERMINOLOGY_AND_TAXONOMY_SYSTEM_PLAN.md)
 - [FOUNDER_LED_SALES_PLAYBOOK.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/reference/FOUNDER_LED_SALES_PLAYBOOK.md)
 - [SALES_PROPOSAL_SPINES.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/reference/SALES_PROPOSAL_SPINES.md)
 - [PRODUCT_TERMINOLOGY_AND_TAXONOMY.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/reference/PRODUCT_TERMINOLOGY_AND_TAXONOMY.md)
@@ -28,17 +32,20 @@ Deze sweep labelt oudere documenten die nog historische termen dragen zoals `Exi
 - de grootste restdrift zat niet meer in de actieve kerncanon, maar in oudere plan- en referentiedocs die nog vaak worden geraadpleegd
 - termen zoals `ExitScan Live` en `RetentieScan ritme` functioneren daar vooral als historische labels, niet als gewenste huidige buyer-facing of paritytaal
 - zonder expliciete boundarynotes kunnen zulke docs opnieuw route- en statusdrift veroorzaken
+- na PR `#28` en `#29` bleek vooral de documentautoriteit nog te breed: oudere trancheplannen en subsystem-docs moesten explicieter onder de huidige first-buy canon worden gehangen
 
 ## Belangrijkste inconsistenties of risico's
 
 - oudere docs blijven nuttig als audit- of structuurlagen, maar kunnen onbedoeld als actuele copycanon worden gelezen
 - sommige historische termen blijven bewust in inhoudelijke context staan om de oorspronkelijke tranche of besluitvorming leesbaar te houden
 - deze sweep vervangt daarom niet alle oude termen, maar begrenst hun gezag
+- volledige tekstuele normalisatie van alle oudere plannen zou nu te breed worden en hoort alleen thuis in een expliciete archive- of rewrite-sweep
 
 ## Beslissingen / canonvoorstellen
 
 - archiefdocs zijn nooit leidend voor actuele producttaal, reportstructuur of buyer-facing routewoorden
 - oudere plan- en referentiedocs mogen historische termen blijven dragen, mits expliciet wordt verwezen naar de actieve canon
+- oudere trancheplannen in `docs/active` mogen subsystemen blijven uitleggen, maar niet meer zelfstandig first-buy, wedge- of routehiërarchie claimen
 - de actieve conflictvolgorde voor taal- en rapportvragen blijft:
   1. embedded truth
   2. actieve canon- en paritydocs
@@ -52,6 +59,10 @@ Deze sweep labelt oudere documenten die nog historische termen dragen zoals `Exi
   - [ACCOUNT_AND_BILLING_MODEL_READINESS_PLAN.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/ACCOUNT_AND_BILLING_MODEL_READINESS_PLAN.md)
   - [CLIENT_ONBOARDING_AND_ADOPTION_PROGRAM_PLAN.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/CLIENT_ONBOARDING_AND_ADOPTION_PROGRAM_PLAN.md)
   - [PORTFOLIO_ARCHITECTURE_PROGRAM_PLAN.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/PORTFOLIO_ARCHITECTURE_PROGRAM_PLAN.md)
+  - [CASE_PROOF_AND_EVIDENCE_PROGRAM_PLAN.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/CASE_PROOF_AND_EVIDENCE_PROGRAM_PLAN.md)
+  - [DEMO_AND_SAMPLE_ENVIRONMENT_PROGRAM_PLAN.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/DEMO_AND_SAMPLE_ENVIRONMENT_PROGRAM_PLAN.md)
+  - [SALES_ENABLEMENT_SYSTEM_PLAN.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/SALES_ENABLEMENT_SYSTEM_PLAN.md)
+  - [PRODUCT_TERMINOLOGY_AND_TAXONOMY_SYSTEM_PLAN.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/PRODUCT_TERMINOLOGY_AND_TAXONOMY_SYSTEM_PLAN.md)
   - [FOUNDER_LED_SALES_PLAYBOOK.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/reference/FOUNDER_LED_SALES_PLAYBOOK.md)
   - [SALES_PROPOSAL_SPINES.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/reference/SALES_PROPOSAL_SPINES.md)
   - [PRODUCT_TERMINOLOGY_AND_TAXONOMY.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/reference/PRODUCT_TERMINOLOGY_AND_TAXONOMY.md)
@@ -60,6 +71,7 @@ Deze sweep labelt oudere documenten die nog historische termen dragen zoals `Exi
 
 - boundarydocs verwijzen nu expliciet naar de actuele canon in plaats van zelfstandig taalgezag te claimen
 - de sweep verandert geen productstatus, pricingbesluit of ExitScan-architectuur
+- de cleanup blijft daarmee binnen documentaire scope en opent geen dashboard-, runtime- of bredere productpromotie opnieuw
 
 ## Assumptions / defaults
 
@@ -68,4 +80,4 @@ Deze sweep labelt oudere documenten die nog historische termen dragen zoals `Exi
 
 ## Next gate
 
-Non-core product parity sweep voor `TeamScan`, `Onboarding 30-60-90`, `Pulse` en `Leadership`.
+Alleen nog expliciete archive/move cleanup voor overgebleven oudere plannen die nog teveel als live truth ogen.

--- a/docs/active/PRODUCT_TERMINOLOGY_AND_TAXONOMY_SYSTEM_PLAN.md
+++ b/docs/active/PRODUCT_TERMINOLOGY_AND_TAXONOMY_SYSTEM_PLAN.md
@@ -1,5 +1,15 @@
 # PRODUCT_TERMINOLOGY_AND_TAXONOMY_SYSTEM_PLAN.md
 
+Status: uitgevoerd in repo
+Last updated: 2026-04-15
+Source of truth: dit bestand documenteert de terminologie-tranche; actuele taal- en routewaarheid wint in de huidige canon- en paritydocs.
+
+Historical boundary note:
+
+- dit plan beschrijft de tranche-uitrol van terminologieharmonisatie, maar is niet de hoogste actieve bron voor commerciële first-buy of routehiërarchie
+- actuele producttaal wint nu in [PRODUCT_LANGUAGE_CANON.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/PRODUCT_LANGUAGE_CANON.md), [COMMERCIAL_LANGUAGE_PARITY_RECHECK.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/COMMERCIAL_LANGUAGE_PARITY_RECHECK.md) en [REPORT_STRUCTURE_CANON.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/REPORT_STRUCTURE_CANON.md)
+- oudere glossary- en checklistdocs blijven bruikbaar, maar alleen ondergeschikt aan die actieve canon
+
 ## 1. Summary
 
 Dit traject heeft de productterminologie en taxonomie van Verisight aangescherpt over reference docs, marketingcopy, preview, dashboard, report-content, surveycopy en paritytests.

--- a/docs/active/SALES_ENABLEMENT_SYSTEM_PLAN.md
+++ b/docs/active/SALES_ENABLEMENT_SYSTEM_PLAN.md
@@ -1,5 +1,15 @@
 # SALES_ENABLEMENT_SYSTEM_PLAN.md
 
+Status: uitgevoerd in repo
+Last updated: 2026-04-15
+Source of truth: dit bestand documenteert de sales enablement tranche; actuele commerciële routewaarheid wint in de actieve canon en de actuele sales reference docs.
+
+Historical boundary note:
+
+- dit plan beschrijft de tranche-uitrol, maar is niet de hoogste actieve first-buy of routecanon
+- buyer-facing routevolgorde en commerciële guardrails winnen nu in [STRATEGY.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/strategy/STRATEGY.md), [PRICING_AND_PACKAGING_PROGRAM_PLAN.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/PRICING_AND_PACKAGING_PROGRAM_PLAN.md), [COMMERCIAL_AND_ONBOARDING_SIGNOFF.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/COMMERCIAL_AND_ONBOARDING_SIGNOFF.md) en [PACKAGING_AND_ROUTE_LOGIC.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/PACKAGING_AND_ROUTE_LOGIC.md)
+- dagelijkse sales-uitvoering wint in [SALES_ENABLEMENT_SYSTEM_PLAYBOOK.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/reference/SALES_ENABLEMENT_SYSTEM_PLAYBOOK.md) en [SALES_PRODUCT_DECISION_TREE.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/reference/SALES_PRODUCT_DECISION_TREE.md)
+
 ## 1. Summary
 
 Dit traject heeft van de bestaande founder-led backbone, boardroom-laag, trustcontracten, pricingrichting en voorbeeldoutput een herhaalbaar Sales Enablement System gemaakt dat direct aansluit op de actuele repo-implementatie.

--- a/docs/reference/CASE_PROOF_AND_EVIDENCE_ACCEPTANCE_CHECKLIST.md
+++ b/docs/reference/CASE_PROOF_AND_EVIDENCE_ACCEPTANCE_CHECKLIST.md
@@ -4,7 +4,7 @@
 
 - [ ] Er is een expliciete scheiding tussen deliverable-proof, trustproof, validation evidence, case candidate, approved case proof en reference-ready.
 - [ ] Sample-output, demo en validatie kunnen niet ongemerkt opschuiven naar marktbewijs.
-- [ ] ExitScan staat expliciet als primaire case-proofroute en RetentieScan blijft complementair.
+- [ ] ExitScan staat expliciet als default publieke case-anchor en RetentieScan leest als geldige first-buy evidence-route bij een expliciete actieve behoudsvraag, zonder de verification-first grens te verliezen.
 - [ ] De repo maakt duidelijk dat echte case-proof nog pas buyer-facing wordt na approval.
 
 ## Capture Read

--- a/docs/reference/CASE_PROOF_AND_EVIDENCE_SYSTEM.md
+++ b/docs/reference/CASE_PROOF_AND_EVIDENCE_SYSTEM.md
@@ -7,6 +7,8 @@ Laatste update: 2026-04-15
 
 Dit document legt vast hoe Verisight bewijs ordent tussen deliverable-proof, trustproof, validatie, case-opbouw en referentiegebruik.
 
+Commerciële first-buy truth en routehiërarchie worden niet zelfstandig in dit document bepaald; daarvoor winnen de actieve strategy-, pricing- en signoff-docs.
+
 Gebruik het als eerste referentie voor:
 
 - evidence-tiers en claimgrenzen
@@ -20,13 +22,14 @@ Gebruik het als eerste referentie voor:
 Gebruik bij spanning deze volgorde:
 
 1. `docs/strategy/STRATEGY.md`
-2. `docs/reference/METHODOLOGY.md`
-3. `docs/reference/TRUST_AND_CLAIMS_MATRIX.md`
-4. `docs/active/PILOT_AND_EARLY_CUSTOMER_LEARNING_SYSTEM_PLAN.md`
-5. `docs/reference/SAMPLE_OUTPUT_AND_SHOWCASE_SYSTEM.md`
-6. `docs/reference/FOUNDER_LED_SALES_PLAYBOOK.md`
-7. dit document
-8. `frontend/lib/case-proof-evidence.ts`
+2. `docs/active/PRICING_AND_PACKAGING_PROGRAM_PLAN.md`
+3. `docs/active/COMMERCIAL_AND_ONBOARDING_SIGNOFF.md`
+4. `docs/reference/TRUST_AND_CLAIMS_MATRIX.md`
+5. `docs/reference/METHODOLOGY.md`
+6. `docs/active/PILOT_AND_EARLY_CUSTOMER_LEARNING_SYSTEM_PLAN.md`
+7. `docs/reference/SAMPLE_OUTPUT_AND_SHOWCASE_SYSTEM.md`
+8. dit document
+9. `frontend/lib/case-proof-evidence.ts`
 
 ## Baseline van de huidige repo
 
@@ -147,8 +150,8 @@ Per format gelden deze minimumregels:
 
 ## Productspecifieke defaults
 
-- ExitScan blijft de primaire case-proofroute.
-- RetentieScan blijft complementair en verification-first.
+- ExitScan blijft de default publieke case-anchor in generieke proofflows.
+- RetentieScan kan een geldige eerste evidence-route zijn wanneer de actieve behoudsvraag primair is, maar blijft verification-first en bewijstechnisch strenger.
 - De eerste publieke prooflaag groeit anoniem of minimaal herleidbaar.
 - Named proof is nooit de default.
 
@@ -174,6 +177,6 @@ Refresh en review zijn verplicht wanneer:
 - Sample-output blijft deliverable-proof en trustproof, niet case-proof.
 - Synthetische, dummy- en showcase-data tellen nooit als market evidence.
 - Internal-only lessons worden pas buyer-facing na expliciete evidence- en claimreview.
-- ExitScan blijft de eerste publieke case-anchor.
-- RetentieScan krijgt pas een publieke case-anchor zodra daar echte bewijsbasis voor is.
+- ExitScan blijft de default eerste publieke case-anchor in generieke buyer-flows.
+- RetentieScan krijgt pas een eigen publieke case-anchor zodra daar echte bewijsbasis voor is; tot die tijd blijft die route verification-first en vraaggestuurd.
 - Named testimonials, logo use en ROI-verhalen zijn verboden zonder expliciete basis en toestemming.

--- a/docs/reference/CONTENT_OPERATING_SYSTEM.md
+++ b/docs/reference/CONTENT_OPERATING_SYSTEM.md
@@ -6,6 +6,8 @@ Laatste update: 2026-04-15
 ## Doel
 
 Dit document legt vast hoe Verisight content als systeem ordent in plaats van als losse marketing- of salesassets.
+
+De commerciële first-buy waarheid en routehiërarchie worden niet zelfstandig in dit document vastgelegd; dit systeemdoc volgt de actieve canon.
 Gebruik het als eerste referentie voor:
 
 - buyer-facing websitecopy
@@ -37,16 +39,17 @@ Gebruik het als eerste referentie voor:
 Gebruik bij spanning deze volgorde:
 
 1. `docs/strategy/STRATEGY.md`
-2. `docs/strategy/ROADMAP.md`
-3. `docs/prompts/PROMPT_CHECKLIST.xlsx`
-4. `docs/active/CONTENT_OPERATING_SYSTEM_PLAN.md`
-5. `docs/reference/PRODUCT_TERMINOLOGY_AND_TAXONOMY.md`
-6. `docs/reference/TRUST_AND_CLAIMS_MATRIX.md`
-7. `docs/reference/SAMPLE_OUTPUT_AND_SHOWCASE_SYSTEM.md`
-8. `docs/reference/CASE_PROOF_AND_EVIDENCE_SYSTEM.md`
-9. `docs/reference/SALES_ENABLEMENT_SYSTEM_PLAYBOOK.md`
-10. `frontend/lib/content-operating-system.ts`
-11. buyer-facing registries zoals `site-content.ts`, `marketing-products.ts`, `seo-solution-pages.ts` en `sample-showcase-assets.ts`
+2. `docs/active/PRICING_AND_PACKAGING_PROGRAM_PLAN.md`
+3. `docs/active/COMMERCIAL_AND_ONBOARDING_SIGNOFF.md`
+4. `docs/active/PACKAGING_AND_ROUTE_LOGIC.md`
+5. `docs/active/PRODUCT_LANGUAGE_CANON.md`
+6. `docs/active/COMMERCIAL_LANGUAGE_PARITY_RECHECK.md`
+7. `docs/reference/TRUST_AND_CLAIMS_MATRIX.md`
+8. `docs/reference/SAMPLE_OUTPUT_AND_SHOWCASE_SYSTEM.md`
+9. `docs/reference/CASE_PROOF_AND_EVIDENCE_SYSTEM.md`
+10. `docs/reference/SALES_ENABLEMENT_SYSTEM_PLAYBOOK.md`
+11. `frontend/lib/content-operating-system.ts`
+12. buyer-facing registries zoals `site-content.ts`, `marketing-products.ts`, `seo-solution-pages.ts` en `sample-showcase-assets.ts`
 
 Belangrijke interpretatie:
 
@@ -157,7 +160,7 @@ Nieuwe of gewijzigde buyer-facing content gaat in deze volgorde langs review:
 
 Praktische betekenis:
 
-- klopt de content nog met ExitScan-first, RetentieScan-complementair en de huidige assisted productvorm?
+- klopt de content nog met de huidige first-buy truth: ExitScan als default, RetentieScan als volwaardige eerste route bij een expliciete actieve behoudsvraag, en de assisted productvorm daaronder?
 - gebruikt de content canonieke product- en outputtaal?
 - claimt de content niets dat trust-, methodiek- of privacydocs niet dragen?
 - gebruikt de content sample, validation of case-proof op de juiste evidence-tier?
@@ -221,8 +224,8 @@ Werk dan minimaal mee:
 
 ## Guardrails
 
-- ExitScan blijft de primaire content-, SEO- en saleswedge.
-- RetentieScan blijft complementair en verification-first.
+- ExitScan blijft de default content-, SEO- en saleswedge in generieke buyer-flows.
+- RetentieScan blijft een volwaardige first-buy route wanneer de actieve behoudsvraag primair is, en blijft verification-first in claims en proof.
 - Combinatie blijft een portfolioroute en geen derde contentzwaartepunt.
 - Sample-output blijft publieke proofdefault tot approved case-proof echt bestaat.
 - Trust blijft reassurance en due diligence, niet de eerste pitch.

--- a/docs/reference/CONTENT_OPERATING_SYSTEM_ACCEPTANCE_CHECKLIST.md
+++ b/docs/reference/CONTENT_OPERATING_SYSTEM_ACCEPTANCE_CHECKLIST.md
@@ -7,7 +7,7 @@ Laatste update: 2026-04-15
 
 - [ ] Er is een expliciet contentmodel met route, proof, trust, conversion, sales enablement en reserved growth.
 - [ ] `docs/reference/CONTENT_OPERATING_SYSTEM.md` en `frontend/lib/content-operating-system.ts` noemen dezelfde contentlagen en defaults.
-- [ ] ExitScan staat expliciet als primaire contentwedge en RetentieScan blijft complementair.
+- [ ] ExitScan staat expliciet als default contentwedge en RetentieScan leest als volwaardige eerste route bij een expliciete actieve behoudsvraag, zonder de verification-first grens te verliezen.
 - [ ] Portfolio-architectuur blijft expliciet als upstream dependency zichtbaar en wordt in deze tranche niet opnieuw geopend.
 
 ## Surface Ownership

--- a/docs/reference/PRODUCT_TERMINOLOGY_REVIEW_CHECKLIST.md
+++ b/docs/reference/PRODUCT_TERMINOLOGY_REVIEW_CHECKLIST.md
@@ -4,8 +4,8 @@ Gebruik deze checklist bij wijzigingen in website, dashboard, rapport, survey, p
 
 ## Portfolio And Routing
 
-- [ ] ExitScan blijft de primaire entreepropositie.
-- [ ] RetentieScan blijft complementair tenzij de buyer-vraag expliciet over actieve medewerkers en vroegsignalering gaat.
+- [ ] ExitScan blijft de default entreepropositie in generieke buyer-flows.
+- [ ] RetentieScan blijft een volwaardige first-buy route wanneer de buyer-vraag expliciet over actieve medewerkers en vroegsignalering gaat; verification-first blijft intact.
 - [ ] Combinatie wordt gelezen als portfolioroute en niet als derde peer-product.
 
 ## Canonical Terms

--- a/docs/reference/SAMPLE_OUTPUT_AND_SHOWCASE_ACCEPTANCE_CHECKLIST.md
+++ b/docs/reference/SAMPLE_OUTPUT_AND_SHOWCASE_ACCEPTANCE_CHECKLIST.md
@@ -9,8 +9,8 @@ Laatste update: 2026-04-15
 - [ ] RetentieScan-voorbeeldrapport opent zonder vertrouwelijkheidsframing.
 - [ ] Beide actieve pdf's gebruiken expliciet fictieve data.
 - [ ] Beide actieve pdf's volgen dezelfde managementstructuur als live output.
-- [ ] ExitScan leest als primaire showcase voor vertrekduiding.
-- [ ] RetentieScan leest als complementaire verification-first showcase voor behoud op groepsniveau.
+- [ ] ExitScan leest als default showcase voor vertrekduiding in generieke buyer-flows.
+- [ ] RetentieScan leest als geldige verification-first showcase wanneer de actieve behoudsvraag primair is.
 - [ ] Geen actief sample-asset verkoopt diagnose, predictor, performance-instrument of bewezen causaliteit.
 
 ## Website showcase

--- a/docs/reference/SAMPLE_OUTPUT_AND_SHOWCASE_SYSTEM.md
+++ b/docs/reference/SAMPLE_OUTPUT_AND_SHOWCASE_SYSTEM.md
@@ -7,6 +7,8 @@ Laatste update: 2026-04-15
 
 Dit document legt vast welke sample-assets buyer-facing actief zijn, welke alleen ondersteunend zijn en welke alleen nog als legacy-archief bestaan.
 
+De showcase-hiërarchie volgt de actieve first-buy canon en bepaalt die niet zelfstandig opnieuw.
+
 Gebruik het als eerste referentie voor:
 
 - buyer-facing voorbeeldrapporten
@@ -28,14 +30,13 @@ Voor internal sales demo, QA/live-fixtures en validation-sandboxes geldt:
 Gebruik bij spanning deze volgorde:
 
 1. `docs/strategy/STRATEGY.md`
-2. `docs/reference/METHODOLOGY.md`
-3. `docs/reference/TRUST_AND_CLAIMS_MATRIX.md`
-4. `docs/active/BOARDROOM_READINESS_PLAN.md`
-5. `docs/active/REPORT_VISUAL_AND_COMMERCIAL_UPLIFT_PLAN.md`
-6. `docs/active/SAMPLE_OUTPUT_AND_SHOWCASE_PLAN.md`
-7. `docs/reference/CASE_PROOF_AND_EVIDENCE_SYSTEM.md`
-8. dit document
-9. `frontend/lib/sample-showcase-assets.ts`
+2. `docs/active/PRICING_AND_PACKAGING_PROGRAM_PLAN.md`
+3. `docs/active/COMMERCIAL_AND_ONBOARDING_SIGNOFF.md`
+4. `docs/reference/TRUST_AND_CLAIMS_MATRIX.md`
+5. `docs/active/SAMPLE_OUTPUT_AND_SHOWCASE_PLAN.md`
+6. `docs/reference/CASE_PROOF_AND_EVIDENCE_SYSTEM.md`
+7. dit document
+8. `frontend/lib/sample-showcase-assets.ts`
 
 ## Canonieke asset stack
 
@@ -91,8 +92,8 @@ Elke actieve sample-asset volgt deze regels:
 - Home en producten-overzicht gebruiken alleen teaser-preview en routekeuze.
 - Productdetailpagina's zijn de primaire showcase-ingang voor volledige voorbeeldrapporten.
 - Tarieven en vertrouwen gebruiken sample-output alleen ondersteunend als deliverable-proof en trustproof.
-- ExitScan blijft de standaard eerste showcase-route.
-- RetentieScan blijft complementair en verification-first.
+- ExitScan blijft de standaard eerste showcase-route in generieke buyer-flows.
+- RetentieScan blijft een geldige showcase-route wanneer de actieve behoudsvraag primair is, maar blijft verification-first.
 
 ## Generator and refresh governance
 
@@ -111,8 +112,8 @@ Werk sample-output en showcase bij wanneer:
 
 ## Guardrails
 
-- ExitScan blijft de primaire buyer-facing showcase-route.
-- RetentieScan blijft complementair en verification-first.
+- ExitScan blijft de default buyer-facing showcase-route in generieke buyer-flows.
+- RetentieScan blijft een geldige verification-first showcase-route wanneer de actieve behoudsvraag primair is.
 - Demo-output mag niet rijker ogen dan het echte product.
 - Sample-output is deliverable-proof, geen case-proof.
 - Voor echte case-proof en references geldt `docs/reference/CASE_PROOF_AND_EVIDENCE_SYSTEM.md`.


### PR DESCRIPTION
## Summary
- scope Issue #30 terug naar een bounded documentaire/commercile cleanup door de actuele first-buy canon expliciet boven oudere trancheplannen en subsystem-docs te zetten
- update de live reference systems voor content, sample/showcase en case-proof zodat ze de huidige truth volgen: ExitScan blijft de default eerste route, RetentieScan blijft een volwaardige first-buy route bij een expliciete actieve behoudsvraag
- markeer oudere `docs/active/*` trancheplannen als downstream context in plaats van zelfstandige commerciële waarheid, zonder dashboard, runtime of bredere productpromotie te heropenen

## Why
PR #28 en #29 trokken strategy/pricing en de smalle publieke slice al los. Daarna bleef vooral documentaire drift over: oudere reference docs en uitgevoerde trancheplannen konden nog een oudere commerciële hirarchie terug de repo in lezen. Deze cleanup houdt dat bounded door doc-authority en wording te normaliseren in plaats van brede inhoudelijke rewrites te doen.

## Impact
- actuele commerciële/documentaire truth is nu explicieter gecentreerd in `STRATEGY`, pricing/signoff en de boundary registerlaag
- current reference docs voor content, sample/showcase en case-proof spreken dezelfde first-buy taal
- oudere trancheplannen blijven bruikbaar als audit/context, maar claimen niet langer zelfstandig de actuele routecanon

## Validation
- `git diff --check`
- negatieve drift check op de bijgewerkte live reference docs voor oudere `primary/complementary` first-buy formuleringen
- handmatige scopecheck tegen Issue #30: alleen `docs/active/*`, `docs/reference/*` en `docs/DOCUMENT_INDEX.md`; geen dashboard, runtime, Action Center of guided-execution wijzigingen

## Out of Scope
- Action Center
- dashboard redesign
- guided-execution of runtime behavior
- bredere product- of portfolioscope buiten de al afgesplitste documentaire/commercile drift

Closes #30