### PR TITLE
Close out the Action Center commercial track

### DIFF
--- a/docs/active/ACTION_CENTER_COMMERCIAL_TRACK_CLOSEOUT_2026-04-26.md
+++ b/docs/active/ACTION_CENTER_COMMERCIAL_TRACK_CLOSEOUT_2026-04-26.md
@@ -1,0 +1,131 @@
+# ACTION_CENTER_COMMERCIAL_TRACK_CLOSEOUT_2026-04-26.md
+
+Last updated: 2026-04-26
+Status: active closeout
+Scope: complete commercial track `CT-0` through `CT-6`
+Source of truth: current public runtime on `main`, Action Center proposition contract, message architecture, live suite shell, manager-access hardening, and the bounded proof layer now visible on the site.
+
+## 1. Summary
+
+Deze closeout legt vast wat de commerciële track nu echt heeft afgerond.
+
+De publieke waarheid is niet langer:
+
+- Verisight = survey + dashboard + rapport
+
+De publieke waarheid is nu:
+
+- Verisight = bounded people suite
+- die helpt signalen zien
+- prioriteren wat eerst telt
+- acties expliciet maken
+- acties toewijzen
+- follow-up en reviewdiscipline bewaken
+
+Action Center is daarmee niet meer een verborgen vervolgstap, maar een hoofdonderdeel van de propositie.
+
+## 2. Wat nu publiek waar is
+
+De site mag vanaf nu expliciet claimen dat Verisight:
+
+- people insights zichtbaar maakt
+- managementreads deelt via dashboard en rapport
+- follow-through expliciet organiseert in Action Center
+- managers per afdeling bounded laat opvolgen zonder survey-inzichten open te zetten
+- dashboard, rapport en Action Center samen in één suite-omgeving laat werken
+
+Deze claims zijn commercieel toegestaan omdat ze inmiddels op `main` productmatig en operationeel gedragen worden.
+
+## 3. Wat in deze track is geland
+
+### CT-0 Proposition contract
+
+- Action Center is commercieel vastgezet als bounded follow-through module
+- de propositie verschuift van alleen insights naar insights plus prioritering en opvolging
+
+### CT-1 Message architecture
+
+- home, producten, aanpak, tarieven, vertrouwen en demo-flow spreken nu vanuit dezelfde hiërarchie
+- Action Center is daarin expliciet de tweede helft van de suitebelofte
+
+### CT-2 Homepage en hoofdnavigatie
+
+- homepage opent nu rond de suitebelofte
+- contactpanelen zijn sitebreed ruimer gezet
+- navigatie en CTA’s verwijzen niet meer alleen naar een eerste gesprek, maar naar een suite-demo
+
+### CT-3 Product-, oplossing-, tarieven- en vertrouwen-copy
+
+- `/producten/combinatie` is herschreven naar de nieuwe suitewaarheid
+- tarieven, vertrouwen en intakecopy volgen dezelfde bounded producttaal
+
+### CT-4 CTA, demo- en salesflow
+
+- primaire CTA’s verkopen nu een suite-demo
+- de flow kwalificeert niet alleen op scan, maar op managementvraag en vervolgdiscipline
+
+### CT-5 Prooflaag
+
+- publieke proof maakt nu zichtbaar dat:
+  - er één suite-login is
+  - dashboard/rapport en Action Center twee samenhangende modules zijn
+  - managers bounded via afdelingstoewijzing kunnen werken zonder insighttoegang
+
+## 4. Wat bewust bounded bleef
+
+Deze track heeft nadrukkelijk niet geclaimd dat Verisight al is:
+
+- een generieke taakmanagementsuite
+- een volledige HR-operationslaag
+- een autonome actie-engine
+- een ROI-machine met bewezen effectclaims
+- full self-service enterprise SaaS
+
+De site verkoopt nu wel meer dan alleen insights, maar blijft begrensd in wat de suite werkelijk draagt.
+
+## 5. Nieuwe commerciële hoofdzin
+
+De aanbevolen hoofdzin voor site, deck en salescontext is nu:
+
+> Verisight is een people suite die organisaties helpt zien wat speelt, bepalen wat eerst telt en opvolging bounded organiseren.
+
+Ondersteunende zinnen:
+
+- van signaal naar prioriteit
+- van rapport naar eigenaar en reviewritme
+- van people insights naar expliciete follow-through
+
+## 6. Wat nu de nieuwe commerciële basis is
+
+De commerciële basis op `main` is nu:
+
+- homepage met suite-openingsframing
+- product- en oplossingspagina’s die Action Center niet meer verbergen
+- tarieven en vertrouwen die dezelfde bounded suitewaarheid dragen
+- demo-flow die een suite-demo verkoopt
+- prooflaag die manager-access en follow-through geloofwaardig maakt
+
+Daarmee is de eerste grote commerciële herpositionering afgerond.
+
+## 7. Wat daarna pas logisch is
+
+Na deze closeout horen vervolgsporen niet opnieuw te gaan over de basisframing, maar over:
+
+- pilot proof en verkoopclaims na extra live gebruik
+- assisted SaaS operations
+- suite governance
+- latere sales enablement of proof packaging
+
+## 8. Validation
+
+- De commerciële track volgt de huidige `main`-waarheid van dashboard + rapport + Action Center in één suite.
+- De publieke manager-claims volgen de gelande manager-only Action Center hardening.
+- De closeout claimt geen bredere productvolwassenheid dan de suite nu daadwerkelijk heeft.
+
+## 9. Oordeel
+
+Spoor 8 is nu commercieel afgerond als eerste grote herpositionering:
+
+- Action Center staat als hoofd-USP zichtbaar op de site
+- de site verkoopt nu niet alleen people insights, maar ook prioritering, toewijzing en follow-through
+- de copy blijft bounded en geloofwaardig


### PR DESCRIPTION
## Summary
- add a formal closeout artifact for commercial track 8
- document what is now publicly true on main after the Action Center proposition, message architecture, homepage, copy, CTA and proof slices
- lock the bounded commercial claims and the next-step handoff to operations and governance

## Testing
- npm run test -- lib/marketing-proof-layer.test.ts lib/marketing-flow.test.ts lib/marketing-positioning.test.ts lib/seo-conversion.test.ts
- npm run build