### PR TITLE
Sharpen the suite demo sales flow

### DIFF
--- a/frontend/app/aanpak/page.tsx
+++ b/frontend/app/aanpak/page.tsx
@@ -41,7 +41,7 @@ export default function AanpakPage() {
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }} />
       <div className="min-h-screen">
-        <PublicHeader ctaHref={ctaHref} ctaLabel="Plan een kennismaking" />
+      <PublicHeader ctaHref={ctaHref} ctaLabel="Plan suite-demo" />
         <main id="hoofdinhoud">
           <AanpakContent />
         </main>

--- a/frontend/app/producten/[slug]/page.tsx
+++ b/frontend/app/producten/[slug]/page.tsx
@@ -181,7 +181,7 @@ function ExitScanPage() {
 
   return (
     <div style={{ background: T.paper, color: T.ink, overflowX: 'hidden' }}>
-      <PublicHeader ctaHref={ctaHref} ctaLabel="Plan een kennismaking" />
+      <PublicHeader ctaHref={ctaHref} ctaLabel="Plan suite-demo" />
       <main>
         {/* Hero */}
         <section style={{ background: T.white, padding: 'clamp(52px,6.5vw,80px) 0 clamp(48px,6vw,72px)', borderBottom: `1px solid ${T.rule}`, position: 'relative', overflow: 'hidden' }}>
@@ -208,7 +208,7 @@ function ExitScanPage() {
                 </div>
                 <div style={{ animation: 'slideUpFade .7s cubic-bezier(.16,1,.3,1) .44s both', display: 'flex', gap: 12, flexWrap: 'wrap' }}>
                   <a href="#kennismaking" style={{ textDecoration: 'none', display: 'inline-flex', alignItems: 'center', gap: 7, fontSize: 14.5, fontWeight: 600, padding: '12px 28px', color: '#fff', background: T.ink }}>
-                    Plan een kennismaking
+                    Plan suite-demo
                   </a>
                   <Link href="/tarieven" style={{ textDecoration: 'none', display: 'inline-flex', alignItems: 'center', fontSize: 14, fontWeight: 500, padding: '11px 24px', color: T.inkSoft, border: `1px solid ${T.rule}` }}>
                     Bekijk tarieven
@@ -304,7 +304,7 @@ function ExitScanPage() {
               </div>
               <div style={{ display: 'flex', flexDirection: 'column', gap: 12, alignSelf: 'center', minWidth: 200 }}>
                 <a href="#kennismaking" style={{ textDecoration: 'none', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 7, fontSize: 14, fontWeight: 600, padding: '14px 28px', color: T.ink, background: '#fff', whiteSpace: 'nowrap' }}>
-                  Plan een kennismaking
+                  Plan suite-demo
                 </a>
                 <Link href="/tarieven" style={{ textDecoration: 'none', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', fontSize: 13, fontWeight: 500, padding: '12px 24px', color: 'rgba(255,255,255,.6)', border: '1px solid rgba(255,255,255,.2)', whiteSpace: 'nowrap' }}>
                   Bekijk tarieven
@@ -318,7 +318,7 @@ function ExitScanPage() {
         <section id="kennismaking" style={{ background: T.paperSoft, padding: 'clamp(52px,6vw,80px) 0' }}>
           <div style={{ ...SH, maxWidth: 1180 }}>
             <MarketingInlineContactPanel
-              eyebrow="Kennismaking"
+              eyebrow="Plan suite-demo"
               title="Plan een gesprek over ExitScan"
               body="Beschrijf kort welke vertrekvraag nu bestuurlijk aandacht vraagt. Dan toetsen we of ExitScan de juiste eerste stap is en hoe de aanpak eruitziet."
               defaultRouteInterest="exitscan"
@@ -348,7 +348,7 @@ function RetentionScanPage() {
 
   return (
     <div style={{ background: T.paper, color: T.ink, overflowX: 'hidden' }}>
-      <PublicHeader ctaHref={ctaHref} ctaLabel="Plan een kennismaking" />
+      <PublicHeader ctaHref={ctaHref} ctaLabel="Plan suite-demo" />
       <main>
         {/* Hero */}
         <section style={{ background: T.white, padding: 'clamp(52px,6.5vw,80px) 0 clamp(48px,6vw,72px)', borderBottom: `1px solid ${T.rule}`, position: 'relative', overflow: 'hidden' }}>
@@ -375,7 +375,7 @@ function RetentionScanPage() {
                 </div>
                 <div style={{ animation: 'slideUpFade .7s cubic-bezier(.16,1,.3,1) .44s both', display: 'flex', gap: 12, flexWrap: 'wrap' }}>
                   <a href="#kennismaking" style={{ textDecoration: 'none', display: 'inline-flex', alignItems: 'center', gap: 7, fontSize: 14.5, fontWeight: 600, padding: '12px 28px', color: '#fff', background: T.ink }}>
-                    Plan een kennismaking
+                    Plan suite-demo
                   </a>
                   <Link href="/tarieven" style={{ textDecoration: 'none', display: 'inline-flex', alignItems: 'center', fontSize: 14, fontWeight: 500, padding: '11px 24px', color: T.inkSoft, border: `1px solid ${T.rule}` }}>
                     Bekijk tarieven
@@ -465,7 +465,7 @@ function RetentionScanPage() {
               </div>
               <div style={{ display: 'flex', flexDirection: 'column', gap: 12, alignSelf: 'center', minWidth: 200 }}>
                 <a href="#kennismaking" style={{ textDecoration: 'none', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 7, fontSize: 14, fontWeight: 600, padding: '14px 28px', color: T.ink, background: '#fff', whiteSpace: 'nowrap' }}>
-                  Plan een kennismaking
+                  Plan suite-demo
                 </a>
                 <Link href="/tarieven" style={{ textDecoration: 'none', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', fontSize: 13, fontWeight: 500, padding: '12px 24px', color: 'rgba(255,255,255,.6)', border: '1px solid rgba(255,255,255,.2)', whiteSpace: 'nowrap' }}>
                   Bekijk tarieven
@@ -479,7 +479,7 @@ function RetentionScanPage() {
         <section id="kennismaking" style={{ background: T.paperSoft, padding: 'clamp(52px,6vw,80px) 0' }}>
           <div style={{ ...SH, maxWidth: 1180 }}>
             <MarketingInlineContactPanel
-              eyebrow="Kennismaking"
+              eyebrow="Plan suite-demo"
               title="Plan een gesprek over RetentieScan"
               body="Beschrijf kort waar behoud nu onder druk staat. Dan toetsen we of RetentieScan de juiste eerste stap is en hoe de aanpak eruitziet."
               defaultRouteInterest="retentiescan"
@@ -673,7 +673,7 @@ function PulsePage() {
 
       <MarketingSection tone="plain">
         <MarketingInlineContactPanel
-          eyebrow="Kennismaking"
+          eyebrow="Plan suite-demo"
           title="Toets of Pulse als vervolgroute nu echt logisch is."
           body="Beschrijf kort welke eerste baseline, managementread of actie al loopt en wat je nu vooral wilt herchecken. Dan bepalen we of Pulse past of dat een bredere vervolgroute logischer is."
           defaultRouteInterest="pulse"
@@ -687,7 +687,7 @@ function PulsePage() {
           title="Twijfel je tussen Pulse en een bredere vervolgronde?"
           body="We helpen je kiezen tussen een compacte Pulse-hercheck, RetentieScan ritmeroute of een andere vervolgroute. Zo blijft de volgende stap scherp in plaats van breder dan nodig."
           primaryHref={buildContactHref({ routeInterest: 'pulse', ctaSource: 'product_pulse_callout' })}
-          primaryLabel="Plan kennismaking"
+          primaryLabel="Plan suite-demo"
           secondaryHref="/tarieven"
           secondaryLabel="Bekijk tarieven"
         />
@@ -719,7 +719,7 @@ function TeamScanPage() {
                 href={buildContactHref({ routeInterest: 'teamscan', ctaSource: 'product_team_hero' })}
                 className="inline-flex items-center justify-center rounded-full bg-[#3C8D8A] px-6 py-3 text-sm font-semibold text-white shadow-[0_16px_40px_rgba(60,141,138,0.18)] transition-all hover:-translate-y-0.5 hover:bg-[#2d6e6b]"
               >
-                Plan kennismaking
+                Plan suite-demo
               </a>
               <Link
                 href="/producten"
@@ -877,7 +877,7 @@ function TeamScanPage() {
 
       <MarketingSection tone="plain">
         <MarketingInlineContactPanel
-          eyebrow="Kennismaking"
+          eyebrow="Plan suite-demo"
           title="Toets of TeamScan als lokale vervolgronde nu echt logisch is."
           body="Beschrijf kort welk bredere signaal al zichtbaar is en waar de lokale onzekerheid nu zit. Dan bepalen we of TeamScan past of dat een bredere route of add-on logischer blijft."
           defaultRouteInterest="teamscan"
@@ -891,7 +891,7 @@ function TeamScanPage() {
           title="Twijfel je tussen TeamScan en een andere vervolgronde?"
           body="We helpen je kiezen tussen TeamScan, Segment Deep Dive of terug naar een bredere kernroute. Zo blijft de vervolgstap lokaal scherp in plaats van diffuser dan nodig."
           primaryHref={buildContactHref({ routeInterest: 'teamscan', ctaSource: 'product_team_callout' })}
-          primaryLabel="Plan kennismaking"
+          primaryLabel="Plan suite-demo"
           secondaryHref="/tarieven"
           secondaryLabel="Bekijk tarieven"
         />
@@ -927,7 +927,7 @@ function OnboardingPage() {
                 href={buildContactHref({ routeInterest: 'onboarding', ctaSource: 'product_onboarding_hero' })}
                 className="inline-flex items-center justify-center rounded-full bg-amber-600 px-6 py-3 text-sm font-semibold text-white shadow-[0_16px_40px_rgba(217,119,6,0.18)] transition-all hover:-translate-y-0.5 hover:bg-amber-700"
               >
-                Plan kennismaking
+                Plan suite-demo
               </a>
               <Link
                 href="/producten"
@@ -1086,7 +1086,7 @@ function OnboardingPage() {
 
       <MarketingSection tone="plain">
         <MarketingInlineContactPanel
-          eyebrow="Kennismaking"
+          eyebrow="Plan suite-demo"
           title="Toets of onboarding als lifecycle-vervolgronde nu echt logisch is."
           body="Beschrijf kort welke vraag nu speelt rond nieuwe medewerkers en of het gaat om een vroeg checkpoint, een bredere retentievraag of juist client onboarding. Dan bepalen we welke route past."
           defaultRouteInterest="onboarding"
@@ -1100,7 +1100,7 @@ function OnboardingPage() {
           title="Twijfel je tussen onboarding, RetentieScan of client onboarding?"
           body="We helpen je kiezen tussen een vroege onboardingcheck, een bredere retentie- of teamroute of terug naar implementatiebegeleiding. Zo blijft de vervolgstap kleiner en eerlijker dan nodig."
           primaryHref={buildContactHref({ routeInterest: 'onboarding', ctaSource: 'product_onboarding_callout' })}
-          primaryLabel="Plan kennismaking"
+          primaryLabel="Plan suite-demo"
           secondaryHref="/tarieven"
           secondaryLabel="Bekijk tarieven"
         />
@@ -1195,7 +1195,7 @@ function LeadershipScanPage() {
 
       <MarketingSection tone="plain">
         <MarketingInlineContactPanel
-          eyebrow="Kennismaking"
+          eyebrow="Plan suite-demo"
           title="Toets of Leadership Scan nu de logische vervolgronde is."
           body="Beschrijf kort welk bestaand signaal nu speelt en waarom de vraag verschuift naar managementcontext. Dan bepalen we of Leadership Scan echt de juiste bounded follow-on route is."
           defaultRouteInterest="leadership"
@@ -1229,7 +1229,7 @@ function CombinatiePage() {
                 href={buildContactHref({ routeInterest: 'combinatie', ctaSource: 'product_combination_hero' })}
                 className="inline-flex items-center justify-center rounded-full bg-[#3C8D8A] px-6 py-3 text-sm font-semibold text-white shadow-[0_16px_40px_rgba(60,141,138,0.18)] transition-all hover:-translate-y-0.5 hover:bg-[#2d6e6b]"
               >
-                Plan kennismaking
+                Plan suite-demo
               </a>
               <Link
                 href="/producten"
@@ -1375,7 +1375,7 @@ function CombinatiePage() {
 
       <MarketingSection tone="plain">
         <MarketingInlineContactPanel
-          eyebrow="Kennismaking"
+          eyebrow="Plan suite-demo"
           title="Plan een gesprek over de combinatieroute"
           body="Beschrijf kort of jullie vooral met een product willen starten of dat beide managementvragen nu al tegelijk spelen. Dan bepalen we welke route logisch is en wanneer dashboard, rapport en Action Center daarna in dezelfde suite-omgeving mogen samenkomen."
           defaultRouteInterest="combinatie"
@@ -1389,7 +1389,7 @@ function CombinatiePage() {
           title="Wil je bepalen of de combinatie logisch is?"
           body="In een kort gesprek kijken we of jullie vooral met een product moeten starten of dat beide managementvragen pas na de eerste route genoeg onderbouwd zijn voor een portfolio-aanpak in dezelfde suite-omgeving."
           primaryHref={buildContactHref({ routeInterest: 'combinatie', ctaSource: 'product_combination_callout' })}
-          primaryLabel="Plan kennismaking"
+          primaryLabel="Plan suite-demo"
           secondaryHref="/producten"
           secondaryLabel="Bekijk producten"
         />

--- a/frontend/app/producten/page.tsx
+++ b/frontend/app/producten/page.tsx
@@ -43,7 +43,7 @@ export default function ProductenPage() {
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }} />
       <div className="min-h-screen">
-        <PublicHeader ctaHref={ctaHref} ctaLabel="Plan een kennismaking" />
+      <PublicHeader ctaHref={ctaHref} ctaLabel="Plan suite-demo" />
         <main id="hoofdinhoud">
           <ProductenContent />
         </main>

--- a/frontend/app/tarieven/page.tsx
+++ b/frontend/app/tarieven/page.tsx
@@ -41,7 +41,7 @@ export default function TarievenPage() {
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }} />
       <div className="min-h-screen">
-        <PublicHeader ctaHref={ctaHref} ctaLabel="Plan een kennismaking" />
+      <PublicHeader ctaHref={ctaHref} ctaLabel="Plan suite-demo" />
         <main id="hoofdinhoud">
           <TarievenContent />
         </main>

--- a/frontend/app/vertrouwen/page.tsx
+++ b/frontend/app/vertrouwen/page.tsx
@@ -41,7 +41,7 @@ export default function VertrouwenPage() {
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }} />
       <div className="min-h-screen">
-        <PublicHeader ctaHref={ctaHref} ctaLabel="Plan een kennismaking" />
+      <PublicHeader ctaHref={ctaHref} ctaLabel="Plan suite-demo" />
         <main id="hoofdinhoud">
           <VertrouwenContent />
         </main>

--- a/frontend/components/marketing/aanpak-content.tsx
+++ b/frontend/components/marketing/aanpak-content.tsx
@@ -34,7 +34,7 @@ function HeroSection() {
               <Link href={ctaHref} style={{ textDecoration: 'none', display: 'inline-flex', alignItems: 'center', gap: 7, fontSize: 14.5, fontWeight: 600, padding: '12px 28px', color: '#fff', background: T.ink, transition: 'all .18s cubic-bezier(.4,0,0,1)' }}
                 onMouseEnter={e => { (e.currentTarget as HTMLElement).style.transform = 'translateY(-2px)'; (e.currentTarget as HTMLElement).style.background = AC.deep }}
                 onMouseLeave={e => { (e.currentTarget as HTMLElement).style.transform = 'none'; (e.currentTarget as HTMLElement).style.background = T.ink }}>
-                Plan een kennismaking <Arrow />
+              Plan suite-demo <Arrow />
               </Link>
               <Link href="/tarieven" style={{ textDecoration: 'none', display: 'inline-flex', alignItems: 'center', gap: 7, fontSize: 14.5, fontWeight: 500, padding: '11px 27px', color: T.inkSoft, border: `1px solid ${T.rule}`, transition: 'all .18s' }}
                 onMouseEnter={e => { (e.currentTarget as HTMLElement).style.borderColor = T.inkMuted; (e.currentTarget as HTMLElement).style.color = T.ink }}
@@ -215,9 +215,9 @@ function ContactSection() {
     <section id="kennismaking" style={{ background: T.paperSoft, padding: 'clamp(52px,6vw,80px) 0' }}>
       <div style={{ ...SHELL, maxWidth: 1180 }}>
         <MarketingInlineContactPanel
-          eyebrow="Plan kennismaking"
+          eyebrow="Plan suite-demo"
           title="Vertel kort welke managementvraag nu speelt."
-          body="In circa 20 minuten krijgt u helderheid over productkeuze, aanpak, timing, privacy en prijs."
+          body="In circa 20 minuten krijgt u helderheid over productkeuze, aanpak, timing, privacy, prijs en hoe de suite-demo naar een bounded eerste route leidt."
           defaultRouteInterest="exitscan"
           defaultCtaSource="approach_form"
         />

--- a/frontend/components/marketing/contact-form.tsx
+++ b/frontend/components/marketing/contact-form.tsx
@@ -209,8 +209,8 @@ export function ContactForm({
         }`}
       >
         {isCompact
-          ? 'Gebruik dit formulier om snel te bepalen welke eerste route nu het best past en welke output of intake daarbij logisch wordt.'
-          : 'Gebruik dit formulier in de eerste plaats om te bepalen of ExitScan, RetentieScan of de combinatieroute nu de logische eerste stap is. Onboarding 30-60-90 behandelen we als bounded peer wanneer de vraag direct over nieuwe medewerkers gaat. Pulse en Leadership Scan blijven bounded vervolgroutes die pas logisch worden nadat een eerste signaal, baseline of managementread al staat. We gebruiken de intake ook om te bepalen wanneer dashboard, rapport of Action Center daarna logisch in dezelfde suite-omgeving landen. De informatie uit dit formulier gebruiken we alleen om jullie vraag te duiden en gericht op te volgen.'}
+          ? 'Gebruik dit formulier om snel te bepalen welke eerste route nu het best past en welke suite-output daarna logisch wordt.'
+          : 'Gebruik dit formulier in de eerste plaats om te bepalen of ExitScan, RetentieScan of de combinatieroute nu de logische eerste stap is. Onboarding 30-60-90 behandelen we als bounded peer wanneer de vraag direct over nieuwe medewerkers gaat. Pulse en Leadership Scan blijven bounded vervolgroutes die pas logisch worden nadat een eerste signaal, baseline of managementread al staat. We gebruiken de intake ook om te bepalen wanneer dashboard, rapport of Action Center daarna logisch in dezelfde suite-omgeving landen en hoe een bounded suite-demo eruit moet zien. De informatie uit dit formulier gebruiken we alleen om jullie vraag te duiden en gericht op te volgen.'}
       </div>
 
       {!isCompact ? (
@@ -367,7 +367,7 @@ export function ContactForm({
 
       {successState ? (
         <div className={`mt-5 rounded-[1.5rem] border px-5 py-5 text-sm ${successClass}`}>
-          <p className="font-semibold">Aanvraag ontvangen.</p>
+          <p className="font-semibold">Suite-demo aangevraagd.</p>
           <div className="mt-2 space-y-2 leading-7">
             <p>
               We reageren meestal binnen 1 werkdag met een eerste route-inschatting voor{' '}
@@ -375,9 +375,9 @@ export function ContactForm({
               <span className="font-semibold">{successState.firstStepLabel}</span> nu logisch is.
             </p>
             <p>
-              In het gesprek toetsen we jullie managementvraag, gewenste timing (
+              In de suite-demo toetsen we jullie managementvraag, gewenste timing (
               <span className="font-semibold">{successState.desiredTimingLabel}</span>) en welke intake of
-              databasis nodig is om vlot naar uitvoering en eerste waarde te gaan.
+              databasis nodig is om vlot naar dashboard, rapport, Action Center en eerste waarde te gaan.
             </p>
             <p>Een vervolgroute of combinatieroute wordt pas concreet zodra de eerste route en eerste managementwaarde helder zijn.</p>
             <p>In deze stap krijg je nog geen live inrichting of definitieve offerte zonder intake.</p>
@@ -400,7 +400,7 @@ export function ContactForm({
           disabled={loading}
           className={`inline-flex w-full items-center justify-center rounded-2xl px-6 py-3 text-sm font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-60 sm:ml-auto sm:min-w-[14rem] sm:w-auto ${buttonClass}`}
         >
-          {loading ? 'Verstuur bericht...' : isCompact ? 'Plan kennismaking' : 'Verstuur bericht'}
+          {loading ? 'Suite-demo wordt verstuurd...' : isCompact ? 'Plan suite-demo' : 'Vraag suite-demo aan'}
         </button>
       </div>
 

--- a/frontend/components/marketing/home-page-content.tsx
+++ b/frontend/components/marketing/home-page-content.tsx
@@ -380,7 +380,7 @@ function HeroSection() {
                     background: T.ink,
                   }}
                 >
-                  Plan een kennismaking <Arrow />
+            Plan suite-demo <Arrow />
                 </Link>
                 <Link
                   href="/#suite"
@@ -681,20 +681,20 @@ function CTASection() {
         </Reveal>
         <Reveal delay={0.06}>
           <h2 style={{ fontFamily: FF, fontSize: 'clamp(36px,5.5vw,64px)', fontWeight: 400, letterSpacing: '-.03em', color: '#fff', lineHeight: 1, marginBottom: 22 }}>
-            Plan een eerste gesprek
+            Plan een suite-demo
             <br />
             <em style={{ fontStyle: 'italic', fontWeight: 300, color: AC.light }}>en maak de juiste route scherp.</em>
           </h2>
         </Reveal>
         <Reveal delay={0.12}>
           <p style={{ fontSize: 16, lineHeight: 1.72, color: 'rgba(255,255,255,.6)', maxWidth: '42ch', margin: '0 auto 38px' }}>
-            In een eerste gesprek toetsen we niet alleen welke scan past, maar ook waar prioritering, actie en follow-through nu het meeste verschil maken.
+            In een suite-demo toetsen we niet alleen welke scan past, maar ook hoe prioritering, actie en follow-through daarna bounded samenkomen.
           </p>
         </Reveal>
         <Reveal delay={0.18}>
           <div style={{ display: 'flex', gap: 14, justifyContent: 'center', flexWrap: 'wrap' }}>
             <Link href={ctaHref} style={{ fontSize: 15, fontWeight: 700, color: T.ink, textDecoration: 'none', padding: '15px 36px', borderRadius: 999, background: AC.mid, display: 'inline-flex', alignItems: 'center', gap: 9 }}>
-              Plan een kennismaking <Arrow />
+              Plan suite-demo <Arrow />
             </Link>
             <Link href="/#suite" style={{ fontSize: 15, fontWeight: 500, borderRadius: 999, color: 'rgba(255,255,255,.78)', textDecoration: 'none', padding: '15px 30px', border: '1.5px solid rgba(255,255,255,.24)', display: 'inline-flex', alignItems: 'center', gap: 9 }}>
               Bekijk de suite
@@ -711,7 +711,7 @@ function ContactSection() {
     <section style={{ background: T.paperSoft, padding: 'clamp(52px,6vw,80px) 0', borderTop: `1px solid ${T.rule}` }}>
       <div style={{ ...SHELL, maxWidth: 1180 }}>
         <MarketingInlineContactPanel
-          eyebrow="Plan kennismaking"
+          eyebrow="Plan suite-demo"
           title="Vertel kort welke managementvraag nu speelt."
           body="In circa 20 minuten krijgt u helderheid over productkeuze, aanpak, timing, privacy, prijs en welke opvolging daarna logisch wordt."
           defaultRouteInterest="exitscan"

--- a/frontend/components/marketing/marketing-inline-contact-panel.tsx
+++ b/frontend/components/marketing/marketing-inline-contact-panel.tsx
@@ -19,7 +19,7 @@ export function MarketingInlineContactPanel({
   defaultRouteInterest,
   defaultCtaSource,
   id = 'kennismaking',
-  badge = 'Vrijblijvend gesprek',
+  badge = 'Vrijblijvende suite-demo',
 }: MarketingInlineContactPanelProps) {
   return (
     <div
@@ -47,7 +47,7 @@ export function MarketingInlineContactPanel({
           <Suspense
             fallback={
               <div className="rounded-[1.6rem] border border-[var(--border)] bg-[var(--surface)] p-6 text-sm leading-7 text-[var(--text)]">
-                Het kennismakingsformulier wordt geladen.
+                Het suite-demoformulier wordt geladen.
               </div>
             }
           >

--- a/frontend/components/marketing/producten-content.tsx
+++ b/frontend/components/marketing/producten-content.tsx
@@ -95,7 +95,7 @@ function HeroSection() {
             <Link href={ctaHref} style={{ textDecoration: 'none', display: 'inline-flex', alignItems: 'center', gap: 7, fontSize: 14.5, fontWeight: 600, padding: '12px 28px', color: '#fff', background: T.ink, transition: 'all .18s cubic-bezier(.4,0,0,1)' }}
               onMouseEnter={e => { (e.currentTarget as HTMLElement).style.transform = 'translateY(-2px)'; (e.currentTarget as HTMLElement).style.background = AC.deep }}
               onMouseLeave={e => { (e.currentTarget as HTMLElement).style.transform = 'none'; (e.currentTarget as HTMLElement).style.background = T.ink }}>
-              Plan een kennismaking <Arrow />
+              Plan suite-demo <Arrow />
             </Link>
             <Link href="/tarieven" style={{ textDecoration: 'none', display: 'inline-flex', alignItems: 'center', gap: 7, fontSize: 14.5, fontWeight: 500, padding: '11px 27px', color: T.inkSoft, border: `1px solid ${T.rule}`, transition: 'all .18s' }}
               onMouseEnter={e => { (e.currentTarget as HTMLElement).style.borderColor = T.inkMuted }}
@@ -220,7 +220,7 @@ function ContactSection() {
     <section id="kennismaking" style={{ background: T.paperSoft, padding: 'clamp(52px,6vw,80px) 0' }}>
       <div style={{ ...SHELL, maxWidth: 1180 }}>
         <MarketingInlineContactPanel
-          eyebrow="Plan kennismaking"
+          eyebrow="Plan suite-demo"
           title="Twijfelt u tussen ExitScan, RetentieScan, onboarding of een vervolgronde?"
           body="In een eerste gesprek bepalen we welke route nu echt logisch is, hoe dashboard, rapport en Action Center daarna in dezelfde suite-omgeving landen en welke vervolgstap bewust kleiner moet blijven."
           defaultRouteInterest="exitscan"

--- a/frontend/components/marketing/site-content.ts
+++ b/frontend/components/marketing/site-content.ts
@@ -11,12 +11,12 @@ export const marketingNavLinks = [
 
 export const marketingPrimaryCta = {
   href: buildContactHref({ routeInterest: 'exitscan', ctaSource: 'global_primary_cta' }),
-  label: 'Plan kennismaking',
+  label: 'Plan suite-demo',
 } as const
 
 export const marketingSecondaryCta = {
-  href: '/producten',
-  label: 'Bekijk de routes',
+  href: '/#suite',
+  label: 'Bekijk de suite',
 } as const
 
 export const marketingFooterLinks = [

--- a/frontend/components/marketing/tarieven-content.tsx
+++ b/frontend/components/marketing/tarieven-content.tsx
@@ -192,7 +192,7 @@ function CtaBand() {
               <Link href={ctaHref} style={{ textDecoration: 'none', display: 'inline-flex', alignItems: 'center', gap: 7, fontSize: 14, fontWeight: 600, padding: '12px 26px', color: '#fff', background: T.ink, transition: 'all .18s' }}
                 onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = AC.deep }}
                 onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = T.ink }}>
-                Plan een kennismaking <Arrow />
+                Plan suite-demo <Arrow />
               </Link>
               <Link href="/aanpak" style={{ textDecoration: 'none', display: 'inline-flex', alignItems: 'center', gap: 7, fontSize: 14, fontWeight: 500, padding: '11px 24px', color: T.inkSoft, border: `1px solid ${T.rule}`, transition: 'all .18s' }}
                 onMouseEnter={e => { (e.currentTarget as HTMLElement).style.borderColor = T.inkMuted }}
@@ -213,7 +213,7 @@ function ContactSection() {
     <section id="kennismaking" style={{ background: T.paperSoft, padding: 'clamp(52px,6vw,80px) 0' }}>
       <div style={{ ...SHELL, maxWidth: 1180 }}>
         <MarketingInlineContactPanel
-          eyebrow="Plan kennismaking"
+          eyebrow="Plan suite-demo"
           title="Vertel kort welke managementvraag nu speelt."
           body="In circa 20 minuten krijgt u helderheid over productkeuze, aanpak, timing, privacy, prijs en hoe dashboard, rapport en Action Center daarna bounded samenkomen."
           defaultRouteInterest="exitscan"

--- a/frontend/components/marketing/vertrouwen-content.tsx
+++ b/frontend/components/marketing/vertrouwen-content.tsx
@@ -236,7 +236,7 @@ function ContactSection() {
     <section id="kennismaking" style={{ background: T.paperSoft, padding: 'clamp(52px,6vw,80px) 0' }}>
       <div style={{ ...SHELL, maxWidth: 1180 }}>
         <MarketingInlineContactPanel
-          eyebrow="Plan kennismaking"
+          eyebrow="Plan suite-demo"
           title="Vertel kort welke managementvraag nu speelt."
           body="In circa 20 minuten krijgt u helderheid over productkeuze, aanpak, timing, privacy, prijs en hoe dashboard, rapport en Action Center bounded samenhangen."
           defaultRouteInterest="exitscan"

--- a/frontend/lib/marketing-flow.test.ts
+++ b/frontend/lib/marketing-flow.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
 import { REPORT_PREVIEW_COPY } from '@/lib/report-preview-copy'
 import {
   buildContactHref,
@@ -22,17 +24,29 @@ describe('marketing flow defaults', () => {
   it('keeps the primary and secondary CTA labels aligned with the redesign', () => {
     expect(marketingPrimaryCta).toEqual({
       href: buildContactHref({ routeInterest: 'exitscan', ctaSource: 'global_primary_cta' }),
-      label: 'Plan kennismaking',
+      label: 'Plan suite-demo',
     })
     expect(marketingSecondaryCta).toEqual({
-      href: '/producten',
-      label: 'Bekijk de routes',
+      href: '/#suite',
+      label: 'Bekijk de suite',
     })
+  })
+
+  it('keeps the contact flow framed as a suite demo instead of a generic message send', () => {
+    const contactFormSource = fs.readFileSync(path.join(process.cwd(), 'components', 'marketing', 'contact-form.tsx'), 'utf8')
+    const solutionSource = fs.readFileSync(path.join(process.cwd(), 'lib', 'seo-solution-pages.ts'), 'utf8')
+
+    expect(contactFormSource).toContain('Vraag suite-demo aan')
+    expect(contactFormSource).toContain('Plan suite-demo')
+    expect(contactFormSource).toContain('Suite-demo aangevraagd.')
+    expect(solutionSource).toContain('Plan een suite-demo over verloopanalyse')
+    expect(solutionSource).toContain('Plan een suite-demo over medewerkersbehoud analyseren')
   })
 
   it('keeps the top navigation focused on products, process, pricing and trust', () => {
     expect(marketingNavLinks).toEqual([
       { href: '/', label: 'Home' },
+      { href: '/#suite', label: 'Suite' },
       { href: '/producten', label: 'Producten' },
       { href: '/aanpak', label: 'Aanpak' },
       { href: '/tarieven', label: 'Tarieven' },

--- a/frontend/lib/seo-solution-pages.ts
+++ b/frontend/lib/seo-solution-pages.ts
@@ -88,7 +88,7 @@ export const SEO_SOLUTION_PAGES: readonly SeoSolutionPage[] = [
     proofTitle: 'Laat eerst de deliverable zien, daarna pas de uitleg.',
     proofBody:
       'De voorbeeldoutput op de ExitScan-productpagina laat zien hoe bestuurlijke read, topfactoren en bestuurlijke handoff werkelijk samenkomen.',
-    contactTitle: 'Plan een kennismaking over verloopanalyse',
+    contactTitle: 'Plan een suite-demo over verloopanalyse',
     contactBody:
       'Beschrijf kort waar jullie verloopvraag nu vastloopt. Dan toetsen we of ExitScan Baseline de juiste eerste stap is en welke databasis nodig is om snel naar een geloofwaardige eerste managementread te komen.',
   },
@@ -145,7 +145,7 @@ export const SEO_SOLUTION_PAGES: readonly SeoSolutionPage[] = [
     proofTitle: 'Voorbeeldrapporten maken de stap van gesprek naar managementbeeld tastbaar.',
     proofBody:
       'De ExitScan showcase laat zien hoe vertrekredenen, signalen van werkfrictie en eerste managementvragen in één executive leeslijn landen.',
-    contactTitle: 'Plan een kennismaking over exitgesprekken analyseren',
+    contactTitle: 'Plan een suite-demo over exitgesprekken analyseren',
     contactBody:
       'Beschrijf kort hoe exitgesprekken nu worden verzameld en waar interpretatie of besluitvorming vastloopt. Dan toetsen we of ExitScan Baseline de juiste eerste structuur biedt.',
   },
@@ -202,7 +202,7 @@ export const SEO_SOLUTION_PAGES: readonly SeoSolutionPage[] = [
     proofTitle: 'Laat eerst de groepsgerichte output zien.',
     proofBody:
       'De RetentieScan showcase laat zien hoe retentiesignaal, topfactoren en bestuurlijke handoff samenkomen zonder brede MTO- of predictorclaim.',
-    contactTitle: 'Plan een kennismaking over medewerkersbehoud analyseren',
+    contactTitle: 'Plan een suite-demo over medewerkersbehoud analyseren',
     contactBody:
       'Beschrijf kort waar de actieve behoudsvraag nu zit. Dan toetsen we of RetentieScan Baseline de juiste eerste stap is en hoe een geloofwaardige eerste meetroute eruitziet.',
   },


### PR DESCRIPTION
## Summary
- reframe the public CTA stack around a suite demo instead of a generic kennismaking
- align header, homepage, product pages, contact flow and SEO solution entries with the same sales path
- add a regression test for CTA and contact flow copy

## Verification
- `npm run test -- lib/marketing-flow.test.ts lib/contact-funnel.test.ts lib/marketing-positioning.test.ts lib/seo-conversion.test.ts`
- `npm run build`