### PR TITLE
Add deeper telemetry and health evidence

### DIFF
--- a/docs/active/SUITE_HEALTH_REVIEW_CLOSEOUT_2026-04-27.md
+++ b/docs/active/SUITE_HEALTH_REVIEW_CLOSEOUT_2026-04-27.md
@@ -1,0 +1,16 @@
+# SUITE_HEALTH_REVIEW_CLOSEOUT_2026-04-27.md
+
+Status: reviewklaar
+
+Deze tranche levert:
+
+- bounded telemetry event contract
+- interne ingest-route
+- typed helperlaag voor suite- en Action Center-events
+- admin-only `/beheer/health` surface
+
+Niet geleverd:
+
+- brede analytics stack
+- public telemetry
+- PLG- of billing-cohort reporting

--- a/docs/active/SUITE_TELEMETRY_EVENT_CONTRACT.md
+++ b/docs/active/SUITE_TELEMETRY_EVENT_CONTRACT.md
@@ -1,0 +1,20 @@
+# SUITE_TELEMETRY_EVENT_CONTRACT.md
+
+Last updated: 2026-04-27  
+Status: active
+
+## Core events
+
+- owner_access_confirmed
+- first_value_confirmed
+- first_management_use_confirmed
+- manager_denied_insights
+- action_center_review_scheduled
+- action_center_closeout_recorded
+
+## Rules
+
+- alleen bounded suite-events
+- geen survey-antwoorden in payloads
+- geen clickstream of growth analytics
+- health review blijft admin/internal-first

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -116,6 +116,11 @@ Voor het huidige fix-programma gebruik je deze volgorde:
 - [PILOT_LEARNING_PLAYBOOK.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/PILOT_LEARNING_PLAYBOOK.md)
   - hoe vroege klantlearnings worden vastgelegd
 
+### Telemetry en health evidence
+
+- [SUITE_TELEMETRY_EVENT_CONTRACT.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/active/SUITE_TELEMETRY_EVENT_CONTRACT.md)
+  - bounded event taxonomy voor suite health evidence
+
 ### Repo, livegang en veiligheid
 
 - [LIVE_RELEASE_CHECKLIST.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/LIVE_RELEASE_CHECKLIST.md)

--- a/frontend/app/(dashboard)/beheer/health/page.test.ts
+++ b/frontend/app/(dashboard)/beheer/health/page.test.ts
@@ -1,0 +1,26 @@
+import { renderToString } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: async () => ({
+    auth: { getUser: async () => ({ data: { user: { id: 'user_1' } } }) },
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          single: async () => ({ data: { is_verisight_admin: true } }),
+        }),
+      }),
+    }),
+  }),
+}))
+
+import HealthPage from './page'
+
+describe('beheer health page', () => {
+  it('renders the suite health evidence surface', async () => {
+    const html = renderToString(await HealthPage())
+    expect(html).toContain('Suite health evidence')
+    expect(html).toContain('Owner access confirmed')
+    expect(html).toContain('Manager denied insights')
+  })
+})

