### PR TITLE
Align marketing canon with action center track

### DIFF
--- a/frontend/app/producten/[slug]/page.tsx
+++ b/frontend/app/producten/[slug]/page.tsx
@@ -91,11 +91,10 @@ export default async function ProductDetailPage({ params }: Props) {
       {slug === 'retentiescan' ? <RetentionScanPage /> : null}
       {slug === 'exitscan' ? <ExitScanPage /> : null}
       {slug === 'pulse' ? <PulsePage /> : null}
-      {slug === 'teamscan' ? <TeamScanPage /> : null}
       {slug === 'onboarding-30-60-90' ? <OnboardingPage /> : null}
       {slug === 'leadership-scan' ? <LeadershipScanPage /> : null}
       {slug === 'combinatie' ? <CombinatiePage /> : null}
-      {!['retentiescan', 'exitscan', 'pulse', 'teamscan', 'onboarding-30-60-90', 'leadership-scan', 'combinatie'].includes(slug) ? <UpcomingProductPage slug={slug} /> : null}
+      {!['retentiescan', 'exitscan', 'pulse', 'onboarding-30-60-90', 'leadership-scan', 'combinatie'].includes(slug) ? <UpcomingProductPage slug={slug} /> : null}
     </>
   )
 }
@@ -499,7 +498,7 @@ function PulsePage() {
     <MarketingPageShell
       theme="neutral"
       pageType="product"
-      ctaHref={buildContactHref({ routeInterest: 'nog-onzeker', ctaSource: 'product_pulse_hero' })}
+      ctaHref={buildContactHref({ routeInterest: 'pulse', ctaSource: 'product_pulse_hero' })}
       ctaLabel="Bespreek Pulse"
       heroIntro={
         <MarketingHeroIntro>
@@ -515,7 +514,7 @@ function PulsePage() {
           <div className="marketing-hero-actions">
             <div className="marketing-hero-cta-row">
               <a
-                href={buildContactHref({ routeInterest: 'nog-onzeker', ctaSource: 'product_pulse_hero' })}
+                href={buildContactHref({ routeInterest: 'pulse', ctaSource: 'product_pulse_hero' })}
                 className="inline-flex items-center justify-center rounded-full bg-amber-600 px-6 py-3 text-sm font-semibold text-white shadow-[0_16px_40px_rgba(217,119,6,0.22)] transition-all hover:-translate-y-0.5 hover:bg-amber-700"
               >
                 Bespreek Pulse
@@ -677,7 +676,7 @@ function PulsePage() {
           eyebrow="Kennismaking"
           title="Toets of Pulse als vervolgroute nu echt logisch is."
           body="Beschrijf kort welke eerste baseline, managementread of actie al loopt en wat je nu vooral wilt herchecken. Dan bepalen we of Pulse past of dat een bredere vervolgroute logischer is."
-          defaultRouteInterest="nog-onzeker"
+          defaultRouteInterest="pulse"
           defaultCtaSource="product_pulse_form"
         />
       </MarketingSection>
@@ -687,7 +686,7 @@ function PulsePage() {
           eyebrow="Portfoliohelderheid"
           title="Twijfel je tussen Pulse en een bredere vervolgronde?"
           body="We helpen je kiezen tussen een compacte Pulse-hercheck, RetentieScan ritmeroute of een andere vervolgroute. Zo blijft de volgende stap scherp in plaats van breder dan nodig."
-          primaryHref={buildContactHref({ routeInterest: 'nog-onzeker', ctaSource: 'product_pulse_callout' })}
+          primaryHref={buildContactHref({ routeInterest: 'pulse', ctaSource: 'product_pulse_callout' })}
           primaryLabel="Plan kennismaking"
           secondaryHref="/tarieven"
           secondaryLabel="Bekijk tarieven"
@@ -901,6 +900,8 @@ function TeamScanPage() {
   )
 }
 
+void TeamScanPage
+
 function OnboardingPage() {
   return (
     <MarketingPageShell
@@ -1010,7 +1011,7 @@ function OnboardingPage() {
           {[
             {
               title: 'Wanneer deze route logisch wordt',
-              body: 'Gebruik onboarding wanneer management vroeg wil toetsen hoe nieuwe medewerkers nu landen en die vraag smaller is dan een bredere retentiescan of teamscan.',
+              body: 'Gebruik onboarding wanneer management vroeg wil toetsen hoe nieuwe medewerkers nu landen en die vraag smaller is dan een bredere retentiescan of combinatieroute.',
             },
             {
               title: 'Wat je nu krijgt',
@@ -1173,7 +1174,7 @@ function LeadershipScanPage() {
           {[
             {
               title: 'Wanneer deze route logisch wordt',
-              body: 'Na een bestaand signaal uit ExitScan, RetentieScan, TeamScan of onboarding, wanneer de vraag verschuift naar managementcontext en eerste verificatie.',
+              body: 'Na een bestaand signaal uit ExitScan, RetentieScan, onboarding of Pulse, wanneer de vraag verschuift naar managementcontext en eerste verificatie.',
             },
             {
               title: 'Wat je nu krijgt',

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -39,12 +39,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.6,
     },
     {
-      url: 'https://www.verisight.nl/producten/teamscan',
-      lastModified: new Date('2026-04-17'),
-      changeFrequency: 'monthly',
-      priority: 0.6,
-    },
-    {
       url: 'https://www.verisight.nl/producten/onboarding-30-60-90',
       lastModified: new Date('2026-04-17'),
       changeFrequency: 'monthly',

--- a/frontend/app/vertrouwen/page.tsx
+++ b/frontend/app/vertrouwen/page.tsx
@@ -7,12 +7,12 @@ import { buildContactHref } from '@/lib/contact-funnel'
 export const metadata: Metadata = {
   title: 'Vertrouwen',
   description:
-    'Methodiek, privacy en rapportlezing van Verisight. Groepsinzichten met heldere claimsgrenzen voor ExitScan, RetentieScan, Pulse, TeamScan, onboarding en Leadership Scan.',
+    'Methodiek, privacy en rapportlezing van Verisight. Groepsinzichten met heldere claimsgrenzen voor ExitScan, RetentieScan, Onboarding 30-60-90, Pulse en Leadership Scan.',
   alternates: { canonical: '/vertrouwen' },
   openGraph: {
     title: 'Vertrouwen | Verisight',
     description:
-      'Methodiek, privacy en rapportlezing van Verisight. Groepsinzichten met heldere claimsgrenzen voor ExitScan, RetentieScan, Pulse, TeamScan, onboarding en Leadership Scan.',
+      'Methodiek, privacy en rapportlezing van Verisight. Groepsinzichten met heldere claimsgrenzen voor ExitScan, RetentieScan, Onboarding 30-60-90, Pulse en Leadership Scan.',
     url: 'https://www.verisight.nl/vertrouwen',
     images: ['/opengraph-image'],
   },
@@ -20,7 +20,7 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     title: 'Vertrouwen | Verisight',
     description:
-      'Methodiek, privacy en rapportlezing van Verisight. Groepsinzichten met heldere claimsgrenzen voor ExitScan, RetentieScan, Pulse, TeamScan, onboarding en Leadership Scan.',
+      'Methodiek, privacy en rapportlezing van Verisight. Groepsinzichten met heldere claimsgrenzen voor ExitScan, RetentieScan, Onboarding 30-60-90, Pulse en Leadership Scan.',
     images: ['/opengraph-image'],
   },
 }

--- a/frontend/components/marketing/contact-form.tsx
+++ b/frontend/components/marketing/contact-form.tsx
@@ -210,7 +210,7 @@ export function ContactForm({
       >
         {isCompact
           ? 'Gebruik dit formulier om snel te bepalen welke eerste route nu het best past en welke output of intake daarbij logisch wordt.'
-          : 'Gebruik dit formulier in de eerste plaats om te bepalen of ExitScan, RetentieScan of de combinatieroute nu de logische eerste stap is. TeamScan, Onboarding 30-60-90 en Leadership Scan blijven bounded follow-on routes die pas logisch worden nadat een eerste signaal, baseline of managementread al staat. De informatie uit dit formulier gebruiken we alleen om jullie vraag te duiden en gericht op te volgen.'}
+          : 'Gebruik dit formulier in de eerste plaats om te bepalen of ExitScan, RetentieScan of de combinatieroute nu de logische eerste stap is. Onboarding 30-60-90 behandelen we als bounded peer wanneer de vraag direct over nieuwe medewerkers gaat. Pulse en Leadership Scan blijven bounded vervolgroutes die pas logisch worden nadat een eerste signaal, baseline of managementread al staat. De informatie uit dit formulier gebruiken we alleen om jullie vraag te duiden en gericht op te volgen.'}
       </div>
 
       {!isCompact ? (

--- a/frontend/components/marketing/home-page-content.tsx
+++ b/frontend/components/marketing/home-page-content.tsx
@@ -582,9 +582,12 @@ function RoutesSection() {
     },
   ]
 
+  const primaryRoutes = mainRoutes.slice(0, 2)
+
   const supportRoutes = [
+    { tag: 'Bounded peer', title: 'Onboarding 30-60-90', desc: 'Vroege checkpoint-read voor nieuwe medewerkers, naast de kernroutes maar kleiner dan een hoofdproduct.', color: 'oklch(.46 .14 72)', href: '/producten/onboarding-30-60-90' },
     { tag: 'Vervolgstap', title: 'Pulse', desc: 'Korte hercheck na een traject. Snel zichtbaar of de beweging zet.', color: AC.mid, href: '/producten/pulse' },
-    { tag: 'Extra duiding voor management', title: 'Leadership Scan', desc: 'Alleen als vervolgstap.', color: 'oklch(.42 .12 290)', href: '/producten' },
+    { tag: 'Extra duiding voor management', title: 'Leadership Scan', desc: 'Alleen als vervolgstap na een bestaand people-signaal.', color: 'oklch(.42 .12 290)', href: '/producten/leadership-scan' },
   ]
 
   return (
@@ -601,15 +604,15 @@ function RoutesSection() {
           </Reveal>
           <Reveal delay={.14}>
             <p style={{ fontSize: 15, lineHeight: 1.7, color: T.inkSoft, maxWidth: '32ch' }}>
-              Drie hoofdroutes. Aanvullende routes sluiten later aan.
+              Twee hoofdroutes. Onboarding staat daarnaast als bounded peer. Pulse en Leadership sluiten later aan.
             </p>
           </Reveal>
         </div>
 
-        <div className="grid grid-cols-1 gap-10 lg:grid-cols-3 lg:gap-0" style={{ borderBottom: `1px solid ${T.rule}`, paddingBottom: 0 }}>
-          {mainRoutes.map((r, i) => (
+        <div className="grid grid-cols-1 gap-10 lg:grid-cols-2 lg:gap-0" style={{ borderBottom: `1px solid ${T.rule}`, paddingBottom: 0 }}>
+          {primaryRoutes.map((r, i) => (
             <Reveal key={i} delay={.08 + i * .1}>
-              <div style={{ paddingRight: i < 2 ? 'clamp(0px,3vw,44px)' : 0, paddingLeft: i > 0 ? 'clamp(0px,3vw,44px)' : 0, borderLeft: i > 0 ? `1px solid ${T.rule}` : 'none', paddingBottom: 32 }}>
+              <div style={{ paddingRight: i < 1 ? 'clamp(0px,3vw,44px)' : 0, paddingLeft: i > 0 ? 'clamp(0px,3vw,44px)' : 0, borderLeft: i > 0 ? `1px solid ${T.rule}` : 'none', paddingBottom: 32 }}>
                 <RouteColumn route={r} />
               </div>
             </Reveal>
@@ -619,13 +622,13 @@ function RoutesSection() {
         <div style={{ marginTop: 0 }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 20 }}>
             <div style={{ flex: 1, height: '1px', background: T.rule }} />
-            <span style={{ fontSize: 10, fontWeight: 600, letterSpacing: '.16em', textTransform: 'uppercase', color: T.inkFaint, whiteSpace: 'nowrap', padding: '0 4px' }}>Vervolg- en supportroutes</span>
+            <span style={{ fontSize: 10, fontWeight: 600, letterSpacing: '.16em', textTransform: 'uppercase', color: T.inkFaint, whiteSpace: 'nowrap', padding: '0 4px' }}>Bounded peer en vervolgroutes</span>
             <div style={{ flex: 1, height: '1px', background: T.rule }} />
           </div>
-          <div className="grid grid-cols-1 sm:grid-cols-2">
+          <div className="grid grid-cols-1 sm:grid-cols-3">
             {supportRoutes.map((r, i) => (
               <Reveal key={i} delay={.1 + i * .08}>
-                <div style={{ padding: '20px 24px', borderTop: `1px solid ${T.rule}`, borderRight: i === 0 ? `1px solid ${T.rule}` : 'none' }}
+                <div style={{ padding: '20px 24px', borderTop: `1px solid ${T.rule}`, borderRight: i < supportRoutes.length - 1 ? `1px solid ${T.rule}` : 'none' }}
                   className="transition-colors hover:bg-[oklch(0.956_0.018_60)]">
                   <div style={{ fontSize: 9.5, fontWeight: 600, letterSpacing: '.14em', textTransform: 'uppercase', color: T.inkFaint, marginBottom: 7 }}>{r.tag}</div>
                   <div style={{ fontFamily: FF, fontSize: 18, fontWeight: 400, color: T.inkMuted, marginBottom: 6 }}>{r.title}</div>

--- a/frontend/components/marketing/producten-content.tsx
+++ b/frontend/components/marketing/producten-content.tsx
@@ -44,14 +44,31 @@ const mainRoutes = [
   },
 ] as const
 
+const boundedPeerRoute = {
+  title: 'Onboarding 30-60-90',
+  label: 'Bounded peer',
+  desc: 'Vroege checkpoint-read voor nieuwe medewerkers op 30, 60 en 90 dagen. Kleiner dan een hoofdproduct, maar ook niet zomaar een gewone vervolgronde.',
+  href: '/producten/onboarding-30-60-90',
+  color: 'oklch(.46 .14 72)',
+} as const
+
 const followOnRoutes = [
-  { title: 'Pulse', label: 'Vervolgroute', desc: 'Compacte reviewlaag na een eerste baseline. Kort en gericht zicht op wat nu verschuift.', href: '/producten/pulse', color: AC.mid },
-  { title: 'TeamScan', label: 'Lokalisatie', desc: 'Bounded lokale verdieping nadat een breder signaal al zichtbaar is.', href: '/producten/teamscan', color: T.teal },
-  { title: 'Onboarding 30·60·90', label: 'Lifecycle-check', desc: 'Vroege checkpoint-read voor nieuwe medewerkers op 30, 60 en 90 dagen.', href: '/producten/onboarding-30-60-90', color: 'oklch(.46 .14 72)' },
-  { title: 'Leadership Scan', label: 'Managementcontext', desc: 'Begrensde managementread nadat een bestaand people-signaal duiding vraagt.', href: '/producten/leadership-scan', color: 'oklch(.42 .12 290)' },
+  {
+    title: 'Pulse',
+    label: 'Vervolgroute',
+    desc: 'Compacte reviewlaag na een eerste baseline. Kort en gericht zicht op wat nu verschuift.',
+    href: '/producten/pulse',
+    color: AC.mid,
+  },
+  {
+    title: 'Leadership Scan',
+    label: 'Managementcontext',
+    desc: 'Begrensde managementread nadat een bestaand people-signaal duiding vraagt.',
+    href: '/producten/leadership-scan',
+    color: 'oklch(.42 .12 290)',
+  },
 ] as const
 
-// ── ① Hero ────────────────────────────────────────────────────────
 function HeroSection() {
   const ctaHref = buildContactHref({ routeInterest: 'exitscan', ctaSource: 'products_hero_primary' })
   return (
@@ -60,7 +77,7 @@ function HeroSection() {
       <div style={{ position: 'absolute', top: -80, right: -60, width: 500, height: 500, background: `radial-gradient(circle,${AC.soft} 0%,transparent 65%)`, pointerEvents: 'none' }} />
       <div style={{ ...SHELL, position: 'relative' }}>
         <div style={{ animation: 'slideDownFade .55s cubic-bezier(.16,1,.3,1) .05s both' }}>
-          <SectionMark num="——" label="Twee kernproducten · bewuste vervolgroutes" inView />
+          <SectionMark num="--" label="Twee kernproducten · bounded peer · bewuste vervolgroutes" inView />
         </div>
         <div style={{ maxWidth: '68ch' }}>
           <div style={{ animation: 'slideUpFade .9s cubic-bezier(.16,1,.3,1) .15s both' }}>
@@ -71,7 +88,7 @@ function HeroSection() {
           </div>
           <div style={{ animation: 'slideUpFade .8s cubic-bezier(.16,1,.3,1) .3s both' }}>
             <p style={{ fontSize: 16.5, lineHeight: 1.72, color: T.inkSoft, margin: '28px 0 36px' }}>
-              ExitScan helpt vertrek achteraf begrijpen. RetentieScan helpt eerder signaleren waar behoud onder druk staat. Combinatie en vervolgroutes blijven bewust kleiner.
+              ExitScan helpt vertrek achteraf begrijpen. RetentieScan helpt eerder signaleren waar behoud onder druk staat. Combinatie blijft een kleinere portfolioroute, onboarding een bounded peer en Pulse plus Leadership Scan blijven bewust vervolg.
             </p>
           </div>
           <div style={{ animation: 'slideUpFade .7s cubic-bezier(.16,1,.3,1) .44s both', display: 'flex', gap: 12, flexWrap: 'wrap' }}>
@@ -92,7 +109,6 @@ function HeroSection() {
   )
 }
 
-// ── ② Core routes ─────────────────────────────────────────────────
 function CoreRoutesSection() {
   const [sRef, sInView] = useInView(.06)
   return (
@@ -104,7 +120,7 @@ function CoreRoutesSection() {
           {mainRoutes.map((route, i) => (
             <Reveal key={i} delay={.06 + i * .09}>
               <div style={{ padding: 'clamp(20px,3vw,40px)', paddingBottom: 36, borderLeft: i > 0 ? `1px solid ${T.rule}` : 'none', position: 'relative' }}>
-                <div style={{ position: 'absolute', top: 0, left: i > 0 ? 0 : 0, right: 0, height: 3, background: route.accent }} />
+                <div style={{ position: 'absolute', top: 0, left: 0, right: 0, height: 3, background: route.accent }} />
                 <div style={{ marginTop: 12, marginBottom: 20 }}>
                   <span style={{ fontSize: 9, fontWeight: 700, letterSpacing: '.18em', textTransform: 'uppercase', padding: '3px 9px', background: route.accentFaint, color: route.accent }}>{route.chip}</span>
                 </div>
@@ -115,10 +131,10 @@ function CoreRoutesSection() {
                 <div style={{ fontFamily: FF, fontSize: 'clamp(28px,3vw,36px)', fontWeight: 400, color: T.ink, letterSpacing: '-.02em', lineHeight: 1.1, marginBottom: 14 }}>{route.title}</div>
                 <p style={{ fontSize: 13.5, lineHeight: 1.7, color: T.inkSoft, marginBottom: 20 }}>{route.desc}</p>
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 24 }}>
-                  {route.bullets.map((b, j) => (
-                    <div key={j} style={{ display: 'flex', alignItems: 'center', gap: 10, fontSize: 13, color: T.inkSoft }}>
+                  {route.bullets.map((bullet, index) => (
+                    <div key={index} style={{ display: 'flex', alignItems: 'center', gap: 10, fontSize: 13, color: T.inkSoft }}>
                       <div style={{ width: 4, height: 4, background: route.accent, flexShrink: 0 }} />
-                      {b}
+                      {bullet}
                     </div>
                   ))}
                 </div>
@@ -136,31 +152,40 @@ function CoreRoutesSection() {
   )
 }
 
-// ── ③ Follow-on routes ────────────────────────────────────────────
 function FollowOnSection() {
   const [sRef, sInView] = useInView(.08)
   return (
     <section style={{ background: T.white, padding: 'clamp(52px,6vw,80px) 0', borderBottom: `1px solid ${T.rule}`, position: 'relative', overflow: 'hidden' }}>
       <div style={{ position: 'absolute', left: -20, top: '50%', transform: 'translateY(-50%)', fontFamily: FF, fontSize: 260, fontWeight: 400, color: T.rule, lineHeight: 1, pointerEvents: 'none', userSelect: 'none', opacity: .4 }}>03</div>
       <div ref={sRef} style={{ ...SHELL, position: 'relative' }}>
-        <SectionMark num="03" label="Bewuste vervolgroutes" inView={sInView} />
+        <SectionMark num="03" label="Bounded peer en vervolg" inView={sInView} />
         <Reveal delay={.05}>
           <h2 style={{ fontFamily: FF, fontSize: 'clamp(26px,3vw,38px)', fontWeight: 400, letterSpacing: '-.022em', color: T.ink, marginBottom: 14, lineHeight: 1.1 }}>
-            Kleiner vervolg na de eerste managementread.
+            Eerst een bounded peer, daarna pas kleiner vervolg.
           </h2>
           <p style={{ fontSize: 15, lineHeight: 1.7, color: T.inkSoft, marginBottom: 40, maxWidth: '52ch' }}>
-            Pulse, TeamScan, onboarding en Leadership Scan zijn geen extra wedge-producten. Ze bestaan om het vervolg kleiner, gerichter en bestuurlijk logisch te houden.
+            Onboarding 30-60-90 staat buyer-facing naast de kernroutes als bounded peer. Pulse en Leadership Scan blijven daarna bewust kleiner als vervolgroutes.
           </p>
+        </Reveal>
+        <Reveal delay={.08}>
+          <div style={{ padding: '24px 26px', borderTop: `1px solid ${T.rule}`, borderBottom: `1px solid ${T.rule}`, background: T.paperSoft }}>
+            <div style={{ fontSize: 9, fontWeight: 600, letterSpacing: '.16em', textTransform: 'uppercase', color: boundedPeerRoute.color, marginBottom: 8 }}>{boundedPeerRoute.label}</div>
+            <div style={{ fontFamily: FF, fontSize: 22, fontWeight: 400, color: T.ink, marginBottom: 8 }}>{boundedPeerRoute.title}</div>
+            <p style={{ fontSize: 13, lineHeight: 1.65, color: T.inkMuted, marginBottom: 14, maxWidth: '58ch' }}>{boundedPeerRoute.desc}</p>
+            <Link href={boundedPeerRoute.href} style={{ fontSize: 12.5, fontWeight: 600, color: boundedPeerRoute.color, textDecoration: 'none', display: 'inline-flex', alignItems: 'center', gap: 5 }}>
+              Meer informatie <Arrow />
+            </Link>
+          </div>
         </Reveal>
         <div style={{ display: 'flex', alignItems: 'center', gap: 20, marginBottom: 0 }}>
           <div style={{ flex: 1, height: '1px', background: T.rule }} />
-          <span style={{ fontSize: 10, fontWeight: 600, letterSpacing: '.16em', textTransform: 'uppercase', color: T.inkFaint, whiteSpace: 'nowrap', padding: '0 4px' }}>Vervolg- en supportroutes</span>
+          <span style={{ fontSize: 10, fontWeight: 600, letterSpacing: '.16em', textTransform: 'uppercase', color: T.inkFaint, whiteSpace: 'nowrap', padding: '0 4px' }}>Vervolgroutes</span>
           <div style={{ flex: 1, height: '1px', background: T.rule }} />
         </div>
         <div className="grid grid-cols-1 sm:grid-cols-2">
-          {followOnRoutes.map((route, i) => (
-            <Reveal key={i} delay={.08 + i * .07}>
-              <div style={{ padding: '22px 26px', borderTop: `1px solid ${T.rule}`, borderRight: i % 2 === 0 ? `1px solid ${T.rule}` : 'none', transition: 'background .15s' }}
+          {followOnRoutes.map((route, index) => (
+            <Reveal key={index} delay={.08 + index * .07}>
+              <div style={{ padding: '22px 26px', borderTop: `1px solid ${T.rule}`, borderRight: index % 2 === 0 ? `1px solid ${T.rule}` : 'none', transition: 'background .15s' }}
                 onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = T.paperSoft }}
                 onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = 'transparent' }}>
                 <div style={{ fontSize: 9, fontWeight: 600, letterSpacing: '.16em', textTransform: 'uppercase', color: T.inkFaint, marginBottom: 8 }}>{route.label}</div>
@@ -177,7 +202,7 @@ function FollowOnSection() {
           <Reveal delay={.1}>
             <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 24, flexWrap: 'wrap' }}>
               <p style={{ fontSize: 13.5, color: T.inkSoft, lineHeight: 1.6 }}>
-                Buyer-facing blijft Verisight draaien om twee kernproducten en een bewust opgebouwde portfolioroute.
+                Buyer-facing blijft Verisight draaien om twee kernproducten, een kleine portfolioroute en een scherp begrensde vervolglaag.
               </p>
               <Link href="/vertrouwen" style={{ fontSize: 13, fontWeight: 600, color: T.teal, textDecoration: 'none', display: 'inline-flex', alignItems: 'center', gap: 5, flexShrink: 0 }}>
                 Meer over trust en privacy <Arrow />
@@ -190,15 +215,14 @@ function FollowOnSection() {
   )
 }
 
-// ── ④ Contact ─────────────────────────────────────────────────────
 function ContactSection() {
   return (
     <section id="kennismaking" style={{ background: T.paperSoft, padding: 'clamp(52px,6vw,80px) 0' }}>
       <div style={{ ...SHELL, maxWidth: 820 }}>
         <MarketingInlineContactPanel
           eyebrow="Plan kennismaking"
-          title="Twijfelt u tussen ExitScan, RetentieScan of een vervolgronde?"
-          body="In een eerste gesprek bepalen we welke route nu echt logisch is, hoe de productvorm eruitziet en welke vervolgstap bewust kleiner moet blijven."
+          title="Twijfelt u tussen ExitScan, RetentieScan, onboarding of een vervolgronde?"
+          body="In een eerste gesprek bepalen we welke route nu echt logisch is, of onboarding een bounded peer blijft en welke vervolgstap bewust kleiner moet blijven."
           defaultRouteInterest="exitscan"
           defaultCtaSource="products_form"
         />

--- a/frontend/components/marketing/public-footer.tsx
+++ b/frontend/components/marketing/public-footer.tsx
@@ -6,9 +6,10 @@ export function PublicFooter() {
   const productLinks = [
     { href: '/producten/exitscan', label: 'ExitScan' },
     { href: '/producten/retentiescan', label: 'RetentieScan' },
-    { href: '/producten/pulse', label: 'Pulse' },
-    { href: '/producten/teamscan', label: 'TeamScan' },
+    { href: '/producten/combinatie', label: 'Combinatie' },
     { href: '/producten/onboarding-30-60-90', label: 'Onboarding 30-60-90' },
+    { href: '/producten/pulse', label: 'Pulse' },
+    { href: '/producten/leadership-scan', label: 'Leadership Scan' },
   ]
 
   const navLinks = [

--- a/frontend/components/marketing/site-content.ts
+++ b/frontend/components/marketing/site-content.ts
@@ -225,7 +225,7 @@ export const trustVerificationCards = [
   },
   {
     title: 'Waar sample-proof bewust stopt',
-    body: 'ExitScan en RetentieScan dragen de publieke voorbeeldrapporten. Pulse, TeamScan, onboarding en Leadership Scan blijven bounded follow-on routes met formele output, maar zonder aparte publieke samplebibliotheek.',
+    body: 'ExitScan en RetentieScan dragen de publieke voorbeeldrapporten. Onboarding blijft een bounded peer en Pulse plus Leadership Scan blijven bounded vervolgroutes met formele output, maar zonder aparte publieke samplebibliotheek.',
   },
   {
     title: 'Wat management wel ziet',

--- a/frontend/components/marketing/tarieven-content.tsx
+++ b/frontend/components/marketing/tarieven-content.tsx
@@ -40,9 +40,8 @@ const followOnRows = [
   ['ExitScan ritmeroute', 'Op aanvraag', 'Logisch vervolg na eerste baseline wanneer proces, volume en eigenaarschap al staan.'],
   ['RetentieScan ritmeroute', 'Op aanvraag', 'Doorlopende vervolgvorm wanneer vroegsignalering structureel onderdeel van de managementcyclus wordt.'],
   ['Segment Deep Dive', 'EUR 950', 'Extra segmentanalyse als metadata en minimale respondentengroep dat dragen.'],
+  ['Onboarding 30-60-90', 'Op aanvraag', 'Bounded peer-route wanneer vroege landing van nieuwe medewerkers centraal staat.'],
   ['Pulse', 'Op aanvraag', 'Compacte reviewlaag na een eerste kernroute of baseline, geen nieuwe eerste instap.'],
-  ['TeamScan', 'Op aanvraag', 'Bounded lokale verdieping nadat een breder signaal al zichtbaar is.'],
-  ['Onboarding 30-60-90', 'Op aanvraag', 'Gerichte lifecycle-check wanneer vroege landing van nieuwe medewerkers centraal staat.'],
   ['Leadership Scan', 'Op aanvraag', 'Begrensde managementread nadat een bestaand people-signaal eerst duiding of verificatie vraagt.'],
 ] as const
 
@@ -140,13 +139,13 @@ function FollowOnSection() {
     <section style={{ background: T.white, padding: 'clamp(52px,6vw,80px) 0', borderBottom: `1px solid ${T.rule}`, position: 'relative', overflow: 'hidden' }}>
       <div style={{ position: 'absolute', left: -20, top: '50%', transform: 'translateY(-50%)', fontFamily: FF, fontSize: 260, fontWeight: 400, color: T.rule, lineHeight: 1, pointerEvents: 'none', userSelect: 'none', opacity: .4 }}>03</div>
       <div ref={sRef} style={{ ...SHELL, position: 'relative' }}>
-        <SectionMark num="03" label="Vervolg en add-ons" inView={sInView} />
+        <SectionMark num="03" label="Peer, vervolg en add-ons" inView={sInView} />
         <Reveal delay={.05}>
           <h2 style={{ fontFamily: FF, fontSize: 'clamp(26px,3vw,38px)', fontWeight: 400, letterSpacing: '-.022em', color: T.ink, marginBottom: 14, lineHeight: 1.1 }}>
-            Kleinere routes na de eerste kernroute.
+            Kleinere routes rond de eerste kernroute.
           </h2>
           <p style={{ fontSize: 15, lineHeight: 1.7, color: T.inkSoft, marginBottom: 40, maxWidth: '52ch' }}>
-            De vervolglaag blijft bewust bounded. Vervolgprijzen blijven logisch in verhouding tot de eerste managementvraag.
+            Onboarding blijft een bounded peer. Pulse en Leadership Scan blijven bewust klein als vervolg. De prijslaag blijft zo logisch in verhouding tot de eerste managementvraag.
           </p>
         </Reveal>
         <Reveal delay={.1}>

--- a/frontend/lib/contact-commerce.test.ts
+++ b/frontend/lib/contact-commerce.test.ts
@@ -12,7 +12,7 @@ describe('bounded commerce helpers', () => {
     expect(supportsBoundedCommerceRoute('exitscan')).toBe(true)
     expect(supportsBoundedCommerceRoute('retentiescan')).toBe(true)
     expect(supportsBoundedCommerceRoute('combinatie')).toBe(false)
-    expect(supportsBoundedCommerceRoute('teamscan')).toBe(false)
+    expect(supportsBoundedCommerceRoute('pulse')).toBe(false)
     expect(supportsBoundedCommerceRoute('leadership')).toBe(false)
   })
 
@@ -77,7 +77,7 @@ describe('bounded commerce helpers', () => {
 
   it('keeps non-core routes outside bounded commerce visibility', () => {
     const summary = buildBoundedCommerceVisibilitySummary({
-      routeInterest: 'teamscan',
+      routeInterest: 'pulse',
       agreementStatus: 'confirmed',
       pricingMode: 'custom_quote',
       startReadinessStatus: 'ready',

--- a/frontend/lib/contact-funnel.test.ts
+++ b/frontend/lib/contact-funnel.test.ts
@@ -38,18 +38,30 @@ describe('contact qualification guidance', () => {
     expect(guidance.recommendedCoreRoute).toBe('combinatie')
   })
 
-  it('treats follow-on routes as bounded vervolgkeuzes when a prior signal is explicitly present', () => {
+  it('treats Pulse and Leadership as bounded vervolgkeuzes when a prior signal is explicitly present', () => {
     const guidance = getContactQualificationGuidance({
-      routeInterest: 'teamscan',
+      routeInterest: 'pulse',
       desiredTiming: 'deze-maand',
-      currentQuestion:
-        'Na een bestaand retentiesignaal willen we lokaal zien in welke teams eerst verificatie nodig is.',
+      currentQuestion: 'Na een bestaand retentiesignaal willen we met een compacte vervolgmeting zien wat nu verschuift.',
     })
 
     expect(guidance.status).toBe('bounded_follow_on_review')
     expect(guidance.recommendedCoreRoute).toBe('retentiescan')
-    expect(guidance.followOnCandidateRoute).toBe('teamscan')
+    expect(guidance.followOnCandidateRoute).toBe('pulse')
     expect(guidance.detail.toLowerCase()).toContain('bestaand signaal')
+  })
+
+  it('keeps onboarding as a bounded peer wanneer de vraag direct over nieuwe medewerkers gaat', () => {
+    const guidance = getContactQualificationGuidance({
+      routeInterest: 'onboarding',
+      desiredTiming: 'deze-maand',
+      currentQuestion: 'We willen op 30, 60 en 90 dagen beter zien hoe nieuwe medewerkers landen.',
+    })
+
+    expect(guidance.status).toBe('bounded_peer_review')
+    expect(guidance.recommendedCoreRoute).toBe('exitscan')
+    expect(guidance.followOnCandidateRoute).toBe('onboarding')
+    expect(guidance.headline.toLowerCase()).toContain('bounded peer')
   })
 
   it('reframes follow-on routes back to a core route when no earlier signal is present', () => {

--- a/frontend/lib/contact-funnel.ts
+++ b/frontend/lib/contact-funnel.ts
@@ -18,16 +18,16 @@ export const CONTACT_ROUTE_OPTIONS = [
     firstStepLabel: 'een gefaseerde combinatieroute',
   },
   {
-    value: 'teamscan',
-    label: 'TeamScan',
-    description: 'Na een breder signaal willen we lokaal bepalen waar eerst verificatie nodig is.',
-    firstStepLabel: 'een bounded TeamScan follow-on route na een bestaand signaal',
-  },
-  {
     value: 'onboarding',
     label: 'Onboarding 30-60-90',
-    description: 'Na een onboardingvraag willen we vroeg zien hoe nieuwe medewerkers in een checkpoint landen.',
-    firstStepLabel: 'een bounded onboarding follow-on route na een eerste lifecycle-vraag',
+    description: 'We willen vroeg zien hoe nieuwe medewerkers landen zonder daar een brede lifecycle-suite van te maken.',
+    firstStepLabel: 'een bounded peer onboarding-route naast de kernproducten',
+  },
+  {
+    value: 'pulse',
+    label: 'Pulse',
+    description: 'Na een eerste baseline of managementread willen we compact herchecken wat nu verschuift.',
+    firstStepLabel: 'een bounded Pulse vervolgroute na een eerste baseline of managementread',
   },
   {
     value: 'leadership',
@@ -40,6 +40,15 @@ export const CONTACT_ROUTE_OPTIONS = [
     label: 'Nog niet zeker',
     description: 'We willen eerst de juiste route bepalen.',
     firstStepLabel: 'de logischste eerste route',
+  },
+] as const
+
+const LEGACY_HIDDEN_CONTACT_ROUTE_OPTIONS = [
+  {
+    value: 'teamscan',
+    label: 'TeamScan',
+    description: 'Verborgen legacy route voor interne of historische teamreads.',
+    firstStepLabel: 'een legacy TeamScan-route na een bestaand signaal',
   },
 ] as const
 
@@ -66,14 +75,17 @@ export const CONTACT_DESIRED_TIMING_OPTIONS = [
   },
 ] as const
 
-export type ContactRouteInterest = (typeof CONTACT_ROUTE_OPTIONS)[number]['value']
+export type ContactRouteInterest =
+  | (typeof CONTACT_ROUTE_OPTIONS)[number]['value']
+  | (typeof LEGACY_HIDDEN_CONTACT_ROUTE_OPTIONS)[number]['value']
 export type ContactDesiredTiming = (typeof CONTACT_DESIRED_TIMING_OPTIONS)[number]['value']
 export type CoreContactRouteInterest = Extract<ContactRouteInterest, 'exitscan' | 'retentiescan' | 'combinatie'>
-export type FollowOnContactRouteInterest = Extract<ContactRouteInterest, 'teamscan' | 'onboarding' | 'leadership'>
+export type FollowOnContactRouteInterest = Extract<ContactRouteInterest, 'teamscan' | 'onboarding' | 'pulse' | 'leadership'>
 export type ContactQualificationStatus =
   | 'core_default'
   | 'retention_primary'
   | 'combination_candidate'
+  | 'bounded_peer_review'
   | 'bounded_follow_on_review'
   | 'follow_on_reframe'
   | 'uncertain_core_review'
@@ -99,9 +111,9 @@ export type ContactQualificationGuidance = {
   operatorSummary: string
 }
 
-const routeOptionMap = new Map(CONTACT_ROUTE_OPTIONS.map((option) => [option.value, option]))
+const routeOptionMap = new Map([...CONTACT_ROUTE_OPTIONS, ...LEGACY_HIDDEN_CONTACT_ROUTE_OPTIONS].map((option) => [option.value, option]))
 const timingOptionMap = new Map(CONTACT_DESIRED_TIMING_OPTIONS.map((option) => [option.value, option]))
-const followOnRoutes = new Set<FollowOnContactRouteInterest>(['teamscan', 'onboarding', 'leadership'])
+const followOnRoutes = new Set<FollowOnContactRouteInterest>(['pulse', 'leadership'])
 
 const EXIT_SIGNAL_KEYWORDS = [
   'exit',
@@ -124,6 +136,14 @@ const RETENTION_SIGNAL_KEYWORDS = [
   'verloop voorkomen',
 ]
 
+const PULSE_SIGNAL_KEYWORDS = [
+  'pulse',
+  'hercheck',
+  'hermeting',
+  'vervolgmeting',
+  'effectcheck',
+  'ritme',
+]
 const TEAM_SIGNAL_KEYWORDS = ['team', 'teams', 'afdeling', 'afdelingen', 'lokaal', 'leidingcontext']
 const ONBOARDING_SIGNAL_KEYWORDS = [
   'onboarding',
@@ -141,8 +161,11 @@ const FOLLOW_ON_EVIDENCE_KEYWORDS = [
   'baseline',
   'bestaand beeld',
   'vervolg',
+  'vervolgmeting',
   'verdieping',
   'opvolging',
+  'hercheck',
+  'hermeting',
   'review',
   'na een',
   'na het',
@@ -185,6 +208,9 @@ export function inferRouteInterestFromSource(source: string | null | undefined):
   if (normalizedSource.includes('onboarding')) {
     return 'onboarding'
   }
+  if (normalizedSource.includes('pulse')) {
+    return 'pulse'
+  }
   if (normalizedSource.includes('leadership')) {
     return 'leadership'
   }
@@ -222,6 +248,9 @@ function detectFollowOnCandidateRoute(text: string): FollowOnContactRouteInteres
   if (includesAnyKeyword(text, ONBOARDING_SIGNAL_KEYWORDS)) {
     return 'onboarding'
   }
+  if (includesAnyKeyword(text, PULSE_SIGNAL_KEYWORDS)) {
+    return 'pulse'
+  }
   if (includesAnyKeyword(text, LEADERSHIP_SIGNAL_KEYWORDS)) {
     return 'leadership'
   }
@@ -244,12 +273,25 @@ export function getContactQualificationGuidance({
     : null
   const inferredFollowOnCandidate = detectFollowOnCandidateRoute(normalizedQuestion)
   const followOnCandidateRoute = explicitFollowOnCandidate ?? inferredFollowOnCandidate
+  const onboardingCandidate =
+    normalizedRoute === 'onboarding' || inferredFollowOnCandidate === 'onboarding' ? 'onboarding' : null
 
   let recommendedCoreRoute: CoreContactRouteInterest = 'exitscan'
   if (hasExitSignal && hasRetentionSignal) {
     recommendedCoreRoute = 'combinatie'
   } else if (hasRetentionSignal && !hasExitSignal) {
     recommendedCoreRoute = 'retentiescan'
+  }
+
+  if (onboardingCandidate) {
+    return {
+      status: 'bounded_peer_review',
+      recommendedCoreRoute,
+      followOnCandidateRoute: 'onboarding',
+      headline: 'Onboarding 30-60-90 blijft een bounded peer naast de kernroutes.',
+      detail: `We behandelen onboarding als een eigen lifecycle-check voor nieuwe medewerkers. De route hoeft niet eerst te worden teruggeduwd naar een gewone follow-up, maar we toetsen wel bewust of een smallere onboardingread past of dat ${getContactRouteLabel(recommendedCoreRoute)} inhoudelijk logischer blijft.`,
+      operatorSummary: `Onboarding is genoemd als bounded peer; toets direct de lifecycle-vraag, maar check ook of ${getContactRouteLabel(recommendedCoreRoute)} toch de sterkere eerste managementroute is.`,
+    }
   }
 
   if (followOnCandidateRoute && followOnEvidence) {

--- a/frontend/lib/contact-qualification.test.ts
+++ b/frontend/lib/contact-qualification.test.ts
@@ -26,17 +26,17 @@ describe('contact qualification visibility summary', () => {
     expect(summary.recommendationLabel).toContain('RetentieScan')
   })
 
-  it('treats follow-on routes as review items instead of flat first routes', () => {
+  it('treats onboarding as a bounded peer instead of a flat first route', () => {
     const summary = buildContactQualificationVisibilitySummary({
-      routeInterest: 'teamscan',
+      routeInterest: 'onboarding',
       desiredTiming: 'dit-kwartaal',
-      currentQuestion: 'Na een bestaand retentiesignaal willen we in teams zien waar eerst verificatie nodig is.',
+      currentQuestion: 'We willen vroeg zien hoe nieuwe medewerkers landen en waar het eerste checkpoint frictie laat zien.',
     })
 
     expect(summary.tone).toBe('amber')
-    expect(summary.headline).toContain('TeamScan')
-    expect(summary.recommendationLabel).toContain('RetentieScan')
-    expect(summary.nextAction.toLowerCase()).toContain('baseline')
+    expect(summary.headline.toLowerCase()).toContain('bounded peer')
+    expect(summary.routeReviewLabel).toContain('Onboarding 30-60-90')
+    expect(summary.nextAction.toLowerCase()).toContain('checkpoint')
   })
 
   it('shows confirmed qualification routes as the handoff truth once review is done', () => {

--- a/frontend/lib/contact-qualification.ts
+++ b/frontend/lib/contact-qualification.ts
@@ -86,6 +86,15 @@ export function buildContactQualificationVisibilitySummary({
         routeReviewLabel: `Geselecteerd: ${selectedRouteLabel}`,
         nextAction: 'Toets expliciet of zowel vertrekduiding als vroeg behoudssignaal direct nodig zijn; zo niet, vernauw eerst naar een enkele kernroute.',
       }
+    case 'bounded_peer_review':
+      return {
+        tone: 'amber',
+        headline: 'Onboarding blijft hier een bounded peer, geen gewone vervolgronde.',
+        detail: `${guidance.detail} Gewenste timing: ${timingLabel}.`,
+        recommendationLabel: `Kernroute-check: ${recommendedRouteLabel}`,
+        routeReviewLabel: `Geselecteerd: ${selectedRouteLabel}`,
+        nextAction: 'Toets eerst of de onboardingvraag echt smal en checkpoint-gedreven is. Bevestig anders alsnog een kernroute als eerste managementstap.',
+      }
     case 'bounded_follow_on_review':
       return {
         tone: 'amber',

--- a/frontend/lib/marketing-flow.test.ts
+++ b/frontend/lib/marketing-flow.test.ts
@@ -74,37 +74,42 @@ describe('marketing flow defaults', () => {
     expect(getContactRouteLabel('exitscan')).toBe('ExitScan')
     expect(getContactRouteLabel('retentiescan')).toBe('RetentieScan')
     expect(getContactFirstStepLabel('combinatie')).toBe('een gefaseerde combinatieroute')
-    expect(getContactFirstStepLabel('teamscan')).toContain('na een bestaand signaal')
+    expect(getContactFirstStepLabel('onboarding')).toContain('bounded peer')
+    expect(getContactFirstStepLabel('pulse')).toContain('na een eerste baseline')
     expect(getContactFirstStepLabel('leadership')).toContain('na een bestaand signaal')
   })
 
-  it('keeps the contact route ordering core-first before bounded follow-on routes', () => {
+  it('keeps the contact route ordering core-first with onboarding as bounded peer and pulse plus leadership as follow-up', () => {
     expect(CONTACT_ROUTE_OPTIONS.map((option) => option.value)).toEqual([
       'exitscan',
       'retentiescan',
       'combinatie',
-      'teamscan',
       'onboarding',
+      'pulse',
       'leadership',
       'nog-onzeker',
     ])
-    expect(CONTACT_ROUTE_OPTIONS.find((option) => option.value === 'teamscan')?.description.toLowerCase()).toContain(
-      'na een breder signaal',
+    expect(CONTACT_ROUTE_OPTIONS.find((option) => option.value === 'onboarding')?.description.toLowerCase()).toContain(
+      'nieuwe medewerkers',
+    )
+    expect(CONTACT_ROUTE_OPTIONS.find((option) => option.value === 'pulse')?.description.toLowerCase()).toContain(
+      'na een eerste baseline',
     )
     expect(CONTACT_ROUTE_OPTIONS.find((option) => option.value === 'leadership')?.description.toLowerCase()).toContain(
       'na een bestaand people-signaal',
     )
   })
 
-  it('keeps qualification defaults core-first even when follow-on routes are visible in the funnel', () => {
+  it('keeps onboarding qualified as a bounded peer instead of reframing it as a gewone follow-up', () => {
     const onboardingGuidance = getContactQualificationGuidance({
       routeInterest: 'onboarding',
       desiredTiming: 'orienterend',
       currentQuestion: 'We willen onboarding beter organiseren voor nieuwe medewerkers.',
     })
 
-    expect(onboardingGuidance.status).toBe('follow_on_reframe')
+    expect(onboardingGuidance.status).toBe('bounded_peer_review')
     expect(onboardingGuidance.recommendedCoreRoute).toBe('exitscan')
     expect(onboardingGuidance.followOnCandidateRoute).toBe('onboarding')
+    expect(onboardingGuidance.headline.toLowerCase()).toContain('bounded peer')
   })
 })

--- a/frontend/lib/marketing-positioning.test.ts
+++ b/frontend/lib/marketing-positioning.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  BOUNDED_PEER_MARKETING_PRODUCTS,
   CORE_MARKETING_PRODUCTS,
   FOLLOW_ON_MARKETING_PRODUCTS,
   LIVE_MARKETING_PRODUCTS,
@@ -25,8 +26,9 @@ import {
 } from '@/components/marketing/site-content'
 
 describe('Portfolio architecture marketing model', () => {
-  it('keeps a core-first seven-route suite with visible bounded follow-on routes', () => {
+  it('keeps a core-first six-route suite with onboarding as bounded peer and only pulse plus leadership as follow-up', () => {
     const combination = PORTFOLIO_ROUTE_MARKETING_PRODUCTS[0]
+    const boundedPeerSlugs = BOUNDED_PEER_MARKETING_PRODUCTS.map((product) => product.slug)
     const followOnSlugs = FOLLOW_ON_MARKETING_PRODUCTS.map((product) => product.slug)
     const reservedSlugs = RESERVED_MARKETING_PRODUCTS.map((product) => product.slug)
 
@@ -36,13 +38,16 @@ describe('Portfolio architecture marketing model', () => {
     expect(combination.portfolioRole).toBe('portfolio_route')
     expect(combination.description.toLowerCase()).toContain('portfolioroute')
     expect(combination.description.toLowerCase()).toContain('derde kernproduct')
-    expect(followOnSlugs).toEqual(['pulse', 'teamscan', 'onboarding-30-60-90', 'leadership-scan'])
+    expect(boundedPeerSlugs).toEqual(['onboarding-30-60-90'])
+    expect(BOUNDED_PEER_MARKETING_PRODUCTS.every((product) => product.status === 'bounded_live')).toBe(true)
+    expect(BOUNDED_PEER_MARKETING_PRODUCTS.every((product) => product.portfolioRole === 'bounded_peer_route')).toBe(true)
+    expect(followOnSlugs).toEqual(['pulse', 'leadership-scan'])
     expect(FOLLOW_ON_MARKETING_PRODUCTS.every((product) => product.status === 'bounded_live')).toBe(true)
     expect(FOLLOW_ON_MARKETING_PRODUCTS.every((product) => product.portfolioRole === 'follow_on_route')).toBe(true)
     expect(FOLLOW_ON_MARKETING_PRODUCTS.every((product) => !product.description.toLowerCase().includes('live bounded'))).toBe(true)
     expect(CORE_MARKETING_PRODUCTS.every((product) => product.status === 'core_live')).toBe(true)
     expect(PORTFOLIO_ROUTE_MARKETING_PRODUCTS.every((product) => product.status === 'portfolio_live')).toBe(true)
-    expect(LIVE_MARKETING_PRODUCTS).toHaveLength(7)
+    expect(LIVE_MARKETING_PRODUCTS).toHaveLength(6)
     expect(reservedSlugs).toEqual(['mto', 'customer-feedback'])
     expect(RESERVED_MARKETING_PRODUCTS.every((product) => product.status === 'reserved_future')).toBe(true)
     expect(RESERVED_MARKETING_PRODUCTS.every((product) => product.portfolioRole === 'future_reserved_route')).toBe(

--- a/frontend/lib/marketing-products.ts
+++ b/frontend/lib/marketing-products.ts
@@ -2,6 +2,7 @@ export type MarketingProductStatus = 'core_live' | 'portfolio_live' | 'bounded_l
 export type MarketingProductPortfolioRole =
   | 'core_product'
   | 'portfolio_route'
+  | 'bounded_peer_route'
   | 'follow_on_route'
   | 'future_reserved_route'
 
@@ -77,6 +78,26 @@ export const PORTFOLIO_ROUTE_MARKETING_PRODUCTS: MarketingProduct[] = [
   },
 ]
 
+export const BOUNDED_PEER_MARKETING_PRODUCTS: MarketingProduct[] = [
+  {
+    slug: 'onboarding-30-60-90',
+    label: 'Onboarding 30-60-90',
+    shortLabel: 'Onboarding 30-60-90',
+    tagline: 'Vroege lifecycle-check voor nieuwe medewerkers',
+    description:
+      'Bounded peer-route voor een assisted single-checkpoint onboardingread. Bedoeld om vroege landing en eerste frictie zichtbaar te maken, zonder daarvan een derde hoofdproduct of brede lifecycle-suite te maken.',
+    seoTitle: 'Onboarding 30-60-90 | Vroege lifecycle-check voor nieuwe medewerkers',
+    ogAlt: 'Onboarding 30-60-90 productpagina van Verisight',
+    serviceType: 'Assisted single-checkpoint onboardingread',
+    serviceAudience: 'HR-teams en directies die een vroege onboardingcheck buyer-facing willen openen',
+    serviceOutput:
+      'Checkpointsignaal, owner, eerste actie en bounded managementhandoff zonder brede journey-claims',
+    status: 'bounded_live',
+    portfolioRole: 'bounded_peer_route',
+    href: '/producten/onboarding-30-60-90',
+  },
+]
+
 export const FOLLOW_ON_MARKETING_PRODUCTS: MarketingProduct[] = [
   {
     slug: 'pulse',
@@ -94,40 +115,6 @@ export const FOLLOW_ON_MARKETING_PRODUCTS: MarketingProduct[] = [
     status: 'bounded_live',
     portfolioRole: 'follow_on_route',
     href: '/producten/pulse',
-  },
-  {
-    slug: 'teamscan',
-    label: 'TeamScan',
-    shortLabel: 'TeamScan',
-    tagline: 'Lokale verificatie na een breder signaal',
-    description:
-      'Bounded vervolgroute voor department-first lokalisatie nadat een breder signaal al zichtbaar is. Bedoeld voor lokale verificatie en prioriteit, niet voor manager ranking of brede teamsoftware.',
-    seoTitle: 'TeamScan | Lokale verificatie na een breder signaal',
-    ogAlt: 'TeamScan productpagina van Verisight',
-    serviceType: 'Lokale verificatie en bounded teamprioritering',
-    serviceAudience: 'HR-teams en directies die na een breder signaal lokale verificatie willen starten',
-    serviceOutput:
-      'Lokale prioriteitsread, bounded managementhandoff en suppressie-aware lokale duiding',
-    status: 'bounded_live',
-    portfolioRole: 'follow_on_route',
-    href: '/producten/teamscan',
-  },
-  {
-    slug: 'onboarding-30-60-90',
-    label: 'Onboarding 30-60-90',
-    shortLabel: 'Onboarding 30-60-90',
-    tagline: 'Vroege lifecycle-check voor nieuwe medewerkers',
-    description:
-      'Bounded vervolgroute voor een assisted single-checkpoint onboardingread. Bedoeld om vroege landing en eerste frictie zichtbaar te maken, niet als journey-engine of brede lifecycle-suite.',
-    seoTitle: 'Onboarding 30-60-90 | Vroege lifecycle-check voor nieuwe medewerkers',
-    ogAlt: 'Onboarding 30-60-90 productpagina van Verisight',
-    serviceType: 'Assisted single-checkpoint onboardingread',
-    serviceAudience: 'HR-teams en directies die een vroege onboardingcheck buyer-facing willen openen',
-    serviceOutput:
-      'Checkpointsignaal, owner, eerste actie en bounded managementhandoff zonder brede journey-claims',
-    status: 'bounded_live',
-    portfolioRole: 'follow_on_route',
-    href: '/producten/onboarding-30-60-90',
   },
   {
     slug: 'leadership-scan',
@@ -151,6 +138,7 @@ export const FOLLOW_ON_MARKETING_PRODUCTS: MarketingProduct[] = [
 export const LIVE_MARKETING_PRODUCTS: MarketingProduct[] = [
   ...CORE_MARKETING_PRODUCTS,
   ...PORTFOLIO_ROUTE_MARKETING_PRODUCTS,
+  ...BOUNDED_PEER_MARKETING_PRODUCTS,
   ...FOLLOW_ON_MARKETING_PRODUCTS,
 ]
 
@@ -196,4 +184,8 @@ export function isCoreMarketingProduct(product: MarketingProduct) {
 
 export function isFollowOnMarketingProduct(product: MarketingProduct) {
   return product.portfolioRole === 'follow_on_route'
+}
+
+export function isBoundedPeerMarketingProduct(product: MarketingProduct) {
+  return product.portfolioRole === 'bounded_peer_route'
 }

--- a/frontend/lib/seo-conversion.test.ts
+++ b/frontend/lib/seo-conversion.test.ts
@@ -53,9 +53,9 @@ describe('SEO conversion tranche', () => {
     expect(urls).toContain('https://www.verisight.nl/oplossingen/exitgesprekken-analyse')
     expect(urls).toContain('https://www.verisight.nl/oplossingen/medewerkersbehoud-analyse')
     expect(urls).toContain('https://www.verisight.nl/producten/pulse')
-    expect(urls).toContain('https://www.verisight.nl/producten/teamscan')
     expect(urls).toContain('https://www.verisight.nl/producten/onboarding-30-60-90')
     expect(urls).toContain('https://www.verisight.nl/producten/leadership-scan')
+    expect(urls).not.toContain('https://www.verisight.nl/producten/teamscan')
     expect(urls.some((url) => url.includes('/examples/'))).toBe(false)
   })
 
@@ -91,9 +91,6 @@ describe('SEO conversion tranche', () => {
     const pulseProductMetadata = await generateProductMetadata({
       params: Promise.resolve({ slug: 'pulse' }),
     })
-    const teamProductMetadata = await generateProductMetadata({
-      params: Promise.resolve({ slug: 'teamscan' }),
-    })
     const onboardingProductMetadata = await generateProductMetadata({
       params: Promise.resolve({ slug: 'onboarding-30-60-90' }),
     })
@@ -107,8 +104,6 @@ describe('SEO conversion tranche', () => {
     expect(exitProductMetadata.alternates?.canonical).toBe('/producten/exitscan')
     expect(pulseProductMetadata.title).toBe('Pulse | Compacte reviewmetingen na eerste baseline of managementread')
     expect(pulseProductMetadata.alternates?.canonical).toBe('/producten/pulse')
-    expect(teamProductMetadata.title).toBe('TeamScan | Lokale verificatie na een breder signaal')
-    expect(teamProductMetadata.alternates?.canonical).toBe('/producten/teamscan')
     expect(onboardingProductMetadata.title).toBe('Onboarding 30-60-90 | Vroege lifecycle-check voor nieuwe medewerkers')
     expect(onboardingProductMetadata.alternates?.canonical).toBe('/producten/onboarding-30-60-90')
     expect(leadershipProductMetadata.title).toBe('Leadership Scan | Begrensde managementread na een bestaand signaal')
@@ -124,6 +119,10 @@ describe('SEO conversion tranche', () => {
       path.join(process.cwd(), 'app', 'tarieven', 'page.tsx'),
       'utf8',
     )
+    const pricingContentSource = fs.readFileSync(
+      path.join(process.cwd(), 'components', 'marketing', 'tarieven-content.tsx'),
+      'utf8',
+    )
     const solutionPageSource = fs.readFileSync(
       path.join(process.cwd(), 'app', 'oplossingen', '[slug]', 'page.tsx'),
       'utf8',
@@ -132,12 +131,11 @@ describe('SEO conversion tranche', () => {
     expect(productPageSource).toContain('defaultCtaSource="product_exit_form"')
     expect(productPageSource).toContain('defaultCtaSource="product_retention_form"')
     expect(productPageSource).toContain('defaultCtaSource="product_pulse_form"')
-    expect(productPageSource).toContain('defaultCtaSource="product_team_form"')
     expect(productPageSource).toContain('defaultCtaSource="product_onboarding_form"')
     expect(productPageSource).toContain('defaultCtaSource="product_leadership_form"')
     expect(productPageSource.includes('ctaHref="#kennismaking"') || productPageSource.includes('href="#kennismaking"')).toBe(true)
     expect(pricingPageSource).toContain("ctaSource: 'pricing_primary_cta'")
-    expect(pricingPageSource).toContain("ctaSource: 'pricing_closing_cta'")
+    expect(pricingContentSource).toContain("ctaSource: 'pricing_closing_cta'")
     expect(solutionPageSource).toContain('MarketingInlineContactPanel')
     expect(solutionPageSource).toContain('defaultCtaSource={solutionPage.ctaSource}')
   })
@@ -148,14 +146,14 @@ describe('SEO conversion tranche', () => {
     expect(llmsText).toContain('ExitScan Baseline: EUR 2.950')
     expect(llmsText).toContain('RetentieScan Baseline: EUR 3.450')
     expect(llmsText).toContain('Pulse: op aanvraag')
-    expect(llmsText).toContain('TeamScan: op aanvraag')
     expect(llmsText).toContain('Onboarding 30-60-90: op aanvraag')
     expect(llmsText).toContain('Leadership Scan: op aanvraag')
     expect(llmsText).toContain('https://www.verisight.nl/producten/exitscan')
     expect(llmsText).toContain('https://www.verisight.nl/producten/retentiescan')
     expect(llmsText).toContain('https://www.verisight.nl/producten/pulse')
-    expect(llmsText).toContain('https://www.verisight.nl/producten/teamscan')
     expect(llmsText).toContain('https://www.verisight.nl/producten/onboarding-30-60-90')
     expect(llmsText).toContain('https://www.verisight.nl/producten/leadership-scan')
+    expect(llmsText).not.toContain('TeamScan')
+    expect(llmsText).not.toContain('https://www.verisight.nl/producten/teamscan')
   })
 })

--- a/frontend/public/llms.txt
+++ b/frontend/public/llms.txt
@@ -3,20 +3,19 @@
 > Verisight helpt HR-teams bij organisaties vanaf circa 200 medewerkers om
 > eerst de juiste managementroute te kiezen: ExitScan voor vertrekduiding en
 > verloopanalyse, RetentieScan voor vroegsignalering op behoud, Pulse als
-> compacte vervolgroute na diagnose of baseline, TeamScan als bounded
-> lokalisatieroute na een breder signaal, onboarding als bounded
-> lifecycle-check voor nieuwe medewerkers, Leadership Scan als bounded
+> compacte vervolgroute na diagnose of baseline, onboarding als bounded
+> peer-route voor nieuwe medewerkers, Leadership Scan als bounded
 > managementread na een bestaand people-signaal, of een bewuste combinatie van beide.
 
 ## Publieke routes
 
 - [Homepage](https://www.verisight.nl): routekeuze, proof en kennismaking
-- [Producten](https://www.verisight.nl/producten): overzicht van ExitScan, RetentieScan, Pulse, TeamScan, Onboarding 30-60-90, Leadership Scan en Combinatie
+- [Producten](https://www.verisight.nl/producten): overzicht van ExitScan, RetentieScan, Combinatie, Onboarding 30-60-90, Pulse en Leadership Scan
 - [ExitScan](https://www.verisight.nl/producten/exitscan): primaire route voor vertrekduiding en verloopanalyse
 - [RetentieScan](https://www.verisight.nl/producten/retentiescan): gerichte route voor medewerkersbehoud en vroegsignalering
+- [Combinatie](https://www.verisight.nl/producten/combinatie): portfolioroute wanneer vertrekduiding en vroegsignalering bewust in dezelfde managementlijn moeten samenkomen
+- [Onboarding 30-60-90](https://www.verisight.nl/producten/onboarding-30-60-90): bounded peer-route voor een vroege checkpoint-read bij nieuwe medewerkers
 - [Pulse](https://www.verisight.nl/producten/pulse): compacte vervolgroute voor bounded managementreviews na diagnose of baseline
-- [TeamScan](https://www.verisight.nl/producten/teamscan): bounded lokalisatieroute voor veilige lokale verificatie na een breder signaal
-- [Onboarding 30-60-90](https://www.verisight.nl/producten/onboarding-30-60-90): bounded lifecycle-check voor assisted single-checkpoint managementreads bij nieuwe medewerkers
 - [Leadership Scan](https://www.verisight.nl/producten/leadership-scan): bounded group-level managementread zonder named leaders, manager ranking of 360-logica
 - [Tarieven](https://www.verisight.nl/tarieven): eerste trajecten, vervolgvormen en add-ons
 - [Aanpak](https://www.verisight.nl/aanpak): intake, setup, livegang en eerste managementwaarde
@@ -28,15 +27,15 @@
 - RetentieScan Baseline: EUR 3.450
 - ExitScan Live: op aanvraag
 - RetentieScan ritme: vanaf EUR 4.950
-- Pulse: op aanvraag
-- TeamScan: op aanvraag
+- Combinatie: op aanvraag
 - Onboarding 30-60-90: op aanvraag
+- Pulse: op aanvraag
 - Leadership Scan: op aanvraag
 - Segment deep dive: EUR 950
 
 ## Proof en documenten
 
-- Publieke deliverable-proof blijft bewust core-first op ExitScan en RetentieScan; bounded follow-on routes worden publiek vooral via productpagina en trustlaag gekaderd.
+- Publieke deliverable-proof blijft bewust core-first op ExitScan en RetentieScan; Onboarding wordt publiek als bounded peer uitgelegd en Pulse plus Leadership Scan vooral via productpagina en trustlaag gekaderd.
 - [ExitScan voorbeeldrapport](https://www.verisight.nl/examples/voorbeeldrapport_verisight.pdf)
 - [RetentieScan voorbeeldrapport](https://www.verisight.nl/examples/voorbeeldrapport_retentiescan.pdf)
 - [Privacybeleid](https://www.verisight.nl/privacy)


### PR DESCRIPTION
## Samenvatting
- vertaalt de aangescherpte Action Center-canon en portfoliohierarchie door naar de publieke marketinglaag
- zet Onboarding 30-60-90 buyer-facing neer als bounded peer, met Pulse en Leadership Scan als bewust kleinere vervolgroutes
- houdt publieke proof bewust core-first op ExitScan en RetentieScan terwijl de propositionele waarde van follow-through scherper zichtbaar wordt
- werkt homepage, producten, tarieven, trustlaag, llms.txt en contactfunneltests bij op dezelfde waarheid

## Waarom
De huidige fase vraagt niet alleen om app-runtime en dashboardwaarheid, maar ook om een publieke site die dezelfde canonieke Action Center- en portfolioverhoudingen vertelt. Deze slice maakt die vertaling expliciet op de bestaande website en op de preview die al klaar stond.

## Verificatie
- `npm test -- marketing-positioning.test.ts marketing-flow.test.ts contact-funnel.test.ts contact-commerce.test.ts contact-qualification.test.ts seo-conversion.test.ts`
- `npm run build`
- lokale previewcheck op `http://127.0.0.1:3001`, inclusief `/`, `/producten` en `/vertrouwen`

## Buiten scope
- geen dashboard-runtime wijzigingen
- geen Action Center productruntime wijzigingen
- geen brede nieuwe marketingdesignwave buiten deze canon/copy-vertaling
