### PR TITLE
Strengthen report layer surface

### DIFF
--- a/frontend/app/(dashboard)/reports/page.tsx
+++ b/frontend/app/(dashboard)/reports/page.tsx
@@ -1,0 +1,228 @@
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { PdfDownloadButton } from '@/app/(dashboard)/campaigns/[id]/pdf-download-button'
+import {
+  DashboardChip,
+  DashboardHero,
+  DashboardSection,
+} from '@/components/dashboard/dashboard-primitives'
+import {
+  buildReportLibraryEntries,
+  filterReportLibraryEntries,
+  type ReportLibraryCategory,
+} from '@/lib/dashboard/report-library'
+import { createClient } from '@/lib/supabase/server'
+import { getCampaignAverageSignalScore } from '@/lib/types'
+
+const CATEGORY_OPTIONS: Array<{ key: ReportLibraryCategory; label: string }> = [
+  { key: 'all', label: 'Alle' },
+  { key: 'management', label: 'Management' },
+  { key: 'module', label: 'Module' },
+  { key: 'cohort', label: 'Cohort' },
+]
+
+function normalizeCategory(value: string | string[] | undefined): ReportLibraryCategory {
+  return typeof value === 'string' && CATEGORY_OPTIONS.some((option) => option.key === value)
+    ? (value as ReportLibraryCategory)
+    : 'all'
+}
+
+export default async function ReportsPage({
+  searchParams,
+}: {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>
+}) {
+  const resolvedSearchParams = searchParams ? await searchParams : undefined
+  const category = normalizeCategory(resolvedSearchParams?.kind)
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/login')
+  }
+
+  const { data: stats } = await supabase.from('campaign_stats').select('*').order('created_at', { ascending: false })
+  const campaigns = stats ?? []
+  const reportModel = buildReportLibraryEntries(campaigns)
+  const filteredEntries = filterReportLibraryEntries(reportModel.entries, category)
+  const averageSignal =
+    reportModel.entries.length > 0
+      ? (
+          reportModel.entries.reduce((sum, entry) => {
+            const source = campaigns.find((campaign) => campaign.campaign_id === entry.campaignId)
+            return sum + (source ? (getCampaignAverageSignalScore(source) ?? 0) : 0)
+          }, 0) / reportModel.entries.length
+        ).toFixed(1)
+      : null
+
+  return (
+    <div className="space-y-6">
+      <DashboardHero
+        eyebrow="Reports & Exports"
+        title="Klaar voor het overleg."
+        description="Gebruik de rapportlaag als compacte managementread en handofflaag: eerst wat nu telt, daarna welke verificatie, eigenaar en opvolging logisch zijn. Geen ruwe data-dump, wel bestuurlijke output in dezelfde familie als dashboard en Action Center."
+        tone="slate"
+        meta={
+          <>
+            <DashboardChip label={`${reportModel.entries.length} rapport${reportModel.entries.length === 1 ? '' : 'en'} beschikbaar`} tone="emerald" />
+            <DashboardChip label={averageSignal ? `${averageSignal}/10 gemiddeld signaal` : 'Respons bepaalt beschikbaarheid'} tone={averageSignal ? 'blue' : 'slate'} />
+            <DashboardChip label={reportModel.featured ? 'Boardroom-ready' : 'Nog geen MT-ready rapport'} tone={reportModel.featured ? 'emerald' : 'amber'} />
+          </>
+        }
+        actions={
+          reportModel.featured ? (
+            <>
+              <PdfDownloadButton
+                campaignId={reportModel.featured.campaignId}
+                campaignName={reportModel.featured.campaignName}
+                scanType={reportModel.featured.scanType}
+              />
+              <Link
+                href={`/campaigns/${reportModel.featured.campaignId}`}
+                className="inline-flex rounded-full border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-ink)] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#1B2E45]"
+              >
+                Open in viewer
+              </Link>
+            </>
+          ) : (
+            <DashboardChip label="Nog geen rapportready campaign" tone="amber" />
+          )
+        }
+        aside={
+          reportModel.featured ? (
+            <div className="space-y-4">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--dashboard-accent-strong)]">
+                  Aanbevolen voor MT
+                </p>
+                <p className="mt-2 text-[1.45rem] font-semibold tracking-[-0.04em] text-[color:var(--dashboard-ink)]">
+                  {reportModel.featured.title}
+                </p>
+                <p className="mt-2 text-sm text-[color:var(--dashboard-text)]">{reportModel.featured.description}</p>
+              </div>
+              <div className="grid grid-cols-3 gap-3">
+                {reportModel.featured.stats.map((stat) => (
+                  <div
+                    key={stat.label}
+                    className="rounded-[20px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-blue-soft)] px-3 py-3"
+                  >
+                    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--dashboard-muted)]">{stat.label}</p>
+                    <p className="mt-2 text-lg font-semibold text-[color:var(--dashboard-ink)]">{stat.value}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              <p className="text-sm font-semibold text-[color:var(--dashboard-ink)]">Wanneer de rapportlaag opent</p>
+              <p className="text-sm leading-6 text-[color:var(--dashboard-text)]">
+                Rapporten verschijnen pas als een campaign genoeg respons en managementduiding heeft om een bounded handoff te dragen.
+              </p>
+            </div>
+          )
+        }
+      />
+
+      <DashboardSection
+        eyebrow="Bibliotheek"
+        title="Beschikbare rapporten"
+        description="Open alleen rapporten die al een echte managementread dragen. De rapportlaag blijft gekoppeld aan echte campaigns en volgt dezelfde bounded taal als dashboard en Action Center."
+        aside={
+          <div className="flex flex-wrap justify-start gap-2 lg:justify-end">
+            {CATEGORY_OPTIONS.map((option) => {
+              const active = option.key === category
+              return (
+                <Link
+                  key={option.key}
+                  href={option.key === 'all' ? '/reports' : `/reports?kind=${option.key}`}
+                  className={`inline-flex rounded-full border px-4 py-2 text-sm font-semibold transition-colors ${
+                    active
+                      ? 'border-[color:var(--dashboard-ink)] bg-[color:var(--dashboard-ink)] text-white'
+                      : 'border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)] text-[color:var(--dashboard-ink)] hover:border-[#d6e4e8] hover:text-[#234B57]'
+                  }`}
+                >
+                  {option.label}
+                </Link>
+              )
+            })}
+          </div>
+        }
+      >
+        {filteredEntries.length > 0 ? (
+          <div className="grid gap-4 xl:grid-cols-2">
+            {filteredEntries.map((entry) => (
+              <div
+                key={entry.campaignId}
+                className={`relative overflow-hidden rounded-[28px] border px-4 py-4 shadow-[0_18px_40px_rgba(17,24,39,0.07)] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-white/72 sm:px-5 sm:py-5 ${
+                  entry.recommended
+                    ? 'border-[color:var(--dashboard-accent-soft-border)] bg-[color:var(--dashboard-accent-soft)]'
+                    : 'border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)]'
+                }`}
+              >
+                <div className="space-y-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--dashboard-muted)]">
+                        {entry.categoryLabel}
+                      </p>
+                      <h3 className="mt-2 text-[1.45rem] font-semibold tracking-[-0.04em] text-[color:var(--dashboard-ink)]">
+                        {entry.title}
+                      </h3>
+                    </div>
+                    {entry.recommended ? <DashboardChip label="Aanbevolen" tone="emerald" /> : null}
+                  </div>
+
+                  <p className="text-sm leading-7 text-[color:var(--dashboard-text)]">{entry.summary}</p>
+
+                  <div className="grid grid-cols-2 gap-3 border-t border-[color:var(--dashboard-frame-border)] pt-4 text-sm text-[color:var(--dashboard-text)]">
+                    <div>{entry.metaLeft}</div>
+                    <div className="text-right">{entry.metaRight}</div>
+                  </div>
+
+                  <div className="flex flex-wrap items-center gap-3">
+                    <Link
+                      href={`/campaigns/${entry.campaignId}`}
+                      className="inline-flex rounded-full border border-[color:var(--dashboard-frame-border)] px-4 py-2 text-sm font-semibold text-[color:var(--dashboard-accent-strong)] transition-colors hover:border-[#d6e4e8] hover:bg-white"
+                    >
+                      Open ↗
+                    </Link>
+                    <PdfDownloadButton campaignId={entry.campaignId} campaignName={entry.campaignName} scanType={entry.scanType} />
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-[24px] border border-dashed border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)] px-5 py-8 text-sm leading-7 text-[color:var(--dashboard-text)]">
+            Er zijn in deze categorie nog geen rapporten met voldoende respons en managementduiding. Gebruik eerst dashboard en campaignroute om de eerste read te laten landen.
+          </div>
+        )}
+      </DashboardSection>
+
+      <DashboardSection
+        eyebrow="Handoff"
+        title="Van rapport naar opvolging"
+        description="De rapportlaag is geen eindpunt. Gebruik hem om managementduiding te bundelen en leg daarna in Action Center expliciet vast wie de eigenaar is, wat de eerste stap is en wanneer het reviewmoment terugkomt."
+        tone="blue"
+      >
+        <div className="grid gap-4 lg:grid-cols-3">
+          {[
+            ['1. Managementread', 'Gebruik dashboard en rapport samen om te bepalen welk patroon nu bestuurlijk telt en welke claim bewust nog niet hoort.'],
+            ['2. Eerste stap', 'Leg de eerste eigenaar en eerste stap vast zodra het rapport een echt managementgesprek opent. Zo blijft de output niet hangen in alleen inzicht.'],
+            ['3. Reviewmoment', 'Koppel het rapport altijd aan een reviewmoment in Action Center. Dan wordt opvolging zichtbaar, bounded en controleerbaar.'],
+          ].map(([title, body]) => (
+            <div
+              key={title}
+              className="relative overflow-hidden rounded-[28px] border border-[#c8d7df] bg-[color:var(--dashboard-blue-soft)] px-4 py-4 shadow-[0_18px_40px_rgba(17,24,39,0.07)] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-white/72 sm:px-5 sm:py-5"
+            >
+              <p className="text-sm font-semibold text-[color:var(--dashboard-ink)]">{title}</p>
+              <p className="mt-3 text-sm leading-7 text-[color:var(--dashboard-text)]">{body}</p>
+            </div>
+          ))}
+        </div>
+      </DashboardSection>
+    </div>
+  )
+}