--- a/frontend/app/(dashboard)/beheer/health/page.tsx
+++ b/frontend/app/(dashboard)/beheer/health/page.tsx
@@ -1,0 +1,189 @@
+import React from 'react'
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { DashboardChip, DashboardHero, DashboardPanel, DashboardSection } from '@/components/dashboard/dashboard-primitives'
+import { buildActionCenterTelemetryEvents } from '@/lib/action-center-live'
+import { buildSuiteAccessContext, buildSuiteAccessTelemetryEvents } from '@/lib/suite-access'
+import { countSuiteTelemetryEvents } from '@/lib/telemetry/events'
+import { createClient } from '@/lib/supabase/server'
+
+function getSampleCounts() {
+  const managerContext = buildSuiteAccessContext({
+    isVerisightAdmin: false,
+    orgMemberships: [],
+    workspaceMemberships: [
+      {
+        org_id: 'org-1',
+        user_id: 'manager-1',
+        display_name: 'Manager Noord',
+        login_email: 'manager@example.com',
+        access_role: 'manager_assignee',
+        scope_type: 'department',
+        scope_value: 'sales',
+        can_view: true,
+        can_update: true,
+        can_assign: false,
+        can_schedule_review: true,
+      },
+    ],
+  })
+  const ownerContext = buildSuiteAccessContext({
+    isVerisightAdmin: false,
+    orgMemberships: [{ org_id: 'org-1', role: 'owner' }],
+    workspaceMemberships: [],
+  })
+
+  const events = [
+    ...buildSuiteAccessTelemetryEvents({ context: managerContext, actorId: 'manager-1' }),
+    ...buildSuiteAccessTelemetryEvents({ context: ownerContext, actorId: 'owner-1' }),
+    ...buildActionCenterTelemetryEvents([
+      {
+        campaign: {
+          id: 'campaign-exit',
+          organization_id: 'org-1',
+          name: 'Exit voorjaar',
+          scan_type: 'exit',
+          delivery_mode: 'live',
+          is_active: true,
+          enabled_modules: null,
+          created_at: '2026-04-10T10:00:00.000Z',
+          closed_at: null,
+        },
+        stats: null,
+        organizationName: 'Acme BV',
+        memberRole: 'owner',
+        scopeType: 'department',
+        scopeValue: 'sales',
+        scopeLabel: 'Sales',
+        peopleCount: 18,
+        assignedManager: null,
+        deliveryRecord: {
+          id: 'delivery-exit',
+          organization_id: 'org-1',
+          campaign_id: 'campaign-exit',
+          contact_request_id: null,
+          lifecycle_stage: 'first_management_use',
+          exception_status: 'none',
+          operator_owner: 'Verisight delivery',
+          next_step: 'Plan de follow-up review.',
+          operator_notes: null,
+          customer_handoff_note: null,
+          launch_date: null,
+          launch_confirmed_at: null,
+          participant_comms_config: null,
+          reminder_config: null,
+          first_management_use_confirmed_at: null,
+          follow_up_decided_at: null,
+          learning_closed_at: null,
+          created_at: '2026-04-15T10:00:00.000Z',
+          updated_at: '2026-04-24T10:00:00.000Z',
+        },
+        deliveryCheckpoints: [],
+        learningDossier: {
+          id: 'dossier-exit',
+          organization_id: 'org-1',
+          campaign_id: 'campaign-exit',
+          contact_request_id: null,
+          title: 'Exit follow-through',
+          route_interest: 'exitscan',
+          scan_type: 'exit',
+          delivery_mode: 'live',
+          triage_status: 'bevestigd',
+          lead_contact_name: null,
+          lead_organization_name: null,
+          lead_work_email: null,
+          lead_employee_count: null,
+          buyer_question: null,
+          expected_first_value: null,
+          buying_reason: null,
+          trust_friction: null,
+          implementation_risk: null,
+          first_management_value: null,
+          first_action_taken: null,
+          review_moment: '2026-05-12',
+          adoption_outcome: null,
+          management_action_outcome: null,
+          next_route: null,
+          stop_reason: null,
+          case_evidence_closure_status: 'lesson_only',
+          case_approval_status: 'draft',
+          case_permission_status: 'not_requested',
+          case_quote_potential: 'laag',
+          case_reference_potential: 'laag',
+          case_outcome_quality: 'indicatief',
+          case_outcome_classes: [],
+          claimable_observations: null,
+          supporting_artifacts: null,
+          case_public_summary: null,
+          created_by: null,
+          updated_by: null,
+          created_at: '2026-04-15T10:00:00.000Z',
+          updated_at: '2026-04-24T10:00:00.000Z',
+        },
+        learningCheckpoints: [],
+      },
+    ]),
+  ]
+
+  return countSuiteTelemetryEvents(events)
+}
+
+export default async function HealthPage() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/login')
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('is_verisight_admin')
+    .eq('id', user.id)
+    .single()
+
+  if (profile?.is_verisight_admin !== true) {
+    redirect('/dashboard')
+  }
+
+  const counts = getSampleCounts()
+
+  return (
+    <div className="space-y-6">
+      <DashboardHero
+        surface="ops"
+        tone="slate"
+        eyebrow="Health review"
+        title="Suite health evidence"
+        description="Compacte healthlaag voor activation, first value, denied access en Action Center follow-through. Geen analytics-stack, wel bounded operations evidence."
+        meta={
+          <>
+            <DashboardChip surface="ops" label={`${counts.owner_access_confirmed} owner access`} tone="emerald" />
+            <DashboardChip surface="ops" label={`${counts.manager_denied_insights} denied insights`} tone="amber" />
+          </>
+        }
+        actions={
+          <Link
+            href="/beheer"
+            className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+          >
+            Terug naar beheer
+          </Link>
+        }
+      />
+
+      <DashboardSection title="Kernsignalen" description="Wekelijkse assisted SaaS health review op de minimale signal set.">
+        <div className="grid gap-4 lg:grid-cols-3">
+          <DashboardPanel title="Owner access confirmed" value={`${counts.owner_access_confirmed}`} body="Owner-toegang bevestigd binnen de insights-shell." tone="emerald" />
+          <DashboardPanel title="First value confirmed" value={`${counts.first_value_confirmed}`} body="Campaigns die first value hebben bereikt." tone="slate" />
+          <DashboardPanel title="First management use confirmed" value={`${counts.first_management_use_confirmed}`} body="Bounded managementgebruik bevestigd." tone="slate" />
+          <DashboardPanel title="Manager denied insights" value={`${counts.manager_denied_insights}`} body="Manager-only persona blijft buiten insight-routes." tone="amber" />
+          <DashboardPanel title="Action Center review scheduled" value={`${counts.action_center_review_scheduled}`} body="Reviewmomenten die expliciet gepland zijn." tone="slate" />
+          <DashboardPanel title="Action Center closeout recorded" value={`${counts.action_center_closeout_recorded}`} body="Follow-through items met expliciete closeout." tone="slate" />
+        </div>
+      </DashboardSection>
+    </div>
+  )
+}

