### PR TITLE
Strengthen public proof for bounded manager follow-through

### DIFF
--- a/frontend/components/marketing/home-page-content.tsx
+++ b/frontend/components/marketing/home-page-content.tsx
@@ -402,7 +402,7 @@ function HeroSection() {
             </Reveal>
             <Reveal delay={0.34}>
               <div style={{ paddingTop: 24, borderTop: `1px solid ${T.rule}`, display: 'flex', alignItems: 'center', gap: 24, flexWrap: 'wrap' }}>
-                {['Dashboard + rapport', 'Action Center follow-through', 'AVG-conform op groepsniveau'].map((label) => (
+                {['Eén suite-login', 'Action Center follow-through', 'AVG-conform op groepsniveau'].map((label) => (
                   <span key={label} style={{ fontSize: 11.5, color: T.inkFaint, display: 'flex', alignItems: 'center', gap: 5 }}>
                     <span style={{ width: 3, height: 3, borderRadius: '50%', background: T.tealMid, display: 'inline-block', flexShrink: 0 }} />
                     {label}
@@ -474,7 +474,7 @@ function SuiteSection() {
     {
       label: 'Action Center',
       title: 'Organiseer de opvolging.',
-      body: 'Maak acties expliciet, wijs eigenaren toe en bewaak reviewmomenten zonder dat follow-through verdwijnt in losse notities.',
+      body: 'HR kan acties expliciet toewijzen, managers per afdeling laten opvolgen en reviewmomenten bewaken zonder dat managers survey-inzicht hoeven te krijgen.',
     },
   ]
 
@@ -547,7 +547,7 @@ function RoutesSection() {
   const boundedRoutes = [
     { label: 'Bounded peer', title: 'Onboarding 30-60-90', body: 'Vroege lifecycle-check naast de kernroutes, niet als brede suite op zichzelf.', href: '/producten/onboarding-30-60-90' },
     { label: 'Portfolioroute', title: 'Combinatie', body: 'Voeg pas een tweede route toe wanneer beide managementvragen echt actief zijn.', href: '/producten/combinatie' },
-    { label: 'Vervolgroute', title: 'Pulse + Leadership', body: 'Compacte review en extra managementduiding na de eerste scan of eerste actie.', href: '/producten' },
+    { label: 'Vervolgroute', title: 'Pulse + Leadership', body: 'Compacte review en extra managementduiding na de eerste scan of eerste actie, terwijl managers alleen de opvolglaag zien.', href: '/producten' },
   ]
 
   return (
@@ -619,6 +619,7 @@ function TrustSection() {
     'Groepsniveau en expliciete n-grenzen',
     'Geen individuele voorspellingen of performanceframing',
     'Dashboard, rapport en Action Center vertellen dezelfde bounded waarheid',
+    'Managers kunnen na HR-toewijzing alleen de opvolglaag zien',
     'AVG-conform en begeleid in plaats van losse surveysoftware',
   ]
 

--- a/frontend/components/marketing/site-content.ts
+++ b/frontend/components/marketing/site-content.ts
@@ -95,8 +95,9 @@ export const homepageComparisonRows = [
 ] as const
 
 export const homepageProofSignals = [
+  'Eén suite-login voor dashboard, rapport en Action Center',
+  'HR kan managers per afdeling toewijzen zonder survey-inzichten open te zetten',
   'ExitScan als default route, RetentieScan als volwaardige eerste route bij expliciete behoudsvraag',
-  'Dashboard, rapport en bestuurlijke handoff in dezelfde leeslijn',
   'Groepsinzichten met expliciete claims- en privacygrenzen',
 ] as const
 
@@ -206,6 +207,10 @@ export const trustSignalHighlights = [
     body: 'Dashboard, rapport en preview volgen dezelfde bestuurlijke leeslijn, zodat de site niet rijker verkoopt dan het product werkelijk levert.',
   },
   {
+    title: 'Manager-scope blijft bounded',
+    body: 'HR kan managers per afdeling toewijzen. Zij loggen in via dezelfde suite, maar zien alleen Action Center en geen dashboard- of rapportinzichten.',
+  },
+  {
     title: 'Core proof blijft expliciet',
     body: 'Publieke deliverable-proof blijft bewust anchored op ExitScan en RetentieScan. Bounded follow-on routes zijn wel formeel, maar krijgen publiek vooral bewijs via productpagina en trustlaag.',
   },
@@ -233,6 +238,10 @@ export const trustVerificationCards = [
     body: 'Geaggregeerde bestuurlijke read, bestuurlijke handoff, topfactoren, hypotheses, prioriteiten en vervolgrichtingen in een vaste executive leeslijn.',
   },
   {
+    title: 'Hoe manager-toegang werkt',
+    body: 'HR kan managers per afdeling toewijzen. Zij loggen in via dezelfde suite, maar zien alleen Action Center en geen dashboard- of rapportinzichten.',
+  },
+  {
     title: 'Wat we bewust niet claimen',
     body: 'Geen individuele voorspelling, geen persoonsgerichte beoordeling, geen brede people-suite en geen bewijsclaims die niet door de repo-basis worden gedragen.',
   },
@@ -254,6 +263,10 @@ export const trustHubAnswerCards = [
   {
     title: 'Hoe lees je de output?',
     body: 'Verisight gebruikt signalen, hypotheses en bestuurlijke reads als gespreksinput. De output ondersteunt verificatie en prioritering, niet causaliteitsclaims of harde diagnoses.',
+  },
+  {
+    title: 'Hoe werkt manager-toegang?',
+    body: 'HR kan managers per afdeling toewijzen. Zij loggen in via dezelfde suite, maar zien alleen Action Center en geen dashboard- of rapportinzichten.',
   },
   {
     title: 'Welke juridische basis is publiek beschikbaar?',
@@ -323,19 +336,19 @@ export const contactTrustSignals = [
 
 export const statCards = [
   {
-    value: '2 kernproducten',
-    label: 'heldere kernportfolio',
-    detail: 'ExitScan en RetentieScan als twee kernroutes binnen een duidelijke first-buy logica.',
+    value: '1 suite-login',
+    label: 'voor inzicht + opvolging',
+    detail: 'Dashboard, rapport en Action Center blijven bereikbaar in dezelfde omgeving.',
   },
   {
-    value: '1 leeslijn',
-    label: 'van demo tot rapport',
-    detail: 'Preview, dashboard, managementrapport en bestuurlijke handoff vertellen hetzelfde verhaal.',
+    value: '2 modules',
+    label: 'insights en follow-through',
+    detail: 'HR en klant zien dashboard plus Action Center; managers kunnen bounded alleen de opvolglaag in.',
   },
   {
-    value: '1 portfolioroute',
-    label: 'bewust aanvullend',
-    detail: 'Combinatie blijft zichtbaar als route tussen twee producten en niet als derde kernpropositie.',
+    value: 'Afdelingstoewijzing',
+    label: 'bounded manager-scope',
+    detail: 'HR kan managers aan afdelingen koppelen terwijl survey-inzicht en rapportlezing afgeschermd blijven.',
   },
 ] as const
 
@@ -350,7 +363,7 @@ export const outcomeCards = [
   ],
   [
     'Proof die kooprust geeft',
-    'Voorbeeldrapporten, pricing en trust werken samen als bewijs van de productvorm in plaats van als losse supportblokken.',
+    'Voorbeeldrapporten, pricing, trust en bounded manager-toegang werken samen als bewijs van de productvorm in plaats van als losse supportblokken.',
   ],
   [
     'Geen extra toolbeheer',

--- a/frontend/lib/marketing-proof-layer.test.ts
+++ b/frontend/lib/marketing-proof-layer.test.ts
@@ -1,0 +1,34 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  homepageProofSignals,
+  statCards,
+  trustHubAnswerCards,
+  trustSignalHighlights,
+} from '@/components/marketing/site-content'
+
+describe('Marketing proof layer', () => {
+  it('anchors public proof on the live suite and bounded manager access model', () => {
+    expect(homepageProofSignals).toContain('Eén suite-login voor dashboard, rapport en Action Center')
+    expect(homepageProofSignals).toContain('HR kan managers per afdeling toewijzen zonder survey-inzichten open te zetten')
+    expect(statCards.some((card) => card.value === '1 suite-login')).toBe(true)
+    expect(statCards.some((card) => card.value === '2 modules')).toBe(true)
+    expect(statCards.some((card) => card.value === 'Afdelingstoewijzing')).toBe(true)
+    expect(trustSignalHighlights.some((item) => item.title === 'Manager-scope blijft bounded')).toBe(true)
+    expect(
+      trustHubAnswerCards.some(
+        (card) =>
+          card.title === 'Hoe werkt manager-toegang?' &&
+          card.body.toLowerCase().includes('alleen action center'),
+      ),
+    ).toBe(true)
+  })
+
+  it('keeps the homepage Action Center proof explicit about assignment and review', () => {
+    const homeSource = fs.readFileSync(path.join(process.cwd(), 'components', 'marketing', 'home-page-content.tsx'), 'utf8')
+
+    expect(homeSource).toContain('HR kan acties expliciet toewijzen')
+    expect(homeSource).toContain('alleen de opvolglaag zien')
+  })
+})


### PR DESCRIPTION
## Summary
- strengthen the public proof layer around the live suite and bounded manager access model
- make homepage, trust and proof copy explicit about one suite login, two modules and department-scoped manager follow-through
- add a targeted marketing proof regression test for these claims

## Testing
- npm run test -- lib/marketing-proof-layer.test.ts lib/marketing-flow.test.ts lib/marketing-positioning.test.ts lib/seo-conversion.test.ts
- npm run build