--- a/frontend/components/dashboard/dashboard-shell.tsx
+++ b/frontend/components/dashboard/dashboard-shell.tsx
@@ -137,7 +137,7 @@ export function DashboardShellFrame({
               </div>
 
               <Link
-                href="/dashboard#reports"
+                href="/reports"
                 className="hidden rounded-full border border-[color:var(--dashboard-ink)] bg-[color:var(--dashboard-ink)] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#1B2E45] lg:inline-flex"
               >
                 Rapportlaag

--- a/frontend/lib/dashboard/report-library.test.ts
+++ b/frontend/lib/dashboard/report-library.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import { buildReportLibraryEntries, filterReportLibraryEntries } from './report-library'
+import type { CampaignStats } from '@/lib/types'
+
+const campaigns: CampaignStats[] = [
+  {
+    campaign_id: 'exit-1',
+    campaign_name: 'ExitScan Ops — Q3',
+    scan_type: 'exit',
+    organization_id: 'org-1',
+    is_active: true,
+    created_at: '2025-10-12T09:00:00Z',
+    total_invited: 24,
+    total_completed: 14,
+    completion_rate_pct: 58,
+    avg_risk_score: 5.9,
+    avg_signal_score: 6.1,
+    band_high: 6,
+    band_medium: 5,
+    band_low: 3,
+  },
+  {
+    campaign_id: 'pulse-1',
+    campaign_name: 'Pulse week 36-38',
+    scan_type: 'pulse',
+    organization_id: 'org-1',
+    is_active: true,
+    created_at: '2025-09-22T09:00:00Z',
+    total_invited: 80,
+    total_completed: 11,
+    completion_rate_pct: 13,
+    avg_risk_score: 4.6,
+    avg_signal_score: 4.8,
+    band_high: 2,
+    band_medium: 6,
+    band_low: 3,
+  },
+  {
+    campaign_id: 'onboarding-1',
+    campaign_name: 'Onboarding cohort sep 25',
+    scan_type: 'onboarding',
+    organization_id: 'org-1',
+    is_active: true,
+    created_at: '2025-10-01T09:00:00Z',
+    total_invited: 18,
+    total_completed: 7,
+    completion_rate_pct: 39,
+    avg_risk_score: 5.1,
+    avg_signal_score: 5.1,
+    band_high: 2,
+    band_medium: 3,
+    band_low: 2,
+  },
+  {
+    campaign_id: 'tiny-1',
+    campaign_name: 'Nog te klein',
+    scan_type: 'retention',
+    organization_id: 'org-1',
+    is_active: true,
+    created_at: '2025-10-10T09:00:00Z',
+    total_invited: 40,
+    total_completed: 4,
+    completion_rate_pct: 10,
+    avg_risk_score: 5.2,
+    avg_signal_score: 5.2,
+    band_high: 1,
+    band_medium: 2,
+    band_low: 1,
+  },
+]
+
+describe('report library', () => {
+  it('builds only report-ready entries and marks one featured management report', () => {
+    const model = buildReportLibraryEntries(campaigns)
+
+    expect(model.entries.map((entry) => entry.campaignId)).toEqual(['exit-1', 'onboarding-1', 'pulse-1'])
+    expect(model.featured).toMatchObject({
+      campaignId: 'exit-1',
+      scanType: 'exit',
+    })
+    expect(model.entries.find((entry) => entry.campaignId === 'exit-1')?.recommended).toBe(true)
+  })
+
+  it('maps management, module and cohort categories in a bounded way', () => {
+    const model = buildReportLibraryEntries(campaigns)
+
+    expect(model.entries.find((entry) => entry.campaignId === 'exit-1')?.category).toBe('management')
+    expect(model.entries.find((entry) => entry.campaignId === 'pulse-1')?.category).toBe('module')
+    expect(model.entries.find((entry) => entry.campaignId === 'onboarding-1')?.category).toBe('cohort')
+  })
+
+  it('filters cards per category without inventing an all-in-one export layer', () => {
+    const model = buildReportLibraryEntries(campaigns)
+
+    expect(filterReportLibraryEntries(model.entries, 'all')).toHaveLength(3)
+    expect(filterReportLibraryEntries(model.entries, 'management').map((entry) => entry.campaignId)).toEqual(['exit-1'])
+    expect(filterReportLibraryEntries(model.entries, 'module').map((entry) => entry.campaignId)).toEqual(['pulse-1'])
+    expect(filterReportLibraryEntries(model.entries, 'cohort').map((entry) => entry.campaignId)).toEqual(['onboarding-1'])
+  })
+})
+

--- a/frontend/lib/dashboard/report-library.ts
+++ b/frontend/lib/dashboard/report-library.ts
@@ -1,0 +1,167 @@
+import { FIRST_DASHBOARD_THRESHOLD } from '@/lib/response-activation'
+import { SCAN_TYPE_LABELS, getCampaignAverageSignalScore, type CampaignStats, type ScanType } from '@/lib/types'
+
+export type ReportLibraryCategory = 'all' | 'management' | 'module' | 'cohort'
+
+export interface ReportLibraryEntry {
+  campaignId: string
+  campaignName: string
+  scanType: ScanType
+  category: Exclude<ReportLibraryCategory, 'all'>
+  categoryLabel: string
+  title: string
+  summary: string
+  metaLeft: string
+  metaRight: string
+  recommended: boolean
+}
+
+export interface FeaturedReportEntry {
+  campaignId: string
+  campaignName: string
+  scanType: ScanType
+  title: string
+  subtitle: string
+  description: string
+  stats: Array<{ label: string; value: string }>
+}
+
+const MANAGEMENT_SCAN_TYPES: ScanType[] = ['exit', 'retention', 'leadership']
+const MODULE_SCAN_TYPES: ScanType[] = ['pulse', 'team']
+
+function formatDutchDate(dateLike: string) {
+  return new Intl.DateTimeFormat('nl-NL', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  }).format(new Date(dateLike))
+}
+
+function formatDutchQuarter(dateLike: string) {
+  const date = new Date(dateLike)
+  const quarter = Math.floor(date.getUTCMonth() / 3) + 1
+  return `Q${quarter} ${date.getUTCFullYear()}`
+}
+
+function getCategory(scanType: ScanType): Exclude<ReportLibraryCategory, 'all'> {
+  if (scanType === 'onboarding') return 'cohort'
+  if (MANAGEMENT_SCAN_TYPES.includes(scanType)) return 'management'
+  if (MODULE_SCAN_TYPES.includes(scanType)) return 'module'
+  return 'module'
+}
+
+function getCategoryLabel(category: Exclude<ReportLibraryCategory, 'all'>) {
+  switch (category) {
+    case 'management':
+      return 'Managementsamenvatting'
+    case 'cohort':
+      return 'Cohortrapport'
+    case 'module':
+    default:
+      return 'Modulerapport'
+  }
+}
+
+function getEntrySummary(campaign: CampaignStats, category: Exclude<ReportLibraryCategory, 'all'>) {
+  const signalDisplay = getCampaignAverageSignalScore(campaign)
+  const signalText = signalDisplay !== null ? `${signalDisplay.toFixed(1)}/10 signaal` : 'signaal volgt na voldoende respons'
+
+  if (category === 'management') {
+    return `${SCAN_TYPE_LABELS[campaign.scan_type]} voor eerste managementduiding, handoff en reviewmoment.`
+  }
+
+  if (category === 'cohort') {
+    return `${SCAN_TYPE_LABELS[campaign.scan_type]} als bounded cohortread, met nadruk op checkpointduiding en opvolging.`
+  }
+
+  return `${SCAN_TYPE_LABELS[campaign.scan_type]} als verdiepende modulelaag, met ${signalText.toLowerCase()}.`
+}
+
+function getEntryTitle(campaign: CampaignStats, category: Exclude<ReportLibraryCategory, 'all'>) {
+  if (category === 'cohort') {
+    return campaign.campaign_name || `${SCAN_TYPE_LABELS[campaign.scan_type]} cohort ${formatDutchQuarter(campaign.created_at)}`
+  }
+
+  return campaign.campaign_name || `${SCAN_TYPE_LABELS[campaign.scan_type]} ${formatDutchQuarter(campaign.created_at)}`
+}
+
+function getPriority(campaign: CampaignStats) {
+  const base =
+    campaign.scan_type === 'exit'
+      ? 6
+      : campaign.scan_type === 'retention'
+        ? 5
+        : campaign.scan_type === 'leadership'
+          ? 4
+          : campaign.scan_type === 'pulse'
+            ? 3
+            : campaign.scan_type === 'team'
+              ? 2
+              : 1
+
+  return base * 1000 + campaign.total_completed
+}
+
+export function buildReportLibraryEntries(campaigns: CampaignStats[]) {
+  const readyCampaigns = campaigns
+    .filter((campaign) => campaign.total_completed >= FIRST_DASHBOARD_THRESHOLD)
+    .sort((left, right) => {
+      const createdDiff = new Date(right.created_at).getTime() - new Date(left.created_at).getTime()
+      if (createdDiff !== 0) return createdDiff
+      return right.total_completed - left.total_completed
+    })
+
+  const featuredCandidate =
+    [...readyCampaigns]
+      .filter((campaign) => campaign.total_completed >= 10)
+      .sort((left, right) => getPriority(right) - getPriority(left))[0] ?? null
+
+  const entries: ReportLibraryEntry[] = readyCampaigns.map((campaign) => {
+    const category = getCategory(campaign.scan_type)
+
+    return {
+      campaignId: campaign.campaign_id,
+      campaignName: campaign.campaign_name,
+      scanType: campaign.scan_type,
+      category,
+      categoryLabel: getCategoryLabel(category),
+      title: getEntryTitle(campaign, category),
+      summary: getEntrySummary(campaign, category),
+      metaLeft: `${campaign.total_completed} responses`,
+      metaRight: formatDutchDate(campaign.created_at),
+      recommended: featuredCandidate?.campaign_id === campaign.campaign_id,
+    }
+  })
+
+  const featured: FeaturedReportEntry | null = featuredCandidate
+    ? {
+        campaignId: featuredCandidate.campaign_id,
+        campaignName: featuredCandidate.campaign_name,
+        scanType: featuredCandidate.scan_type,
+        title:
+          featuredCandidate.campaign_name ||
+          `${SCAN_TYPE_LABELS[featuredCandidate.scan_type]} ${formatDutchQuarter(featuredCandidate.created_at)}`,
+        subtitle: `${SCAN_TYPE_LABELS[featuredCandidate.scan_type]} · ${formatDutchQuarter(featuredCandidate.created_at)}`,
+        description:
+          'Gebruik dit rapport als eerste boardroom-ready handoff: wat speelt nu, wat vraagt verificatie en welke eigenaar, eerste stap en reviewmoment moeten daarna expliciet worden vastgelegd.',
+        stats: [
+          { label: 'Responses', value: String(featuredCandidate.total_completed) },
+          {
+            label: 'Signaal',
+            value: `${(getCampaignAverageSignalScore(featuredCandidate) ?? 0).toFixed(1)}/10`,
+          },
+          { label: 'Route', value: SCAN_TYPE_LABELS[featuredCandidate.scan_type] },
+        ],
+      }
+    : null
+
+  return {
+    entries,
+    featured,
+  }
+}
+
+export function filterReportLibraryEntries(entries: ReportLibraryEntry[], category: ReportLibraryCategory) {
+  if (category === 'all') return entries
+  return entries.filter((entry) => entry.category === category)
+}

--- a/frontend/lib/dashboard/shell-navigation.test.ts
+++ b/frontend/lib/dashboard/shell-navigation.test.ts
@@ -90,7 +90,7 @@ describe('dashboard shell navigation', () => {
       {
         key: 'reports',
         label: 'Reports',
-        href: '/dashboard#reports',
+        href: '/reports',
         disabled: false,
       },
     ])
@@ -126,7 +126,7 @@ describe('dashboard shell navigation', () => {
     expect(getActiveModuleFromPathname('/campaigns/retention-1', [...campaigns])).toBe('retention')
     expect(getActiveModuleFromPathname('/campaigns/pulse-1', [...campaigns])).toBe('pulse')
     expect(getActiveModuleFromPathname('/campaigns/unknown', [...campaigns])).toBe('overview')
-    expect(getActiveModuleFromPathname('/dashboard#reports', [...campaigns])).toBe('overview')
+    expect(getActiveModuleFromPathname('/reports', [...campaigns])).toBe('reports')
     expect(getActiveModuleFromPathname('/beheer', [...campaigns])).toBe('overview')
   })
 
@@ -155,7 +155,7 @@ describe('dashboard shell navigation', () => {
     })
     expect(navigation.modules[6]).toMatchObject({
       key: 'reports',
-      href: '/dashboard#reports',
+      href: '/reports',
       disabled: false,
     })
   })

