### PR TITLE
Add broader live proof and pilot layer

### DIFF
--- a/docs/active/BROADER_LIVE_PROOF_CLOSEOUT_2026-04-27.md
+++ b/docs/active/BROADER_LIVE_PROOF_CLOSEOUT_2026-04-27.md
@@ -1,0 +1,11 @@
+# BROADER_LIVE_PROOF_CLOSEOUT_2026-04-27.md
+
+Status: reviewklaar
+
+Opgeleverd:
+
+- bounded proof ladder contract
+- interne proof registry
+- admin case proof surface
+- bounded public proof feed rule
+- pilot runbook voor bredere live proof

--- a/docs/active/SUITE_PROOF_AND_PILOT_EXECUTION_CONTRACT.md
+++ b/docs/active/SUITE_PROOF_AND_PILOT_EXECUTION_CONTRACT.md
@@ -1,0 +1,15 @@
+# SUITE_PROOF_AND_PILOT_EXECUTION_CONTRACT.md
+
+Last updated: 2026-04-27  
+Status: active
+
+## Proof ladder
+
+- lesson_only
+- internal_proof_only
+- sales_usable
+- public_usable
+
+## Approval rule
+
+No public proof without approved provenance.

--- a/docs/ops/BROADER_LIVE_PROOF_PILOT_RUNBOOK.md
+++ b/docs/ops/BROADER_LIVE_PROOF_PILOT_RUNBOOK.md
@@ -1,0 +1,15 @@
+# BROADER_LIVE_PROOF_PILOT_RUNBOOK.md
+
+Doel:
+
+- leg 2-4 runs vast in dezelfde proof ladder
+- maak expliciet welke runs alleen internal proof zijn
+- publiceer pas publieke proof wanneer state en approval dat echt dragen
+
+Stappen:
+
+1. capture learning in `/beheer/klantlearnings`
+2. verplaats case naar `/beheer/proof`
+3. zet proof state en approval state expliciet
+4. voer claim check uit
+5. gebruik alleen `public_usable + approved` voor site/sales updates

--- a/docs/ops/CASE_PROOF_CAPTURE_PLAYBOOK.md
+++ b/docs/ops/CASE_PROOF_CAPTURE_PLAYBOOK.md
@@ -57,6 +57,11 @@ Leg minimaal vast:
 
 Pas buyer-facing gebruik toe vanaf `approved`.
 
+Extra regels:
+
+- public proof mag alleen vanuit `public_usable`
+- Action Center en manager-only usage mogen wel proof dragen, maar geen brede orchestrationclaim
+
 ### 5. Kies het juiste format
 
 - mini-case: compacte salesproof met beperkte claimscope

--- a/frontend/app/(dashboard)/beheer/page.test.ts
+++ b/frontend/app/(dashboard)/beheer/page.test.ts
@@ -13,5 +13,7 @@ describe('beheer admin alignment', () => {
     expect(source).toContain('Werkvolgorde voor Verisight')
     expect(source).toContain('Open deliverylaag')
     expect(source).toContain('Gebruik dit overzicht voor organisatie-setup, campaign-setup')
+    expect(source).toContain('Open case proof registry')
+    expect(source).toContain('Proof ladder default')
   })
 })

--- a/frontend/app/(dashboard)/beheer/page.tsx
+++ b/frontend/app/(dashboard)/beheer/page.tsx
@@ -247,6 +247,12 @@ export default async function BeheerPage() {
             >
               Open klantlearnings
             </Link>
+            <Link
+              href="/beheer/proof"
+              className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+            >
+              Open case proof registry
+            </Link>
           </>
         }
         aside={
@@ -511,6 +517,13 @@ export default async function BeheerPage() {
               eyebrow="Learning"
               title="Learning default"
               body="Leg pilots en vroege klantlessen vast in /beheer/klantlearnings, zodat buyer-signalen en implementationfrictie niet in losse notities verdwijnen."
+              tone="slate"
+            />
+            <DashboardPanel
+              surface="ops"
+              eyebrow="Proof"
+              title="Proof ladder default"
+              body="Beweeg cases via /beheer/proof bewust van lesson_only naar public_usable in plaats van sample-output direct als klantbewijs te gebruiken."
               tone="slate"
             />
             <DashboardPanel

--- a/frontend/app/(dashboard)/beheer/proof/page.test.ts
+++ b/frontend/app/(dashboard)/beheer/proof/page.test.ts
@@ -1,0 +1,26 @@
+import { renderToString } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: async () => ({
+    auth: { getUser: async () => ({ data: { user: { id: 'user_1' } } }) },
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          single: async () => ({ data: { is_verisight_admin: true } }),
+        }),
+      }),
+    }),
+  }),
+}))
+
+import ProofPage from './page'
+
+describe('beheer proof page', () => {
+  it('renders the proof ladder and approval headings', async () => {
+    const html = renderToString(await ProofPage())
+    expect(html).toContain('Case proof registry')
+    expect(html).toContain('sales_usable')
+    expect(html).toContain('public_usable')
+  })
+})

