### PR TITLE
Define Action Center proposition contract

### DIFF
--- a/docs/active/ACTION_CENTER_PROPOSITION_CONTRACT.md
+++ b/docs/active/ACTION_CENTER_PROPOSITION_CONTRACT.md
@@ -1,0 +1,135 @@
+# ACTION_CENTER_PROPOSITION_CONTRACT.md
+
+Last updated: 2026-04-26
+Status: active
+Source of truth: current suite runtime on `main`, Action Center canon, live dashboard shell, pilot and manager access hardening, and public commercial track.
+
+## 1. Summary
+
+Deze contractlaag legt vast hoe Action Center vanaf nu commercieel mag worden geduid.
+
+De kernverschuiving is:
+
+- Verisight verkoopt niet meer alleen people insights
+- Verisight verkoopt ook niet alleen dashboard + rapport
+- Verisight verkoopt een bounded people suite die helpt:
+  - signalen zien
+  - kiezen wat eerst telt
+  - acties expliciet maken
+  - acties toewijzen
+  - review en follow-up bewaken
+
+Action Center is daarmee geen losse add-on, geen verborgen admintool en geen cosmetische vervolgstap. Het is de follow-through module die de suitepropositie harder, zwaarder en onderscheidender maakt.
+
+## 2. Proposition truth
+
+### Wat Action Center commercieel wél is
+
+Action Center is commercieel:
+
+- de laag waarin people insights worden omgezet naar expliciete opvolging
+- de plek waar eigenaar, eerste stap, reviewmoment en vervolgdruk zichtbaar blijven
+- een bounded management- en follow-through module binnen dezelfde suite als dashboard en rapport
+- een sterke propositionele uitbreiding op people insights: niet alleen zien wat speelt, maar ook bewaken wat ermee gebeurt
+
+### Wat Verisight daardoor nu mag claimen
+
+Verisight helpt organisaties:
+
+- people insights zichtbaar maken
+- prioriteren wat eerst managementaandacht vraagt
+- opvolgacties expliciet maken
+- acties aan teams of verantwoordelijken toewijzen
+- reviewmomenten en follow-through bounded bewaken
+
+### Wat Action Center bewust níet is
+
+Action Center is niet:
+
+- een generieke projectmanagementtool
+- een onbeperkte taakmanager voor de hele organisatie
+- een adviesmachine die autonoom het juiste plan bepaalt
+- een bewijs dat Verisight al full self-service SaaS is
+- een vervanging van het managementgesprek of van menselijke afweging
+
+## 3. Relationship to the rest of the suite
+
+### Dashboard
+
+Dashboard blijft:
+
+- de insights- en managementread module
+- de plek waar signalen, patronen en productresultaten eerst zichtbaar worden
+
+### Report
+
+Rapport blijft:
+
+- de compacte management read en handofflaag
+- de formele output die gedeeld, besproken en doorverteld kan worden
+
+### Action Center
+
+Action Center blijft:
+
+- de follow-through module
+- de plek waar eigenaar, actie, reviewmoment en bounded vervolgbesluit blijven leven
+
+De commerciële suitewaarheid is dus:
+
+- dashboard = zien
+- rapport = samenvatten en overdragen
+- Action Center = opvolging organiseren en bewaken
+
+## 4. Strong propositional framing
+
+De aanbevolen hoofdframing is:
+
+> Verisight is niet alleen een people insights tool. Het is een people suite die organisaties helpt zien wat speelt, bepalen wat eerst telt en opvolging expliciet organiseren.
+
+Daaronder gelden deze ondersteunende proposities:
+
+- van insight naar prioriteit
+- van patroon naar expliciete actie
+- van rapport naar eigenaar en reviewritme
+- van losse people data naar bounded management-opvolging
+
+## 5. Guardrails
+
+### Claims that are allowed
+
+- people insights met dashboard en rapport
+- prioritering van wat eerst telt
+- acties expliciteren
+- acties toewijzen
+- review en follow-up zichtbaar houden
+
+### Claims that are not allowed
+
+- volledig geautomatiseerde actie-engine
+- gegarandeerde gedragsverandering of cultuurverbetering
+- autonome interventie zonder menselijk besluit
+- onbeperkte operations-suite voor elk HR-proces
+- full self-service enterprise platform
+
+## 6. Commercial implications
+
+Deze contractlaag betekent voor de commerciële track:
+
+- homepage en hoofdnavigatie moeten Action Center zichtbaar als hoofdonderdeel van de propositie dragen
+- product-, oplossing-, tarieven- en vertrouwenpagina’s moeten dezelfde suitewaarheid vertellen
+- CTA’s en demo-flow moeten niet alleen “inzage” verkopen, maar ook opvolging en reviewdiscipline
+- proof en claims moeten na pilot eerlijk laten zien dat Action Center geen mock meer is, maar een werkende follow-through laag
+
+## 7. Validation
+
+- De contracttaal volgt de huidige `main`-realiteit van dashboard + reports + `/action-center`.
+- De contracttaal volgt de huidige manager-only hardening en semireële pilot.
+- De contracttaal claimt geen autonomie, AI-advieslaag of algemene task-suite die het product nu niet draagt.
+
+## 8. Next step
+
+Gebruik dit contract als leidende waarheid voor:
+
+- `CT-1` message architecture
+- daarna pas `CT-2` homepage en hoofdnavigatie