--- a/frontend/lib/dashboard/shell-navigation.ts
+++ b/frontend/lib/dashboard/shell-navigation.ts
@@ -91,6 +91,7 @@ export function getActiveModuleFromPathname(
   pathname: string,
   campaigns: DashboardShellCampaignRef[],
 ): DashboardModuleKey {
+  if (pathname.startsWith('/reports')) return 'reports'
   if (!pathname.startsWith('/campaigns/')) return 'overview'
 
   const [, , campaignId] = pathname.split('/')
@@ -128,7 +129,7 @@ export function buildDashboardShellNavigation({
       return {
         key: item.key,
         label: item.label,
-        href: '/dashboard#reports',
+        href: '/reports',
         disabled: false,
       }
     }
@@ -174,6 +175,7 @@ export function buildDashboardShellNavigation({
 }
 
 export function getDashboardShellCurrentLabel(pathname: string) {
+  if (pathname.startsWith('/reports')) return 'Reports & exports'
   if (pathname.startsWith('/campaigns/')) return 'Campagneread'
   if (pathname.startsWith('/beheer/contact-aanvragen')) return 'Leadcontext'
   if (pathname.startsWith('/beheer/klantlearnings')) return 'Action Center'


### PR DESCRIPTION
## Samenvatting
Deze slice versterkt de rapportlaag als echte managementread- en handoffsurface binnen dezelfde dashboardfamilie.

## In deze PR
- voegt een echte `/reports` route toe in de dashboardshell
- bouwt een bounded rapportbibliotheek met management-, module- en cohortindeling op basis van echte campaignstats
- zet een boardroom-ready featured report neer zonder een onware all-in-one exportmachine te claimen
- maakt de handoff naar Action Center expliciet op dezelfde reportsurface
- trekt de shellnavigatie recht zodat `Reports` een echte route is in plaats van een dashboard-anchor

## Buiten scope
- geen brede export composer
- geen nieuwe report backend of multi-campaign PDF-engine
- geen nieuwe productscope buiten de bestaande campaign- en PDF-laag
- geen pilot- of live usage-besluit

## Verificatie
- `npm test -- "lib/dashboard/report-library.test.ts" "lib/dashboard/shell-navigation.test.ts"`
- `NEXT_PUBLIC_SUPABASE_URL=https://placeholder.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=placeholder-anon-key npm run build`