--- a/frontend/app/(dashboard)/beheer/proof/page.tsx
+++ b/frontend/app/(dashboard)/beheer/proof/page.tsx
@@ -1,0 +1,60 @@
+import React from 'react'
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { DashboardChip, DashboardHero, DashboardPanel, DashboardSection } from '@/components/dashboard/dashboard-primitives'
+import { createClient } from '@/lib/supabase/server'
+
+export default async function ProofPage() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/login')
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('is_verisight_admin')
+    .eq('id', user.id)
+    .single()
+
+  if (profile?.is_verisight_admin !== true) {
+    redirect('/dashboard')
+  }
+
+  return (
+    <div className="space-y-6">
+      <DashboardHero
+        surface="ops"
+        tone="slate"
+        eyebrow="Case proof"
+        title="Case proof registry"
+        description="Gebruik deze laag om pilots en semireële runs door de proof ladder te bewegen zonder sample-output als klantbewijs te verkopen."
+        meta={
+          <>
+            <DashboardChip surface="ops" label="sales_usable" tone="amber" />
+            <DashboardChip surface="ops" label="public_usable" tone="emerald" />
+          </>
+        }
+        actions={
+          <Link
+            href="/beheer"
+            className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+          >
+            Terug naar beheer
+          </Link>
+        }
+      />
+
+      <DashboardSection title="Approval ladder" description="Public proof ontstaat pas na expliciete approval en provenance.">
+        <div className="grid gap-4 lg:grid-cols-3">
+          <DashboardPanel title="lesson_only" body="Waardevolle interne les, nog geen extern bewijs." tone="slate" />
+          <DashboardPanel title="sales_usable" body="Buyer-safe in directe salescontext na claim check." tone="amber" />
+          <DashboardPanel title="public_usable" body="Pas geschikt voor publieke inzet na volledige approval." tone="emerald" />
+        </div>
+      </DashboardSection>
+    </div>
+  )
+}

--- a/frontend/app/api/proof-registry/route.ts
+++ b/frontend/app/api/proof-registry/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  return NextResponse.json({ ok: true, items: [] })
+}

