### PR TITLE
Close out the assisted SaaS program

### DIFF
--- a/docs/active/ASSISTED_SAAS_CROSS_TRACK_GAP_CLOSURE_2026-04-26.md
+++ b/docs/active/ASSISTED_SAAS_CROSS_TRACK_GAP_CLOSURE_2026-04-26.md
@@ -1,0 +1,35 @@
+# ASSISTED_SAAS_CROSS_TRACK_GAP_CLOSURE_2026-04-26.md
+
+Last updated: 2026-04-26
+Status: active
+Scope: `AS-1`
+
+## 1. Summary
+
+Deze gap closure check beoordeelt of er nog kleine resterende gaten tussen de sporen zitten die eerst expliciet dicht moeten.
+
+## 2. Small remaining gaps
+
+### Gap A - Billing and plans
+
+- bewust geen blocker voor assisted SaaS verdict
+- blijft aparte latere self-serve/billing wave
+
+### Gap B - Deeper telemetry
+
+- health review staat, maar geen zware analytics stack
+- bewust geen blocker voor current assisted model
+
+### Gap C - Broader external proof
+
+- semireële pilot en bounded usageproof staan
+- bredere multi-customer evidence mag later groeien
+
+## 3. Closure decision
+
+Er zijn geen kleine code- of policygaten gevonden die nog vóór een assisted SaaS verdict moeten worden gerepareerd.
+
+De resterende punten zijn:
+
+- bewust later werk
+- geen open inconsistenties tussen product, commercie, ops en governance

--- a/docs/active/ASSISTED_SAAS_FINAL_CLOSEOUT_AND_PAPER_TRAIL_2026-04-26.md
+++ b/docs/active/ASSISTED_SAAS_FINAL_CLOSEOUT_AND_PAPER_TRAIL_2026-04-26.md
@@ -1,0 +1,61 @@
+# ASSISTED_SAAS_FINAL_CLOSEOUT_AND_PAPER_TRAIL_2026-04-26.md
+
+Last updated: 2026-04-26
+Status: active closeout
+Scope: `AS-3`
+
+## 1. Summary
+
+Dit is de formele paper trail voor de route naar de huidige assisted SaaS-basis.
+
+## 2. What now forms the standard base
+
+### Live product base
+
+- één suite-shell
+- dashboard + reports + Action Center
+- manager-only Action Center access
+- meerdere bounded productlijnen
+
+### Commercial base
+
+- Action Center publiek als kern-USP
+- site verkoopt nu inzicht + prioritering + opvolging
+
+### Operations base
+
+- explicit provisioning, activation, lifecycle and support truth
+
+### Governance base
+
+- productfamilie
+- shared language
+- packaging logic
+- release/change discipline
+
+## 3. What the program does not claim
+
+Deze closeout claimt niet dat Verisight nu:
+
+- full self-serve SaaS is
+- billing-led is
+- alle toekomstige modules al live en volwassen heeft
+
+## 4. New default
+
+Gebruik vanaf nu als bestuurlijke standaard:
+
+- Verisight = assisted SaaS people suite
+- productlijnen binnen één suite
+- dashboard voor insight
+- report voor handoff
+- Action Center voor bounded follow-through
+
+## 5. Next bounded backlog
+
+Later werk hoort nu buiten dit programma:
+
+- billing/self-serve model
+- deeper telemetry
+- broader proof layer
+- eventuele nieuwe productfamilie- of moduleactivatie

