### PR TITLE
Define suite governance for the people suite

### DIFF
--- a/docs/active/SUITE_GOVERNANCE_CLOSEOUT_2026-04-26.md
+++ b/docs/active/SUITE_GOVERNANCE_CLOSEOUT_2026-04-26.md
@@ -1,0 +1,45 @@
+# SUITE_GOVERNANCE_CLOSEOUT_2026-04-26.md
+
+Last updated: 2026-04-26
+Status: active closeout
+Scope: `SG-0` through `SG-5`
+
+## 1. Summary
+
+Spoor 10 sluit de bestuurlijke suitegovernance van Verisight af.
+
+Wat nu vastligt:
+
+- één suite governance contract
+- expliciete product family model
+- één shared language contract
+- packaging en rollout rules
+- release en change governance
+
+## 2. Oordeel
+
+De suite is nu bestuurlijk coherenter:
+
+- product
+- commercie
+- operations
+- Action Center
+
+vallen onder dezelfde governancebasis.
+
+## 3. Nieuwe standaard
+
+Nieuwe suiteclaims of moduleverbreding horen pas te gebeuren als:
+
+- runtime bestaat
+- operations truth het draagt
+- taalcontract klopt
+- commerciële boundedness bewaakt blijft
+
+## 4. Handoff
+
+De volgende logische stap is:
+
+- integrated assisted SaaS closeout
+
+Omdat nu product, commercie, operations en governance op één basis staan.

--- a/docs/active/SUITE_GOVERNANCE_CONTRACT.md
+++ b/docs/active/SUITE_GOVERNANCE_CONTRACT.md
@@ -1,0 +1,104 @@
+# SUITE_GOVERNANCE_CONTRACT.md
+
+Last updated: 2026-04-26
+Status: active
+Source of truth: current `main` runtime, commercial track closeout, assisted SaaS operations contract, product language canon and Action Center canon.
+
+## 1. Summary
+
+Dit contract legt de bestuurlijke suitewaarheid van Verisight vast.
+
+De huidige governancebasis is:
+
+- één people suite
+- meerdere bounded productlijnen
+- één gedeelde suite-shell
+- twee modulefamilies:
+  - insights
+  - follow-through
+- duidelijke grens tussen wat shared is en wat productgebonden blijft
+
+## 2. What the suite is
+
+De suite is nu:
+
+- een gedeelde omgeving voor dashboard, reports en Action Center
+- een portfolio met meerdere routekeuzes binnen dezelfde tenantgrens
+- een assisted SaaS-model, niet alleen losse projectlevering
+
+De suite is niet:
+
+- een open productmarktplaats
+- een verzameling losgekoppelde mini-apps
+- een generiek HR operating system
+
+## 3. Governance layers
+
+### Shared suite layer
+
+Shared en suitebreed bestuurd:
+
+- auth
+- organization/workspace boundary
+- shell navigation
+- access model
+- dashboard/report/Action Center samenhang
+- lifecycle- en handofflogica
+
+### Product route layer
+
+Productspecifiek en bounded:
+
+- scan type
+- metrics
+- signal grammar
+- report emphasis
+- route-first onboarding nuances
+- routegebonden vervolglogica
+
+### Follow-through layer
+
+Action Center is shared als productlaag, maar bounded in gebruik:
+
+- follow-through grammar is shared
+- carrier contracts blijven productspecifiek
+- manager-only access blijft module- en scopegebonden
+
+## 4. Decision rules
+
+Gebruik suite governance wanneer een wijziging raakt aan:
+
+- meerdere productlijnen
+- shell, auth of access
+- gedeelde commercial truth
+- packaging of rollout logic
+- shared language over dashboard, reports en Action Center
+
+Gebruik alleen productgovernance wanneer iets uitsluitend raakt aan:
+
+- één route
+- één metric family
+- één report nuance
+
+## 5. Bounded defaults
+
+- ExitScan en RetentieScan blijven de twee kern-first-buy routes
+- Onboarding 30-60-90 blijft bounded peer
+- Pulse en Leadership blijven compacte vervolg- of reviewroutes
+- Combinatie blijft portfolioroute
+- Action Center blijft gedeelde follow-through laag en geen derde first-buy product
+
+## 6. Validation
+
+- Sluit aan op gelande live suite-shell en manager hardening.
+- Sluit aan op commerciële track 8 en operations track 9.
+- Introduceert geen nieuwe productscope of packagefantasie.
+
+## 7. Next step
+
+Gebruik dit contract als basis voor:
+
+- product family model
+- shared language contract
+- packaging en rollout logic
+- release/change governance

