### PR TITLE
Align commercial copy with suite truth

### DIFF
--- a/frontend/app/producten/[slug]/page.tsx
+++ b/frontend/app/producten/[slug]/page.tsx
@@ -1221,7 +1221,7 @@ function CombinatiePage() {
           <p className="marketing-hero-copy text-slate-600">
             De combinatie is logisch voor organisaties die zowel willen leren van uitstroom als eerder willen
             signaleren waar behoud nu onder druk staat, zonder daarvan een bundel of standaardpakket te maken. Het is
-            geen derde kernproduct.
+            geen derde kernproduct. Dashboard, rapport en Action Center komen daarna in dezelfde suite-omgeving samen.
           </p>
           <div className="marketing-hero-actions">
             <div className="marketing-hero-cta-row">
@@ -1250,7 +1250,7 @@ function CombinatiePage() {
             </h2>
             <p className="marketing-stage-copy text-slate-300">
               Deze pagina moet duidelijk maken dat het portfolio pas sterker wordt zodra beide vragen bestaan en de
-              eerste route al scherp staat.
+              eerste route al scherp staat. Pas daarna verbindt dezelfde suite-omgeving dashboard, rapport en Action Center in één bounded managementlijn.
             </p>
             <div className="marketing-stage-list">
               {[
@@ -1270,7 +1270,7 @@ function CombinatiePage() {
         <MarketingHeroSupport>
           <div className="marketing-support-note text-sm leading-7 text-slate-600">
             Combinatie betekent niet meer features, maar twee gerichte routes die pas logisch naast elkaar komen te
-            staan wanneer de eerste keuze al landt.
+            staan wanneer de eerste keuze al landt en dezelfde suite-omgeving daarna de follow-through kan dragen.
           </div>
           <div className="marketing-link-grid">
             <Link
@@ -1299,7 +1299,7 @@ function CombinatiePage() {
               </h2>
               <p className="mt-4 text-sm leading-7 text-slate-600">
                 De combinatie gebruikt dezelfde previewstructuur, maar de echte sample-output blijft via ExitScan en
-                RetentieScan publiek verifieerbaar.
+                RetentieScan publiek verifieerbaar. Daarna moeten dashboard, rapport en Action Center wel in dezelfde bounded lijn blijven lezen.
               </p>
               <div className="mt-6 rounded-[1.5rem] border border-slate-200 bg-slate-50 p-5">
                 <PreviewSlider variant="portfolio" />
@@ -1344,7 +1344,7 @@ function CombinatiePage() {
             },
             {
               title: 'Stap 3: stuur in een lijn',
-              body: 'Gebruik een gedeelde managementtaal voor prioritering, opvolging en herhaalmeting.',
+              body: 'Gebruik een gedeelde managementtaal voor prioritering, opvolging en herhaalmeting via dashboard, rapport en Action Center.',
             },
           ]}
         />
@@ -1355,21 +1355,21 @@ function CombinatiePage() {
             rows={[
               ['Hoofdvraag', 'Hoe verbinden we vertrekduiding en vroegsignalering in dezelfde lijn?'],
               ['Leesrichting', 'Achteraf begrijpen en vooruit kijken'],
-              ['Managementoutput', 'Twee gerichte scans in een gedeeld portfolio'],
+              ['Managementoutput', 'Twee gerichte scans met dashboard, rapport en Action Center in een gedeeld portfolio'],
               ['Niet bedoeld als', 'Een algemene survey waar alles tegelijk in wordt gepropt'],
             ]}
           />
 
-          <div className="marketing-panel-dark p-8">
-            <p className="text-xs font-bold uppercase tracking-[0.22em] text-sky-300">Hoe je het verkoopt</p>
-            <h2 className="font-display mt-4 text-4xl text-white">
-              Start vaak met een product, maar houd de tweede route bewust klaar.
-            </h2>
-            <p className="mt-5 text-base leading-8 text-slate-300">
-              De combinatie is geen verplichte instap. Het is een koopreden voor organisaties die beide vragen tegelijk
-              serieus willen adresseren in dezelfde managementtaal.
-            </p>
-          </div>
+            <div className="marketing-panel-dark p-8">
+              <p className="text-xs font-bold uppercase tracking-[0.22em] text-sky-300">Hoe je het verkoopt</p>
+              <h2 className="font-display mt-4 text-4xl text-white">
+                Start vaak met een product, maar houd de tweede route bewust klaar.
+              </h2>
+              <p className="mt-5 text-base leading-8 text-slate-300">
+                De combinatie is geen verplichte instap. Het is een koopreden voor organisaties die beide vragen tegelijk
+                serieus willen adresseren in dezelfde managementtaal en uiteindelijk in dezelfde suite-omgeving willen laten landen.
+              </p>
+            </div>
         </div>
       </MarketingSection>
 
@@ -1377,7 +1377,7 @@ function CombinatiePage() {
         <MarketingInlineContactPanel
           eyebrow="Kennismaking"
           title="Plan een gesprek over de combinatieroute"
-          body="Beschrijf kort of jullie vooral met een product willen starten of dat beide managementvragen nu al tegelijk spelen. Dan bepalen we welke route logisch is."
+          body="Beschrijf kort of jullie vooral met een product willen starten of dat beide managementvragen nu al tegelijk spelen. Dan bepalen we welke route logisch is en wanneer dashboard, rapport en Action Center daarna in dezelfde suite-omgeving mogen samenkomen."
           defaultRouteInterest="combinatie"
           defaultCtaSource="product_combination_form"
         />
@@ -1387,7 +1387,7 @@ function CombinatiePage() {
         <MarketingCalloutBand
           eyebrow="Volgende stap"
           title="Wil je bepalen of de combinatie logisch is?"
-          body="In een kort gesprek kijken we of jullie vooral met een product moeten starten of dat beide managementvragen pas na de eerste route genoeg onderbouwd zijn voor een portfolio-aanpak."
+          body="In een kort gesprek kijken we of jullie vooral met een product moeten starten of dat beide managementvragen pas na de eerste route genoeg onderbouwd zijn voor een portfolio-aanpak in dezelfde suite-omgeving."
           primaryHref={buildContactHref({ routeInterest: 'combinatie', ctaSource: 'product_combination_callout' })}
           primaryLabel="Plan kennismaking"
           secondaryHref="/producten"

--- a/frontend/components/marketing/contact-form.tsx
+++ b/frontend/components/marketing/contact-form.tsx
@@ -210,7 +210,7 @@ export function ContactForm({
       >
         {isCompact
           ? 'Gebruik dit formulier om snel te bepalen welke eerste route nu het best past en welke output of intake daarbij logisch wordt.'
-          : 'Gebruik dit formulier in de eerste plaats om te bepalen of ExitScan, RetentieScan of de combinatieroute nu de logische eerste stap is. Onboarding 30-60-90 behandelen we als bounded peer wanneer de vraag direct over nieuwe medewerkers gaat. Pulse en Leadership Scan blijven bounded vervolgroutes die pas logisch worden nadat een eerste signaal, baseline of managementread al staat. De informatie uit dit formulier gebruiken we alleen om jullie vraag te duiden en gericht op te volgen.'}
+          : 'Gebruik dit formulier in de eerste plaats om te bepalen of ExitScan, RetentieScan of de combinatieroute nu de logische eerste stap is. Onboarding 30-60-90 behandelen we als bounded peer wanneer de vraag direct over nieuwe medewerkers gaat. Pulse en Leadership Scan blijven bounded vervolgroutes die pas logisch worden nadat een eerste signaal, baseline of managementread al staat. We gebruiken de intake ook om te bepalen wanneer dashboard, rapport of Action Center daarna logisch in dezelfde suite-omgeving landen. De informatie uit dit formulier gebruiken we alleen om jullie vraag te duiden en gericht op te volgen.'}
       </div>
 
       {!isCompact ? (

--- a/frontend/components/marketing/producten-content.tsx
+++ b/frontend/components/marketing/producten-content.tsx
@@ -88,7 +88,7 @@ function HeroSection() {
           </div>
           <div style={{ animation: 'slideUpFade .8s cubic-bezier(.16,1,.3,1) .3s both' }}>
             <p style={{ fontSize: 16.5, lineHeight: 1.72, color: T.inkSoft, margin: '28px 0 36px' }}>
-              ExitScan helpt vertrek achteraf begrijpen. RetentieScan helpt eerder signaleren waar behoud onder druk staat. Combinatie blijft een kleinere portfolioroute, onboarding een bounded peer en Pulse plus Leadership Scan blijven bewust vervolg.
+              ExitScan helpt vertrek achteraf begrijpen. RetentieScan helpt eerder signaleren waar behoud onder druk staat. Daarna landen dashboard, rapport en Action Center in dezelfde suite-omgeving, terwijl combinatie een kleinere portfolioroute blijft en onboarding plus vervolgroutes bounded blijven.
             </p>
           </div>
           <div style={{ animation: 'slideUpFade .7s cubic-bezier(.16,1,.3,1) .44s both', display: 'flex', gap: 12, flexWrap: 'wrap' }}>
@@ -164,7 +164,7 @@ function FollowOnSection() {
             Eerst een bounded peer, daarna pas kleiner vervolg.
           </h2>
           <p style={{ fontSize: 15, lineHeight: 1.7, color: T.inkSoft, marginBottom: 40, maxWidth: '52ch' }}>
-            Onboarding 30-60-90 staat buyer-facing naast de kernroutes als bounded peer. Pulse en Leadership Scan blijven daarna bewust kleiner als vervolgroutes.
+            Onboarding 30-60-90 staat buyer-facing naast de kernroutes als bounded peer. Pulse en Leadership Scan blijven daarna bewust kleiner als vervolgroutes. De gedeelde suite-omgeving blijft wel hetzelfde: eerst inzicht, daarna bounded follow-through.
           </p>
         </Reveal>
         <Reveal delay={.08}>
@@ -202,7 +202,7 @@ function FollowOnSection() {
           <Reveal delay={.1}>
             <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 24, flexWrap: 'wrap' }}>
               <p style={{ fontSize: 13.5, color: T.inkSoft, lineHeight: 1.6 }}>
-                Buyer-facing blijft Verisight draaien om twee kernproducten, een kleine portfolioroute en een scherp begrensde vervolglaag.
+                Buyer-facing blijft Verisight draaien om twee kernproducten, een kleine portfolioroute en een scherp begrensde vervolglaag binnen dezelfde suite-omgeving.
               </p>
               <Link href="/vertrouwen" style={{ fontSize: 13, fontWeight: 600, color: T.teal, textDecoration: 'none', display: 'inline-flex', alignItems: 'center', gap: 5, flexShrink: 0 }}>
                 Meer over trust en privacy <Arrow />
@@ -222,7 +222,7 @@ function ContactSection() {
         <MarketingInlineContactPanel
           eyebrow="Plan kennismaking"
           title="Twijfelt u tussen ExitScan, RetentieScan, onboarding of een vervolgronde?"
-          body="In een eerste gesprek bepalen we welke route nu echt logisch is, of onboarding een bounded peer blijft en welke vervolgstap bewust kleiner moet blijven."
+          body="In een eerste gesprek bepalen we welke route nu echt logisch is, hoe dashboard, rapport en Action Center daarna in dezelfde suite-omgeving landen en welke vervolgstap bewust kleiner moet blijven."
           defaultRouteInterest="exitscan"
           defaultCtaSource="products_form"
         />

--- a/frontend/components/marketing/tarieven-content.tsx
+++ b/frontend/components/marketing/tarieven-content.tsx
@@ -65,7 +65,7 @@ function HeroSection() {
             </div>
             <div style={{ animation: 'slideUpFade .8s cubic-bezier(.16,1,.3,1) .3s both' }}>
               <p style={{ fontSize: 16.5, lineHeight: 1.72, color: T.inkSoft, maxWidth: '46ch', margin: '28px 0 0' }}>
-                U koopt een gerichte route met vaste output, geen licentie. ExitScan en RetentieScan vormen de twee kerninstappen.
+                U koopt een gerichte route met vaste output, geen licentie. ExitScan en RetentieScan vormen de twee kerninstappen; dashboard, rapport en Action Center landen daarna bounded in dezelfde suite-omgeving.
               </p>
             </div>
           </div>
@@ -99,7 +99,7 @@ function CorePricingSection() {
             De eerste koop blijft helder.
           </h2>
           <p style={{ fontSize: 15, lineHeight: 1.7, color: T.inkSoft, marginBottom: 44, maxWidth: '50ch' }}>
-            ExitScan en RetentieScan zijn de twee buyer-facing kernproducten. De prijsopbouw is bedoeld om de eerste route duidelijk te houden.
+            ExitScan en RetentieScan zijn de twee buyer-facing kernproducten. De prijsopbouw is bedoeld om de eerste route duidelijk te houden en pas daarna dashboard, rapport en Action Center als gedeelde suite-output te laten doorlopen.
           </p>
         </Reveal>
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
@@ -145,7 +145,7 @@ function FollowOnSection() {
             Kleinere routes rond de eerste kernroute.
           </h2>
           <p style={{ fontSize: 15, lineHeight: 1.7, color: T.inkSoft, marginBottom: 40, maxWidth: '52ch' }}>
-            Onboarding blijft een bounded peer. Pulse en Leadership Scan blijven bewust klein als vervolg. De prijslaag blijft zo logisch in verhouding tot de eerste managementvraag.
+            Onboarding blijft een bounded peer. Pulse en Leadership Scan blijven bewust klein als vervolg. De prijslaag blijft zo logisch in verhouding tot de eerste managementvraag, terwijl de suite-output daarna wel dezelfde leeslijn houdt.
           </p>
         </Reveal>
         <Reveal delay={.1}>
@@ -185,7 +185,7 @@ function CtaBand() {
                 Twijfelt u welke eerste route commercieel en inhoudelijk het best past?
               </h2>
               <p style={{ fontSize: 14, lineHeight: 1.7, color: T.inkSoft, maxWidth: '52ch' }}>
-                Gebruik het kennismakingsgesprek om eerst de kernroute, timing en privacygrenzen logisch te bepalen. Zo blijft de offerte kleiner, helderder en beter verdedigbaar.
+                Gebruik het kennismakingsgesprek om eerst de kernroute, timing en privacygrenzen logisch te bepalen. Zo blijft de offerte kleiner, helderder en beter verdedigbaar, terwijl dashboard, rapport en Action Center pas meebewegen zodra de eerste route scherp staat.
               </p>
             </div>
             <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
@@ -215,7 +215,7 @@ function ContactSection() {
         <MarketingInlineContactPanel
           eyebrow="Plan kennismaking"
           title="Vertel kort welke managementvraag nu speelt."
-          body="In circa 20 minuten krijgt u helderheid over productkeuze, aanpak, timing, privacy en prijs."
+          body="In circa 20 minuten krijgt u helderheid over productkeuze, aanpak, timing, privacy, prijs en hoe dashboard, rapport en Action Center daarna bounded samenkomen."
           defaultRouteInterest="exitscan"
           defaultCtaSource="pricing_form"
         />

--- a/frontend/components/marketing/vertrouwen-content.tsx
+++ b/frontend/components/marketing/vertrouwen-content.tsx
@@ -1,15 +1,13 @@
 'use client'
 
 import Link from 'next/link'
-import { T, AC, FF, SHELL, useInView, Reveal, Arrow, SectionMark } from '@/components/marketing/design-tokens'
+import { T, FF, SHELL, useInView, Reveal, Arrow, SectionMark } from '@/components/marketing/design-tokens'
 import { MarketingInlineContactPanel } from '@/components/marketing/marketing-inline-contact-panel'
-import { buildContactHref } from '@/lib/contact-funnel'
 import {
   trustItems,
   trustSignalHighlights,
   trustVerificationCards,
   trustHubAnswerCards,
-  trustReadingRows,
   trustSupportCards,
 } from '@/components/marketing/site-content'
 
@@ -28,12 +26,12 @@ function HeroSection() {
             <div style={{ animation: 'slideUpFade .9s cubic-bezier(.16,1,.3,1) .15s both' }}>
               <h1 style={{ fontFamily: FF, fontWeight: 400, fontSize: 'clamp(42px,5.5vw,76px)', lineHeight: .97, letterSpacing: '-.032em', color: T.ink }}>
                 Methodiek, privacy<br />
-                <em style={{ fontStyle: 'italic', color: T.teal }}>en rapportgrenzen.</em>
+                <em style={{ fontStyle: 'italic', color: T.teal }}>en suitegrenzen.</em>
               </h1>
             </div>
             <div style={{ animation: 'slideUpFade .8s cubic-bezier(.16,1,.3,1) .3s both' }}>
               <p style={{ fontSize: 16.5, lineHeight: 1.72, color: T.inkSoft, maxWidth: '46ch', margin: '28px 0 0' }}>
-                Verisight laat publiek zien hoe methodiek, privacy, rapportlezing en formele basis zijn ingericht — zodat u dit kunt toetsen voordat een traject start.
+                Verisight laat publiek zien hoe methodiek, privacy, dashboard, rapport en Action Center samenhangen — en waar die suite-output bewust begrensd blijft voordat een traject start.
               </p>
             </div>
           </div>
@@ -68,7 +66,7 @@ function TrustSignalsSection() {
             <em style={{ fontStyle: 'italic', color: T.teal }}>als het product werkelijk levert.</em>
           </h2>
           <p style={{ fontSize: 15, lineHeight: 1.7, color: T.inkSoft, marginBottom: 44, maxWidth: '50ch' }}>
-            Deze pagina maakt expliciet wat Verisight wel en niet claimt, hoe privacy is ingebouwd en hoe management de output moet lezen.
+            Deze pagina maakt expliciet wat Verisight wel en niet claimt, hoe privacy is ingebouwd en hoe management dashboard, rapport en Action Center in dezelfde bounded leeslijn moet lezen.
           </p>
         </Reveal>
         <div className="grid grid-cols-1 gap-0 md:grid-cols-2 xl:grid-cols-3">
@@ -122,7 +120,7 @@ function VerificationSection() {
                 <em style={{ fontStyle: 'italic', fontWeight: 300, color: 'oklch(.62 .10 185)' }}>zonder schijnzekerheid.</em>
               </h3>
               <p style={{ fontSize: 13, lineHeight: 1.7, color: 'rgba(247,245,241,.65)', marginBottom: 24 }}>
-                Verisight werkt met geaggregeerde uitkomsten en benoemt bewust wat wel en niet geconcludeerd kan worden.
+                Verisight werkt met geaggregeerde uitkomsten en benoemt bewust wat wel en niet geconcludeerd kan worden, ook wanneer follow-through via Action Center wordt toegevoegd.
               </p>
               <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
                 {trustItems.map((item, i) => (
@@ -160,7 +158,7 @@ function ReadingGuideSection() {
             <em style={{ fontStyle: 'italic', color: T.teal }}>niet als diagnose.</em>
           </h2>
           <p style={{ fontSize: 15, lineHeight: 1.7, color: T.inkSoft, marginBottom: 36, maxWidth: '50ch' }}>
-            De publieke reading guide moet dezelfde interpretatiegrenzen laten zien als rapport en dashboard.
+            De publieke reading guide moet dezelfde interpretatiegrenzen laten zien als dashboard, rapport en Action Center.
           </p>
         </Reveal>
         <Reveal delay={.1}>
@@ -240,7 +238,7 @@ function ContactSection() {
         <MarketingInlineContactPanel
           eyebrow="Plan kennismaking"
           title="Vertel kort welke managementvraag nu speelt."
-          body="In circa 20 minuten krijgt u helderheid over productkeuze, aanpak, timing, privacy en prijs."
+          body="In circa 20 minuten krijgt u helderheid over productkeuze, aanpak, timing, privacy, prijs en hoe dashboard, rapport en Action Center bounded samenhangen."
           defaultRouteInterest="exitscan"
           defaultCtaSource="trust_form"
         />

--- a/frontend/lib/commercial-suite-alignment.test.ts
+++ b/frontend/lib/commercial-suite-alignment.test.ts
@@ -1,0 +1,34 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('Commercial suite alignment', () => {
+  it('keeps the combination route framed as a suite path with dashboard, report and Action Center in one line', () => {
+    const productSource = fs.readFileSync(
+      path.join(process.cwd(), 'app', 'producten', '[slug]', 'page.tsx'),
+      'utf8',
+    )
+
+    expect(productSource).toContain('Dashboard, rapport en Action Center')
+    expect(productSource).toContain('dezelfde suite-omgeving')
+  })
+
+  it('connects pricing, trust and contact copy to the bounded suite promise', () => {
+    const pricingSource = fs.readFileSync(
+      path.join(process.cwd(), 'components', 'marketing', 'tarieven-content.tsx'),
+      'utf8',
+    )
+    const trustSource = fs.readFileSync(
+      path.join(process.cwd(), 'components', 'marketing', 'vertrouwen-content.tsx'),
+      'utf8',
+    )
+    const contactFormSource = fs.readFileSync(
+      path.join(process.cwd(), 'components', 'marketing', 'contact-form.tsx'),
+      'utf8',
+    )
+
+    expect(pricingSource).toContain('dashboard, rapport en Action Center')
+    expect(trustSource).toContain('dashboard, rapport en Action Center')
+    expect(contactFormSource).toContain('dashboard, rapport of Action Center')
+  })
+})


### PR DESCRIPTION
## Summary
- align combination, pricing, trust, products and intake copy with the suite truth
- make dashboard, report and Action Center explicit as one bounded suite line after product choice
- add a focused commercial suite alignment regression test

## Verification
- `npm run test -- lib/commercial-suite-alignment.test.ts lib/marketing-positioning.test.ts lib/seo-conversion.test.ts lib/contact-funnel.test.ts`
- `npm run build`