### PR TITLE
Define Action Center message architecture

### DIFF
--- a/docs/active/ACTION_CENTER_MESSAGE_ARCHITECTURE.md
+++ b/docs/active/ACTION_CENTER_MESSAGE_ARCHITECTURE.md
@@ -1,0 +1,183 @@
+# ACTION_CENTER_MESSAGE_ARCHITECTURE.md
+
+Last updated: 2026-04-26
+Status: active
+Source of truth: `ACTION_CENTER_PROPOSITION_CONTRACT.md`, current public routes, current suite runtime and live pilot truth.
+
+## 1. Summary
+
+Deze architectuur verdeelt de commerciële boodschap van Verisight opnieuw rond één hoofdlijn:
+
+- Verisight geeft niet alleen people insights
+- Verisight helpt ook bepalen wat eerst telt
+- Verisight helpt daarna opvolging expliciet organiseren
+
+De publieke hiërarchie wordt daarom:
+
+1. people insights
+2. managementread
+3. prioritering
+4. actie en eigenaarschap
+5. follow-up en reviewdiscipline
+
+Action Center is daarin niet langer een bijzin, maar de expliciete tweede helft van de suitebelofte.
+
+## 2. Core message stack
+
+### Hoofdboodschap
+
+Verisight is een people suite die organisaties helpt zien wat speelt, bepalen wat eerst telt en opvolging bounded organiseren.
+
+### Subboodschap
+
+Dashboard en rapport laten zien wat het signaal is. Action Center maakt zichtbaar wie wat oppakt, wanneer het terugkomt en hoe follow-through niet verdwijnt in losse notities of overleg.
+
+### Bewijslijn
+
+- twee kernroutes voor people insights
+- één gedeelde suite-shell
+- rapport als managementread
+- Action Center als follow-through module
+- echte manager-assignment en reviewdiscipline in dezelfde omgeving
+
+## 3. Message hierarchy
+
+### Niveau 1: categoriebelofte
+
+Verisight helpt HR en management:
+
+- people insights lezen
+- eerste prioriteiten kiezen
+- opvolging expliciet organiseren
+
+### Niveau 2: suite-uitleg
+
+De suite bestaat uit drie samenhangende lagen:
+
+- dashboard voor signalen en inzichten
+- rapport voor managementread en overdracht
+- Action Center voor eigenaar, actie, review en follow-through
+
+### Niveau 3: productroutes
+
+De eerste productkeuze blijft:
+
+- ExitScan
+- RetentieScan
+
+Andere routes of combinaties blijven secundair aan die eerste keuze.
+
+### Niveau 4: commerciële verdieping
+
+Pas daarna komen:
+
+- aanpak
+- tarieven
+- vertrouwen
+- contact / demo
+
+## 4. Page role model
+
+### Home
+
+Doel:
+
+- de suitebelofte openen
+- Action Center zichtbaar maken als groot verschil
+- direct duidelijk maken dat Verisight verder gaat dan alleen meting of rapportage
+
+Home moet dus vooral zeggen:
+
+- people insights
+- prioriteit
+- actie
+- toewijzing
+- follow-up
+
+### Producten
+
+Doel:
+
+- de eerste routes uitleggen
+- laten zien dat Action Center de gedeelde follow-through laag is achter die routes
+
+De productpagina’s blijven primair product-first, maar moeten niet doen alsof de suite na het rapport ophoudt.
+
+### Aanpak
+
+Doel:
+
+- laten zien hoe traject, read en follow-through in elkaar grijpen
+- de stap van rapport naar opvolging expliciet maken
+
+### Tarieven
+
+Doel:
+
+- eerste koop helder houden
+- laten zien dat de waarde niet alleen in de scan zelf zit, maar in de bounded managementroute eromheen
+
+### Vertrouwen
+
+Doel:
+
+- uitleggen waarom deze suite veilig, bounded en geloofwaardig is
+- niet alleen methodiek en privacy tonen, maar ook waarom de opvolgingslaag niet uitmondt in schijnzekerheid of ongecontroleerde claims
+
+### Contact / demo
+
+Doel:
+
+- intake niet alleen laten draaien om “welke scan?”
+- maar ook om:
+  - welke managementvraag?
+  - waar moet prioritering helpen?
+  - waar is opvolging nu te diffuus?
+
+## 5. What must become more explicit on the site
+
+De site moet explicieter maken dat Verisight helpt:
+
+- kiezen wat nu telt
+- acties zichtbaar maken
+- acties toewijzen
+- review en follow-up bewaken
+
+Dat betekent concreet:
+
+- homepage hero en hoofdnavigatie moeten de suitebelofte harder openen
+- kernpagina’s moeten Action Center niet als verborgen module behandelen
+- CTA’s moeten niet alleen op “inzicht” en “rapport” leunen
+
+## 6. What must stay bounded
+
+De commerciële hiërarchie mag niet verschuiven naar:
+
+- “task management platform”
+- “autonome actie-engine”
+- “volledige HR operations suite”
+- “AI bepaalt wat je moet doen”
+
+De bounded waarheid blijft:
+
+- people insights + managementread + follow-through
+- geen generieke enterprise workflowtool
+
+## 7. Phase handoff
+
+Deze architectuur stuurt direct de volgende fases:
+
+- `CT-2`: homepage en hoofdnavigatie
+- `CT-3`: product-, oplossing-, tarieven- en vertrouwen-copy
+- `CT-4`: CTA en salesflow
+
+Concreet mee te nemen in die fases:
+
+- contactformulier sitebreed ruimer en minder opgekropt
+- `/producten/combinatie` herschrijven naar de nieuwe propositie en visuele lijn
+
+## 8. Validation
+
+- De message hierarchy volgt de nieuwe proposition contract truth.
+- De page roles sluiten aan op de huidige publieke routes in de repo.
+- Action Center wordt commercieel groot genoeg gemaakt zonder third-product drift of operations-theater.


### PR DESCRIPTION
## Samenvatting
- leg de commerciële message hierarchy vast rond people insights, managementread en Action Center follow-through
- verdeel expliciet welke publieke pagina welke rol krijgt in die hiërarchie
- maak scherp wat op homepage, producten, aanpak, tarieven, vertrouwen en contact explicieter moet worden

## Verificatie
- message architecture gecontroleerd op current main routes en proposition contract
- bounded claims en page roles handmatig gereviewd

## Scope
- CT-1 Message architecture en informatiehiërarchie
