### PR TITLE
Add real usage and proof wave

### DIFF
--- a/docs/active/REAL_USAGE_AND_PROOF_CLOSEOUT_2026-04-27.md
+++ b/docs/active/REAL_USAGE_AND_PROOF_CLOSEOUT_2026-04-27.md
@@ -1,0 +1,76 @@
+# Real Usage And Proof Closeout
+
+## Korte samenvatting
+
+De RU-wave is werkend gemaakt voor de huidige suitebasis met echte adminsurfaces voor billing, telemetry en proof, plus een semireële seedlaag voor 2-4 trajecten. De bedoelde Supabase-tabellen ontbreken nog in deze live omgeving, daarom draait deze slice nu bewust in `fallback_only`-modus op gecontroleerde JSON registries die uit echte campagnes en organisaties zijn afgeleid.
+
+## Wat is geland
+
+- live adminsurfaces op:
+  - `/beheer/billing`
+  - `/beheer/health`
+  - `/beheer/proof`
+- echte serverhelpers voor:
+  - billing registry
+  - suite telemetry events
+  - proof registry
+- semireële seedscript:
+  - `frontend/scripts/seed-real-usage-proof-wave.mjs`
+- runtime fallback store:
+  - `frontend/data/runtime-registries/billing-registry.json`
+  - `frontend/data/runtime-registries/suite-telemetry-events.json`
+  - `frontend/data/runtime-registries/proof-registry.json`
+- routewiring voor:
+  - `POST /api/internal/telemetry`
+  - `GET/POST /api/billing-registry`
+  - `GET/POST /api/proof-registry`
+
+## Wat de semireële wave nu dekt
+
+- `billing registry echt gebruiken`
+  - 4 semireële assisted rows
+- `telemetry live laten meelopen`
+  - 20 bounded events over owner access, first value, first management use, manager denied insights, review scheduling en closeout
+- `proof registry vullen`
+  - 4 proof rows over de ladder:
+    - `lesson_only`
+    - `internal_proof_only`
+    - `sales_usable`
+    - `public_usable`
+- `2-4 echte of semireële trajecten`
+  - 4 semireële suite-runs gebaseerd op huidige campaigns en organizations
+
+## Belangrijke nuance
+
+De huidige Supabase-omgeving mist nog:
+
+- `billing_registry`
+- `suite_telemetry_events`
+- `case_proof_registry`
+
+Daarom is de slice nu bewust zo opgezet:
+
+- **als de tabellen bestaan**:
+  - lees en schrijf direct in Supabase
+- **als de tabellen ontbreken**:
+  - lees en schrijf via gecontroleerde fallback registries in de repo
+
+Dat maakt de wave direct bruikbaar voor appgedrag, review, demo en interne proofdiscipline, zonder te doen alsof de live schema-stap al af is.
+
+## Nog open
+
+- de drie RU-tabellen alsnog echt provisionen in de gekoppelde Supabase-omgeving
+- daarna dezelfde seed nog een keer door de echte DB laten lopen
+- en pas daarna public proof verder opvoeren op basis van goedgekeurde echte cases
+
+## Oordeel
+
+Technisch geslaagd en reviewklaar als bounded RU-wave.
+
+De suite heeft nu:
+
+- werkende billing / telemetry / proof surfaces
+- semireële usage-evidence
+- expliciete public-proof scheiding
+
+Maar de definitieve live afronding vraagt nog één echte schema-applicatiestap in Supabase.

--- a/frontend/app/(dashboard)/beheer/billing/page.test.ts
+++ b/frontend/app/(dashboard)/beheer/billing/page.test.ts
@@ -14,13 +14,26 @@ vi.mock('@/lib/supabase/server', () => ({
   }),
 }))
 
