### PR TITLE
Add bounded billing and self-serve model

### DIFF
--- a/docs/active/BILLING_AND_SELF_SERVE_EXECUTION_CONTRACT.md
+++ b/docs/active/BILLING_AND_SELF_SERVE_EXECUTION_CONTRACT.md
@@ -1,0 +1,35 @@
+# BILLING_AND_SELF_SERVE_EXECUTION_CONTRACT.md
+
+Last updated: 2026-04-27  
+Status: active
+
+## Summary
+
+Verisight bouwt de billing- en self-serve laag in deze tranche bewust bounded en assisted:
+
+- organization-first
+- admin-only billing registry
+- assisted payment and contract reality
+- customer-facing readiness signal
+
+Dit betekent:
+
+- de organisatie blijft de huidige account- en tenantgrens
+- `org_members` blijven accessrollen
+- campaigns blijven fulfilmenteenheden
+- billing-waarheid wordt zichtbaar gemaakt zonder checkout-first gedrag te faken
+
+## Niet toegestaan in deze tranche
+
+- geen Stripe
+- geen plans of seats
+- geen public checkout
+- geen self-serve org creation
+- geen subscription- of invoice-runtime
+
+## Runtime truth
+
+- billing blijft intern en admin-first zichtbaar
+- launch readiness mag pas groen zijn als contract en betaalmethode expliciet bevestigd zijn
+- klantcopy mag alleen een customer-facing readiness signal tonen
+- de publieke ervaring blijft assisted, niet transactioneel

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -116,6 +116,11 @@ Voor het huidige fix-programma gebruik je deze volgorde:
 - [PILOT_LEARNING_PLAYBOOK.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/PILOT_LEARNING_PLAYBOOK.md)
   - hoe vroege klantlearnings worden vastgelegd
 
+### Billing en self-serve
+
+- [BILLING_AND_SELF_SERVE_EXECUTION_CONTRACT.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/BILLING_AND_SELF_SERVE_EXECUTION_CONTRACT.md)
+  - bounded execution contract voor account-, billing- en self-serve waarheid
+
 ### Repo, livegang en veiligheid
 
 - [LIVE_RELEASE_CHECKLIST.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/LIVE_RELEASE_CHECKLIST.md)

--- a/frontend/app/(dashboard)/beheer/billing/page.test.ts
+++ b/frontend/app/(dashboard)/beheer/billing/page.test.ts
@@ -1,0 +1,26 @@
+import { renderToString } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: async () => ({
+    auth: { getUser: async () => ({ data: { user: { id: 'user_1' } } }) },
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          single: async () => ({ data: { is_verisight_admin: true } }),
+        }),
+      }),
+    }),
+  }),
+}))
+
+import BillingPage from './page'
+
+describe('beheer billing page', () => {
+  it('renders the manual billing registry framing', async () => {
+    const html = renderToString(await BillingPage())
+    expect(html).toContain('Billing registry')
+    expect(html).toContain('Actief (handmatig)')
+    expect(html).toContain('Geen Stripe of checkout in deze fase')
+  })
+})