--- a/docs/active/ASSISTED_SAAS_INTEGRATED_READINESS_REVIEW_2026-04-26.md
+++ b/docs/active/ASSISTED_SAAS_INTEGRATED_READINESS_REVIEW_2026-04-26.md
@@ -1,0 +1,65 @@
+# ASSISTED_SAAS_INTEGRATED_READINESS_REVIEW_2026-04-26.md
+
+Last updated: 2026-04-26
+Status: active
+Scope: `AS-0`
+Source of truth: live suite on `main`, pilot and hardening closeout, commercial track closeout, SaaS operations closeout and suite governance closeout.
+
+## 1. Summary
+
+Deze review trekt de huidige stand integraal samen.
+
+De kernvraag is:
+
+- staat Verisight nu sterk genoeg als assisted SaaS people suite?
+
+## 2. What is now strong enough
+
+### Product layer
+
+- dashboard, reports en Action Center leven nu in één suite-shell
+- manager-only Action Center access is bounded en echt
+- meerdere productlijnen bestaan binnen dezelfde suitebasis
+
+### Commercial layer
+
+- de site verkoopt nu niet alleen insights, maar ook prioritering, toewijzing en follow-through
+- Action Center staat zichtbaar als kern-USP
+
+### Operations layer
+
+- provisioning, activation en lifecycle zijn expliciet genoeg gemaakt
+- first value, first management use en Action Center follow-through zijn operationeel aan elkaar gekoppeld
+
+### Governance layer
+
+- productfamilie, taal, packaging en change discipline zijn bestuurlijk vastgezet
+
+## 3. What is still bounded backlog
+
+Niet launch-blocking voor assisted SaaS, wel bewust open:
+
+- billing runtime
+- plans en seats
+- full self-serve organization provisioning
+- zware usage analytics
+- bredere live pilots over meerdere klanten heen
+
+## 4. Integrated reading
+
+De suite is nu:
+
+- productmatig coherent
+- commercieel scherp genoeg
+- operationeel herhaalbaar genoeg
+- bestuurlijk bounded genoeg
+
+De suite is nog niet:
+
+- self-serve SaaS
+- billing-first SaaS
+- enterprise workflowplatform
+
+## 5. Verdict of this review
+
+Er zijn nu geen duidelijke cross-track blockers meer voor de assisted SaaS-vorm die Verisight werkelijk bedoelt.

--- a/docs/active/ASSISTED_SAAS_LAUNCH_VERDICT_2026-04-26.md
+++ b/docs/active/ASSISTED_SAAS_LAUNCH_VERDICT_2026-04-26.md
@@ -1,0 +1,44 @@
+# ASSISTED_SAAS_LAUNCH_VERDICT_2026-04-26.md
+
+Last updated: 2026-04-26
+Status: active
+Scope: `AS-2`
+
+## 1. Summary
+
+Dit document geeft het expliciete launch verdict.
+
+## 2. Verdict
+
+Verisight is nu sterk genoeg om als **assisted SaaS people suite** te worden gelezen en bestuurd.
+
+Dat verdict geldt expliciet voor deze vorm:
+
+- assisted
+- bounded
+- suite-first
+- productlijnen binnen één people suite
+- dashboard + reports + Action Center
+
+Het verdict geldt expliciet niet voor:
+
+- full self-serve SaaS
+- billing-led SaaS
+- seat-/planproduct
+
+## 3. Why this verdict is justified
+
+- productlaag staat op `main`
+- commerciële hoofdtrack is geland
+- operations model is expliciet en herhaalbaar genoeg
+- governance is expliciet en coherentie-bewakend
+- manager/HR model is live en bounded
+
+## 4. Remaining bounded backlog
+
+- billing en subscriptions
+- self-serve provisioning
+- diepere telemetry
+- bredere evidence/pilotlayer
+
+Deze backlog verandert het assisted SaaS verdict niet.


### PR DESCRIPTION
## Summary
- add an integrated readiness review across product, commercial, operations and governance
- document the bounded cross-track gap closure and the explicit assisted SaaS launch verdict
- add the final closeout and paper trail for the program

## Testing
- npm run test -- "lib/suite-access.test.ts" "app/(dashboard)/route-access.test.ts" "lib/action-center-live.test.ts" "lib/marketing-positioning.test.ts" "lib/marketing-proof-layer.test.ts"
- npm run build