### PR TITLE
Add live Action Center module to the suite shell

### DIFF
--- a/frontend/app/(dashboard)/action-center/page.tsx
+++ b/frontend/app/(dashboard)/action-center/page.tsx
@@ -1,0 +1,204 @@
+import { redirect } from 'next/navigation'
+import { ActionCenterPreview } from '@/components/dashboard/action-center-preview'
+import { buildLiveActionCenterItems, getLiveActionCenterSummary } from '@/lib/action-center-live'
+import { createClient } from '@/lib/supabase/server'
+import type { CampaignDeliveryCheckpoint, CampaignDeliveryRecord } from '@/lib/ops-delivery'
+import type { PilotLearningCheckpoint, PilotLearningDossier } from '@/lib/pilot-learning'
+import type { Campaign, CampaignStats, MemberRole, Organization } from '@/lib/types'
+
+type MembershipRow = {
+  org_id: string
+  role: MemberRole
+}
+
+function getRoleRank(role: MemberRole) {
+  switch (role) {
+    case 'owner':
+      return 3
+    case 'member':
+      return 2
+    case 'viewer':
+    default:
+      return 1
+  }
+}
+
+function getDisplayName(email: string | null | undefined) {
+  if (!email) return 'Verisight klant'
+  const localPart = email.split('@')[0] ?? 'verisight-klant'
+  return localPart
+    .split(/[._-]/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+export default async function ActionCenterPage() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/login')
+  }
+
+  const [{ data: profile }, { data: membershipsRaw }] = await Promise.all([
+    supabase.from('profiles').select('is_verisight_admin').eq('id', user.id).single(),
+    supabase.from('org_members').select('org_id, role').eq('user_id', user.id),
+  ])
+
+  const memberships = (membershipsRaw ?? []) as MembershipRow[]
+  const orgIds = [...new Set(memberships.map((membership) => membership.org_id))]
+  const isAdmin = profile?.is_verisight_admin === true
+
+  if (orgIds.length === 0 && !isAdmin) {
+    redirect('/dashboard')
+  }
+
+  const [
+    { data: organizationsRaw },
+    { data: campaignsRaw },
+    { data: statsRaw },
+    { data: deliveryRecordsRaw },
+    { data: dossiersRaw },
+  ] = await Promise.all([
+    orgIds.length > 0
+      ? supabase.from('organizations').select('id, name, slug, contact_email, is_active, created_at').in('id', orgIds)
+      : Promise.resolve({ data: [] }),
+    orgIds.length > 0
+      ? supabase.from('campaigns').select('*').in('organization_id', orgIds).order('created_at', { ascending: false })
+      : Promise.resolve({ data: [] }),
+    orgIds.length > 0
+      ? supabase.from('campaign_stats').select('*').in('organization_id', orgIds).order('created_at', { ascending: false })
+      : Promise.resolve({ data: [] }),
+    orgIds.length > 0
+      ? supabase.from('campaign_delivery_records').select('*').in('organization_id', orgIds)
+      : Promise.resolve({ data: [] }),
+    orgIds.length > 0
+      ? supabase.from('pilot_learning_dossiers').select('*').in('organization_id', orgIds)
+      : Promise.resolve({ data: [] }),
+  ])
+
+  const organizations = (organizationsRaw ?? []) as Organization[]
+  const campaigns = ((campaignsRaw ?? []) as Campaign[]).filter((campaign) =>
+    ['exit', 'retention', 'onboarding', 'pulse', 'leadership'].includes(campaign.scan_type),
+  )
+  const campaignIds = campaigns.map((campaign) => campaign.id)
+  const stats = (statsRaw ?? []) as CampaignStats[]
+  const deliveryRecords = (deliveryRecordsRaw ?? []) as CampaignDeliveryRecord[]
+  const dossiers = ((dossiersRaw ?? []) as PilotLearningDossier[]).filter((dossier) =>
+    dossier.campaign_id ? campaignIds.includes(dossier.campaign_id) : false,
+  )
+
+  const [{ data: deliveryCheckpointsRaw }, { data: learningCheckpointsRaw }] = await Promise.all([
+    deliveryRecords.length > 0
+      ? supabase
+          .from('campaign_delivery_checkpoints')
+          .select('*')
+          .in(
+            'delivery_record_id',
+            deliveryRecords.map((record) => record.id),
+          )
+      : Promise.resolve({ data: [] }),
+    dossiers.length > 0
+      ? supabase
+          .from('pilot_learning_checkpoints')
+          .select('*')
+          .in(
+            'dossier_id',
+            dossiers.map((dossier) => dossier.id),
+          )
+      : Promise.resolve({ data: [] }),
+  ])
+
+  const deliveryCheckpoints = (deliveryCheckpointsRaw ?? []) as CampaignDeliveryCheckpoint[]
+  const learningCheckpoints = (learningCheckpointsRaw ?? []) as PilotLearningCheckpoint[]
+
+  const roleByOrgId = memberships.reduce<Record<string, MemberRole>>((acc, membership) => {
+    const current = acc[membership.org_id]
+    if (!current || getRoleRank(membership.role) > getRoleRank(current)) {
+      acc[membership.org_id] = membership.role
+    }
+    return acc
+  }, {})
+  const organizationById = new Map(organizations.map((organization) => [organization.id, organization]))
+  const statsByCampaignId = new Map(stats.map((entry) => [entry.campaign_id, entry]))
+  const deliveryRecordByCampaignId = new Map(deliveryRecords.map((record) => [record.campaign_id, record]))
+  const deliveryCheckpointMap = deliveryCheckpoints.reduce<Record<string, CampaignDeliveryCheckpoint[]>>((acc, checkpoint) => {
+    acc[checkpoint.delivery_record_id] ??= []
+    acc[checkpoint.delivery_record_id].push(checkpoint)
+    return acc
+  }, {})
+  const learningDossierByCampaignId = new Map(dossiers.map((dossier) => [dossier.campaign_id ?? dossier.id, dossier]))
+  const learningCheckpointMap = learningCheckpoints.reduce<Record<string, PilotLearningCheckpoint[]>>((acc, checkpoint) => {
+    acc[checkpoint.dossier_id] ??= []
+    acc[checkpoint.dossier_id].push(checkpoint)
+    return acc
+  }, {})
+
+  const items = buildLiveActionCenterItems(
+    campaigns.map((campaign) => {
+      const deliveryRecord = deliveryRecordByCampaignId.get(campaign.id) ?? null
+      const learningDossier = learningDossierByCampaignId.get(campaign.id) ?? null
+
+      return {
+        campaign,
+        stats: statsByCampaignId.get(campaign.id) ?? null,
+        organizationName: organizationById.get(campaign.organization_id)?.name ?? 'Verisight organisatie',
+        memberRole: roleByOrgId[campaign.organization_id] ?? null,
+        deliveryRecord,
+        deliveryCheckpoints: deliveryRecord ? (deliveryCheckpointMap[deliveryRecord.id] ?? []) : [],
+        learningDossier,
+        learningCheckpoints: learningDossier ? (learningCheckpointMap[learningDossier.id] ?? []) : [],
+      }
+    }),
+  )
+
+  const ownerOptions = [...new Set(items.map((item) => item.ownerName).filter((value): value is string => Boolean(value)))]
+    .sort((left, right) => left.localeCompare(right))
+  const itemHrefs = Object.fromEntries(campaigns.map((campaign) => [campaign.id, `/campaigns/${campaign.id}`]))
+  const summary = getLiveActionCenterSummary(items)
+  const workspaceSubtitle =
+    summary.productCount > 0
+      ? `Live opvolging over ${summary.productCount} product${summary.productCount === 1 ? '' : 'en'} in dezelfde suite-shell`
+      : 'Live opvolging binnen dezelfde suite-shell'
+
+  if (items.length === 0) {
+    return (
+      <div className="rounded-[28px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)] px-6 py-8">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--dashboard-muted)]">
+          Action Center
+        </p>
+        <h1 className="mt-2 text-[1.8rem] font-semibold tracking-[-0.04em] text-[color:var(--dashboard-ink)]">
+          Nog geen live opvolging zichtbaar
+        </h1>
+        <p className="mt-3 max-w-3xl text-sm leading-7 text-[color:var(--dashboard-text)]">
+          Zodra er actieve campaigns, bounded deliverycontext of bestaande follow-through dossiers voor jouw organisaties
+          staan, opent deze module automatisch in dezelfde ingelogde suite-shell.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-[24px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)] px-5 py-4 text-sm text-[color:var(--dashboard-text)]">
+        Action Center is hier een aparte module binnen dezelfde ingelogde suite-shell. Je leest opvolging nu live mee per
+        productlijn; bounded owner-mutaties openen we pas waar bronlaag en roltoegang dat veilig dragen.
+      </div>
+      <ActionCenterPreview
+        initialItems={items}
+        initialView="overview"
+        fallbackOwnerName={getDisplayName(user.email)}
+        ownerOptions={ownerOptions}
+        workbenchHref="/dashboard"
+        workbenchLabel="Open broncampaign"
+        workspaceName={getDisplayName(user.email)}
+        workspaceSubtitle={workspaceSubtitle}
+        readOnly
+        itemHrefs={itemHrefs}
+      />
+    </div>
+  )
+}