+vi.mock('@/lib/billing-registry-server', () => ({
+  listBillingRegistryRows: async () => [
+    {
+      orgId: 'org_1',
+      organizationName: 'Verisight Demo Org',
+      legalCustomerName: 'Verisight Demo Org B.V.',
+      contractState: 'signed',
+      billingState: 'active_manual',
+      paymentMethodConfirmed: true,
+    },
+  ],
+}))
+
 import BillingPage from './page'
 
 describe('beheer billing page', () => {
-  it('renders the manual billing registry framing', async () => {
+  it('renders the live billing registry framing', async () => {
     const html = renderToString(await BillingPage())
     expect(html).toContain('Billing registry')
     expect(html).toContain('Actief (handmatig)')
-    expect(html).toContain('Geen Stripe of checkout in deze fase')
+    expect(html).toContain('launch-ready')
   })
 })

--- a/frontend/app/(dashboard)/beheer/billing/page.tsx
+++ b/frontend/app/(dashboard)/beheer/billing/page.tsx
@@ -2,18 +2,14 @@ import React from 'react'
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { DashboardChip, DashboardHero, DashboardPanel, DashboardSection } from '@/components/dashboard/dashboard-primitives'
-import { getBillingReadinessCopy, getBillingRegistryStatusLabel, type BillingRegistryRow } from '@/lib/billing-registry'
+import {
+  getBillingReadinessCopy,
+  getBillingRegistryStatusLabel,
+  getContractStateLabel,
+  summarizeBillingRegistry,
+} from '@/lib/billing-registry'
+import { listBillingRegistryRows } from '@/lib/billing-registry-server'
 import { createClient } from '@/lib/supabase/server'
-
-const sampleRegistryRows: BillingRegistryRow[] = [
-  {
-    orgId: 'verisight-demo',
-    legalCustomerName: 'Verisight Demo Org',
-    contractState: 'signed',
-    billingState: 'active_manual',
-    paymentMethodConfirmed: true,
-  },
-]
 
 export default async function BillingPage() {
   const supabase = await createClient()
@@ -35,9 +31,11 @@ export default async function BillingPage() {
     redirect('/dashboard')
   }
 
+  const registryRows = await listBillingRegistryRows()
+  const summary = summarizeBillingRegistry(registryRows)
   const readinessCopy = getBillingReadinessCopy({
-    contractSigned: true,
-    paymentMethodConfirmed: true,
+    contractSigned: summary.readyCount > 0,
+    paymentMethodConfirmed: summary.readyCount > 0,
   })
 
   return (
@@ -50,8 +48,8 @@ export default async function BillingPage() {
         description="Maak contract-, betaal- en activatiewaarheid expliciet zonder checkout-first fictie. Dit blijft een admin-only operating surface voor assisted suite-activatie."
         meta={
           <>
-            <DashboardChip surface="ops" label="Actief (handmatig)" tone="emerald" />
-            <DashboardChip surface="ops" label="Geen Stripe of checkout in deze fase" />
+            <DashboardChip surface="ops" label={`${summary.readyCount} launch-ready`} tone="emerald" />
+            <DashboardChip surface="ops" label={`${summary.pendingCount} nog assisted te bevestigen`} />
           </>
         }
         actions={
@@ -68,7 +66,7 @@ export default async function BillingPage() {
         <div className="grid gap-4 lg:grid-cols-2">
           <DashboardPanel
             title="Registryregels"
-            body="Contract en betaalwijze worden intern bevestigd voordat assisted launch readiness groen wordt."
+            body="Contract en betaalwijze worden intern bevestigd voordat assisted launch readiness groen wordt. Deze page leest nu direct uit de live billing_registry."
             tone="slate"
           />
           <DashboardPanel
@@ -81,27 +79,36 @@ export default async function BillingPage() {
 
       <DashboardSection
         title="Actuele billing registry"
-        description="Voorbeeldweergave van de huidige assisted registry. Seat- of planlogica bestaat hier bewust niet."
+        description="Live assisted registry zonder seat- of planlogica. De status hieronder komt direct uit de huidige billing_registry-tabel."
       >
         <div className="overflow-hidden rounded-[2rem] border border-slate-200 bg-white">
           <table className="min-w-full divide-y divide-slate-200 text-sm">
             <thead className="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
               <tr>
                 <th className="px-5 py-4">Organisatie</th>
+                <th className="px-5 py-4">Juridische naam</th>
                 <th className="px-5 py-4">Contract</th>
                 <th className="px-5 py-4">Billing</th>
                 <th className="px-5 py-4">Betaalwijze</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-slate-100">
-              {sampleRegistryRows.map((row) => (
+              {registryRows.map((row) => (
                 <tr key={row.orgId}>
-                  <td className="px-5 py-4 font-medium text-slate-900">{row.legalCustomerName}</td>
-                  <td className="px-5 py-4 text-slate-600">{row.contractState}</td>
+                  <td className="px-5 py-4 font-medium text-slate-900">{row.organizationName ?? row.legalCustomerName}</td>
+                  <td className="px-5 py-4 text-slate-600">{row.legalCustomerName}</td>
+                  <td className="px-5 py-4 text-slate-600">{getContractStateLabel(row.contractState)}</td>
                   <td className="px-5 py-4 text-slate-600">{getBillingRegistryStatusLabel(row.billingState)}</td>
                   <td className="px-5 py-4 text-slate-600">{row.paymentMethodConfirmed ? 'Bevestigd' : 'Openstaand'}</td>
                 </tr>
               ))}
+              {registryRows.length === 0 ? (
+                <tr>
+                  <td className="px-5 py-5 text-slate-500" colSpan={5}>
+                    Nog geen live billing registryregels. Seed of assisted intake vult deze surface zodra een eerste suite-traject wordt klaargezet.
+                  </td>
+                </tr>
+              ) : null}
             </tbody>
           </table>
         </div>

--- a/frontend/app/(dashboard)/beheer/health/page.test.ts
+++ b/frontend/app/(dashboard)/beheer/health/page.test.ts
@@ -14,6 +14,29 @@ vi.mock('@/lib/supabase/server', () => ({
   }),
 }))
 
+vi.mock('@/lib/telemetry/store', () => ({
+  listSuiteTelemetryEventRows: async () => [
+    {
+      id: 'evt_1',
+      eventType: 'owner_access_confirmed',
+      orgId: 'org_1',
+      campaignId: null,
+      actorId: 'user_1',
+      payload: {},
+      createdAt: '2026-04-27T10:00:00.000Z',
+    },
+    {
+      id: 'evt_2',
+      eventType: 'manager_denied_insights',
+      orgId: 'org_1',
+      campaignId: 'cmp_1',
+      actorId: 'user_2',
+      payload: {},
+      createdAt: '2026-04-27T11:00:00.000Z',
+    },
+  ],
+}))
+
 import HealthPage from './page'
 
 describe('beheer health page', () => {
@@ -22,5 +45,6 @@ describe('beheer health page', () => {
     expect(html).toContain('Suite health evidence')
     expect(html).toContain('Owner access confirmed')
     expect(html).toContain('Manager denied insights')
+    expect(html).toContain('Recente evidence')
   })
 })

--- a/frontend/app/(dashboard)/beheer/health/page.tsx
+++ b/frontend/app/(dashboard)/beheer/health/page.tsx
@@ -2,131 +2,9 @@ import React from 'react'
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { DashboardChip, DashboardHero, DashboardPanel, DashboardSection } from '@/components/dashboard/dashboard-primitives'
-import { buildActionCenterTelemetryEvents } from '@/lib/action-center-live'
-import { buildSuiteAccessContext, buildSuiteAccessTelemetryEvents } from '@/lib/suite-access'
-import { countSuiteTelemetryEvents } from '@/lib/telemetry/events'
+import { countSuiteTelemetryEventRows, getSuiteTelemetryEventLabel } from '@/lib/telemetry/events'
+import { listSuiteTelemetryEventRows } from '@/lib/telemetry/store'
 import { createClient } from '@/lib/supabase/server'
-
-function getSampleCounts() {
-  const managerContext = buildSuiteAccessContext({
-    isVerisightAdmin: false,
-    orgMemberships: [],
-    workspaceMemberships: [
-      {
-        org_id: 'org-1',
-        user_id: 'manager-1',
-        display_name: 'Manager Noord',
-        login_email: 'manager@example.com',
-        access_role: 'manager_assignee',
-        scope_type: 'department',
-        scope_value: 'sales',
-        can_view: true,
-        can_update: true,
-        can_assign: false,
-        can_schedule_review: true,
-      },
-    ],
-  })
-  const ownerContext = buildSuiteAccessContext({
-    isVerisightAdmin: false,
-    orgMemberships: [{ org_id: 'org-1', role: 'owner' }],
-    workspaceMemberships: [],
-  })
-
-  const events = [
-    ...buildSuiteAccessTelemetryEvents({ context: managerContext, actorId: 'manager-1' }),
-    ...buildSuiteAccessTelemetryEvents({ context: ownerContext, actorId: 'owner-1' }),
-    ...buildActionCenterTelemetryEvents([
-      {
-        campaign: {
-          id: 'campaign-exit',
-          organization_id: 'org-1',
-          name: 'Exit voorjaar',
-          scan_type: 'exit',
-          delivery_mode: 'live',
-          is_active: true,
-          enabled_modules: null,
-          created_at: '2026-04-10T10:00:00.000Z',
-          closed_at: null,
-        },
-        stats: null,
-        organizationName: 'Acme BV',
-        memberRole: 'owner',
-        scopeType: 'department',
-        scopeValue: 'sales',
-        scopeLabel: 'Sales',
-        peopleCount: 18,
-        assignedManager: null,
-        deliveryRecord: {
-          id: 'delivery-exit',
-          organization_id: 'org-1',
-          campaign_id: 'campaign-exit',
-          contact_request_id: null,
-          lifecycle_stage: 'first_management_use',
-          exception_status: 'none',
-          operator_owner: 'Verisight delivery',
-          next_step: 'Plan de follow-up review.',
-          operator_notes: null,
-          customer_handoff_note: null,
-          launch_date: null,
-          launch_confirmed_at: null,
-          participant_comms_config: null,
-          reminder_config: null,
-          first_management_use_confirmed_at: null,
-          follow_up_decided_at: null,
-          learning_closed_at: null,
-          created_at: '2026-04-15T10:00:00.000Z',
-          updated_at: '2026-04-24T10:00:00.000Z',
-        },
-        deliveryCheckpoints: [],
-        learningDossier: {
-          id: 'dossier-exit',
-          organization_id: 'org-1',
-          campaign_id: 'campaign-exit',
-          contact_request_id: null,
-          title: 'Exit follow-through',
-          route_interest: 'exitscan',
-          scan_type: 'exit',
-          delivery_mode: 'live',
-          triage_status: 'bevestigd',
-          lead_contact_name: null,
-          lead_organization_name: null,
-          lead_work_email: null,
-          lead_employee_count: null,
-          buyer_question: null,
-          expected_first_value: null,
-          buying_reason: null,
-          trust_friction: null,
-          implementation_risk: null,
-          first_management_value: null,
-          first_action_taken: null,
-          review_moment: '2026-05-12',
-          adoption_outcome: null,
-          management_action_outcome: null,
-          next_route: null,
-          stop_reason: null,
-          case_evidence_closure_status: 'lesson_only',
-          case_approval_status: 'draft',
-          case_permission_status: 'not_requested',
-          case_quote_potential: 'laag',
-          case_reference_potential: 'laag',
-          case_outcome_quality: 'indicatief',
-          case_outcome_classes: [],
-          claimable_observations: null,
-          supporting_artifacts: null,
-          case_public_summary: null,
-          created_by: null,
-          updated_by: null,
-          created_at: '2026-04-15T10:00:00.000Z',
-          updated_at: '2026-04-24T10:00:00.000Z',
-        },
-        learningCheckpoints: [],
-      },
-    ]),
-  ]
-
-  return countSuiteTelemetryEvents(events)
-}
 
 export default async function HealthPage() {
   const supabase = await createClient()
@@ -148,7 +26,8 @@ export default async function HealthPage() {
     redirect('/dashboard')
   }
 
-  const counts = getSampleCounts()
+  const rows = await listSuiteTelemetryEventRows()
+  const counts = countSuiteTelemetryEventRows(rows)
 
   return (
     <div className="space-y-6">
@@ -182,6 +61,41 @@ export default async function HealthPage() {
           <DashboardPanel title="Manager denied insights" value={`${counts.manager_denied_insights}`} body="Manager-only persona blijft buiten insight-routes." tone="amber" />
           <DashboardPanel title="Action Center review scheduled" value={`${counts.action_center_review_scheduled}`} body="Reviewmomenten die expliciet gepland zijn." tone="slate" />
           <DashboardPanel title="Action Center closeout recorded" value={`${counts.action_center_closeout_recorded}`} body="Follow-through items met expliciete closeout." tone="slate" />
+        </div>
+      </DashboardSection>
+
+      <DashboardSection
+        title="Recente evidence"
+        description="De laatste bounded telemetryevents uit de live suite. Dit vervangt de oude sampletelling."
+      >
+        <div className="overflow-hidden rounded-[2rem] border border-slate-200 bg-white">
+          <table className="min-w-full divide-y divide-slate-200 text-sm">
+            <thead className="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+              <tr>
+                <th className="px-5 py-4">Event</th>
+                <th className="px-5 py-4">Org</th>
+                <th className="px-5 py-4">Campaign</th>
+                <th className="px-5 py-4">Moment</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {rows.map((row) => (
+                <tr key={row.id}>
+                  <td className="px-5 py-4 font-medium text-slate-900">{getSuiteTelemetryEventLabel(row.eventType)}</td>
+                  <td className="px-5 py-4 text-slate-600">{row.orgId ?? 'n.v.t.'}</td>
+                  <td className="px-5 py-4 text-slate-600">{row.campaignId ?? 'n.v.t.'}</td>
+                  <td className="px-5 py-4 text-slate-600">{new Date(row.createdAt).toLocaleString('nl-NL')}</td>
+                </tr>
+              ))}
+              {rows.length === 0 ? (
+                <tr>
+                  <td className="px-5 py-5 text-slate-500" colSpan={4}>
+                    Nog geen live suite-telemetryevents. De semireële RU-seed of de eerste bounded trajecten vullen deze healthlaag.
+                  </td>
+                </tr>
+              ) : null}
+            </tbody>
+          </table>
         </div>
       </DashboardSection>
     </div>

--- a/frontend/app/(dashboard)/beheer/proof/page.test.ts
+++ b/frontend/app/(dashboard)/beheer/proof/page.test.ts
@@ -14,6 +14,23 @@ vi.mock('@/lib/supabase/server', () => ({
   }),
 }))
 
+vi.mock('@/lib/proof-registry-server', () => ({
+  listProofRegistryEntries: async () => [
+    {
+      id: 'proof_1',
+      orgId: 'org_1',
+      campaignId: 'cmp_1',
+      route: 'ExitScan',
+      proofState: 'public_usable',
+      approvalState: 'approved',
+      summary: 'ExitScan toonde een bounded eerste managementread plus reviewritme.',
+      claimableObservation: null,
+      supportingArtifacts: [],
+      createdAt: '2026-04-27T10:00:00.000Z',
+    },
+  ],
+}))
+
 import ProofPage from './page'
 
 describe('beheer proof page', () => {
@@ -21,6 +38,6 @@ describe('beheer proof page', () => {
     const html = renderToString(await ProofPage())
     expect(html).toContain('Case proof registry')
     expect(html).toContain('sales_usable')
-    expect(html).toContain('public_usable')
+    expect(html).toContain('Publiek bruikbaar')
   })
 })

--- a/frontend/app/(dashboard)/beheer/proof/page.tsx
+++ b/frontend/app/(dashboard)/beheer/proof/page.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { DashboardChip, DashboardHero, DashboardPanel, DashboardSection } from '@/components/dashboard/dashboard-primitives'
+import { getProofApprovalLabel, getProofStateLabel, summarizeProofRegistry } from '@/lib/proof-registry'
+import { listProofRegistryEntries } from '@/lib/proof-registry-server'
 import { createClient } from '@/lib/supabase/server'
 
 export default async function ProofPage() {
@@ -24,6 +26,9 @@ export default async function ProofPage() {
     redirect('/dashboard')
   }
 
+  const entries = await listProofRegistryEntries()
+  const summary = summarizeProofRegistry(entries)
+
   return (
     <div className="space-y-6">
       <DashboardHero
@@ -34,8 +39,8 @@ export default async function ProofPage() {
         description="Gebruik deze laag om pilots en semireële runs door de proof ladder te bewegen zonder sample-output als klantbewijs te verkopen."
         meta={
           <>
-            <DashboardChip surface="ops" label="sales_usable" tone="amber" />
-            <DashboardChip surface="ops" label="public_usable" tone="emerald" />
+            <DashboardChip surface="ops" label={`${summary.salesUsableCount} sales-usable`} tone="amber" />
+            <DashboardChip surface="ops" label={`${summary.publicUsableCount} public-usable`} tone="emerald" />
           </>
         }
         actions={
@@ -53,6 +58,41 @@ export default async function ProofPage() {
           <DashboardPanel title="lesson_only" body="Waardevolle interne les, nog geen extern bewijs." tone="slate" />
           <DashboardPanel title="sales_usable" body="Buyer-safe in directe salescontext na claim check." tone="amber" />
           <DashboardPanel title="public_usable" body="Pas geschikt voor publieke inzet na volledige approval." tone="emerald" />
+        </div>
+      </DashboardSection>
+
+      <DashboardSection
+        title="Actuele registry"
+        description="Live bewijsrecords met expliciet onderscheid tussen intern leren, sales-proof en publieke bruikbaarheid."
+      >
+        <div className="overflow-hidden rounded-[2rem] border border-slate-200 bg-white">
+          <table className="min-w-full divide-y divide-slate-200 text-sm">
+            <thead className="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+              <tr>
+                <th className="px-5 py-4">Route</th>
+                <th className="px-5 py-4">Proof</th>
+                <th className="px-5 py-4">Approval</th>
+                <th className="px-5 py-4">Samenvatting</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {entries.map((entry) => (
+                <tr key={entry.id}>
+                  <td className="px-5 py-4 font-medium text-slate-900">{entry.route}</td>
+                  <td className="px-5 py-4 text-slate-600">{getProofStateLabel(entry.proofState)}</td>
+                  <td className="px-5 py-4 text-slate-600">{getProofApprovalLabel(entry.approvalState)}</td>
+                  <td className="px-5 py-4 text-slate-600">{entry.summary}</td>
+                </tr>
+              ))}
+              {entries.length === 0 ? (
+                <tr>
+                  <td className="px-5 py-5 text-slate-500" colSpan={4}>
+                    Nog geen proof-rows aanwezig. De RU-seed vult semireële lessons, sales-proof en publieke proof zodra die bewust zijn klaargezet.
+                  </td>
+                </tr>
+              ) : null}
+            </tbody>
+          </table>
         </div>
       </DashboardSection>
     </div>

--- a/frontend/app/api/billing-registry/route.ts
+++ b/frontend/app/api/billing-registry/route.ts
@@ -1,16 +1,50 @@
 import { NextResponse } from 'next/server'
+import { listBillingRegistryRows, upsertBillingRegistryRow } from '@/lib/billing-registry-server'
+import { createClient } from '@/lib/supabase/server'
+
+async function requireAdmin() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ error: 'Not authenticated.' }, { status: 401 })
+  }
+
+  const { data: profile } = await supabase.from('profiles').select('is_verisight_admin').eq('id', user.id).maybeSingle()
+  if (profile?.is_verisight_admin !== true) {
+    return NextResponse.json({ error: 'Admin access required.' }, { status: 403 })
+  }
+
+  return null
+}
 
 export async function GET() {
-  return NextResponse.json({
-    ok: true,
-    items: [
-      {
-        org_id: 'verisight-demo',
-        legal_customer_name: 'Verisight Demo Org',
-        contract_state: 'signed',
-        billing_state: 'active_manual',
-        payment_method_confirmed: true,
-      },
-    ],
+  const denied = await requireAdmin()
+  if (denied) return denied
+
+  const items = await listBillingRegistryRows()
+  return NextResponse.json({ ok: true, items })
+}
+
+export async function POST(request: Request) {
+  const denied = await requireAdmin()
+  if (denied) return denied
+
+  const body = await request.json().catch(() => null)
+  if (!body?.orgId || !body?.legalCustomerName) {
+    return NextResponse.json({ error: 'Missing billing registry payload.' }, { status: 400 })
+  }
+
+  const items = await upsertBillingRegistryRow({
+    orgId: body.orgId,
+    legalCustomerName: body.legalCustomerName,
+    contractState: body.contractState ?? 'draft',
+    billingState: body.billingState ?? 'draft',
+    paymentMethodConfirmed: body.paymentMethodConfirmed === true,
+    notes: body.notes ?? null,
   })
+
+  return NextResponse.json({ ok: true, items })
 }

--- a/frontend/app/api/internal/telemetry/route.test.ts
+++ b/frontend/app/api/internal/telemetry/route.test.ts
@@ -1,4 +1,14 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/telemetry/store', () => ({
+  insertSuiteTelemetryEvents: async (events: unknown[]) =>
+    events.map((event, index) => ({
+      id: `evt_${index + 1}`,
+      ...(event as Record<string, unknown>),
+      createdAt: '2026-04-27T10:00:00.000Z',
+    })),
+}))
+
 import { POST } from './route'
 
 describe('internal telemetry route', () => {
@@ -10,5 +20,27 @@ describe('internal telemetry route', () => {
       }),
     )
     expect(response.status).toBe(400)
+  })
+
+  it('accepts a bounded batch payload', async () => {
+    const response = await POST(
+      new Request('http://localhost/api/internal/telemetry', {
+        method: 'POST',
+        body: JSON.stringify({
+          events: [
+            {
+              eventType: 'first_value_confirmed',
+              orgId: 'org_1',
+              campaignId: 'cmp_1',
+              payload: { source: 'seed' },
+            },
+          ],
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    const payload = await response.json()
+    expect(payload.inserted).toBe(1)
   })
 })

--- a/frontend/app/api/internal/telemetry/route.ts
+++ b/frontend/app/api/internal/telemetry/route.ts
@@ -1,10 +1,30 @@
 import { NextResponse } from 'next/server'
+import { isSuiteTelemetryEventType, type SuiteTelemetryEvent } from '@/lib/telemetry/events'
+import { insertSuiteTelemetryEvents } from '@/lib/telemetry/store'
 
 export async function POST(request: Request) {
   const body = await request.json().catch(() => null)
-  if (!body?.eventType) {
+  const rawEvents = Array.isArray(body?.events) ? body.events : body ? [body] : []
+
+  if (rawEvents.length === 0) {
     return NextResponse.json({ error: 'Missing event type.' }, { status: 400 })
   }
 
-  return NextResponse.json({ ok: true })
+  const events: SuiteTelemetryEvent[] = []
+  for (const rawEvent of rawEvents) {
+    if (!rawEvent || !isSuiteTelemetryEventType(rawEvent.eventType)) {
+      return NextResponse.json({ error: 'Unknown event type.' }, { status: 400 })
+    }
+
+    events.push({
+      eventType: rawEvent.eventType,
+      orgId: rawEvent.orgId ?? null,
+      campaignId: rawEvent.campaignId ?? null,
+      actorId: rawEvent.actorId ?? null,
+      payload: rawEvent.payload && typeof rawEvent.payload === 'object' ? rawEvent.payload : {},
+    })
+  }
+
+  const rows = await insertSuiteTelemetryEvents(events)
+  return NextResponse.json({ ok: true, inserted: events.length, rows })
 }

--- a/frontend/app/api/proof-registry/route.ts
+++ b/frontend/app/api/proof-registry/route.ts
@@ -1,5 +1,53 @@
 import { NextResponse } from 'next/server'
+import { listProofRegistryEntries, upsertProofRegistryEntry } from '@/lib/proof-registry-server'
+import { createClient } from '@/lib/supabase/server'
+
+async function requireAdmin() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ error: 'Not authenticated.' }, { status: 401 })
+  }
+
+  const { data: profile } = await supabase.from('profiles').select('is_verisight_admin').eq('id', user.id).maybeSingle()
+  if (profile?.is_verisight_admin !== true) {
+    return NextResponse.json({ error: 'Admin access required.' }, { status: 403 })
+  }
+
+  return null
+}
 
 export async function GET() {
-  return NextResponse.json({ ok: true, items: [] })
+  const denied = await requireAdmin()
+  if (denied) return denied
+
+  const items = await listProofRegistryEntries()
+  return NextResponse.json({ ok: true, items })
+}
+
+export async function POST(request: Request) {
+  const denied = await requireAdmin()
+  if (denied) return denied
+
+  const body = await request.json().catch(() => null)
+  if (!body?.route || !body?.summary) {
+    return NextResponse.json({ error: 'Missing proof registry payload.' }, { status: 400 })
+  }
+
+  const items = await upsertProofRegistryEntry({
+    id: body.id,
+    orgId: body.orgId ?? null,
+    campaignId: body.campaignId ?? null,
+    route: body.route,
+    proofState: body.proofState ?? 'lesson_only',
+    approvalState: body.approvalState ?? 'draft',
+    summary: body.summary,
+    claimableObservation: body.claimableObservation ?? null,
+    supportingArtifacts: Array.isArray(body.supportingArtifacts) ? body.supportingArtifacts : [],
+  })
+
+  return NextResponse.json({ ok: true, items })
 }

--- a/frontend/data/runtime-registries/billing-registry.json
+++ b/frontend/data/runtime-registries/billing-registry.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "26b85e72-2f92-4995-b995-2f435830ebcf-billing",
+    "orgId": "26b85e72-2f92-4995-b995-2f435830ebcf",
+    "organizationName": "Pulse Smoke 8afc",
+    "legalCustomerName": "Pulse Smoke 8afc",
+    "contractState": "signed",
+    "billingState": "active_manual",
+    "paymentMethodConfirmed": true,
+    "notes": "Semireële assisted registryseed voor Pulse Smoke 8afc.",
+    "createdAt": "2026-04-27T08:07:04.767Z",
+    "updatedAt": "2026-04-27T08:07:04.769Z"
+  },
+  {
+    "id": "6487223a-b61c-402b-8fa0-c1d5bb551938-billing",
+    "orgId": "6487223a-b61c-402b-8fa0-c1d5bb551938",
+    "organizationName": "Pulse Smoke 955e",
+    "legalCustomerName": "Pulse Smoke 955e",
+    "contractState": "pending_signature",
+    "billingState": "draft",
+    "paymentMethodConfirmed": false,
+    "notes": "Semireële assisted registryseed voor Pulse Smoke 955e.",
+    "createdAt": "2026-04-27T08:07:04.769Z",
+    "updatedAt": "2026-04-27T08:07:04.769Z"
+  },
+  {
+    "id": "43165d75-08b2-497b-a52c-e566d47d1bfc-billing",
+    "orgId": "43165d75-08b2-497b-a52c-e566d47d1bfc",
+    "organizationName": "Pulse Smoke 134b",
+    "legalCustomerName": "Pulse Smoke 134b",
+    "contractState": "signed",
+    "billingState": "paused",
+    "paymentMethodConfirmed": true,
+    "notes": "Semireële assisted registryseed voor Pulse Smoke 134b.",
+    "createdAt": "2026-04-27T08:07:04.769Z",
+    "updatedAt": "2026-04-27T08:07:04.769Z"
+  },
+  {
+    "id": "9d476aa5-9e79-4b5e-9dab-112265a6fae7-billing",
+    "orgId": "9d476aa5-9e79-4b5e-9dab-112265a6fae7",
+    "organizationName": "Verisight Guided Self-Serve Acceptance",
+    "legalCustomerName": "Verisight Guided Self-Serve Acceptance",
+    "contractState": "signed",
+    "billingState": "active_manual",
+    "paymentMethodConfirmed": false,
+    "notes": "Semireële assisted registryseed voor Verisight Guided Self-Serve Acceptance.",
+    "createdAt": "2026-04-27T08:07:04.769Z",
+    "updatedAt": "2026-04-27T08:07:04.769Z"
+  }
+]

--- a/frontend/data/runtime-registries/proof-registry.json
+++ b/frontend/data/runtime-registries/proof-registry.json
@@ -1,0 +1,102 @@
+[
+  {
+    "id": "proof-1",
+    "orgId": "9d476aa5-9e79-4b5e-9dab-112265a6fae7",
+    "campaignId": "069ee28a-2038-46ba-9d37-6a38d0fd8691",
+    "route": "ExitScan",
+    "proofState": "lesson_only",
+    "approvalState": "draft",
+    "summary": "Semireële suite-run: Verisight Guided Self-Serve Acceptance gebruikte ExitScan voor eerste managementduiding en een bounded vervolgritme.",
+    "claimableObservation": "ExitScan leverde een bounded les op voor managementread en vervolgstap.",
+    "supportingArtifacts": [
+      {
+        "type": "seed_marker",
+        "seed": "real_usage_wave"
+      },
+      {
+        "type": "campaign",
+        "name": "Guided Self-Serve - Setup Journey"
+      },
+      {
+        "type": "stats",
+        "total_completed": 0
+      }
+    ],
+    "createdAt": "2026-04-27T08:07:05.186Z"
+  },
+  {
+    "id": "proof-2",
+    "orgId": "43165d75-08b2-497b-a52c-e566d47d1bfc",
+    "campaignId": "7e74e0f8-48e1-4ca7-acc0-63e4f679c51a",
+    "route": "Pulse",
+    "proofState": "internal_proof_only",
+    "approvalState": "internal_review",
+    "summary": "Semireële suite-run: Pulse Smoke 134b gebruikte Pulse voor eerste managementduiding en een bounded vervolgritme.",
+    "claimableObservation": "Pulse leverde een bounded les op voor managementread en vervolgstap.",
+    "supportingArtifacts": [
+      {
+        "type": "seed_marker",
+        "seed": "real_usage_wave"
+      },
+      {
+        "type": "campaign",
+        "name": "Pulse baseline smoke"
+      },
+      {
+        "type": "stats",
+        "total_completed": 1
+      }
+    ],
+    "createdAt": "2026-04-27T08:06:05.186Z"
+  },
+  {
+    "id": "proof-3",
+    "orgId": "6487223a-b61c-402b-8fa0-c1d5bb551938",
+    "campaignId": "535a57d2-b0b5-4acb-9f12-8cf18c8fb359",
+    "route": "Pulse",
+    "proofState": "sales_usable",
+    "approvalState": "claim_check",
+    "summary": "Semireële suite-run: Pulse Smoke 955e gebruikte Pulse voor eerste managementduiding en een bounded vervolgritme.",
+    "claimableObservation": "Pulse leverde een bounded les op voor managementread en vervolgstap.",
+    "supportingArtifacts": [
+      {
+        "type": "seed_marker",
+        "seed": "real_usage_wave"
+      },
+      {
+        "type": "campaign",
+        "name": "Pulse baseline smoke"
+      },
+      {
+        "type": "stats",
+        "total_completed": 1
+      }
+    ],
+    "createdAt": "2026-04-27T08:05:05.186Z"
+  },
+  {
+    "id": "proof-4",
+    "orgId": "26b85e72-2f92-4995-b995-2f435830ebcf",
+    "campaignId": "2f452cfe-bc3e-4afc-aedc-b3344d369464",
+    "route": "Pulse",
+    "proofState": "public_usable",
+    "approvalState": "approved",
+    "summary": "Semireële suite-run: Pulse Smoke 8afc gebruikte Pulse voor eerste managementduiding en een bounded vervolgritme.",
+    "claimableObservation": "Pulse maakte prioriteit, toewijzing en reviewmoment expliciet binnen dezelfde suite.",
+    "supportingArtifacts": [
+      {
+        "type": "seed_marker",
+        "seed": "real_usage_wave"
+      },
+      {
+        "type": "campaign",
+        "name": "Pulse baseline smoke"
+      },
+      {
+        "type": "stats",
+        "total_completed": 1
+      }
+    ],
+    "createdAt": "2026-04-27T08:04:05.186Z"
+  }
+]

--- a/frontend/data/runtime-registries/suite-telemetry-events.json
+++ b/frontend/data/runtime-registries/suite-telemetry-events.json
@@ -1,0 +1,306 @@
+[
+  {
+    "id": "telemetry-1",
+    "eventType": "owner_access_confirmed",
+    "orgId": "9d476aa5-9e79-4b5e-9dab-112265a6fae7",
+    "campaignId": "069ee28a-2038-46ba-9d37-6a38d0fd8691",
+    "actorId": null,
+    "payload": {
+      "seeded_by": "real_usage_wave",
+      "source": "semireal_suite_run",
+      "organization_name": "Verisight Guided Self-Serve Acceptance",
+      "route": "ExitScan",
+      "step": "owner_access"
+    },
+    "createdAt": "2026-04-27T08:07:04.842Z"
+  },
+  {
+    "id": "telemetry-2",
+    "eventType": "first_value_confirmed",
+    "orgId": "9d476aa5-9e79-4b5e-9dab-112265a6fae7",
+    "campaignId": "069ee28a-2038-46ba-9d37-6a38d0fd8691",
+    "actorId": null,
+    "payload": {
+      "seeded_by": "real_usage_wave",
+      "source": "semireal_suite_run",
+      "organization_name": "Verisight Guided Self-Serve Acceptance",
+      "route": "ExitScan",
+      "step": "first_value",
+      "completion_rate_pct": null
+    },
+    "createdAt": "2026-04-27T08:06:04.842Z"
+  },
+  {
+    "id": "telemetry-3",
+    "eventType": "first_management_use_confirmed",
+    "orgId": "9d476aa5-9e79-4b5e-9dab-112265a6fae7",
+    "campaignId": "069ee28a-2038-46ba-9d37-6a38d0fd8691",
+    "actorId": null,
+    "payload": {
+      "seeded_by": "real_usage_wave",
+      "source": "semireal_suite_run",
+      "organization_name": "Verisight Guided Self-Serve Acceptance",
+      "route": "ExitScan",
+      "step": "management_use"
+    },
+    "createdAt": "2026-04-27T08:05:04.842Z"
+  },
+  {
+    "id": "telemetry-4",
+    "eventType": "action_center_review_scheduled",
+    "orgId": "9d476aa5-9e79-4b5e-9dab-112265a6fae7",
+    "campaignId": "069ee28a-2038-46ba-9d37-6a38d0fd8691",
+    "actorId": null,
+    "payload": {
+      "seeded_by": "real_usage_wave",
+      "source": "semireal_suite_run",
+      "organization_name": "Verisight Guided Self-Serve Acceptance",
+      "route": "ExitScan",
+      "review_window": "14_dagen"
+    },
+    "createdAt": "2026-04-27T08:04:04.842Z"
+  },
+  {
+    "id": "telemetry-5",
+    "eventType": "action_center_closeout_recorded",
+    "orgId": "9d476aa5-9e79-4b5e-9dab-112265a6fae7",
+    "campaignId": "069ee28a-2038-46ba-9d37-6a38d0fd8691",
+    "actorId": null,
+    "payload": {
+      "seeded_by": "real_usage_wave",
+      "source": "semireal_suite_run",
+      "organization_name": "Verisight Guided Self-Serve Acceptance",
+      "route": "ExitScan",
+      "closeout_state": "bounded_next_step"
+    },
+    "createdAt": "2026-04-27T08:03:04.842Z"
+  },
+  {
+    "id": "telemetry-6",
+    "eventType": "owner_access_confirmed",
+    "orgId": "43165d75-08b2-497b-a52c-e566d47d1bfc",
+    "campaignId": "7e74e0f8-48e1-4ca7-acc0-63e4f679c51a",
+    "actorId": null,
+    "payload": {
+      "seeded_by": "real_usage_wave",
+      "source": "semireal_suite_run",
+      "organization_name": "Pulse Smoke 134b",
+      "route": "Pulse",
+      "step": "owner_access"
+    },
+    "createdAt": "2026-04-27T08:02:04.842Z"
+  },
+  {
+    "id": "telemetry-7",
+    "eventType": "first_value_confirmed",
+    "orgId": "43165d75-08b2-497b-a52c-e566d47d1bfc",
+    "campaignId": "7e74e0f8-48e1-4ca7-acc0-63e4f679c51a",
+    "actorId": null,
+    "payload": {
+      "seeded_by": "real_usage_wave",
+      "source": "semireal_suite_run",
+      "organization_name": "Pulse Smoke 134b",
+      "route": "Pulse",
+      "step": "first_value",
+      "completion_rate_pct": 100
+    },
+    "createdAt": "2026-04-27T08:01:04.842Z"
+  },
+  {
+    "id": "telemetry-8",
+    "eventType": "first_management_use_confirmed",
+    "orgId": "43165d75-08b2-497b-a52c-e566d47d1bfc",
+    "campaignId": "7e74e0f8-48e1-4ca7-acc0-63e4f679c51a",
+    "actorId": null,
+    "payload": {
+      "seeded_by": "real_usage_wave",
+      "source": "semireal_suite_run",
+      "organization_name": "Pulse Smoke 134b",
+      "route": "Pulse",
+      "step": "management_use"
+    },
+    "createdAt": "2026-04-27T08:00:04.842Z"
+  },
+  {
+    "id": "telemetry-9",
+    "eventType": "action_center_review_scheduled",
+    "orgId": "43165d75-08b2-497b-a52c-e566d47d1bfc",
+    "campaignId": "7e74e0f8-48e1-4ca7-acc0-63e4f679c51a",
+    "actorId": null,
+    "payload": {
+      "seeded_by": "real_usage_wave",
+      "source": "semireal_suite_run",
+      "organization_name": "Pulse Smoke 134b",
+      "route": "Pulse",
+      "review_window": "14_dagen"
+    },
+    "createdAt": "2026-04-27T07:59:04.842Z"
+  },
+  {
+    "id": "telemetry-10",
+    "eventType": "action_center_closeout_recorded",
+    "orgId": "43165d75-08b2-497b-a52c-e566d47d1bfc",
+    "campaignId": "7e74e0f8-48e1-4ca7-acc0-63e4f679c51a",
+    "actorId": null,
+    "payload": {
+      "seeded_by": "real_usage_wave",
+      "source": "semireal_suite_run",
+      "organization_name": "Pulse Smoke 134b",
+      "route": "Pulse",
+      "closeout_state": "bounded_next_step"
+    },
+    "createdAt": "2026-04-27T07:58:04.842Z"
+  },
+  {
+    "id": "telemetry-11",
+    "eventType": "owner_access_confirmed",
+    "orgId": "6487223a-b61c-402b-8fa0-c1d5bb551938",
+    "campaignId": "535a57d2-b0b5-4acb-9f12-8cf18c8fb359",
+    "actorId": null,
+    "payload": {
+      "seeded_by": "real_usage_wave",
+      "source": "semireal_suite_run",
+      "organization_name": "Pulse Smoke 955e",
+      "route": "Pulse",
+      "step": "owner_access"
+    },
+    "createdAt": "2026-04-27T07:57:04.842Z"
+  },
+  {
+    "id": "telemetry-12",
+    "eventType": "first_value_confirmed",
+    "orgId": "6487223a-b61c-402b-8fa0-c1d5bb551938",
+    "campaignId": "535a57d2-b0b5-4acb-9f12-8cf18c8fb359",
+    "actorId": null,
+    "payload": {
+      "seeded_by": "real_usage_wave",
+      "source": "semireal_suite_run",
+      "organization_name": "Pulse Smoke 955e",
+      "route": "Pulse",
+      "step": "first_value",
+      "completion_rate_pct": 100
+    },
+    "createdAt": "2026-04-27T07:56:04.842Z"
+  },
+  {
+    "id": "telemetry-13",
+    "eventType": "first_management_use_confirmed",
+    "orgId": "6487223a-b61c-402b-8fa0-c1d5bb551938",
+    "campaignId": "535a57d2-b0b5-4acb-9f12-8cf18c8fb359",
+    "actorId": null,
+    "payload": {
+      "seeded_by": "real_usage_wave",
+      "source": "semireal_suite_run",
+      "organization_name": "Pulse Smoke 955e",
+      "route": "Pulse",
+      "step": "management_use"
+    },
+    "createdAt": "2026-04-27T07:55:04.842Z"
+  },
+  {
+    "id": "telemetry-14",
+    "eventType": "action_center_review_scheduled",
+    "orgId": "6487223a-b61c-402b-8fa0-c1d5bb551938",
+    "campaignId": "535a57d2-b0b5-4acb-9f12-8cf18c8fb359",
+    "actorId": null,
+    "payload": {
+      "seeded_by": "real_usage_wave",
+      "source": "semireal_suite_run",
+      "organization_name": "Pulse Smoke 955e",
+      "route": "Pulse",
+      "review_window": "14_dagen"
+    },
+    "createdAt": "2026-04-27T07:54:04.842Z"
+  },
+  {
+    "id": "telemetry-15",
+    "eventType": "action_center_closeout_recorded",
+    "orgId": "6487223a-b61c-402b-8fa0-c1d5bb551938",
+    "campaignId": "535a57d2-b0b5-4acb-9f12-8cf18c8fb359",
+    "actorId": null,
+    "payload": {
+      "seeded_by": "real_usage_wave",
+      "source": "semireal_suite_run",
+      "organization_name": "Pulse Smoke 955e",
+      "route": "Pulse",
+      "closeout_state": "bounded_next_step"
+    },
+    "createdAt": "2026-04-27T07:53:04.842Z"
+  },
+  {
+    "id": "telemetry-16",
+    "eventType": "owner_access_confirmed",
+    "orgId": "26b85e72-2f92-4995-b995-2f435830ebcf",
+    "campaignId": "2f452cfe-bc3e-4afc-aedc-b3344d369464",
+    "actorId": null,
+    "payload": {
+      "seeded_by": "real_usage_wave",
+      "source": "semireal_suite_run",
+      "organization_name": "Pulse Smoke 8afc",
+      "route": "Pulse",
+      "step": "owner_access"
+    },
+    "createdAt": "2026-04-27T07:52:04.842Z"
+  },
+  {
+    "id": "telemetry-17",
+    "eventType": "first_value_confirmed",
+    "orgId": "26b85e72-2f92-4995-b995-2f435830ebcf",
+    "campaignId": "2f452cfe-bc3e-4afc-aedc-b3344d369464",
+    "actorId": null,
+    "payload": {
+      "seeded_by": "real_usage_wave",
+      "source": "semireal_suite_run",
+      "organization_name": "Pulse Smoke 8afc",
+      "route": "Pulse",
+      "step": "first_value",
+      "completion_rate_pct": 100
+    },
+    "createdAt": "2026-04-27T07:51:04.842Z"
+  },
+  {
+    "id": "telemetry-18",
+    "eventType": "first_management_use_confirmed",
+    "orgId": "26b85e72-2f92-4995-b995-2f435830ebcf",
+    "campaignId": "2f452cfe-bc3e-4afc-aedc-b3344d369464",
+    "actorId": null,
+    "payload": {
+      "seeded_by": "real_usage_wave",
+      "source": "semireal_suite_run",
+      "organization_name": "Pulse Smoke 8afc",
+      "route": "Pulse",
+      "step": "management_use"
+    },
+    "createdAt": "2026-04-27T07:50:04.842Z"
+  },
+  {
+    "id": "telemetry-19",
+    "eventType": "action_center_review_scheduled",
+    "orgId": "26b85e72-2f92-4995-b995-2f435830ebcf",
+    "campaignId": "2f452cfe-bc3e-4afc-aedc-b3344d369464",
+    "actorId": null,
+    "payload": {
+      "seeded_by": "real_usage_wave",
+      "source": "semireal_suite_run",
+      "organization_name": "Pulse Smoke 8afc",
+      "route": "Pulse",
+      "review_window": "14_dagen"
+    },
+    "createdAt": "2026-04-27T07:49:04.842Z"
+  },
+  {
+    "id": "telemetry-20",
+    "eventType": "action_center_closeout_recorded",
+    "orgId": "26b85e72-2f92-4995-b995-2f435830ebcf",
+    "campaignId": "2f452cfe-bc3e-4afc-aedc-b3344d369464",
+    "actorId": null,
+    "payload": {
+      "seeded_by": "real_usage_wave",
+      "source": "semireal_suite_run",
+      "organization_name": "Pulse Smoke 8afc",
+      "route": "Pulse",
+      "closeout_state": "bounded_next_step"
+    },
+    "createdAt": "2026-04-27T07:48:04.842Z"
+  }
+]

--- a/frontend/lib/billing-registry-server.ts
+++ b/frontend/lib/billing-registry-server.ts
@@ -1,0 +1,103 @@
+import 'server-only'
+
+import { randomUUID } from 'node:crypto'
+import type { BillingRegistry } from '@/lib/types'
+import type { BillingRegistryRow, BillingState, ContractState } from '@/lib/billing-registry'
+import { isMissingSchemaError, readFallbackRegistryFile, writeFallbackRegistryFile } from '@/lib/runtime-registry-fallback'
+import { createAdminClient } from '@/lib/supabase/admin'
+
+type BillingRegistryDbRow = BillingRegistry
+type OrganizationNameRow = { id: string; name: string }
+
+function normalizeContractState(value: string): ContractState {
+  return value === 'signed' || value === 'pending_signature' ? value : 'draft'
+}
+
+function normalizeBillingState(value: string): BillingState {
+  return value === 'active_manual' || value === 'paused' || value === 'closed' ? value : 'draft'
+}
+
+export async function listBillingRegistryRows() {
+  const admin = createAdminClient()
+  const { data, error } = await admin
+    .from('billing_registry')
+    .select('id, org_id, legal_customer_name, contract_state, billing_state, payment_method_confirmed, notes, created_at, updated_at')
+    .order('updated_at', { ascending: false })
+
+  if (error) {
+    if (isMissingSchemaError(error)) {
+      return readFallbackRegistryFile<BillingRegistryRow[]>('billing-registry.json', [])
+    }
+    throw error
+  }
+
+  const registryRows = (data ?? []) as BillingRegistryDbRow[]
+  const orgIds = [...new Set(registryRows.map((row) => row.org_id))]
+
+  const { data: organizations, error: orgError } =
+    orgIds.length > 0
+      ? await admin.from('organizations').select('id, name').in('id', orgIds)
+      : { data: [], error: null }
+
+  if (orgError) throw orgError
+
+  const organizationById = new Map(((organizations ?? []) as OrganizationNameRow[]).map((organization) => [organization.id, organization.name]))
+
+  return registryRows.map(
+    (row) =>
+      ({
+        id: row.id,
+        orgId: row.org_id,
+        organizationName: organizationById.get(row.org_id) ?? row.legal_customer_name,
+        legalCustomerName: row.legal_customer_name,
+        contractState: normalizeContractState(row.contract_state),
+        billingState: normalizeBillingState(row.billing_state),
+        paymentMethodConfirmed: row.payment_method_confirmed,
+        notes: row.notes,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+      }) satisfies BillingRegistryRow,
+  )
+}
+
+export async function upsertBillingRegistryRow(input: {
+  orgId: string
+  legalCustomerName: string
+  contractState: ContractState
+  billingState: BillingState
+  paymentMethodConfirmed: boolean
+  notes?: string | null
+}) {
+  const admin = createAdminClient()
+  const payload = {
+    org_id: input.orgId,
+    legal_customer_name: input.legalCustomerName,
+    contract_state: input.contractState,
+    billing_state: input.billingState,
+    payment_method_confirmed: input.paymentMethodConfirmed,
+    notes: input.notes ?? null,
+  }
+
+  const { error } = await admin.from('billing_registry').upsert(payload, { onConflict: 'org_id' })
+  if (error) {
+    if (isMissingSchemaError(error)) {
+      const existing = await readFallbackRegistryFile<BillingRegistryRow[]>('billing-registry.json', [])
+      const nextRow: BillingRegistryRow = {
+        id: existing.find((row) => row.orgId === input.orgId)?.id ?? randomUUID(),
+        orgId: input.orgId,
+        organizationName: existing.find((row) => row.orgId === input.orgId)?.organizationName ?? input.legalCustomerName,
+        legalCustomerName: input.legalCustomerName,
+        contractState: input.contractState,
+        billingState: input.billingState,
+        paymentMethodConfirmed: input.paymentMethodConfirmed,
+        notes: input.notes ?? null,
+      }
+      const next = [...existing.filter((row) => row.orgId !== input.orgId), nextRow]
+      await writeFallbackRegistryFile('billing-registry.json', next)
+      return next
+    }
+    throw error
+  }
+
+  return listBillingRegistryRows()
+}

--- a/frontend/lib/billing-registry.test.ts
+++ b/frontend/lib/billing-registry.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest'
 import {
   getBillingReadinessCopy,
   getBillingRegistryStatusLabel,
+  getContractStateLabel,
   isBillingReadyForAssistedLaunch,
+  summarizeBillingRegistry,
 } from '@/lib/billing-registry'
 
 describe('billing registry helpers', () => {
@@ -16,5 +18,31 @@ describe('billing registry helpers', () => {
   it('uses a customer-facing readiness signal instead of checkout language', () => {
     expect(getBillingReadinessCopy({ contractSigned: false, paymentMethodConfirmed: false })).toContain('assisted')
     expect(getBillingReadinessCopy({ contractSigned: true, paymentMethodConfirmed: true })).toContain('suite-activatie')
+  })
+
+  it('summarizes live registry rows for admin surfaces', () => {
+    expect(getContractStateLabel('signed')).toBe('Getekend')
+    expect(
+      summarizeBillingRegistry([
+        {
+          orgId: 'org_1',
+          legalCustomerName: 'Org 1',
+          contractState: 'signed',
+          billingState: 'active_manual',
+          paymentMethodConfirmed: true,
+        },
+        {
+          orgId: 'org_2',
+          legalCustomerName: 'Org 2',
+          contractState: 'draft',
+          billingState: 'draft',
+          paymentMethodConfirmed: false,
+        },
+      ]),
+    ).toEqual({
+      total: 2,
+      readyCount: 1,
+      pendingCount: 1,
+    })
   })
 })

--- a/frontend/lib/billing-registry.ts
+++ b/frontend/lib/billing-registry.ts
@@ -2,17 +2,34 @@ export type ContractState = 'draft' | 'pending_signature' | 'signed'
 export type BillingState = 'draft' | 'active_manual' | 'paused' | 'closed'
 
 export interface BillingRegistryRow {
+  id?: string
   orgId: string
+  organizationName?: string | null
   legalCustomerName: string
   contractState: ContractState
   billingState: BillingState
   paymentMethodConfirmed: boolean
+  notes?: string | null
+  createdAt?: string
+  updatedAt?: string
+}
+
+export interface BillingRegistrySummary {
+  total: number
+  readyCount: number
+  pendingCount: number
 }
 
 export function getBillingRegistryStatusLabel(state: BillingState) {
   if (state === 'active_manual') return 'Actief (handmatig)'
   if (state === 'paused') return 'Gepauzeerd'
   if (state === 'closed') return 'Gesloten'
+  return 'Concept'
+}
+
+export function getContractStateLabel(state: ContractState) {
+  if (state === 'signed') return 'Getekend'
+  if (state === 'pending_signature') return 'Wacht op akkoord'
   return 'Concept'
 }
 
@@ -30,4 +47,19 @@ export function getBillingReadinessCopy(args: {
   return isBillingReadyForAssistedLaunch(args)
     ? 'Contract en betaalwijze zijn bevestigd; bounded suite-activatie kan assisted doorlopen.'
     : 'Billing en activatie blijven assisted: contract en betaalwijze worden eerst handmatig bevestigd.'
+}
+
+export function summarizeBillingRegistry(rows: BillingRegistryRow[]): BillingRegistrySummary {
+  const readyCount = rows.filter((row) =>
+    isBillingReadyForAssistedLaunch({
+      contractSigned: row.contractState === 'signed',
+      paymentMethodConfirmed: row.paymentMethodConfirmed,
+    }),
+  ).length
+
+  return {
+    total: rows.length,
+    readyCount,
+    pendingCount: rows.length - readyCount,
+  }
 }

--- a/frontend/lib/proof-registry-server.ts
+++ b/frontend/lib/proof-registry-server.ts
@@ -1,0 +1,119 @@
+import 'server-only'
+
+import { randomUUID } from 'node:crypto'
+import type { EvidenceApprovalStatus } from '@/lib/case-proof-evidence'
+import { createAdminClient } from '@/lib/supabase/admin'
+import type { ProofRegistryEntry, ProofState } from '@/lib/proof-registry'
+import { isMissingSchemaError, readFallbackRegistryFile, writeFallbackRegistryFile } from '@/lib/runtime-registry-fallback'
+
+type ProofRegistryDbRow = {
+  id: string
+  org_id: string | null
+  campaign_id: string | null
+  route: string
+  proof_state: string
+  approval_state: string
+  summary: string
+  claimable_observation: string | null
+  supporting_artifacts: unknown[] | null
+  created_at: string
+}
+
+function normalizeProofState(value: string): ProofState {
+  return value === 'internal_proof_only' || value === 'sales_usable' || value === 'public_usable' || value === 'rejected'
+    ? value
+    : 'lesson_only'
+}
+
+function normalizeApprovalState(value: string): EvidenceApprovalStatus | 'rejected' {
+  return value === 'internal_review' ||
+    value === 'claim_check' ||
+    value === 'customer_permission' ||
+    value === 'approved' ||
+    value === 'rejected'
+    ? value
+    : 'draft'
+}
+
+export async function listProofRegistryEntries() {
+  const admin = createAdminClient()
+  const { data, error } = await admin
+    .from('case_proof_registry')
+    .select('id, org_id, campaign_id, route, proof_state, approval_state, summary, claimable_observation, supporting_artifacts, created_at')
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    if (isMissingSchemaError(error)) {
+      return readFallbackRegistryFile<ProofRegistryEntry[]>('proof-registry.json', [])
+    }
+    throw error
+  }
+
+  return ((data ?? []) as ProofRegistryDbRow[]).map(
+    (row) =>
+      ({
+        id: row.id,
+        orgId: row.org_id,
+        campaignId: row.campaign_id,
+        route: row.route,
+        proofState: normalizeProofState(row.proof_state),
+        approvalState: normalizeApprovalState(row.approval_state),
+        summary: row.summary,
+        claimableObservation: row.claimable_observation,
+        supportingArtifacts: Array.isArray(row.supporting_artifacts) ? row.supporting_artifacts : [],
+        createdAt: row.created_at,
+      }) satisfies ProofRegistryEntry,
+  )
+}
+
+export async function upsertProofRegistryEntry(input: {
+  id?: string
+  orgId?: string | null
+  campaignId?: string | null
+  route: string
+  proofState: ProofState
+  approvalState: EvidenceApprovalStatus | 'rejected'
+  summary: string
+  claimableObservation?: string | null
+  supportingArtifacts?: unknown[]
+}) {
+  const admin = createAdminClient()
+  const payload = {
+    ...(input.id ? { id: input.id } : {}),
+    org_id: input.orgId ?? null,
+    campaign_id: input.campaignId ?? null,
+    route: input.route,
+    proof_state: input.proofState,
+    approval_state: input.approvalState,
+    summary: input.summary,
+    claimable_observation: input.claimableObservation ?? null,
+    supporting_artifacts: input.supportingArtifacts ?? [],
+  }
+
+  const { error } = await admin.from('case_proof_registry').upsert(payload)
+  if (error) {
+    if (isMissingSchemaError(error)) {
+      const existing = await readFallbackRegistryFile<ProofRegistryEntry[]>('proof-registry.json', [])
+      const nextEntry: ProofRegistryEntry = {
+        id: input.id ?? randomUUID(),
+        orgId: input.orgId ?? null,
+        campaignId: input.campaignId ?? null,
+        route: input.route,
+        proofState: input.proofState,
+        approvalState: input.approvalState,
+        summary: input.summary,
+        claimableObservation: input.claimableObservation ?? null,
+        supportingArtifacts: input.supportingArtifacts ?? [],
+        createdAt: existing.find((entry) => entry.id === input.id)?.createdAt ?? new Date().toISOString(),
+      }
+      const next = [...existing.filter((entry) => entry.id !== nextEntry.id), nextEntry].sort((left, right) =>
+        right.createdAt.localeCompare(left.createdAt),
+      )
+      await writeFallbackRegistryFile('proof-registry.json', next)
+      return next
+    }
+    throw error
+  }
+
+  return listProofRegistryEntries()
+}

--- a/frontend/lib/proof-registry.test.ts
+++ b/frontend/lib/proof-registry.test.ts
@@ -1,9 +1,26 @@
 import { describe, expect, it } from 'vitest'
-import { getProofApprovalLabel } from '@/lib/proof-registry'
+import { getProofApprovalLabel, getProofStateLabel, summarizeProofRegistry } from '@/lib/proof-registry'
 
 describe('proof registry helpers', () => {
   it('labels proof approval states correctly', () => {
     expect(getProofApprovalLabel('draft')).toBe('Concept')
     expect(getProofApprovalLabel('approved')).toBe('Goedgekeurd')
+    expect(getProofStateLabel('public_usable')).toBe('Publiek bruikbaar')
+    expect(
+      summarizeProofRegistry([
+        {
+          id: 'proof_1',
+          orgId: null,
+          campaignId: null,
+          route: 'ExitScan',
+          proofState: 'sales_usable',
+          approvalState: 'claim_check',
+          summary: 'test',
+          claimableObservation: null,
+          supportingArtifacts: [],
+          createdAt: '2026-04-27T10:00:00.000Z',
+        },
+      ]),
+    ).toMatchObject({ salesUsableCount: 1 })
   })
 })

--- a/frontend/lib/proof-registry.ts
+++ b/frontend/lib/proof-registry.ts
@@ -2,6 +2,26 @@ import type { EvidenceApprovalStatus, CaseEvidenceClosureStatus } from '@/lib/ca
 
 export type ProofState = Exclude<CaseEvidenceClosureStatus, 'rejected'> | 'rejected'
 
+export interface ProofRegistryEntry {
+  id: string
+  orgId: string | null
+  campaignId: string | null
+  route: string
+  proofState: ProofState
+  approvalState: EvidenceApprovalStatus | 'rejected'
+  summary: string
+  claimableObservation: string | null
+  supportingArtifacts: unknown[]
+  createdAt: string
+}
+
+export interface ProofRegistrySummary {
+  total: number
+  lessonOnlyCount: number
+  salesUsableCount: number
+  publicUsableCount: number
+}
+
 export function getProofApprovalLabel(state: EvidenceApprovalStatus | 'rejected') {
   if (state === 'approved') return 'Goedgekeurd'
   if (state === 'rejected') return 'Afgewezen'
@@ -9,4 +29,21 @@ export function getProofApprovalLabel(state: EvidenceApprovalStatus | 'rejected'
   if (state === 'claim_check') return 'Claim check'
   if (state === 'customer_permission') return 'Klanttoestemming'
   return 'Concept'
+}
+
+export function getProofStateLabel(state: ProofState) {
+  if (state === 'internal_proof_only') return 'Alleen intern'
+  if (state === 'sales_usable') return 'Sales-usable'
+  if (state === 'public_usable') return 'Publiek bruikbaar'
+  if (state === 'rejected') return 'Afgewezen'
+  return 'Lesson only'
+}
+
+export function summarizeProofRegistry(entries: ProofRegistryEntry[]): ProofRegistrySummary {
+  return {
+    total: entries.length,
+    lessonOnlyCount: entries.filter((entry) => entry.proofState === 'lesson_only').length,
+    salesUsableCount: entries.filter((entry) => entry.proofState === 'sales_usable').length,
+    publicUsableCount: entries.filter((entry) => entry.proofState === 'public_usable').length,
+  }
 }

--- a/frontend/lib/public-proof-feed.test.ts
+++ b/frontend/lib/public-proof-feed.test.ts
@@ -1,9 +1,23 @@
 import { describe, expect, it } from 'vitest'
-import { canPublishProofCard } from '@/lib/public-proof-feed'
+import { canPublishProofCard, mapPublicProofCard } from '@/lib/public-proof-feed'
 
 describe('public proof feed', () => {
   it('only publishes approved public proof', () => {
     expect(canPublishProofCard({ proofState: 'public_usable', approvalState: 'approved' })).toBe(true)
     expect(canPublishProofCard({ proofState: 'sales_usable', approvalState: 'approved' })).toBe(false)
+  })
+
+  it('maps approved proof rows into public card shape', () => {
+    expect(
+      mapPublicProofCard({
+        route: 'ExitScan',
+        summary: 'Bounded summary',
+        claimableObservation: 'Claimable approved observation',
+      }),
+    ).toEqual({
+      title: 'ExitScan in gebruik',
+      body: 'Claimable approved observation',
+      approval: 'public_usable',
+    })
   })
 })

--- a/frontend/lib/public-proof-feed.ts
+++ b/frontend/lib/public-proof-feed.ts
@@ -4,3 +4,15 @@ export function canPublishProofCard(args: {
 }) {
   return args.proofState === 'public_usable' && args.approvalState === 'approved'
 }
+
+export function mapPublicProofCard(args: {
+  route: string
+  summary: string
+  claimableObservation?: string | null
+}) {
+  return {
+    title: `${args.route} in gebruik`,
+    body: args.claimableObservation?.trim() || args.summary,
+    approval: 'public_usable' as const,
+  }
+}

--- a/frontend/lib/runtime-registry-fallback.ts
+++ b/frontend/lib/runtime-registry-fallback.ts
@@ -1,0 +1,24 @@
+import 'server-only'
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+const FALLBACK_DIR = path.join(process.cwd(), 'data', 'runtime-registries')
+
+export function isMissingSchemaError(error: unknown): error is { code: string } {
+  return typeof error === 'object' && error !== null && 'code' in error && (error as { code?: string }).code === 'PGRST205'
+}
+
+export async function readFallbackRegistryFile<T>(fileName: string, defaultValue: T): Promise<T> {
+  try {
+    const source = await readFile(path.join(FALLBACK_DIR, fileName), 'utf8')
+    return JSON.parse(source) as T
+  } catch {
+    return defaultValue
+  }
+}
+
+export async function writeFallbackRegistryFile<T>(fileName: string, value: T) {
+  await mkdir(FALLBACK_DIR, { recursive: true })
+  await writeFile(path.join(FALLBACK_DIR, fileName), JSON.stringify(value, null, 2), 'utf8')
+}

--- a/frontend/lib/telemetry/events.test.ts
+++ b/frontend/lib/telemetry/events.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { buildSuiteTelemetryEvent, countSuiteTelemetryEvents } from '@/lib/telemetry/events'
+import {
+  buildSuiteTelemetryEvent,
+  countSuiteTelemetryEvents,
+  countSuiteTelemetryEventRows,
+  getSuiteTelemetryEventLabel,
+  isSuiteTelemetryEventType,
+} from '@/lib/telemetry/events'
 
 describe('suite telemetry event builder', () => {
   it('normalizes a bounded telemetry payload', () => {
@@ -20,5 +26,24 @@ describe('suite telemetry event builder', () => {
     ])
     expect(counts.owner_access_confirmed).toBe(2)
     expect(counts.manager_denied_insights).toBe(1)
+  })
+
+  it('validates and labels live telemetry rows', () => {
+    expect(isSuiteTelemetryEventType('first_value_confirmed')).toBe(true)
+    expect(isSuiteTelemetryEventType('unexpected_event')).toBe(false)
+    expect(getSuiteTelemetryEventLabel('action_center_closeout_recorded')).toContain('closeout')
+    expect(
+      countSuiteTelemetryEventRows([
+        {
+          id: 'evt_1',
+          eventType: 'first_value_confirmed',
+          orgId: 'org_1',
+          campaignId: 'cmp_1',
+          actorId: null,
+          payload: {},
+          createdAt: '2026-04-27T10:00:00.000Z',
+        },
+      ]),
+    ).toMatchObject({ first_value_confirmed: 1 })
   })
 })

--- a/frontend/lib/telemetry/events.ts
+++ b/frontend/lib/telemetry/events.ts
@@ -14,6 +14,27 @@ export interface SuiteTelemetryEvent {
   payload: Record<string, unknown>
 }
 
+export interface SuiteTelemetryEventRow {
+  id: string
+  eventType: SuiteTelemetryEventType
+  orgId: string | null
+  campaignId: string | null
+  actorId: string | null
+  payload: Record<string, unknown>
+  createdAt: string
+}
+
+export function isSuiteTelemetryEventType(value: string): value is SuiteTelemetryEventType {
+  return (
+    value === 'owner_access_confirmed' ||
+    value === 'first_value_confirmed' ||
+    value === 'first_management_use_confirmed' ||
+    value === 'manager_denied_insights' ||
+    value === 'action_center_review_scheduled' ||
+    value === 'action_center_closeout_recorded'
+  )
+}
+
 export function buildSuiteTelemetryEvent(
   eventType: SuiteTelemetryEventType,
   args: { orgId?: string | null; campaignId?: string | null; actorId?: string | null; payload?: Record<string, unknown> },
@@ -42,4 +63,27 @@ export function countSuiteTelemetryEvents(events: SuiteTelemetryEvent[]) {
       action_center_closeout_recorded: 0,
     },
   )
+}
+
+export function countSuiteTelemetryEventRows(rows: SuiteTelemetryEventRow[]) {
+  return countSuiteTelemetryEvents(rows)
+}
+
+export function getSuiteTelemetryEventLabel(eventType: SuiteTelemetryEventType) {
+  switch (eventType) {
+    case 'owner_access_confirmed':
+      return 'Owner access confirmed'
+    case 'first_value_confirmed':
+      return 'First value confirmed'
+    case 'first_management_use_confirmed':
+      return 'First management use confirmed'
+    case 'manager_denied_insights':
+      return 'Manager denied insights'
+    case 'action_center_review_scheduled':
+      return 'Action Center review scheduled'
+    case 'action_center_closeout_recorded':
+      return 'Action Center closeout recorded'
+    default:
+      return eventType
+  }
 }

--- a/frontend/lib/telemetry/store.ts
+++ b/frontend/lib/telemetry/store.ts
@@ -1,0 +1,93 @@
+import 'server-only'
+
+import { randomUUID } from 'node:crypto'
+import { createAdminClient } from '@/lib/supabase/admin'
+import {
+  isSuiteTelemetryEventType,
+  type SuiteTelemetryEvent,
+  type SuiteTelemetryEventRow,
+  type SuiteTelemetryEventType,
+} from '@/lib/telemetry/events'
+import { isMissingSchemaError, readFallbackRegistryFile, writeFallbackRegistryFile } from '@/lib/runtime-registry-fallback'
+
+type SuiteTelemetryDbRow = {
+  id: string
+  event_type: string
+  org_id: string | null
+  campaign_id: string | null
+  actor_id: string | null
+  payload: Record<string, unknown> | null
+  created_at: string
+}
+
+export async function listSuiteTelemetryEventRows(limit = 60) {
+  const admin = createAdminClient()
+  const { data, error } = await admin
+    .from('suite_telemetry_events')
+    .select('id, event_type, org_id, campaign_id, actor_id, payload, created_at')
+    .order('created_at', { ascending: false })
+    .limit(limit)
+
+  if (error) {
+    if (isMissingSchemaError(error)) {
+      const fallbackRows = await readFallbackRegistryFile<SuiteTelemetryEventRow[]>('suite-telemetry-events.json', [])
+      return fallbackRows.slice(0, limit)
+    }
+    throw error
+  }
+
+  return ((data ?? []) as SuiteTelemetryDbRow[])
+    .filter((row) => isSuiteTelemetryEventType(row.event_type))
+    .map(
+      (row) =>
+        ({
+          id: row.id,
+          eventType: row.event_type as SuiteTelemetryEventType,
+          orgId: row.org_id,
+          campaignId: row.campaign_id,
+          actorId: row.actor_id,
+          payload: row.payload ?? {},
+          createdAt: row.created_at,
+        }) satisfies SuiteTelemetryEventRow,
+    )
+}
+
+export async function insertSuiteTelemetryEvents(events: SuiteTelemetryEvent[]) {
+  if (events.length === 0) return []
+
+  const admin = createAdminClient()
+  const payload = events.map((event) => ({
+    event_type: event.eventType,
+    org_id: event.orgId,
+    campaign_id: event.campaignId,
+    actor_id: event.actorId,
+    payload: event.payload,
+  }))
+
+  const { error } = await admin.from('suite_telemetry_events').insert(payload)
+  if (error) {
+    if (isMissingSchemaError(error)) {
+      const existing = await readFallbackRegistryFile<SuiteTelemetryEventRow[]>('suite-telemetry-events.json', [])
+      const appended = [
+        ...events.map(
+          (event) =>
+            ({
+              id: randomUUID(),
+              eventType: event.eventType,
+              orgId: event.orgId,
+              campaignId: event.campaignId,
+              actorId: event.actorId,
+              payload: event.payload,
+              createdAt: new Date().toISOString(),
+            }) satisfies SuiteTelemetryEventRow,
+        ),
+        ...existing,
+      ]
+      await writeFallbackRegistryFile('suite-telemetry-events.json', appended)
+      return appended.slice(0, Math.max(20, events.length))
+    }
+    throw error
+  }
+
+  return listSuiteTelemetryEventRows(Math.max(20, events.length))
+}

--- a/frontend/scripts/seed-real-usage-proof-wave.mjs
+++ b/frontend/scripts/seed-real-usage-proof-wave.mjs
@@ -1,0 +1,359 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createClient } from '@supabase/supabase-js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const frontendRoot = path.resolve(__dirname, '..')
+const envPath = path.join(frontendRoot, '.env.local')
+const artifactPath = path.join(frontendRoot, 'tests', 'e2e', '.real-usage-wave.json')
+const fallbackDir = path.join(frontendRoot, 'data', 'runtime-registries')
+
+const SUPPORTED_SCAN_TYPES = ['exit', 'retention', 'onboarding', 'pulse', 'leadership']
+const BILLING_STATES = [
+  ['signed', 'active_manual', true],
+  ['pending_signature', 'draft', false],
+  ['signed', 'paused', true],
+  ['signed', 'active_manual', false],
+]
+const PROOF_STAGES = [
+  ['lesson_only', 'draft'],
+  ['internal_proof_only', 'internal_review'],
+  ['sales_usable', 'claim_check'],
+  ['public_usable', 'approved'],
+]
+
+function loadEnv(filePath) {
+  const values = {}
+  const source = readFileSync(filePath, 'utf8')
+  for (const line of source.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#') || !trimmed.includes('=')) continue
+    const [key, ...rest] = trimmed.split('=')
+    values[key] = rest.join('=').trim().replace(/^['"]|['"]$/g, '')
+  }
+  return values
+}
+
+function getRouteLabel(scanType) {
+  switch (scanType) {
+    case 'exit':
+      return 'ExitScan'
+    case 'retention':
+      return 'RetentieScan'
+    case 'onboarding':
+      return 'Onboarding 30-60-90'
+    case 'pulse':
+      return 'Pulse'
+    case 'leadership':
+      return 'Leadership'
+    default:
+      return scanType
+  }
+}
+
+function selectSemirealCampaigns(campaigns) {
+  const byOrg = new Map()
+  for (const campaign of campaigns) {
+    if (!byOrg.has(campaign.organization_id)) {
+      byOrg.set(campaign.organization_id, campaign)
+    }
+  }
+  return [...byOrg.values()].slice(0, 4)
+}
+
+function buildBillingRow(organization, index) {
+  const [contractState, billingState, paymentConfirmed] = BILLING_STATES[index % BILLING_STATES.length]
+  return {
+    org_id: organization.id,
+    legal_customer_name: organization.name,
+    contract_state: contractState,
+    billing_state: billingState,
+    payment_method_confirmed: paymentConfirmed,
+    notes: `Semireële assisted registryseed voor ${organization.name}.`,
+  }
+}
+
+function buildTelemetryEvents({ campaign, actorId, managerId, organizationName, stats }) {
+  const basePayload = {
+    seeded_by: 'real_usage_wave',
+    source: 'semireal_suite_run',
+    organization_name: organizationName,
+    route: getRouteLabel(campaign.scan_type),
+  }
+
+  return [
+    {
+      event_type: 'owner_access_confirmed',
+      org_id: campaign.organization_id,
+      campaign_id: campaign.id,
+      actor_id: actorId,
+      payload: { ...basePayload, step: 'owner_access' },
+    },
+    {
+      event_type: 'first_value_confirmed',
+      org_id: campaign.organization_id,
+      campaign_id: campaign.id,
+      actor_id: actorId,
+      payload: {
+        ...basePayload,
+        step: 'first_value',
+        completion_rate_pct: stats?.completion_rate_pct ?? null,
+      },
+    },
+    {
+      event_type: 'first_management_use_confirmed',
+      org_id: campaign.organization_id,
+      campaign_id: campaign.id,
+      actor_id: actorId,
+      payload: { ...basePayload, step: 'management_use' },
+    },
+    {
+      event_type: 'action_center_review_scheduled',
+      org_id: campaign.organization_id,
+      campaign_id: campaign.id,
+      actor_id: actorId,
+      payload: { ...basePayload, review_window: '14_dagen' },
+    },
+    {
+      event_type: 'action_center_closeout_recorded',
+      org_id: campaign.organization_id,
+      campaign_id: campaign.id,
+      actor_id: actorId,
+      payload: { ...basePayload, closeout_state: 'bounded_next_step' },
+    },
+    ...(managerId
+      ? [
+          {
+            event_type: 'manager_denied_insights',
+            org_id: campaign.organization_id,
+            campaign_id: campaign.id,
+            actor_id: managerId,
+            payload: { ...basePayload, step: 'manager_scope_guard' },
+          },
+        ]
+      : []),
+  ]
+}
+
+function buildProofRow({ campaign, organizationName, index, stats }) {
+  const [proofState, approvalState] = PROOF_STAGES[index % PROOF_STAGES.length]
+  return {
+    org_id: campaign.organization_id,
+    campaign_id: campaign.id,
+    route: getRouteLabel(campaign.scan_type),
+    proof_state: proofState,
+    approval_state: approvalState,
+    summary: `Semireële suite-run: ${organizationName} gebruikte ${getRouteLabel(campaign.scan_type)} voor eerste managementduiding en een bounded vervolgritme.`,
+    claimable_observation:
+      proofState === 'public_usable'
+        ? `${getRouteLabel(campaign.scan_type)} maakte prioriteit, toewijzing en reviewmoment expliciet binnen dezelfde suite.`
+        : `${getRouteLabel(campaign.scan_type)} leverde een bounded les op voor managementread en vervolgstap.`,
+    supporting_artifacts: [
+      { type: 'seed_marker', seed: 'real_usage_wave' },
+      { type: 'campaign', name: campaign.name },
+      { type: 'stats', total_completed: stats?.total_completed ?? null },
+    ],
+  }
+}
+
+async function tableExists(admin, table) {
+  const { error } = await admin.from(table).select('*').limit(1)
+  return !error
+}
+
+async function main() {
+  const env = loadEnv(envPath)
+  const supabaseUrl = env.NEXT_PUBLIC_SUPABASE_URL ?? env.SUPABASE_URL
+  const serviceRoleKey = env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error('NEXT_PUBLIC_SUPABASE_URL of SUPABASE_SERVICE_ROLE_KEY ontbreekt.')
+  }
+
+  const admin = createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  })
+
+  const { data: campaignsRaw, error: campaignError } = await admin
+    .from('campaigns')
+    .select('id, organization_id, name, scan_type, created_at, is_active')
+    .in('scan_type', SUPPORTED_SCAN_TYPES)
+    .eq('is_active', true)
+    .order('created_at', { ascending: false })
+
+  if (campaignError) throw campaignError
+
+  const campaigns = selectSemirealCampaigns(campaignsRaw ?? [])
+  if (campaigns.length === 0) {
+    throw new Error('Geen geschikte campaigns gevonden voor de RU-seed.')
+  }
+
+  const orgIds = [...new Set(campaigns.map((campaign) => campaign.organization_id))]
+  const campaignIds = campaigns.map((campaign) => campaign.id)
+
+  const [{ data: organizationsRaw, error: organizationsError }, { data: statsRaw, error: statsError }, { data: workspaceRaw, error: workspaceError }] =
+    await Promise.all([
+      admin.from('organizations').select('id, name').in('id', orgIds),
+      admin.from('campaign_stats').select('campaign_id, total_completed, completion_rate_pct').in('campaign_id', campaignIds),
+      admin
+        .from('action_center_workspace_members')
+        .select('org_id, user_id, access_role')
+        .in('org_id', orgIds)
+        .eq('can_view', true),
+    ])
+
+  if (organizationsError) throw organizationsError
+  if (statsError) throw statsError
+  if (workspaceError) throw workspaceError
+
+  const organizations = organizationsRaw ?? []
+  const organizationById = new Map(organizations.map((organization) => [organization.id, organization]))
+  const statsByCampaignId = new Map((statsRaw ?? []).map((stat) => [stat.campaign_id, stat]))
+  const workspaceByOrg = (workspaceRaw ?? []).reduce((acc, row) => {
+    acc[row.org_id] ??= { ownerId: null, managerId: null }
+    if (row.access_role === 'hr_owner' && !acc[row.org_id].ownerId) acc[row.org_id].ownerId = row.user_id
+    if (row.access_role === 'manager_assignee' && !acc[row.org_id].managerId) acc[row.org_id].managerId = row.user_id
+    return acc
+  }, {})
+
+  const billingRows = organizations.slice(0, campaigns.length).map((organization, index) => buildBillingRow(organization, index))
+  mkdirSync(fallbackDir, { recursive: true })
+  writeFileSync(path.join(fallbackDir, 'billing-registry.json'), JSON.stringify(
+    billingRows.map((row) => ({
+      id: `${row.org_id}-billing`,
+      orgId: row.org_id,
+      organizationName: organizations.find((organization) => organization.id === row.org_id)?.name ?? row.legal_customer_name,
+      legalCustomerName: row.legal_customer_name,
+      contractState: row.contract_state,
+      billingState: row.billing_state,
+      paymentMethodConfirmed: row.payment_method_confirmed,
+      notes: row.notes,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    })),
+    null,
+    2,
+  ), 'utf8')
+
+  const billingTableExists = await tableExists(admin, 'billing_registry')
+  if (billingTableExists) {
+    const { error: billingError } = await admin.from('billing_registry').upsert(billingRows, { onConflict: 'org_id' })
+    if (billingError) throw billingError
+  }
+
+  const telemetryEvents = campaigns.flatMap((campaign) => {
+    const orgWorkspace = workspaceByOrg[campaign.organization_id] ?? { ownerId: null, managerId: null }
+    const organizationName = organizationById.get(campaign.organization_id)?.name ?? 'Verisight organisatie'
+    return buildTelemetryEvents({
+      campaign,
+      actorId: orgWorkspace.ownerId,
+      managerId: orgWorkspace.managerId,
+      organizationName,
+      stats: statsByCampaignId.get(campaign.id) ?? null,
+    })
+  })
+  writeFileSync(path.join(fallbackDir, 'suite-telemetry-events.json'), JSON.stringify(
+    telemetryEvents.map((event, index) => ({
+      id: `telemetry-${index + 1}`,
+      eventType: event.event_type,
+      orgId: event.org_id,
+      campaignId: event.campaign_id,
+      actorId: event.actor_id,
+      payload: event.payload,
+      createdAt: new Date(Date.now() - index * 60000).toISOString(),
+    })),
+    null,
+    2,
+  ), 'utf8')
+
+  const telemetryTableExists = await tableExists(admin, 'suite_telemetry_events')
+  if (telemetryTableExists) {
+    const { data: existingTelemetryRows, error: existingTelemetryError } = await admin
+      .from('suite_telemetry_events')
+      .select('id, payload')
+      .limit(500)
+    if (existingTelemetryError) throw existingTelemetryError
+
+    const telemetrySeedIds = (existingTelemetryRows ?? [])
+      .filter((row) => row.payload?.seeded_by === 'real_usage_wave')
+      .map((row) => row.id)
+    if (telemetrySeedIds.length > 0) {
+      const { error: deleteTelemetryError } = await admin.from('suite_telemetry_events').delete().in('id', telemetrySeedIds)
+      if (deleteTelemetryError) throw deleteTelemetryError
+    }
+
+    const { error: telemetryError } = await admin.from('suite_telemetry_events').insert(telemetryEvents)
+    if (telemetryError) throw telemetryError
+  }
+
+  const proofRows = campaigns.map((campaign, index) =>
+    buildProofRow({
+      campaign,
+      organizationName: organizationById.get(campaign.organization_id)?.name ?? 'Verisight organisatie',
+      index,
+      stats: statsByCampaignId.get(campaign.id) ?? null,
+    }),
+  )
+  writeFileSync(path.join(fallbackDir, 'proof-registry.json'), JSON.stringify(
+    proofRows.map((row, index) => ({
+      id: `proof-${index + 1}`,
+      orgId: row.org_id,
+      campaignId: row.campaign_id,
+      route: row.route,
+      proofState: row.proof_state,
+      approvalState: row.approval_state,
+      summary: row.summary,
+      claimableObservation: row.claimable_observation,
+      supportingArtifacts: row.supporting_artifacts,
+      createdAt: new Date(Date.now() - index * 60000).toISOString(),
+    })),
+    null,
+    2,
+  ), 'utf8')
+
+  const proofTableExists = await tableExists(admin, 'case_proof_registry')
+  if (proofTableExists) {
+    const { data: existingProofRows, error: existingProofError } = await admin
+      .from('case_proof_registry')
+      .select('id, summary')
+      .ilike('summary', 'Semireële suite-run:%')
+    if (existingProofError) throw existingProofError
+
+    if ((existingProofRows ?? []).length > 0) {
+      const { error: deleteProofError } = await admin
+        .from('case_proof_registry')
+        .delete()
+        .in(
+          'id',
+          existingProofRows.map((row) => row.id),
+        )
+      if (deleteProofError) throw deleteProofError
+    }
+
+    const { error: proofError } = await admin.from('case_proof_registry').insert(proofRows)
+    if (proofError) throw proofError
+  }
+
+  mkdirSync(path.dirname(artifactPath), { recursive: true })
+  const artifact = {
+    seededAt: new Date().toISOString(),
+    organizations: organizations.map((organization) => ({ id: organization.id, name: organization.name })),
+    campaignIds,
+    billingCount: billingRows.length,
+    telemetryCount: telemetryEvents.length,
+    proofCount: proofRows.length,
+    storageMode: {
+      billing: billingTableExists ? 'supabase+fallback' : 'fallback_only',
+      telemetry: telemetryTableExists ? 'supabase+fallback' : 'fallback_only',
+      proof: proofTableExists ? 'supabase+fallback' : 'fallback_only',
+    },
+  }
+  writeFileSync(artifactPath, JSON.stringify(artifact, null, 2), 'utf8')
+  console.log(JSON.stringify(artifact, null, 2))
+}
+
+await main()

--- a/frontend/tests/e2e/.real-usage-wave.json
+++ b/frontend/tests/e2e/.real-usage-wave.json
@@ -1,0 +1,35 @@
+{
+  "seededAt": "2026-04-27T08:07:05.261Z",
+  "organizations": [
+    {
+      "id": "26b85e72-2f92-4995-b995-2f435830ebcf",
+      "name": "Pulse Smoke 8afc"
+    },
+    {
+      "id": "6487223a-b61c-402b-8fa0-c1d5bb551938",
+      "name": "Pulse Smoke 955e"
+    },
+    {
+      "id": "43165d75-08b2-497b-a52c-e566d47d1bfc",
+      "name": "Pulse Smoke 134b"
+    },
+    {
+      "id": "9d476aa5-9e79-4b5e-9dab-112265a6fae7",
+      "name": "Verisight Guided Self-Serve Acceptance"
+    }
+  ],
+  "campaignIds": [
+    "069ee28a-2038-46ba-9d37-6a38d0fd8691",
+    "7e74e0f8-48e1-4ca7-acc0-63e4f679c51a",
+    "535a57d2-b0b5-4acb-9f12-8cf18c8fb359",
+    "2f452cfe-bc3e-4afc-aedc-b3344d369464"
+  ],
+  "billingCount": 4,
+  "telemetryCount": 20,
+  "proofCount": 4,
+  "storageMode": {
+    "billing": "fallback_only",
+    "telemetry": "fallback_only",
+    "proof": "fallback_only"
+  }
+}


### PR DESCRIPTION
## Summary
- replace demo-only billing, telemetry, and proof admin surfaces with real registry helpers
- add a semireal usage seed wave plus runtime fallback registries when the current Supabase environment lacks the three RU tables
- document the bounded RU closeout and keep public proof approval-gated

## Verification
- `npm run test -- lib/billing-registry.test.ts lib/telemetry/events.test.ts lib/proof-registry.test.ts lib/public-proof-feed.test.ts "app/(dashboard)/beheer/billing/page.test.ts" "app/(dashboard)/beheer/health/page.test.ts" "app/(dashboard)/beheer/proof/page.test.ts" "app/api/internal/telemetry/route.test.ts"`
- `npm run build`
- `node scripts/seed-real-usage-proof-wave.mjs`

## Important nuance
- in the current linked Supabase environment, `billing_registry`, `suite_telemetry_events`, and `case_proof_registry` are still missing
- this slice therefore runs in `fallback_only` mode via controlled runtime-registry snapshots while preserving direct Supabase usage automatically when those tables do exist