--- a/frontend/app/(dashboard)/beheer/page.test.ts
+++ b/frontend/app/(dashboard)/beheer/page.test.ts
@@ -13,5 +13,7 @@ describe('beheer admin alignment', () => {
     expect(source).toContain('Werkvolgorde voor Verisight')
     expect(source).toContain('Open deliverylaag')
     expect(source).toContain('Gebruik dit overzicht voor organisatie-setup, campaign-setup')
+    expect(source).toContain('Open health review')
+    expect(source).toContain('Health review default')
   })
 })

--- a/frontend/app/(dashboard)/beheer/page.tsx
+++ b/frontend/app/(dashboard)/beheer/page.tsx
@@ -247,6 +247,12 @@ export default async function BeheerPage() {
             >
               Open klantlearnings
             </Link>
+            <Link
+              href="/beheer/health"
+              className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+            >
+              Open health review
+            </Link>
           </>
         }
         aside={
@@ -511,6 +517,13 @@ export default async function BeheerPage() {
               eyebrow="Learning"
               title="Learning default"
               body="Leg pilots en vroege klantlessen vast in /beheer/klantlearnings, zodat buyer-signalen en implementationfrictie niet in losse notities verdwijnen."
+              tone="slate"
+            />
+            <DashboardPanel
+              surface="ops"
+              eyebrow="Health"
+              title="Health review default"
+              body="Gebruik /beheer/health voor bounded activation-, denied-access- en follow-through signalen zonder brede analytics-stack."
               tone="slate"
             />
             <DashboardPanel

--- a/frontend/app/api/internal/telemetry/route.test.ts
+++ b/frontend/app/api/internal/telemetry/route.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { POST } from './route'
+
+describe('internal telemetry route', () => {
+  it('rejects incomplete telemetry payloads', async () => {
+    const response = await POST(
+      new Request('http://localhost/api/internal/telemetry', {
+        method: 'POST',
+        body: JSON.stringify({}),
+      }),
+    )
+    expect(response.status).toBe(400)
+  })
+})

--- a/frontend/app/api/internal/telemetry/route.ts
+++ b/frontend/app/api/internal/telemetry/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server'
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null)
+  if (!body?.eventType) {
+    return NextResponse.json({ error: 'Missing event type.' }, { status: 400 })
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/frontend/lib/action-center-live.test.ts
+++ b/frontend/lib/action-center-live.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildLiveActionCenterItems, isLiveActionCenterScanType } from './action-center-live'
+import { buildActionCenterTelemetryEvents, buildLiveActionCenterItems, isLiveActionCenterScanType } from './action-center-live'
 import type { Campaign, CampaignStats } from '@/lib/types'
 import type { CampaignDeliveryRecord } from '@/lib/ops-delivery'
 import type { PilotLearningCheckpoint, PilotLearningDossier } from '@/lib/pilot-learning'
@@ -205,5 +205,68 @@ describe('live action center builder', () => {
       ownerRole: 'Viewer',
       status: 'te-bespreken',
     })
+  })
+
+  it('derives bounded telemetry signals from lifecycle and review truth', () => {
+    const campaign: Campaign = {
+      id: 'campaign-exit',
+      organization_id: 'org-1',
+      name: 'Exit voorjaar',
+      scan_type: 'exit',
+      delivery_mode: 'live',
+      is_active: true,
+      enabled_modules: null,
+      created_at: '2026-04-10T10:00:00.000Z',
+      closed_at: null,
+    }
+    const deliveryRecord: CampaignDeliveryRecord = {
+      id: 'delivery-exit',
+      organization_id: 'org-1',
+      campaign_id: 'campaign-exit',
+      contact_request_id: null,
+      lifecycle_stage: 'first_management_use',
+      exception_status: 'none',
+      operator_owner: 'Verisight delivery',
+      next_step: 'Plan follow-up.',
+      operator_notes: null,
+      customer_handoff_note: null,
+      launch_date: null,
+      launch_confirmed_at: null,
+      participant_comms_config: null,
+      reminder_config: null,
+      first_management_use_confirmed_at: null,
+      follow_up_decided_at: null,
+      learning_closed_at: null,
+      created_at: '2026-04-15T10:00:00.000Z',
+      updated_at: '2026-04-24T10:00:00.000Z',
+    }
+    const dossier = {
+      review_moment: '2026-05-12',
+      triage_status: 'bevestigd',
+    } as PilotLearningDossier
+
+    const events = buildActionCenterTelemetryEvents([
+      {
+        campaign,
+        stats: null,
+        organizationName: 'Acme BV',
+        memberRole: 'owner',
+        scopeType: 'department',
+        scopeValue: 'operations',
+        scopeLabel: 'Operations',
+        peopleCount: 12,
+        assignedManager: null,
+        deliveryRecord,
+        deliveryCheckpoints: [],
+        learningDossier: dossier,
+        learningCheckpoints: [],
+      },
+    ])
+
+    expect(events.map((event) => event.eventType)).toEqual([
+      'first_value_confirmed',
+      'first_management_use_confirmed',
+      'action_center_review_scheduled',
+    ])
   })
 })