--- a/frontend/components/dashboard/action-center-preview.tsx
+++ b/frontend/components/dashboard/action-center-preview.tsx
@@ -46,6 +46,11 @@ interface Props {
   fallbackOwnerName: string
   ownerOptions: string[]
   workbenchHref: string
+  workbenchLabel?: string
+  workspaceName?: string
+  workspaceSubtitle?: string
+  readOnly?: boolean
+  itemHrefs?: Record<string, string>
 }
 
 interface CreateActionFormState {
@@ -293,6 +298,11 @@ export function ActionCenterPreview({
   fallbackOwnerName,
   ownerOptions,
   workbenchHref,
+  workbenchLabel = 'Open dossierbron',
+  workspaceName,
+  workspaceSubtitle = 'Admin-first opvolging',
+  readOnly = false,
+  itemHrefs = {},
 }: Props) {
   const [items, setItems] = useState(initialItems)
   const [activeView, setActiveView] = useState<ActionCenterPreviewView>(initialView)
@@ -344,6 +354,7 @@ export function ActionCenterPreview({
     })
 
   const selectedItem = filteredItems.find((item) => item.id === selectedItemId) ?? items.find((item) => item.id === selectedItemId) ?? filteredItems[0] ?? items[0] ?? null
+  const selectedItemHref = selectedItem ? (itemHrefs[selectedItem.id] ?? workbenchHref) : workbenchHref
   const teamRows = buildTeamRows(items, fallbackOwnerName)
   const selectedTeam = teamRows.find((team) => team.id === selectedTeamId) ?? teamRows[0] ?? null
   const allSources = [...new Set(items.map((item) => item.sourceLabel))]
@@ -561,10 +572,10 @@ export function ActionCenterPreview({
                 Eerstvolgende reviewmoment: <span className="font-semibold text-[#ffb16e]">{earliestReview}</span>
               </p>
               <Link
-                href={workbenchHref}
+                href={selectedItemHref}
                 className="mt-4 inline-flex rounded-full border border-white/10 bg-white/[0.05] px-3 py-1.5 text-sm font-semibold text-white/82 transition hover:bg-white/[0.08]"
               >
-                Open dossierbron
+                {workbenchLabel}
               </Link>
             </div>
           </div>
@@ -575,8 +586,8 @@ export function ActionCenterPreview({
                 {getInitials(fallbackOwnerName)}
               </div>
               <div className="min-w-0">
-                <p className="truncate font-semibold">{fallbackOwnerName}</p>
-                <p className="truncate text-sm text-white/48">Admin-first opvolging</p>
+                <p className="truncate font-semibold">{workspaceName ?? fallbackOwnerName}</p>
+                <p className="truncate text-sm text-white/48">{workspaceSubtitle}</p>
               </div>
             </div>
           </div>
@@ -614,14 +625,16 @@ export function ActionCenterPreview({
                     className="w-full bg-transparent text-[0.97rem] text-[#2a3442] outline-none placeholder:text-[#9a9084]"
                   />
                 </label>
-                <button
-                  type="button"
-                  className="inline-flex items-center justify-center rounded-2xl bg-[#1a2533] px-5 py-3 text-[0.97rem] font-semibold text-white transition hover:bg-[#223247]"
-                  onClick={() => setShowCreateModal(true)}
-                >
-                  <span className="mr-2 text-lg leading-none">+</span>
-                  Actie aanmaken
-                </button>
+                {!readOnly ? (
+                  <button
+                    type="button"
+                    className="inline-flex items-center justify-center rounded-2xl bg-[#1a2533] px-5 py-3 text-[0.97rem] font-semibold text-white transition hover:bg-[#223247]"
+                    onClick={() => setShowCreateModal(true)}
+                  >
+                    <span className="mr-2 text-lg leading-none">+</span>
+                    Actie aanmaken
+                  </button>
+                ) : null}
               </div>
             </div>
           </div>
@@ -752,7 +765,15 @@ export function ActionCenterPreview({
                           </div>
                           <div>
                             <p className="font-semibold">{team.currentManagerName ?? 'Manager toewijzen'}</p>
-                            <p className="mt-1 text-[#7c7368]">{team.currentManagerName ? 'Wijzigbaar in preview' : 'Valt terug op admin'}</p>
+                            <p className="mt-1 text-[#7c7368]">
+                              {readOnly
+                                ? team.currentManagerName
+                                  ? 'Leest live mee vanuit de bronlaag'
+                                  : 'Nog geen expliciete eigenaar in de bronlaag'
+                                : team.currentManagerName
+                                  ? 'Wijzigbaar in preview'
+                                  : 'Valt terug op admin'}
+                            </p>
                           </div>
                           <p>{team.peopleCount}</p>
                           <div>
@@ -787,13 +808,15 @@ export function ActionCenterPreview({
                       <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Dossier-first</p>
                       <h2 className="mt-2 text-[1.25rem] font-semibold tracking-[-0.03em] text-[#132033]">Dossierbron blijft leidend</h2>
                       <p className="mt-3 text-sm leading-7 text-[#4f6175]">
-                        Voor echte wijzigingen blijft de dossierbron onder deze surface de waarheid. Deze preview houdt de adminlaag dicht bij het referentiebeeld, maar opent geen extra carriers of consumerflows.
+                        {readOnly
+                          ? 'Deze live surface leest direct mee met campaigns, delivery en bestaande dossiers. Bewerkbare opvolging openen we alleen waar rol, bronlaag en bounded productwaarheid dat al veilig dragen.'
+                          : 'Voor echte wijzigingen blijft de dossierbron onder deze surface de waarheid. Deze preview houdt de adminlaag dicht bij het referentiebeeld, maar opent geen extra carriers of consumerflows.'}
                       </p>
                       <Link
                         href={workbenchHref}
                         className="mt-4 inline-flex rounded-2xl border border-[#ded3c6] bg-[#faf6f0] px-4 py-2 text-sm font-semibold text-[#1a2533] transition hover:border-[#1a2533]"
                       >
-                        Open dossierbron
+                        {workbenchLabel}
                       </Link>
                     </div>
                   </section>
@@ -812,20 +835,24 @@ export function ActionCenterPreview({
                     >
                       Terug naar overzicht
                     </button>
-                    <button
-                      type="button"
-                      className="inline-flex items-center rounded-full border border-[#ded3c6] bg-white px-4 py-2 text-sm font-semibold text-[#1a2533] transition hover:border-[#1a2533]"
-                      onClick={() => handleStatusChange(selectedItem.status === 'in-uitvoering' ? 'te-bespreken' : 'in-uitvoering')}
-                    >
-                      Status wijzigen
-                    </button>
-                    <button
-                      type="button"
-                      className="inline-flex items-center rounded-full bg-[#ff9b4a] px-4 py-2 text-sm font-semibold text-[#132033] transition hover:brightness-[0.98]"
-                      onClick={() => handleReviewPlanChange(selectedItem.reviewDate ?? new Date().toISOString(), selectedItem.reviewRhythm)}
-                    >
-                      Review plannen
-                    </button>
+                    {!readOnly ? (
+                      <>
+                        <button
+                          type="button"
+                          className="inline-flex items-center rounded-full border border-[#ded3c6] bg-white px-4 py-2 text-sm font-semibold text-[#1a2533] transition hover:border-[#1a2533]"
+                          onClick={() => handleStatusChange(selectedItem.status === 'in-uitvoering' ? 'te-bespreken' : 'in-uitvoering')}
+                        >
+                          Status wijzigen
+                        </button>
+                        <button
+                          type="button"
+                          className="inline-flex items-center rounded-full bg-[#ff9b4a] px-4 py-2 text-sm font-semibold text-[#132033] transition hover:brightness-[0.98]"
+                          onClick={() => handleReviewPlanChange(selectedItem.reviewDate ?? new Date().toISOString(), selectedItem.reviewRhythm)}
+                        >
+                          Review plannen
+                        </button>
+                      </>
+                    ) : null}
                   </div>
 
                   <div className="grid gap-6 xl:grid-cols-[minmax(0,1.7fr),minmax(320px,0.85fr)]">
@@ -847,8 +874,8 @@ export function ActionCenterPreview({
                               <p className="mt-3 text-lg font-semibold tracking-[-0.02em] text-[#132033]">{selectedItem.signalLabel}</p>
                               <p className="mt-2 text-sm leading-7 text-[#4f6175]">{selectedItem.signalBody}</p>
                             </div>
-                            <Link href={workbenchHref} className="text-sm font-semibold text-[#5a7088] transition hover:text-[#132033]">
-                              Open dossierbron
+                            <Link href={selectedItemHref} className="text-sm font-semibold text-[#5a7088] transition hover:text-[#132033]">
+                              {workbenchLabel}
                             </Link>
                           </div>
                         </div>
@@ -878,22 +905,24 @@ export function ActionCenterPreview({
                           )}
                         </div>
 
-                        <div className="mt-8 border-t border-[#efe7dc] pt-6">
-                          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Update toevoegen</p>
-                          <textarea
-                            value={updateDraft}
-                            onChange={(event) => setUpdateDraft(event.target.value)}
-                            placeholder="Korte voortgang of besluit..."
-                            className="mt-4 min-h-[138px] w-full rounded-[20px] border border-[#ddd3c7] bg-[#fbf8f4] px-4 py-4 text-sm leading-7 text-[#132033] outline-none transition focus:border-[#ff9b4a]"
-                          />
-                          <button
-                            type="button"
-                            className="mt-4 inline-flex rounded-2xl bg-[#ff9b4a] px-4 py-2 text-sm font-semibold text-[#132033] transition hover:brightness-[0.98]"
-                            onClick={handleAddUpdate}
-                          >
-                            Update opslaan
-                          </button>
-                        </div>
+                        {!readOnly ? (
+                          <div className="mt-8 border-t border-[#efe7dc] pt-6">
+                            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Update toevoegen</p>
+                            <textarea
+                              value={updateDraft}
+                              onChange={(event) => setUpdateDraft(event.target.value)}
+                              placeholder="Korte voortgang of besluit..."
+                              className="mt-4 min-h-[138px] w-full rounded-[20px] border border-[#ddd3c7] bg-[#fbf8f4] px-4 py-4 text-sm leading-7 text-[#132033] outline-none transition focus:border-[#ff9b4a]"
+                            />
+                            <button
+                              type="button"
+                              className="mt-4 inline-flex rounded-2xl bg-[#ff9b4a] px-4 py-2 text-sm font-semibold text-[#132033] transition hover:brightness-[0.98]"
+                              onClick={handleAddUpdate}
+                            >
+                              Update opslaan
+                            </button>
+                          </div>
+                        ) : null}
                       </div>
                     </section>
 
@@ -937,33 +966,35 @@ export function ActionCenterPreview({
                         </div>
                       </div>
 
-                      <div className="rounded-[24px] border border-[#e4d9cb] bg-white px-6 py-6 shadow-[0_12px_40px_rgba(19,32,51,0.08)]">
-                        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Review plannen</p>
-                        <div className="mt-4 grid gap-4">
-                          <input
-                            type="date"
-                            value={selectedItem.reviewDate ? selectedItem.reviewDate.slice(0, 10) : ''}
-                            onChange={(event) => handleReviewPlanChange(event.target.value, selectedItem.reviewRhythm)}
-                            className="rounded-2xl border border-[#ddd3c7] bg-[#fbf8f4] px-4 py-3 text-sm text-[#132033] outline-none transition focus:border-[#ff9b4a]"
-                          />
-                          <div className="grid grid-cols-2 gap-3">
-                            {REVIEW_RHYTHM_OPTIONS.map((option) => (
-                              <button
-                                key={option}
-                                type="button"
-                                className={`rounded-2xl border px-4 py-3 text-sm font-semibold transition ${
-                                  option === selectedItem.reviewRhythm
-                                    ? 'border-[#ff9b4a] bg-[#fff3e8] text-[#132033]'
-                                    : 'border-[#ddd3c7] bg-[#fbf8f4] text-[#5f564a]'
-                                }`}
-                                onClick={() => handleReviewPlanChange(selectedItem.reviewDate ?? '', option)}
-                              >
-                                {option}
-                              </button>
-                            ))}
+                      {!readOnly ? (
+                        <div className="rounded-[24px] border border-[#e4d9cb] bg-white px-6 py-6 shadow-[0_12px_40px_rgba(19,32,51,0.08)]">
+                          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Review plannen</p>
+                          <div className="mt-4 grid gap-4">
+                            <input
+                              type="date"
+                              value={selectedItem.reviewDate ? selectedItem.reviewDate.slice(0, 10) : ''}
+                              onChange={(event) => handleReviewPlanChange(event.target.value, selectedItem.reviewRhythm)}
+                              className="rounded-2xl border border-[#ddd3c7] bg-[#fbf8f4] px-4 py-3 text-sm text-[#132033] outline-none transition focus:border-[#ff9b4a]"
+                            />
+                            <div className="grid grid-cols-2 gap-3">
+                              {REVIEW_RHYTHM_OPTIONS.map((option) => (
+                                <button
+                                  key={option}
+                                  type="button"
+                                  className={`rounded-2xl border px-4 py-3 text-sm font-semibold transition ${
+                                    option === selectedItem.reviewRhythm
+                                      ? 'border-[#ff9b4a] bg-[#fff3e8] text-[#132033]'
+                                      : 'border-[#ddd3c7] bg-[#fbf8f4] text-[#5f564a]'
+                                  }`}
+                                  onClick={() => handleReviewPlanChange(selectedItem.reviewDate ?? '', option)}
+                                >
+                                  {option}
+                                </button>
+                              ))}
+                            </div>
                           </div>
                         </div>
-                      </div>
+                      ) : null}
                     </section>
                   </div>
                 </div>
@@ -1048,18 +1079,20 @@ export function ActionCenterPreview({
                               <p className="truncate text-[#7c7368]">Wijzigen in preview</p>
                             </div>
                           </div>
-                          <select
-                            value={team.currentManagerName ?? ''}
-                            onChange={(event) => handleManagerChange(team.id, event.target.value)}
-                            className="w-full rounded-2xl border border-[#ddd3c7] bg-[#fbf8f4] px-4 py-2.5 text-sm text-[#132033] outline-none transition focus:border-[#ff9b4a]"
-                          >
-                            <option value="">Manager toewijzen</option>
-                            {ownerOptions.map((option) => (
-                              <option key={`${team.id}-${option}`} value={option}>
-                                {option}
-                              </option>
-                            ))}
-                          </select>
+                          {!readOnly ? (
+                            <select
+                              value={team.currentManagerName ?? ''}
+                              onChange={(event) => handleManagerChange(team.id, event.target.value)}
+                              className="w-full rounded-2xl border border-[#ddd3c7] bg-[#fbf8f4] px-4 py-2.5 text-sm text-[#132033] outline-none transition focus:border-[#ff9b4a]"
+                            >
+                              <option value="">Manager toewijzen</option>
+                              {ownerOptions.map((option) => (
+                                <option key={`${team.id}-${option}`} value={option}>
+                                  {option}
+                                </option>
+                              ))}
+                            </select>
+                          ) : null}
                         </div>
                         <p className="pt-2">{team.peopleCount}</p>
                         <div className="pt-1">

--- a/frontend/components/dashboard/dashboard-shell.tsx
+++ b/frontend/components/dashboard/dashboard-shell.tsx
@@ -136,12 +136,20 @@ export function DashboardShellFrame({
                 <p className="mt-1 text-sm text-[color:var(--dashboard-text)]">{currentLabel}</p>
               </div>
 
-              <Link
-                href="/reports"
-                className="hidden rounded-full border border-[color:var(--dashboard-ink)] bg-[color:var(--dashboard-ink)] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#1B2E45] lg:inline-flex"
-              >
-                Rapportlaag
-              </Link>
+              <div className="hidden items-center gap-2 lg:flex">
+                <Link
+                  href="/reports"
+                  className="rounded-full border border-[color:var(--dashboard-frame-border)] bg-white px-4 py-2 text-sm font-semibold text-[color:var(--dashboard-ink)] transition-colors hover:border-[color:var(--dashboard-accent-soft-border)] hover:text-[color:var(--dashboard-accent-strong)]"
+                >
+                  Reports
+                </Link>
+                <Link
+                  href="/action-center"
+                  className="rounded-full border border-[color:var(--dashboard-ink)] bg-[color:var(--dashboard-ink)] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#1B2E45]"
+                >
+                  Action Center
+                </Link>
+              </div>
             </div>
 
             {mobileNavOpen ? (

--- a/frontend/lib/action-center-live.test.ts
+++ b/frontend/lib/action-center-live.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest'
+import { buildLiveActionCenterItems, isLiveActionCenterScanType } from './action-center-live'
+import type { Campaign, CampaignStats } from '@/lib/types'
+import type { CampaignDeliveryRecord } from '@/lib/ops-delivery'
+import type { PilotLearningCheckpoint, PilotLearningDossier } from '@/lib/pilot-learning'
+
+describe('live action center builder', () => {
+  it('accepts the current live product family as supported action-center carriers', () => {
+    expect(isLiveActionCenterScanType('exit')).toBe(true)
+    expect(isLiveActionCenterScanType('retention')).toBe(true)
+    expect(isLiveActionCenterScanType('onboarding')).toBe(true)
+    expect(isLiveActionCenterScanType('pulse')).toBe(true)
+    expect(isLiveActionCenterScanType('leadership')).toBe(true)
+    expect(isLiveActionCenterScanType('team')).toBe(false)
+  })
+
+  it('builds bounded live items for current product lines from delivery and dossier data', () => {
+    const exitCampaign: Campaign = {
+      id: 'campaign-exit',
+      organization_id: 'org-1',
+      name: 'Exit voorjaar',
+      scan_type: 'exit',
+      delivery_mode: 'live',
+      is_active: true,
+      enabled_modules: null,
+      created_at: '2026-04-10T10:00:00.000Z',
+      closed_at: null,
+    }
+    const pulseCampaign: Campaign = {
+      id: 'campaign-pulse',
+      organization_id: 'org-1',
+      name: 'Pulse april',
+      scan_type: 'pulse',
+      delivery_mode: 'baseline',
+      is_active: true,
+      enabled_modules: null,
+      created_at: '2026-04-12T10:00:00.000Z',
+      closed_at: null,
+    }
+    const exitStats: CampaignStats = {
+      campaign_id: 'campaign-exit',
+      campaign_name: 'Exit voorjaar',
+      scan_type: 'exit',
+      organization_id: 'org-1',
+      is_active: true,
+      created_at: '2026-04-10T10:00:00.000Z',
+      total_invited: 84,
+      total_completed: 26,
+      completion_rate_pct: 31,
+      avg_risk_score: 6.8,
+      avg_signal_score: 6.8,
+      band_high: 12,
+      band_medium: 9,
+      band_low: 5,
+    }
+    const pulseStats: CampaignStats = {
+      campaign_id: 'campaign-pulse',
+      campaign_name: 'Pulse april',
+      scan_type: 'pulse',
+      organization_id: 'org-1',
+      is_active: true,
+      created_at: '2026-04-12T10:00:00.000Z',
+      total_invited: 40,
+      total_completed: 14,
+      completion_rate_pct: 35,
+      avg_risk_score: 4.9,
+      avg_signal_score: 4.9,
+      band_high: 5,
+      band_medium: 6,
+      band_low: 3,
+    }
+    const exitDelivery: CampaignDeliveryRecord = {
+      id: 'delivery-exit',
+      organization_id: 'org-1',
+      campaign_id: 'campaign-exit',
+      contact_request_id: null,
+      lifecycle_stage: 'first_management_use',
+      exception_status: 'blocked',
+      operator_owner: 'Verisight delivery',
+      next_step: 'Plan eerste managementgesprek met HR en sponsor.',
+      operator_notes: null,
+      customer_handoff_note: 'Vertrekduiding is nu scherp genoeg voor een eerste MT-read.',
+      launch_date: null,
+      launch_confirmed_at: null,
+      participant_comms_config: null,
+      reminder_config: null,
+      first_management_use_confirmed_at: null,
+      follow_up_decided_at: null,
+      learning_closed_at: null,
+      created_at: '2026-04-15T10:00:00.000Z',
+      updated_at: '2026-04-24T10:00:00.000Z',
+    }
+    const exitDossier: PilotLearningDossier = {
+      id: 'dossier-exit',
+      organization_id: 'org-1',
+      campaign_id: 'campaign-exit',
+      contact_request_id: null,
+      title: 'Exit follow-through voorjaar',
+      route_interest: 'exitscan',
+      scan_type: 'exit',
+      delivery_mode: 'live',
+      triage_status: 'bevestigd',
+      lead_contact_name: null,
+      lead_organization_name: null,
+      lead_work_email: null,
+      lead_employee_count: null,
+      buyer_question: null,
+      expected_first_value: 'Maak zichtbaar welk vertrekpatroon nu eerst bestuurlijke aandacht vraagt.',
+      buying_reason: null,
+      trust_friction: null,
+      implementation_risk: null,
+      first_management_value: 'Welke vertrekduiding vraagt nu als eerste managementeigenaarschap?',
+      first_action_taken: 'Leg eigenaar en eerste correctie in het MT-overleg vast.',
+      review_moment: '2026-05-12',
+      adoption_outcome: null,
+      management_action_outcome: 'MT kiest een eerste leiderschapsspoor.',
+      next_route: null,
+      stop_reason: null,
+      case_evidence_closure_status: 'lesson_only',
+      case_approval_status: 'draft',
+      case_permission_status: 'not_requested',
+      case_quote_potential: 'laag',
+      case_reference_potential: 'laag',
+      case_outcome_quality: 'indicatief',
+      case_outcome_classes: [],
+      claimable_observations: null,
+      supporting_artifacts: null,
+      case_public_summary: null,
+      created_by: null,
+      updated_by: null,
+      created_at: '2026-04-15T10:00:00.000Z',
+      updated_at: '2026-04-24T10:00:00.000Z',
+    } as PilotLearningDossier
+    const exitLearningCheckpoints: PilotLearningCheckpoint[] = [
+      {
+        id: 'checkpoint-owner',
+        dossier_id: 'dossier-exit',
+        checkpoint_key: 'first_management_use',
+        owner_label: 'HR lead',
+        status: 'bevestigd',
+        objective_signal_notes: null,
+        qualitative_notes: null,
+        interpreted_observation: null,
+        confirmed_lesson: 'HR lead trekt nu de eerste bounded follow-through.',
+        lesson_strength: 'terugkerend_patroon',
+        destination_areas: ['operations'],
+        updated_at: '2026-04-24T09:00:00.000Z',
+        created_at: '2026-04-15T10:00:00.000Z',
+      } as PilotLearningCheckpoint,
+    ]
+
+    const items = buildLiveActionCenterItems([
+      {
+        campaign: exitCampaign,
+        stats: exitStats,
+        organizationName: 'Acme BV',
+        memberRole: 'owner',
+        deliveryRecord: exitDelivery,
+        deliveryCheckpoints: [],
+        learningDossier: exitDossier,
+        learningCheckpoints: exitLearningCheckpoints,
+      },
+      {
+        campaign: pulseCampaign,
+        stats: pulseStats,
+        organizationName: 'Acme BV',
+        memberRole: 'viewer',
+        deliveryRecord: null,
+        deliveryCheckpoints: [],
+        learningDossier: null,
+        learningCheckpoints: [],
+      },
+    ])
+
+    expect(items).toHaveLength(2)
+    expect(items[0]).toMatchObject({
+      id: 'campaign-exit',
+      sourceLabel: 'ExitScan',
+      status: 'geblokkeerd',
+      ownerName: 'HR lead',
+      reviewDate: '2026-05-12',
+      nextStep: 'Leg eigenaar en eerste correctie in het MT-overleg vast.',
+    })
+    expect(items[0]?.openSignals).toContain('blocked_assignment')
+    expect(items[1]).toMatchObject({
+      id: 'campaign-pulse',
+      sourceLabel: 'Pulse',
+      ownerRole: 'Viewer',
+      status: 'te-bespreken',
+    })
+  })
+})

--- a/frontend/lib/action-center-live.ts
+++ b/frontend/lib/action-center-live.ts
@@ -1,0 +1,372 @@
+import type {
+  ActionCenterPreviewItem,
+  ActionCenterPreviewPriority,
+  ActionCenterPreviewStatus,
+  ActionCenterPreviewUpdate,
+} from '@/components/dashboard/action-center-preview'
+import { getScanDefinition } from '@/lib/scan-definitions'
+import type { MemberRole, Campaign, CampaignStats, ScanType } from '@/lib/types'
+import type { CampaignDeliveryCheckpoint, CampaignDeliveryRecord, DeliveryExceptionStatus } from '@/lib/ops-delivery'
+import { getDeliveryExceptionLabel } from '@/lib/ops-delivery'
+import type { PilotLearningCheckpoint, PilotLearningDossier } from '@/lib/pilot-learning'
+
+export interface LiveActionCenterCampaignContext {
+  campaign: Campaign
+  stats: CampaignStats | null
+  organizationName: string
+  memberRole: MemberRole | null
+  deliveryRecord: CampaignDeliveryRecord | null
+  deliveryCheckpoints: CampaignDeliveryCheckpoint[]
+  learningDossier: PilotLearningDossier | null
+  learningCheckpoints: PilotLearningCheckpoint[]
+}
+
+const DUTCH_SHORT_DATE = new Intl.DateTimeFormat('nl-NL', {
+  day: 'numeric',
+  month: 'short',
+})
+
+const SUPPORTED_SCAN_TYPES = new Set<ScanType>(['exit', 'retention', 'onboarding', 'pulse', 'leadership'])
+
+const ROLE_LABELS: Record<MemberRole, string> = {
+  owner: 'Klant owner',
+  member: 'Member',
+  viewer: 'Viewer',
+}
+
+const SCAN_DEFAULTS: Record<
+  ScanType,
+  {
+    managementQuestion: string
+    fallbackStep: string
+    fallbackSummary: string
+    fallbackRhythm: string
+  }
+> = {
+  exit: {
+    managementQuestion: 'Welk vertrekpatroon vraagt nu als eerste een expliciet managementgesprek, eigenaar en bounded vervolg?',
+    fallbackStep: 'Leg de eerste managementreactie, eigenaar en reviewdatum vast op basis van de huidige vertrekduiding.',
+    fallbackSummary: 'ExitScan opent hier de follow-through laag: welke vertrekduiding telt nu, wie pakt die op en wanneer komt dit terug?',
+    fallbackRhythm: 'Maandelijks',
+  },
+  retention: {
+    managementQuestion: 'Welk behoudssignaal verdient nu als eerste een zichtbare behoudsactie en welke eigenaar trekt die follow-through?',
+    fallbackStep: 'Kies de eerste behoudsactie, expliciteer de eigenaar en plan een bounded reviewmoment.',
+    fallbackSummary: 'RetentieScan vertaalt hier signalen naar een eerste behoudsactie met eigenaar en reviewritme.',
+    fallbackRhythm: 'Maandelijks',
+  },
+  onboarding: {
+    managementQuestion: 'Welke vroege landingsfrictie vraagt nu als eerste een checkpoint-correctie en wie bevestigt het volgende reviewmoment?',
+    fallbackStep: 'Kies de eerstvolgende checkpoint-correctie en leg vast wie de stabiele landing bewaakt.',
+    fallbackSummary: 'Onboarding 30-60-90 gebruikt Action Center hier voor eigenaarschap, checkpoint-correctie en expliciete reviewmomenten.',
+    fallbackRhythm: 'Tweewekelijks',
+  },
+  pulse: {
+    managementQuestion: 'Welk reviewsignaal vraagt nu de eerste kleine correctie en wanneer hercheck je die bounded in de volgende cycle?',
+    fallbackStep: 'Kies de eerste kleine correctie, benoem de eigenaar en zet meteen de hercheck klaar.',
+    fallbackSummary: 'Pulse gebruikt Action Center als compacte reviewlaag: kiezen, corrigeren, en bounded opnieuw kijken.',
+    fallbackRhythm: 'Tweewekelijks',
+  },
+  leadership: {
+    managementQuestion: 'Welk leiderschapssignaal vraagt nu de eerste bounded managementactie en hoe wordt die reviewbaar opgevolgd?',
+    fallbackStep: 'Leg de eerste bounded leiderschapsactie en de eerstvolgende review vast.',
+    fallbackSummary: 'Leadership Scan opent hier geen breed traject, maar een bounded follow-through route met eigenaar en reviewritme.',
+    fallbackRhythm: 'Maandelijks',
+  },
+  team: {
+    managementQuestion: 'Welk teamsignaal vraagt nu een eerste lokale managementactie met duidelijke eigenaar en reviewmoment?',
+    fallbackStep: 'Kies de eerste lokale teamactie en leg review en eigenaarschap expliciet vast.',
+    fallbackSummary: 'TeamScan blijft hier een bounded teamfollow-through laag.',
+    fallbackRhythm: 'Maandelijks',
+  },
+}
+
+function formatShortDate(value: string | null) {
+  if (!value) return 'Nog niet gepland'
+
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return value
+  return DUTCH_SHORT_DATE.format(parsed).replace('.', '')
+}
+
+function getPriorityFromSignals(args: {
+  exceptionStatus: DeliveryExceptionStatus | null | undefined
+  avgSignal: number | null
+  totalCompleted: number
+}): ActionCenterPreviewPriority {
+  if (args.exceptionStatus && args.exceptionStatus !== 'none') {
+    return 'hoog'
+  }
+
+  if (typeof args.avgSignal === 'number' && args.avgSignal >= 6.5) {
+    return 'hoog'
+  }
+
+  if (args.totalCompleted > 0 && args.totalCompleted < 10) {
+    return 'midden'
+  }
+
+  return typeof args.avgSignal === 'number' && args.avgSignal >= 4.5 ? 'midden' : 'laag'
+}
+
+function getStatus(args: {
+  learningDossier: PilotLearningDossier | null
+  deliveryRecord: CampaignDeliveryRecord | null
+  reviewDate: string | null
+  ownerName: string | null
+}): ActionCenterPreviewStatus {
+  const triageStatus = args.learningDossier?.triage_status ?? null
+  if (triageStatus === 'uitgevoerd' || args.deliveryRecord?.lifecycle_stage === 'learning_closed') {
+    return 'afgerond'
+  }
+  if (triageStatus === 'verworpen') {
+    return 'gestopt'
+  }
+  if (args.deliveryRecord?.exception_status && args.deliveryRecord.exception_status !== 'none') {
+    return 'geblokkeerd'
+  }
+  if (args.learningDossier?.first_action_taken || args.deliveryRecord?.next_step || args.ownerName || args.reviewDate) {
+    return 'in-uitvoering'
+  }
+  return 'te-bespreken'
+}
+
+function getRoleFallback(memberRole: MemberRole | null) {
+  if (!memberRole) return 'Nog geen expliciete klantrol'
+  return ROLE_LABELS[memberRole]
+}
+
+function getOwnerNames(checkpoints: PilotLearningCheckpoint[], deliveryRecord: CampaignDeliveryRecord | null) {
+  const managementOwner =
+    checkpoints.find((checkpoint) => checkpoint.checkpoint_key === 'first_management_use')?.owner_label?.trim() ?? null
+  const reviewOwner =
+    checkpoints.find((checkpoint) => checkpoint.checkpoint_key === 'follow_up_review')?.owner_label?.trim() ?? null
+
+  return {
+    ownerName: managementOwner || reviewOwner || deliveryRecord?.operator_owner || null,
+    reviewOwnerName: reviewOwner || managementOwner || deliveryRecord?.operator_owner || null,
+  }
+}
+
+function buildOpenSignals(args: {
+  status: ActionCenterPreviewStatus
+  ownerName: string | null
+  reviewDate: string | null
+  deliveryRecord: CampaignDeliveryRecord | null
+}) {
+  const signals: string[] = []
+  if (!args.ownerName) signals.push('owner_missing')
+  if (!args.reviewDate && args.status !== 'afgerond' && args.status !== 'gestopt') signals.push('review_due')
+  if (args.status === 'geblokkeerd') signals.push('blocked_assignment')
+  if (!args.deliveryRecord?.next_step && args.status !== 'afgerond' && args.status !== 'gestopt') signals.push('decision_due')
+  return signals
+}
+
+function buildUpdates(args: {
+  learningCheckpoints: PilotLearningCheckpoint[]
+  deliveryCheckpoints: CampaignDeliveryCheckpoint[]
+  learningDossier: PilotLearningDossier | null
+  deliveryRecord: CampaignDeliveryRecord | null
+  fallbackAuthor: string
+}): ActionCenterPreviewUpdate[] {
+  const learningUpdates = args.learningCheckpoints
+    .map((checkpoint) => ({
+      id: checkpoint.id,
+      author: checkpoint.owner_label?.trim() || args.fallbackAuthor,
+      updatedAt: checkpoint.updated_at,
+      note:
+        checkpoint.confirmed_lesson ||
+        checkpoint.interpreted_observation ||
+        checkpoint.qualitative_notes ||
+        checkpoint.objective_signal_notes ||
+        `${checkpoint.checkpoint_key.replace(/_/g, ' ')} bijgewerkt.`,
+    }))
+    .filter((update) => Boolean(update.note))
+
+  const deliveryUpdates = args.deliveryCheckpoints
+    .map((checkpoint) => ({
+      id: checkpoint.id,
+      author: args.fallbackAuthor,
+      updatedAt: checkpoint.updated_at,
+      note: checkpoint.operator_note || checkpoint.last_auto_summary || `${checkpoint.checkpoint_key.replace(/_/g, ' ')} bijgewerkt.`,
+    }))
+    .filter((update) => Boolean(update.note))
+
+  const combined = [...learningUpdates, ...deliveryUpdates]
+    .sort((left, right) => new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime())
+    .slice(0, 3)
+    .map((update) => ({
+      id: update.id,
+      author: update.author,
+      dateLabel: formatShortDate(update.updatedAt),
+      note: update.note,
+    }))
+
+  if (combined.length > 0) {
+    return combined
+  }
+
+  const fallbackNote =
+    args.learningDossier?.management_action_outcome ||
+    args.learningDossier?.expected_first_value ||
+    args.deliveryRecord?.customer_handoff_note ||
+    'Nog geen expliciete review-update uit campaign of dossierbron.'
+
+  return [
+    {
+      id: `fallback-${args.deliveryRecord?.id ?? args.learningDossier?.id ?? 'action-center'}`,
+      author: args.fallbackAuthor,
+      dateLabel: formatShortDate(args.learningDossier?.updated_at ?? args.deliveryRecord?.updated_at ?? new Date().toISOString()),
+      note: fallbackNote,
+    },
+  ]
+}
+
+function getFallbackStep(scanType: ScanType, lifecycleStage: string | null | undefined) {
+  const defaults = SCAN_DEFAULTS[scanType]
+  if (!lifecycleStage) return defaults.fallbackStep
+
+  if (lifecycleStage === 'client_activation_pending') {
+    return 'Bevestig eerst het vrijgavemoment en leg vast welke eerste managementread daarna zichtbaar moet worden.'
+  }
+  if (lifecycleStage === 'first_value_reached') {
+    return 'Kies nu wie de eerste managementread trekt en welke bounded vervolgstap daarna direct volgt.'
+  }
+  if (lifecycleStage === 'first_management_use') {
+    return 'Leg de eerste managementactie, eigenaar en vervolgreview nu expliciet vast.'
+  }
+  if (lifecycleStage === 'follow_up_decided') {
+    return 'Bevestig of de gekozen follow-through nu doorgaat, bounded verdiept of bewust sluit.'
+  }
+
+  return defaults.fallbackStep
+}
+
+function getSignalBody(scanType: ScanType, deliveryRecord: CampaignDeliveryRecord | null, latestUpdate: string | null) {
+  if (latestUpdate) return latestUpdate
+
+  const defaults = SCAN_DEFAULTS[scanType]
+  if (deliveryRecord?.exception_status && deliveryRecord.exception_status !== 'none') {
+    return `${getDeliveryExceptionLabel(deliveryRecord.exception_status)} vraagt nu een expliciete bounded herstelstap binnen dezelfde productlijn.`
+  }
+  if (deliveryRecord?.customer_handoff_note) return deliveryRecord.customer_handoff_note
+  return defaults.fallbackSummary
+}
+
+function getSortRank(status: ActionCenterPreviewStatus) {
+  switch (status) {
+    case 'geblokkeerd':
+      return 0
+    case 'te-bespreken':
+      return 1
+    case 'in-uitvoering':
+      return 2
+    case 'afgerond':
+      return 3
+    case 'gestopt':
+    default:
+      return 4
+  }
+}
+
+export function isLiveActionCenterScanType(scanType: ScanType) {
+  return SUPPORTED_SCAN_TYPES.has(scanType)
+}
+
+export function buildLiveActionCenterItems(contexts: LiveActionCenterCampaignContext[]): ActionCenterPreviewItem[] {
+  return contexts
+    .filter((context) => isLiveActionCenterScanType(context.campaign.scan_type))
+    .map((context, index) => {
+      const definition = getScanDefinition(context.campaign.scan_type)
+      const defaults = SCAN_DEFAULTS[context.campaign.scan_type]
+      const avgSignal = context.stats?.avg_signal_score ?? context.stats?.avg_risk_score ?? null
+      const fallbackAuthor = context.organizationName || 'Verisight'
+      const reviewDate = context.learningDossier?.review_moment ?? null
+      const { ownerName, reviewOwnerName } = getOwnerNames(context.learningCheckpoints, context.deliveryRecord)
+      const status = getStatus({
+        learningDossier: context.learningDossier,
+        deliveryRecord: context.deliveryRecord,
+        reviewDate,
+        ownerName,
+      })
+      const openSignals = buildOpenSignals({
+        status,
+        ownerName,
+        reviewDate,
+        deliveryRecord: context.deliveryRecord,
+      })
+      const updates = buildUpdates({
+        learningCheckpoints: context.learningCheckpoints,
+        deliveryCheckpoints: context.deliveryCheckpoints,
+        learningDossier: context.learningDossier,
+        deliveryRecord: context.deliveryRecord,
+        fallbackAuthor,
+      })
+      const latestUpdate = updates[0]?.note ?? null
+      const priority = getPriorityFromSignals({
+        exceptionStatus: context.deliveryRecord?.exception_status,
+        avgSignal,
+        totalCompleted: context.stats?.total_completed ?? 0,
+      })
+      const nextStep =
+        context.learningDossier?.first_action_taken ||
+        context.deliveryRecord?.next_step ||
+        getFallbackStep(context.campaign.scan_type, context.deliveryRecord?.lifecycle_stage)
+
+      return {
+        id: context.campaign.id,
+        code: `ACT-${1000 + index + 1}`,
+        title:
+          context.learningDossier?.title ||
+          `${definition.productName}: ${context.campaign.name}`,
+        summary:
+          context.deliveryRecord?.customer_handoff_note ||
+          context.learningDossier?.expected_first_value ||
+          defaults.fallbackSummary,
+        reason:
+          context.learningDossier?.first_management_value ||
+          defaults.managementQuestion,
+        sourceLabel: definition.productName,
+        teamId: context.campaign.id,
+        teamLabel: context.campaign.name,
+        ownerName,
+        ownerRole: ownerName ? `Owner - ${context.organizationName}` : getRoleFallback(context.memberRole),
+        ownerSubtitle: context.organizationName,
+        reviewOwnerName,
+        priority,
+        status,
+        reviewDate,
+        reviewDateLabel: formatShortDate(reviewDate),
+        reviewRhythm: reviewDate ? defaults.fallbackRhythm : defaults.fallbackRhythm,
+        signalLabel: `${definition.productName} - ${context.campaign.name}`,
+        signalBody: getSignalBody(context.campaign.scan_type, context.deliveryRecord, latestUpdate),
+        nextStep,
+        peopleCount: context.stats?.total_invited ?? context.stats?.total_completed ?? 0,
+        openSignals,
+        updates,
+      } satisfies ActionCenterPreviewItem
+    })
+    .sort((left, right) => {
+      const statusDelta = getSortRank(left.status) - getSortRank(right.status)
+      if (statusDelta !== 0) return statusDelta
+
+      const leftDate = left.reviewDate ? new Date(left.reviewDate).getTime() : Number.POSITIVE_INFINITY
+      const rightDate = right.reviewDate ? new Date(right.reviewDate).getTime() : Number.POSITIVE_INFINITY
+      if (leftDate !== rightDate) return leftDate - rightDate
+
+      return left.title.localeCompare(right.title)
+    })
+}
+
+export function getLiveActionCenterSummary(items: ActionCenterPreviewItem[]) {
+  const productLabels = new Set(items.map((item) => item.sourceLabel))
+  const organizations = new Set(items.map((item) => item.ownerSubtitle))
+
+  return {
+    productCount: productLabels.size,
+    organizationCount: organizations.size,
+    actionCount: items.length,
+    blockedCount: items.filter((item) => item.status === 'geblokkeerd').length,
+    reviewCount: items.filter((item) => item.reviewDate).length,
+  }
+}

--- a/frontend/lib/dashboard/shell-navigation.test.ts
+++ b/frontend/lib/dashboard/shell-navigation.test.ts
@@ -35,6 +35,13 @@ describe('dashboard shell navigation', () => {
       created_at: '2026-04-16T10:00:00.000Z',
       total_completed: 22,
     },
+    {
+      campaign_id: 'leadership-1',
+      scan_type: 'leadership',
+      is_active: true,
+      created_at: '2026-04-15T10:00:00.000Z',
+      total_completed: 9,
+    },
   ] as const
 
   it('maps the preview rail onto real overview, campaign and report-layer routes', () => {
@@ -76,21 +83,33 @@ describe('dashboard shell navigation', () => {
         disabled: false,
       },
       {
-        key: 'team',
-        label: 'TeamScan',
-        href: null,
-        disabled: true,
-      },
-      {
         key: 'pulse',
         label: 'Pulse',
         href: '/campaigns/pulse-1',
         disabled: false,
       },
       {
+        key: 'leadership',
+        label: 'Leadership Scan',
+        href: '/campaigns/leadership-1',
+        disabled: false,
+      },
+      {
+        key: 'team',
+        label: 'TeamScan',
+        href: null,
+        disabled: true,
+      },
+      {
         key: 'reports',
         label: 'Reports',
         href: '/reports',
+        disabled: false,
+      },
+      {
+        key: 'action_center',
+        label: 'Action Center',
+        href: '/action-center',
         disabled: false,
       },
     ])
@@ -114,7 +133,7 @@ describe('dashboard shell navigation', () => {
       key: 'overview',
       href: '/dashboard',
     })
-    expect(navigation.admin.map((item) => item.label)).toEqual(['Setup', 'Leads', 'Action Center'])
+    expect(navigation.admin.map((item) => item.label)).toEqual(['Setup', 'Leads', 'Action Center bron'])
     expect(navigation.modules[3]).toMatchObject({
       key: 'onboarding',
       href: '/campaigns/onboarding-1',
@@ -125,8 +144,10 @@ describe('dashboard shell navigation', () => {
     expect(getActiveModuleFromPathname('/dashboard', [...campaigns])).toBe('overview')
     expect(getActiveModuleFromPathname('/campaigns/retention-1', [...campaigns])).toBe('retention')
     expect(getActiveModuleFromPathname('/campaigns/pulse-1', [...campaigns])).toBe('pulse')
+    expect(getActiveModuleFromPathname('/campaigns/leadership-1', [...campaigns])).toBe('leadership')
     expect(getActiveModuleFromPathname('/campaigns/unknown', [...campaigns])).toBe('overview')
     expect(getActiveModuleFromPathname('/reports', [...campaigns])).toBe('reports')
+    expect(getActiveModuleFromPathname('/action-center', [...campaigns])).toBe('action_center')
     expect(getActiveModuleFromPathname('/beheer', [...campaigns])).toBe('overview')
   })
 
@@ -148,14 +169,19 @@ describe('dashboard shell navigation', () => {
       href: null,
       disabled: true,
     })
-    expect(navigation.modules[5]).toMatchObject({
+    expect(navigation.modules[4]).toMatchObject({
       key: 'pulse',
       href: null,
       disabled: true,
     })
-    expect(navigation.modules[6]).toMatchObject({
+    expect(navigation.modules[7]).toMatchObject({
       key: 'reports',
       href: '/reports',
+      disabled: false,
+    })
+    expect(navigation.modules[8]).toMatchObject({
+      key: 'action_center',
+      href: '/action-center',
       disabled: false,
     })
   })

--- a/frontend/lib/dashboard/shell-navigation.ts
+++ b/frontend/lib/dashboard/shell-navigation.ts
@@ -16,9 +16,11 @@ export type DashboardModuleKey =
   | 'exit'
   | 'retention'
   | 'onboarding'
-  | 'team'
   | 'pulse'
+  | 'leadership'
+  | 'team'
   | 'reports'
+  | 'action_center'
 
 export type DashboardModuleNavItem = {
   key: DashboardModuleKey
@@ -42,9 +44,11 @@ const MODULE_LABELS: Array<{ key: DashboardModuleKey; label: string; scanType?: 
   { key: 'exit', label: 'ExitScan', scanType: 'exit' },
   { key: 'retention', label: 'RetentieScan', scanType: 'retention' },
   { key: 'onboarding', label: 'Onboarding 30-60-90', scanType: 'onboarding' },
-  { key: 'team', label: 'TeamScan', scanType: 'team' },
   { key: 'pulse', label: 'Pulse', scanType: 'pulse' },
+  { key: 'leadership', label: 'Leadership Scan', scanType: 'leadership' },
+  { key: 'team', label: 'TeamScan', scanType: 'team' },
   { key: 'reports', label: 'Reports' },
+  { key: 'action_center', label: 'Action Center' },
 ]
 
 export function normalizeDashboardPortfolioView(view: string | undefined): DashboardPortfolioView {
@@ -81,8 +85,8 @@ function getModuleKeyForScanType(scanType: ScanType): Exclude<DashboardModuleKey
     onboarding: 'onboarding',
     team: 'team',
     pulse: 'pulse',
-    leadership: 'team',
-  } as const satisfies Record<ScanType, Exclude<DashboardModuleKey, 'overview' | 'reports'>>
+    leadership: 'leadership',
+  } as const satisfies Record<ScanType, Exclude<DashboardModuleKey, 'overview' | 'reports' | 'action_center'>>
 
   return moduleKeyByScanType[scanType]
 }
@@ -92,6 +96,7 @@ export function getActiveModuleFromPathname(
   campaigns: DashboardShellCampaignRef[],
 ): DashboardModuleKey {
   if (pathname.startsWith('/reports')) return 'reports'
+  if (pathname.startsWith('/action-center')) return 'action_center'
   if (!pathname.startsWith('/campaigns/')) return 'overview'
 
   const [, , campaignId] = pathname.split('/')
@@ -134,6 +139,15 @@ export function buildDashboardShellNavigation({
       }
     }
 
+    if (item.key === 'action_center') {
+      return {
+        key: item.key,
+        label: item.label,
+        href: '/action-center',
+        disabled: false,
+      }
+    }
+
     const campaign = item.scanType ? pickRepresentativeCampaign(campaigns, item.scanType) : null
     const href = getCampaignHref(campaign)
 
@@ -160,8 +174,8 @@ export function buildDashboardShellNavigation({
           disabled: false,
         },
         {
-          label: 'Action Center',
-          detail: 'Admin-first follow-through, reviewdruk en bounded dossieropvolging.',
+          label: 'Action Center bron',
+          detail: 'Dossierbron, admin-first follow-through en bounded dossieropvolging.',
           href: '/beheer/klantlearnings',
           disabled: false,
         },
@@ -176,6 +190,7 @@ export function buildDashboardShellNavigation({
 
 export function getDashboardShellCurrentLabel(pathname: string) {
   if (pathname.startsWith('/reports')) return 'Reports & exports'
+  if (pathname.startsWith('/action-center')) return 'Action Center'
   if (pathname.startsWith('/campaigns/')) return 'Campagneread'
   if (pathname.startsWith('/beheer/contact-aanvragen')) return 'Leadcontext'
   if (pathname.startsWith('/beheer/klantlearnings')) return 'Action Center'


### PR DESCRIPTION
## Summary
- add a customer-facing `/action-center` module inside the shared logged-in suite shell
- expose Action Center navigation alongside overview, product result routes, and reports
- feed the Action Center from real campaigns, delivery records, learning dossiers, and checkpoints across the current product family (`exit`, `retention`, `onboarding`, `pulse`, `leadership`)
- keep the first live slice bounded and read-first while preserving the existing admin workbench as the source layer

## Verification
- `npm run test -- "lib/dashboard/shell-navigation.test.ts" "lib/action-center-live.test.ts"`
- `npm run test -- "app/(dashboard)/dashboard/page.test.ts" "app/(dashboard)/campaigns/[id]/page.test.ts" "app/(dashboard)/beheer/klantlearnings/action-center-preview.test.ts" "lib/dashboard/report-library.test.ts" "lib/dashboard/dashboard-shell.test.ts"` *(campaign detail copy failures are pre-existing on current main and reproduce on an untouched main-based worktree)*
- `npm run build` with current `.env.local`
- production-like runtime check on `127.0.0.1:3011` for `/dashboard`, `/reports`, and `/action-center` with the seeded acceptance account