--- a/docs/active/SUITE_PACKAGING_AND_ROLLOUT_LOGIC.md
+++ b/docs/active/SUITE_PACKAGING_AND_ROLLOUT_LOGIC.md
@@ -1,0 +1,86 @@
+# SUITE_PACKAGING_AND_ROLLOUT_LOGIC.md
+
+Last updated: 2026-04-26
+Status: active
+Source of truth: pricing and packaging plan, product family model, operations contract and commercial closeout.
+
+## 1. Summary
+
+Dit document legt de suitebrede regels vast voor packaging, activatie en rollout van productlijnen en modules.
+
+## 2. Packaging rules
+
+### Kernroutes
+
+First-buy packaging mag nu alleen kerngewicht geven aan:
+
+- ExitScan
+- RetentieScan
+
+### Bounded peers and vervolgroutes
+
+Onboarding 30-60-90, Pulse en Leadership krijgen:
+
+- bounded vervolggewicht
+- geen peerstatus met de kernroutes
+
+### Action Center
+
+Action Center is:
+
+- embedded suitewaarde
+- geen los prijsanker
+- geen third product package
+- geen upsellmodule met eigen planlogica
+
+## 3. Rollout rules
+
+### Nieuwe route activeren
+
+Pas activeren als:
+
+- runtime bestaat
+- opsmodel het draagt
+- taalcontract klopt
+- commerciële claims bounded zijn
+
+### Nieuwe module claimen
+
+Pas publiek claimen als:
+
+- de module op `main` staat
+- de shell/gating klopt
+- denied states en role truth helder zijn
+
+### Combinatieroute
+
+Blijft:
+
+- routebesluit
+- geen bundel
+- geen discount story
+
+## 4. Activation logic
+
+Packaging en rollout volgen:
+
+- organization-first
+- campaign-first activation
+- owner-governed access
+- manager-only Action Center as bounded capability
+
+Niet volgen:
+
+- self-serve checkout
+- plan upgrades
+- seat unlocks
+
+## 5. Validation
+
+- Sluit aan op current operations truth.
+- Houdt commerciële track en productfamilie consistent.
+- Voorkomt dat packaging harder groeit dan runtime of ops.
+
+## 6. Next step
+
+Gebruik dit document als input voor release en change governance.

--- a/docs/active/SUITE_PRODUCT_FAMILY_MODEL.md
+++ b/docs/active/SUITE_PRODUCT_FAMILY_MODEL.md
@@ -1,0 +1,90 @@
+# SUITE_PRODUCT_FAMILY_MODEL.md
+
+Last updated: 2026-04-26
+Status: active
+Source of truth: portfolio architecture, pricing and packaging truth, live product routes and commercial closeout.
+
+## 1. Summary
+
+Dit model legt vast hoe de productfamilie van Verisight nu hiërarchisch gelezen moet worden.
+
+## 2. Family roles
+
+### Core first-buy routes
+
+- ExitScan
+- RetentieScan
+
+Dit zijn de enige twee routes die nu first-buy kerngewicht dragen.
+
+### Bounded peer
+
+- Onboarding 30-60-90
+
+Deze route is zichtbaar en werkbaar, maar niet bedoeld als derde commerciële instaproute met dezelfde suitezwaarte.
+
+### Compact vervolg- en reviewroutes
+
+- Pulse
+- Leadership Scan
+
+Deze routes horen onder review, verdieping of opvolging, niet onder primaire wedge-verkoop.
+
+### Portfolio route
+
+- Combinatie
+
+Dit blijft een route tussen twee bestaande kernvragen, geen derde kernproduct.
+
+### Shared follow-through layer
+
+- Action Center
+
+Dit is géén productlijn naast bovenstaande, maar een gedeelde suitecomponent die meerdere routes ondersteunt.
+
+## 3. Family logic
+
+### First buy
+
+De eerste koop hoort nu bijna altijd te starten bij:
+
+- ExitScan
+- of RetentieScan, als de managementvraag expliciet over actieve behoudsdruk gaat
+
+### Follow-on
+
+Pas daarna zijn logisch:
+
+- ritmeroutes
+- bounded vervolgmetingen
+- Onboarding 30-60-90
+- Pulse
+- Leadership Scan
+- Combinatie
+
+### Shared module logic
+
+Dashboard en report volgen de productroute.
+
+Action Center volgt de follow-through behoefte, niet de first-buy status.
+
+## 4. Governance rules
+
+Niet toestaan zonder apart besluit:
+
+- nieuwe kern-first-buy route
+- nieuwe productlijn met peergewicht
+- Action Center framen als los derde product
+- Pulse of Leadership als aparte brede instaproute verkopen
+
+## 5. Validation
+
+- Sluit aan op huidige `scan_type` realiteit en commerciële track.
+- Houdt bounded peers en vervolgmodules bewust kleiner dan de kernroutes.
+
+## 6. Next step
+
+Gebruik dit model als basis voor:
+
+- shared language contract
+- packaging en rollout logic