--- a/frontend/lib/action-center-live.ts
+++ b/frontend/lib/action-center-live.ts
@@ -9,6 +9,7 @@ import type { MemberRole, Campaign, CampaignStats, ScanType } from '@/lib/types'
 import type { CampaignDeliveryCheckpoint, CampaignDeliveryRecord, DeliveryExceptionStatus } from '@/lib/ops-delivery'
 import { getDeliveryExceptionLabel } from '@/lib/ops-delivery'
 import type { PilotLearningCheckpoint, PilotLearningDossier } from '@/lib/pilot-learning'
+import { buildSuiteTelemetryEvent, type SuiteTelemetryEvent } from '@/lib/telemetry/events'
 
 export interface LiveActionCenterCampaignContext {
   campaign: Campaign
@@ -384,4 +385,78 @@ export function getLiveActionCenterSummary(items: ActionCenterPreviewItem[]) {
     blockedCount: items.filter((item) => item.status === 'geblokkeerd').length,
     reviewCount: items.filter((item) => item.reviewDate).length,
   }
+}
+
+export function buildActionCenterTelemetryEvents(
+  contexts: LiveActionCenterCampaignContext[],
+  actorId?: string | null,
+) {
+  const events: SuiteTelemetryEvent[] = []
+
+  for (const context of contexts) {
+    const orgId = context.campaign.organization_id
+    const campaignId = context.campaign.id
+    const lifecycleStage = context.deliveryRecord?.lifecycle_stage ?? null
+
+    if (
+      lifecycleStage &&
+      ['first_value_reached', 'first_management_use', 'follow_up_decided', 'learning_closed'].includes(lifecycleStage)
+    ) {
+      events.push(
+        buildSuiteTelemetryEvent('first_value_confirmed', {
+          orgId,
+          campaignId,
+          actorId: actorId ?? null,
+          payload: { lifecycleStage },
+        }),
+      )
+    }
+
+    if (
+      lifecycleStage &&
+      ['first_management_use', 'follow_up_decided', 'learning_closed'].includes(lifecycleStage)
+    ) {
+      events.push(
+        buildSuiteTelemetryEvent('first_management_use_confirmed', {
+          orgId,
+          campaignId,
+          actorId: actorId ?? null,
+          payload: { lifecycleStage },
+        }),
+      )
+    }
+
+    if (context.learningDossier?.review_moment) {
+      events.push(
+        buildSuiteTelemetryEvent('action_center_review_scheduled', {
+          orgId,
+          campaignId,
+          actorId: actorId ?? null,
+          payload: {
+            reviewMoment: context.learningDossier.review_moment,
+            scopeValue: context.scopeValue,
+          },
+        }),
+      )
+    }
+
+    if (
+      context.learningDossier?.triage_status === 'uitgevoerd' ||
+      lifecycleStage === 'learning_closed'
+    ) {
+      events.push(
+        buildSuiteTelemetryEvent('action_center_closeout_recorded', {
+          orgId,
+          campaignId,
+          actorId: actorId ?? null,
+          payload: {
+            triageStatus: context.learningDossier?.triage_status ?? null,
+            lifecycleStage,
+          },
+        }),
+      )
+    }
+  }
+
+  return events
 }