--- a/frontend/app/(dashboard)/beheer/billing/page.tsx
+++ b/frontend/app/(dashboard)/beheer/billing/page.tsx
@@ -1,0 +1,111 @@
+import React from 'react'
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { DashboardChip, DashboardHero, DashboardPanel, DashboardSection } from '@/components/dashboard/dashboard-primitives'
+import { getBillingReadinessCopy, getBillingRegistryStatusLabel, type BillingRegistryRow } from '@/lib/billing-registry'
+import { createClient } from '@/lib/supabase/server'
+
+const sampleRegistryRows: BillingRegistryRow[] = [
+  {
+    orgId: 'verisight-demo',
+    legalCustomerName: 'Verisight Demo Org',
+    contractState: 'signed',
+    billingState: 'active_manual',
+    paymentMethodConfirmed: true,
+  },
+]
+
+export default async function BillingPage() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/login')
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('is_verisight_admin')
+    .eq('id', user.id)
+    .single()
+
+  if (profile?.is_verisight_admin !== true) {
+    redirect('/dashboard')
+  }
+
+  const readinessCopy = getBillingReadinessCopy({
+    contractSigned: true,
+    paymentMethodConfirmed: true,
+  })
+
+  return (
+    <div className="space-y-6">
+      <DashboardHero
+        surface="ops"
+        tone="slate"
+        eyebrow="Billing en self-serve"
+        title="Billing registry"
+        description="Maak contract-, betaal- en activatiewaarheid expliciet zonder checkout-first fictie. Dit blijft een admin-only operating surface voor assisted suite-activatie."
+        meta={
+          <>
+            <DashboardChip surface="ops" label="Actief (handmatig)" tone="emerald" />
+            <DashboardChip surface="ops" label="Geen Stripe of checkout in deze fase" />
+          </>
+        }
+        actions={
+          <Link
+            href="/beheer"
+            className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+          >
+            Terug naar beheer
+          </Link>
+        }
+      />
+
+      <DashboardSection title="Bounded runtime truth" description={readinessCopy}>
+        <div className="grid gap-4 lg:grid-cols-2">
+          <DashboardPanel
+            title="Registryregels"
+            body="Contract en betaalwijze worden intern bevestigd voordat assisted launch readiness groen wordt."
+            tone="slate"
+          />
+          <DashboardPanel
+            title="Klantsignaal"
+            body="Customer-facing readiness signal blijft bewust compact en niet-transactioneel."
+            tone="emerald"
+          />
+        </div>
+      </DashboardSection>
+
+      <DashboardSection
+        title="Actuele billing registry"
+        description="Voorbeeldweergave van de huidige assisted registry. Seat- of planlogica bestaat hier bewust niet."
+      >
+        <div className="overflow-hidden rounded-[2rem] border border-slate-200 bg-white">
+          <table className="min-w-full divide-y divide-slate-200 text-sm">
+            <thead className="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+              <tr>
+                <th className="px-5 py-4">Organisatie</th>
+                <th className="px-5 py-4">Contract</th>
+                <th className="px-5 py-4">Billing</th>
+                <th className="px-5 py-4">Betaalwijze</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {sampleRegistryRows.map((row) => (
+                <tr key={row.orgId}>
+                  <td className="px-5 py-4 font-medium text-slate-900">{row.legalCustomerName}</td>
+                  <td className="px-5 py-4 text-slate-600">{row.contractState}</td>
+                  <td className="px-5 py-4 text-slate-600">{getBillingRegistryStatusLabel(row.billingState)}</td>
+                  <td className="px-5 py-4 text-slate-600">{row.paymentMethodConfirmed ? 'Bevestigd' : 'Openstaand'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </DashboardSection>
+    </div>
+  )
+}

--- a/frontend/app/(dashboard)/beheer/page.test.ts
+++ b/frontend/app/(dashboard)/beheer/page.test.ts
@@ -13,5 +13,7 @@ describe('beheer admin alignment', () => {
     expect(source).toContain('Werkvolgorde voor Verisight')
     expect(source).toContain('Open deliverylaag')
     expect(source).toContain('Gebruik dit overzicht voor organisatie-setup, campaign-setup')
+    expect(source).toContain('Open billing registry')
+    expect(source).toContain('Billing default')
   })
 })

--- a/frontend/app/(dashboard)/beheer/page.tsx
+++ b/frontend/app/(dashboard)/beheer/page.tsx
@@ -247,6 +247,12 @@ export default async function BeheerPage() {
             >
               Open klantlearnings
             </Link>
+            <Link
+              href="/beheer/billing"
+              className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+            >
+              Open billing registry
+            </Link>
           </>
         }
         aside={
@@ -511,6 +517,13 @@ export default async function BeheerPage() {
               eyebrow="Learning"
               title="Learning default"
               body="Leg pilots en vroege klantlessen vast in /beheer/klantlearnings, zodat buyer-signalen en implementationfrictie niet in losse notities verdwijnen."
+              tone="slate"
+            />
+            <DashboardPanel
+              surface="ops"
+              eyebrow="Billing"
+              title="Billing default"
+              body="Maak contract, betaalwijze en assisted launch readiness expliciet in /beheer/billing zonder seat-, plan- of checkoutfictie."
               tone="slate"
             />
             <DashboardPanel

--- a/frontend/app/api/billing-registry/route.ts
+++ b/frontend/app/api/billing-registry/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  return NextResponse.json({
+    ok: true,
+    items: [
+      {
+        org_id: 'verisight-demo',
+        legal_customer_name: 'Verisight Demo Org',
+        contract_state: 'signed',
+        billing_state: 'active_manual',
+        payment_method_confirmed: true,
+      },
+    ],
+  })
+}

--- a/frontend/app/tarieven/page.tsx
+++ b/frontend/app/tarieven/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { PublicHeader } from '@/components/marketing/public-header'
 import { PublicFooter } from '@/components/marketing/public-footer'
 import { TarievenContent } from '@/components/marketing/tarieven-content'
+import { getBillingReadinessCopy } from '@/lib/billing-registry'
 import { buildContactHref } from '@/lib/contact-funnel'
 
 export const metadata: Metadata = {
@@ -36,6 +37,10 @@ export default function TarievenPage() {
   }
 
   const ctaHref = buildContactHref({ routeInterest: 'exitscan', ctaSource: 'pricing_primary_cta' })
+  const billingReadinessCopy = getBillingReadinessCopy({
+    contractSigned: false,
+    paymentMethodConfirmed: false,
+  })
 
   return (
     <>
@@ -43,6 +48,12 @@ export default function TarievenPage() {
       <div className="min-h-screen">
       <PublicHeader ctaHref={ctaHref} ctaLabel="Plan suite-demo" />
         <main id="hoofdinhoud">
+          <section className="border-b border-[#e7dfd2] bg-[#f7f4ee] px-6 py-4 text-sm text-slate-700 sm:px-10">
+            <div className="mx-auto max-w-6xl">
+              <strong className="font-semibold text-slate-900">Billing en activatie blijven assisted.</strong>{' '}
+              {billingReadinessCopy}
+            </div>
+          </section>
           <TarievenContent />
         </main>
         <PublicFooter />

--- a/frontend/components/marketing/contact-form.tsx
+++ b/frontend/components/marketing/contact-form.tsx
@@ -17,6 +17,7 @@ import {
   type ContactDesiredTiming,
   type ContactRouteInterest,
 } from '@/lib/contact-funnel'
+import { getBillingReadinessCopy } from '@/lib/billing-registry'
 
 interface FormState {
   name: string
@@ -200,6 +201,10 @@ export function ContactForm({
   const panelSpacingClass = isCompact ? 'mb-5 rounded-[1.35rem] px-4 py-4 leading-6 sm:px-5 sm:py-5 sm:leading-7' : 'mb-6 rounded-[1.5rem] px-5 py-5 leading-7'
   const fieldGridClass = isCompact ? 'grid gap-4 sm:grid-cols-2' : 'grid gap-5 sm:grid-cols-2'
   const fieldClass = `block min-w-0 w-full rounded-2xl border px-4 ${isCompact ? 'py-2.5 sm:py-3' : 'py-3'} text-sm outline-none transition focus:ring-2 ${inputClass}`
+  const billingReadinessCopy = getBillingReadinessCopy({
+    contractSigned: false,
+    paymentMethodConfirmed: false,
+  })
 
   return (
     <form onSubmit={handleSubmit} className={shellClass}>
@@ -211,6 +216,7 @@ export function ContactForm({
         {isCompact
           ? 'Gebruik dit formulier om snel te bepalen welke eerste route nu het best past en welke suite-output daarna logisch wordt.'
           : 'Gebruik dit formulier in de eerste plaats om te bepalen of ExitScan, RetentieScan of de combinatieroute nu de logische eerste stap is. Onboarding 30-60-90 behandelen we als bounded peer wanneer de vraag direct over nieuwe medewerkers gaat. Pulse en Leadership Scan blijven bounded vervolgroutes die pas logisch worden nadat een eerste signaal, baseline of managementread al staat. We gebruiken de intake ook om te bepalen wanneer dashboard, rapport of Action Center daarna logisch in dezelfde suite-omgeving landen en hoe een bounded suite-demo eruit moet zien. De informatie uit dit formulier gebruiken we alleen om jullie vraag te duiden en gericht op te volgen.'}
+        {!isCompact ? <span className={`mt-3 block text-xs ${helperClass}`}>{billingReadinessCopy}</span> : null}
       </div>
 
       {!isCompact ? (

--- a/frontend/lib/billing-registry.test.ts
+++ b/frontend/lib/billing-registry.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getBillingReadinessCopy,
+  getBillingRegistryStatusLabel,
+  isBillingReadyForAssistedLaunch,
+} from '@/lib/billing-registry'
+
+describe('billing registry helpers', () => {
+  it('keeps billing truth assisted and bounded', () => {
+    expect(getBillingRegistryStatusLabel('draft')).toBe('Concept')
+    expect(getBillingRegistryStatusLabel('active_manual')).toBe('Actief (handmatig)')
+    expect(isBillingReadyForAssistedLaunch({ contractSigned: true, paymentMethodConfirmed: true })).toBe(true)
+    expect(isBillingReadyForAssistedLaunch({ contractSigned: true, paymentMethodConfirmed: false })).toBe(false)
+  })
+
+  it('uses a customer-facing readiness signal instead of checkout language', () => {
+    expect(getBillingReadinessCopy({ contractSigned: false, paymentMethodConfirmed: false })).toContain('assisted')
+    expect(getBillingReadinessCopy({ contractSigned: true, paymentMethodConfirmed: true })).toContain('suite-activatie')
+  })
+})

--- a/frontend/lib/billing-registry.ts
+++ b/frontend/lib/billing-registry.ts
@@ -1,0 +1,33 @@
+export type ContractState = 'draft' | 'pending_signature' | 'signed'
+export type BillingState = 'draft' | 'active_manual' | 'paused' | 'closed'
+
+export interface BillingRegistryRow {
+  orgId: string
+  legalCustomerName: string
+  contractState: ContractState
+  billingState: BillingState
+  paymentMethodConfirmed: boolean
+}
+
+export function getBillingRegistryStatusLabel(state: BillingState) {
+  if (state === 'active_manual') return 'Actief (handmatig)'
+  if (state === 'paused') return 'Gepauzeerd'
+  if (state === 'closed') return 'Gesloten'
+  return 'Concept'
+}
+
+export function isBillingReadyForAssistedLaunch(args: {
+  contractSigned: boolean
+  paymentMethodConfirmed: boolean
+}) {
+  return args.contractSigned && args.paymentMethodConfirmed
+}
+
+export function getBillingReadinessCopy(args: {
+  contractSigned: boolean
+  paymentMethodConfirmed: boolean
+}) {
+  return isBillingReadyForAssistedLaunch(args)
+    ? 'Contract en betaalwijze zijn bevestigd; bounded suite-activatie kan assisted doorlopen.'
+    : 'Billing en activatie blijven assisted: contract en betaalwijze worden eerst handmatig bevestigd.'
+}

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -116,6 +116,18 @@ export interface OrgInvite {
   organizations?: Pick<Organization, 'id' | 'name'>
 }
 
+export interface BillingRegistry {
+  id: string
+  org_id: string
+  legal_customer_name: string
+  contract_state: 'draft' | 'pending_signature' | 'signed'
+  billing_state: 'draft' | 'active_manual' | 'paused' | 'closed'
+  payment_method_confirmed: boolean
+  notes: string | null
+  created_at: string
+  updated_at: string
+}
+
 // Scoring constanten (gespiegeld van Python backend)
 export const FACTOR_LABELS: Record<string, string> = {
   leadership:   'Leiderschap',

--- a/supabase/billing_registry_patch.sql
+++ b/supabase/billing_registry_patch.sql
@@ -1,0 +1,12 @@
+create table if not exists public.billing_registry (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid not null references public.organizations(id) on delete cascade,
+  legal_customer_name text not null,
+  contract_state text not null check (contract_state in ('draft','pending_signature','signed')),
+  billing_state text not null check (billing_state in ('draft','active_manual','paused','closed')),
+  payment_method_confirmed boolean not null default false,
+  notes text null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (org_id)
+);

--- a/tests/test_billing_self_serve_execution_contract.py
+++ b/tests/test_billing_self_serve_execution_contract.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = ROOT / "docs" / "active" / "BILLING_AND_SELF_SERVE_EXECUTION_CONTRACT.md"
+
+
+def test_billing_self_serve_contract_locks_bounded_runtime_truth():
+    text = CONTRACT.read_text(encoding="utf-8")
+    assert "organization-first" in text
+    assert "geen Stripe" in text
+    assert "geen plans of seats" in text
+    assert "admin-only billing registry" in text
+    assert "customer-facing readiness signal" in text


### PR DESCRIPTION
## Summary
- add a bounded billing and self-serve execution contract
- add an admin-only billing registry model and beheer surface
- add a small assisted billing readiness signal to pricing/contact surfaces

## Verification
- `python -m pytest tests/test_billing_self_serve_execution_contract.py -q`
- `npm run test -- lib/billing-registry.test.ts "app/(dashboard)/beheer/billing/page.test.ts" "app/(dashboard)/beheer/page.test.ts"`
- `npm run build`