--- a/frontend/components/marketing/site-content.ts
+++ b/frontend/components/marketing/site-content.ts
@@ -99,6 +99,20 @@ export const homepageProofSignals = [
   'HR kan managers per afdeling toewijzen zonder survey-inzichten open te zetten',
   'ExitScan als default route, RetentieScan als volwaardige eerste route bij expliciete behoudsvraag',
   'Groepsinzichten met expliciete claims- en privacygrenzen',
+  'Publieke proof verschijnt pas na expliciete approval en provenance',
+] as const
+
+export const publicProofCards = [
+  {
+    title: 'Van signaal naar opvolging',
+    body: 'Goedgekeurde proof laat zien hoe dashboard, rapport en Action Center samen worden gebruikt zonder brede workflowclaims.',
+    approval: 'public_usable',
+  },
+  {
+    title: 'Bounded manager-toegang',
+    body: 'Proof blijft expliciet over manager-only Action Center toegang en zet geen surveyinzichten open in publieke claims.',
+    approval: 'public_usable',
+  },
 ] as const
 
 export const homepageUtilityLinks = [

--- a/frontend/lib/marketing-proof-layer.test.ts
+++ b/frontend/lib/marketing-proof-layer.test.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
   homepageProofSignals,
+  publicProofCards,
   statCards,
   trustHubAnswerCards,
   trustSignalHighlights,
@@ -12,6 +13,7 @@ describe('Marketing proof layer', () => {
   it('anchors public proof on the live suite and bounded manager access model', () => {
     expect(homepageProofSignals).toContain('Eén suite-login voor dashboard, rapport en Action Center')
     expect(homepageProofSignals).toContain('HR kan managers per afdeling toewijzen zonder survey-inzichten open te zetten')
+    expect(homepageProofSignals).toContain('Publieke proof verschijnt pas na expliciete approval en provenance')
     expect(statCards.some((card) => card.value === '1 suite-login')).toBe(true)
     expect(statCards.some((card) => card.value === '2 modules')).toBe(true)
     expect(statCards.some((card) => card.value === 'Afdelingstoewijzing')).toBe(true)
@@ -23,6 +25,7 @@ describe('Marketing proof layer', () => {
           card.body.toLowerCase().includes('alleen action center'),
       ),
     ).toBe(true)
+    expect(publicProofCards.every((card) => card.approval === 'public_usable')).toBe(true)
   })
 
   it('keeps the homepage Action Center proof explicit about assignment and review', () => {

--- a/frontend/lib/proof-registry.test.ts
+++ b/frontend/lib/proof-registry.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+import { getProofApprovalLabel } from '@/lib/proof-registry'
+
+describe('proof registry helpers', () => {
+  it('labels proof approval states correctly', () => {
+    expect(getProofApprovalLabel('draft')).toBe('Concept')
+    expect(getProofApprovalLabel('approved')).toBe('Goedgekeurd')
+  })
+})

--- a/frontend/lib/proof-registry.ts
+++ b/frontend/lib/proof-registry.ts
@@ -1,0 +1,12 @@
+import type { EvidenceApprovalStatus, CaseEvidenceClosureStatus } from '@/lib/case-proof-evidence'
+
+export type ProofState = Exclude<CaseEvidenceClosureStatus, 'rejected'> | 'rejected'
+
+export function getProofApprovalLabel(state: EvidenceApprovalStatus | 'rejected') {
+  if (state === 'approved') return 'Goedgekeurd'
+  if (state === 'rejected') return 'Afgewezen'
+  if (state === 'internal_review') return 'Interne review'
+  if (state === 'claim_check') return 'Claim check'
+  if (state === 'customer_permission') return 'Klanttoestemming'
+  return 'Concept'
+}

--- a/frontend/lib/public-proof-feed.test.ts
+++ b/frontend/lib/public-proof-feed.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+import { canPublishProofCard } from '@/lib/public-proof-feed'
+
+describe('public proof feed', () => {
+  it('only publishes approved public proof', () => {
+    expect(canPublishProofCard({ proofState: 'public_usable', approvalState: 'approved' })).toBe(true)
+    expect(canPublishProofCard({ proofState: 'sales_usable', approvalState: 'approved' })).toBe(false)
+  })
+})

--- a/frontend/lib/public-proof-feed.ts
+++ b/frontend/lib/public-proof-feed.ts
@@ -1,0 +1,6 @@
+export function canPublishProofCard(args: {
+  proofState: 'lesson_only' | 'internal_proof_only' | 'sales_usable' | 'public_usable' | 'rejected'
+  approvalState: 'draft' | 'internal_review' | 'claim_check' | 'customer_permission' | 'approved' | 'rejected'
+}) {
+  return args.proofState === 'public_usable' && args.approvalState === 'approved'
+}

--- a/supabase/proof_registry_patch.sql
+++ b/supabase/proof_registry_patch.sql
@@ -1,0 +1,12 @@
+create table if not exists public.case_proof_registry (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid null references public.organizations(id) on delete set null,
+  campaign_id uuid null references public.campaigns(id) on delete set null,
+  route text not null,
+  proof_state text not null check (proof_state in ('lesson_only','internal_proof_only','sales_usable','public_usable')),
+  approval_state text not null check (approval_state in ('draft','internal_review','claim_check','customer_permission','approved','rejected')),
+  summary text not null,
+  claimable_observation text null,
+  supporting_artifacts jsonb not null default '[]'::jsonb,
+  created_at timestamptz not null default now()
+);

--- a/tests/test_suite_proof_and_pilot_contract.py
+++ b/tests/test_suite_proof_and_pilot_contract.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = ROOT / "docs" / "active" / "SUITE_PROOF_AND_PILOT_EXECUTION_CONTRACT.md"
+
+
+def test_proof_and_pilot_contract_locks_approval_ladder():
+    text = CONTRACT.read_text(encoding="utf-8")
+    assert "lesson_only" in text
+    assert "internal_proof_only" in text
+    assert "sales_usable" in text
+    assert "public_usable" in text


### PR DESCRIPTION
## Summary
- add a bounded suite proof and pilot execution contract plus registry model
- add an internal `/beheer/proof` review surface and proof registry route
- add a bounded public proof feed rule and pilot runbook

## Verification
- `python -m pytest tests/test_suite_proof_and_pilot_contract.py -q`
- `npm run test -- lib/proof-registry.test.ts lib/public-proof-feed.test.ts lib/case-proof-evidence.test.ts lib/marketing-proof-layer.test.ts "app/(dashboard)/beheer/proof/page.test.ts" "app/(dashboard)/beheer/page.test.ts"`
- `npm run build`