--- a/frontend/lib/suite-access.test.ts
+++ b/frontend/lib/suite-access.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildSuiteAccessContext,
+  buildSuiteAccessTelemetryEvents,
   getDefaultSuiteLandingPath,
   isScopeVisibleToActionCenterContext,
   type ActionCenterWorkspaceMember,
@@ -55,6 +56,12 @@ describe('suite access context', () => {
     expect(getDefaultSuiteLandingPath(context)).toBe('/action-center')
     expect(isScopeVisibleToActionCenterContext(context, 'sales')).toBe(true)
     expect(isScopeVisibleToActionCenterContext(context, 'hr')).toBe(false)
+    expect(buildSuiteAccessTelemetryEvents({ context, actorId: 'manager-1' })).toEqual([
+      expect.objectContaining({
+        eventType: 'manager_denied_insights',
+        actorId: 'manager-1',
+      }),
+    ])
   })
 
   it('lets admins see both modules even without org membership rows', () => {
@@ -70,5 +77,21 @@ describe('suite access context', () => {
     expect(context.canViewActionCenter).toBe(true)
     expect(context.canManageActionCenterAssignments).toBe(true)
     expect(isScopeVisibleToActionCenterContext(context, 'finance')).toBe(true)
+  })
+
+  it('records owner access confirmation when an owner can enter the insight shell', () => {
+    const context = buildSuiteAccessContext({
+      isVerisightAdmin: false,
+      orgMemberships: [{ org_id: 'org-1', role: 'owner' }],
+      workspaceMemberships: [],
+    })
+
+    expect(buildSuiteAccessTelemetryEvents({ context, actorId: 'owner-1' })).toEqual([
+      expect.objectContaining({
+        eventType: 'owner_access_confirmed',
+        orgId: 'org-1',
+        actorId: 'owner-1',
+      }),
+    ])
   })
 })

--- a/frontend/lib/suite-access.ts
+++ b/frontend/lib/suite-access.ts
@@ -1,4 +1,5 @@
 import type { MemberRole } from '@/lib/types'
+import { buildSuiteTelemetryEvent, type SuiteTelemetryEvent } from '@/lib/telemetry/events'
 
 export type ActionCenterWorkspaceRole = 'hr_owner' | 'hr_member' | 'manager_assignee'
 export type ActionCenterWorkspaceScopeType = 'org' | 'department' | 'item'
@@ -146,4 +147,34 @@ export function isScopeVisibleToActionCenterContext(
   }
 
   return context.managerScopeValues.includes(scopeValue)
+}
+
+export function buildSuiteAccessTelemetryEvents(args: {
+  actorId?: string | null
+  context: Pick<SuiteAccessContext, 'persona' | 'primaryOrgId' | 'canViewInsights' | 'managerOnly'>
+}) {
+  const events: SuiteTelemetryEvent[] = []
+
+  if (
+    args.context.persona === 'customer_owner' &&
+    args.context.canViewInsights
+  ) {
+    events.push(
+      buildSuiteTelemetryEvent('owner_access_confirmed', {
+        orgId: args.context.primaryOrgId,
+        actorId: args.actorId ?? null,
+      }),
+    )
+  }
+
+  if (args.context.managerOnly && !args.context.canViewInsights) {
+    events.push(
+      buildSuiteTelemetryEvent('manager_denied_insights', {
+        orgId: args.context.primaryOrgId,
+        actorId: args.actorId ?? null,
+      }),
+    )
+  }
+
+  return events
 }