--- a/docs/active/SUITE_RELEASE_AND_CHANGE_GOVERNANCE.md
+++ b/docs/active/SUITE_RELEASE_AND_CHANGE_GOVERNANCE.md
@@ -1,0 +1,90 @@
+# SUITE_RELEASE_AND_CHANGE_GOVERNANCE.md
+
+Last updated: 2026-04-26
+Status: active
+Source of truth: workbook cadence, live product shell, operations track and commercial track.
+
+## 1. Summary
+
+Dit document legt vast wanneer een wijziging product-, ops-, commercial- of governance-impact heeft en welke discipline daarbij hoort.
+
+## 2. Change categories
+
+### Product-only
+
+Wijziging raakt één route of één bounded runtimepad.
+
+Vereist:
+
+- routegerichte verificatie
+- productreview
+
+### Suite-impacting
+
+Wijziging raakt:
+
+- shell
+- auth
+- access
+- reports
+- Action Center
+- shared language
+
+Vereist:
+
+- suite review
+- impact op ops/commercial check
+
+### Commercial-impacting
+
+Wijziging raakt:
+
+- siteclaims
+- CTA’s
+- pricing/packaging
+- propositionele waarheid
+
+Vereist:
+
+- bounded claims review
+- aansluiting op operations truth
+
+### Governance-impacting
+
+Wijziging raakt:
+
+- product family hierarchy
+- packaging rules
+- rollout rules
+- release discipline
+
+Vereist:
+
+- expliciete governance-update
+
+## 3. Standard discipline
+
+Blijf werken met:
+
+- eigen worktree/branch
+- review artefact
+- closeout of landing
+- workbook update
+
+Nieuwe module- of routeclaims zonder deze cadence zijn niet governance-compliant.
+
+## 4. Trigger examples
+
+- nieuwe manager role change -> suite-impacting
+- nieuwe public pricing claim -> commercial-impacting
+- nieuwe productlijn als first-buy route -> governance-impacting
+- nieuwe report nuance voor één route -> product-only
+
+## 5. Validation
+
+- Sluit aan op de werkwijze die al voor dashboard, Action Center, pilot, commercie en operations is gebruikt.
+- Voorkomt dat losse sporen elkaar weer doorkruisen.
+
+## 6. Next step
+
+Gebruik deze discipline als basis voor governance closeout en final assisted SaaS closeout.

--- a/docs/active/SUITE_SHARED_LANGUAGE_CONTRACT.md
+++ b/docs/active/SUITE_SHARED_LANGUAGE_CONTRACT.md
@@ -1,0 +1,117 @@
+# SUITE_SHARED_LANGUAGE_CONTRACT.md
+
+Last updated: 2026-04-26
+Status: active
+Source of truth: product language canon, Action Center canon, commercial track closeout, report grammar and live shell.
+
+## 1. Summary
+
+Dit contract legt vast welke gedeelde suitegrammatica Verisight nu overal moet gebruiken.
+
+Doel:
+
+- dashboard
+- reports
+- Action Center
+- site
+- onboarding
+- ops
+
+moeten dezelfde werkelijkheid vertellen.
+
+## 2. Shared grammar
+
+### Insight grammar
+
+Gebruik suitebreed:
+
+- signalen
+- managementread
+- eerste managementvraag
+- prioriteit
+- first value
+- first management use
+
+Niet suitebreed gebruiken als hoofdtaal:
+
+- diagnose
+- voorspelling
+- causaliteit
+- performance score
+
+### Follow-through grammar
+
+Gebruik suitebreed:
+
+- eigenaar
+- eerste stap
+- assignment
+- reviewmoment
+- follow-through
+- closeout
+- bounded vervolg
+
+Niet suitebreed gebruiken als hoofdtaal:
+
+- taakplatform
+- orchestration layer
+- cockpitproduct
+- AI actie-engine
+
+### Access grammar
+
+Gebruik suitebreed:
+
+- owner
+- member
+- viewer
+- manager assignee
+- bounded scope
+- denied state
+
+## 3. Cross-surface rules
+
+### Dashboard
+
+Dashboard spreekt vanuit:
+
+- signalen
+- prioriteiten
+- managementread
+
+### Report
+
+Report spreekt vanuit:
+
+- managementsamenvatting
+- bestuurlijke handoff
+- eerste vervolgrichting
+
+### Action Center
+
+Action Center spreekt vanuit:
+
+- follow-through
+- assignment
+- review
+- closure
+
+### Site
+
+De site spiegelt dit als:
+
+- people insights
+- bepalen wat eerst telt
+- acties expliciet maken
+- acties toewijzen
+- review en follow-through bewaken
+
+## 4. Validation
+
+- Sluit aan op gelande commerciële copy.
+- Sluit aan op dashboard/report/action center rollen.
+- Voorkomt nieuwe drift tussen buyer copy en runtime truth.
+
+## 5. Next step
+
+Gebruik dit contract voor packaging en rollout logic en voor latere review van nieuwe route- of moduleclaims.


### PR DESCRIPTION
## Summary
- define the suite governance contract over product, commercial and operations layers
- formalize the product family model, shared language contract, packaging logic and release/change governance
- add a closeout artifact for track 10

## Testing
- npm run test -- "lib/suite-access.test.ts" "app/(dashboard)/route-access.test.ts" "lib/marketing-positioning.test.ts" "lib/marketing-proof-layer.test.ts"
- npm run build