--- a/docs/strategy/STRATEGY.md
+++ b/docs/strategy/STRATEGY.md
@@ -21,6 +21,11 @@ Verisight is nu geen brede people-suite en ook nog geen full self-service SaaS. 
   - begeleidt intake, launchdiscipline, dashboardactivatie en eerste vervolgstap
   - laat de klant zelf werken binnen begrensde product- en deliveryrails
 
+- **Action Center**
+  - bounded follow-through module binnen dezelfde suite als dashboard en rapport
+  - maakt eigenaar, eerste stap, reviewmoment en vervolgbesluit zichtbaar
+  - versterkt Verisight propositioneel van alleen inzicht naar expliciete opvolging
+
 - **Action Center-productlaag**
   - gedeelde follow-through laag onder guided execution en delivery
   - houdt dossiers, assignments, reviewmomenten en open follow-upsignalen bij elkaar op de bestaande adminsurface
@@ -99,12 +104,14 @@ Wat nu verdedigbaar is:
 - werkfactoren rond vertrek of behoud bespreekbaar maken
 - management helpen prioriteren waar verder gesprek of validatie nodig is
 - zelfstandig leesbare rapportage met focusvragen, hypothesen en vervolgrichting
+- opvolging expliciet organiseren via eigenaar, actie, reviewmoment en bounded follow-through
 
 Wat nu niet te hard geclaimd mag worden:
 - harde diagnose van waarom iemand vertrekt
 - voorspellen van individueel verloop
 - exact vaststellen wat vermijdbaar was
 - causale zekerheid op basis van één scan of rapport
+- autonome interventie- of taakmachine die zonder menselijk besluit de juiste actie bepaalt
 
 ### Product-, route- en portfoliovolgorde
 
@@ -228,3 +235,4 @@ Niet alles wat nu belangrijk is, zit in code. Deze afhankelijkheden tellen mee i
 - bounded portfolioroutes blijven ondergeschikt aan een scherp gekozen eerste route en openen geen nieuwe pricing- of propositiescope
 - Action Center blijft commercieel onderliggend aan guided execution: wel echte productlaag, geen zelfstandig prijsanker of pitchlijn
 - de eerste commerciële mijlpaal is niet een nieuwe feature, maar een eerste reeks betaalde trajecten via dezelfde truth-aligned routearchitectuur
+- de volgende commerciële hoofdslag is Action Center expliciet zichtbaar maken als kern-USP binnen die routearchitectuur


### PR DESCRIPTION
## Samenvatting
- leg de propositionele waarheid van Action Center vast als kern-USP binnen de Verisight suite
- update de strategylaag zodat Action Center expliciet onderdeel wordt van de commerciële productwaarheid
- maak duidelijk wat we nu wel en niet mogen claimen rond prioriteren, toewijzing en follow-through

## Verificatie
- propositionele contracttekst gecontroleerd op current main producttruth
- strategie en nieuwe contractlaag handmatig vergeleken op bounded claims en rol van dashboard/report/action center

## Scope
- CT-0 Action Center proposition contract