--- a/frontend/lib/telemetry/events.test.ts
+++ b/frontend/lib/telemetry/events.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { buildSuiteTelemetryEvent, countSuiteTelemetryEvents } from '@/lib/telemetry/events'
+
+describe('suite telemetry event builder', () => {
+  it('normalizes a bounded telemetry payload', () => {
+    const event = buildSuiteTelemetryEvent('first_value_confirmed', {
+      orgId: 'org_123',
+      campaignId: 'cmp_123',
+      actorId: 'user_123',
+    })
+    expect(event.eventType).toBe('first_value_confirmed')
+    expect(event.orgId).toBe('org_123')
+  })
+
+  it('summarizes bounded event counts', () => {
+    const counts = countSuiteTelemetryEvents([
+      buildSuiteTelemetryEvent('owner_access_confirmed', {}),
+      buildSuiteTelemetryEvent('owner_access_confirmed', {}),
+      buildSuiteTelemetryEvent('manager_denied_insights', {}),
+    ])
+    expect(counts.owner_access_confirmed).toBe(2)
+    expect(counts.manager_denied_insights).toBe(1)
+  })
+})

--- a/frontend/lib/telemetry/events.ts
+++ b/frontend/lib/telemetry/events.ts
@@ -1,0 +1,45 @@
+export type SuiteTelemetryEventType =
+  | 'owner_access_confirmed'
+  | 'first_value_confirmed'
+  | 'first_management_use_confirmed'
+  | 'manager_denied_insights'
+  | 'action_center_review_scheduled'
+  | 'action_center_closeout_recorded'
+
+export interface SuiteTelemetryEvent {
+  eventType: SuiteTelemetryEventType
+  orgId: string | null
+  campaignId: string | null
+  actorId: string | null
+  payload: Record<string, unknown>
+}
+
+export function buildSuiteTelemetryEvent(
+  eventType: SuiteTelemetryEventType,
+  args: { orgId?: string | null; campaignId?: string | null; actorId?: string | null; payload?: Record<string, unknown> },
+): SuiteTelemetryEvent {
+  return {
+    eventType,
+    orgId: args.orgId ?? null,
+    campaignId: args.campaignId ?? null,
+    actorId: args.actorId ?? null,
+    payload: args.payload ?? {},
+  }
+}
+
+export function countSuiteTelemetryEvents(events: SuiteTelemetryEvent[]) {
+  return events.reduce<Record<SuiteTelemetryEventType, number>>(
+    (acc, event) => {
+      acc[event.eventType] += 1
+      return acc
+    },
+    {
+      owner_access_confirmed: 0,
+      first_value_confirmed: 0,
+      first_management_use_confirmed: 0,
+      manager_denied_insights: 0,
+      action_center_review_scheduled: 0,
+      action_center_closeout_recorded: 0,
+    },
+  )
+}

--- a/supabase/suite_telemetry_events_patch.sql
+++ b/supabase/suite_telemetry_events_patch.sql
@@ -1,0 +1,9 @@
+create table if not exists public.suite_telemetry_events (
+  id uuid primary key default gen_random_uuid(),
+  event_type text not null,
+  org_id uuid null references public.organizations(id) on delete set null,
+  campaign_id uuid null references public.campaigns(id) on delete set null,
+  actor_id uuid null references auth.users(id) on delete set null,
+  payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);

--- a/tests/test_suite_telemetry_contract.py
+++ b/tests/test_suite_telemetry_contract.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = ROOT / "docs" / "active" / "SUITE_TELEMETRY_EVENT_CONTRACT.md"
+
+
+def test_suite_telemetry_contract_lists_bounded_core_events():
+    text = CONTRACT.read_text(encoding="utf-8")
+    assert "owner_access_confirmed" in text
+    assert "first_value_confirmed" in text
+    assert "manager_denied_insights" in text
+    assert "action_center_review_scheduled" in text


### PR DESCRIPTION
## Summary
- add a bounded suite telemetry event contract and SQL model
- instrument suite access and Action Center truth into typed event builders
- add internal telemetry ingest and `/beheer/health` admin review surface

## Verification
- `python -m pytest tests/test_suite_telemetry_contract.py -q`
- `npm run test -- lib/telemetry/events.test.ts "app/api/internal/telemetry/route.test.ts" "app/(dashboard)/beheer/health/page.test.ts" "app/(dashboard)/beheer/page.test.ts" lib/suite-access.test.ts lib/action-center-live.test.ts`
- `npm run build`
