### PR TITLE
Provision RU registry tables

### DIFF
--- a/docs/active/REAL_USAGE_AND_PROOF_CLOSEOUT_2026-04-27.md
+++ b/docs/active/REAL_USAGE_AND_PROOF_CLOSEOUT_2026-04-27.md
@@ -2,7 +2,7 @@
 
 ## Korte samenvatting
 
-De RU-wave is werkend gemaakt voor de huidige suitebasis met echte adminsurfaces voor billing, telemetry en proof, plus een semireële seedlaag voor 2-4 trajecten. De bedoelde Supabase-tabellen ontbreken nog in deze live omgeving, daarom draait deze slice nu bewust in `fallback_only`-modus op gecontroleerde JSON registries die uit echte campagnes en organisaties zijn afgeleid.
+De RU-wave draait nu echt DB-backed op de huidige suitebasis: billing, telemetry en proof hebben live adminsurfaces, de drie RU-tabellen zijn geprovisioneerd in de gekoppelde Supabase-omgeving en de semireele seedlaag voor 2-4 trajecten schrijft nu direct naar Supabase. De fallback registries blijven bewust bestaan als bounded noodgeval en lokale veiligheidslaag, maar zijn niet langer de primaire runtimewaarheid.
 
 ## Wat is geland
 
@@ -14,7 +14,7 @@ De RU-wave is werkend gemaakt voor de huidige suitebasis met echte adminsurfaces
   - billing registry
   - suite telemetry events
   - proof registry
-- semireële seedscript:
+- semireele seedscript:
   - `frontend/scripts/seed-real-usage-proof-wave.mjs`
 - runtime fallback store:
   - `frontend/data/runtime-registries/billing-registry.json`
@@ -24,11 +24,13 @@ De RU-wave is werkend gemaakt voor de huidige suitebasis met echte adminsurfaces
   - `POST /api/internal/telemetry`
   - `GET/POST /api/billing-registry`
   - `GET/POST /api/proof-registry`
+- live schema-aanvulling:
+  - `migrations/2026_04_27_add_real_usage_registry_tables.sql`
 
-## Wat de semireële wave nu dekt
+## Wat de semireele wave nu dekt
 
 - `billing registry echt gebruiken`
-  - 4 semireële assisted rows
+  - 4 semireele assisted rows
 - `telemetry live laten meelopen`
   - 20 bounded events over owner access, first value, first management use, manager denied insights, review scheduling en closeout
 - `proof registry vullen`
@@ -37,40 +39,38 @@ De RU-wave is werkend gemaakt voor de huidige suitebasis met echte adminsurfaces
     - `internal_proof_only`
     - `sales_usable`
     - `public_usable`
-- `2-4 echte of semireële trajecten`
-  - 4 semireële suite-runs gebaseerd op huidige campaigns en organizations
+- `2-4 echte of semireele trajecten`
+  - 4 semireele suite-runs gebaseerd op huidige campaigns en organizations
 
 ## Belangrijke nuance
 
-De huidige Supabase-omgeving mist nog:
+De slice blijft bewust in een dubbel veilig model:
 
-- `billing_registry`
-- `suite_telemetry_events`
-- `case_proof_registry`
+- **primaire waarheid**:
+  - `billing_registry`
+  - `suite_telemetry_events`
+  - `case_proof_registry`
+  - live in Supabase
+- **fallbacklaag**:
+  - gecontroleerde JSON registries in de repo
+  - alleen voor lokale noodpaden of als een omgeving tijdelijk de schema-objecten nog niet heeft
 
-Daarom is de slice nu bewust zo opgezet:
-
-- **als de tabellen bestaan**:
-  - lees en schrijf direct in Supabase
-- **als de tabellen ontbreken**:
-  - lees en schrijf via gecontroleerde fallback registries in de repo
-
-Dat maakt de wave direct bruikbaar voor appgedrag, review, demo en interne proofdiscipline, zonder te doen alsof de live schema-stap al af is.
+Dat houdt de suite eerlijk assisted en operationeel robuust, zonder de live waarheid opnieuw te verleggen naar demo- of mockdata.
 
 ## Nog open
 
-- de drie RU-tabellen alsnog echt provisionen in de gekoppelde Supabase-omgeving
-- daarna dezelfde seed nog een keer door de echte DB laten lopen
-- en pas daarna public proof verder opvoeren op basis van goedgekeurde echte cases
+- de eerste echte live cases door deze nieuwe registrylaag laten lopen
+- public proof alleen verder opvoeren op basis van goedgekeurde echte cases
+- fallbackgebruik alleen nog als noodgeval of lokale ontwikkelguardrail behandelen
 
 ## Oordeel
 
-Technisch geslaagd en reviewklaar als bounded RU-wave.
+Technisch geslaagd en live afgerond als bounded RU-wave.
 
 De suite heeft nu:
 
 - werkende billing / telemetry / proof surfaces
-- semireële usage-evidence
+- DB-backed semireele usage-evidence
 - expliciete public-proof scheiding
 
-Maar de definitieve live afronding vraagt nog één echte schema-applicatiestap in Supabase.
+De infrastructuurgap is nu gesloten; het vervolgwerk zit niet meer in schema, maar in echt gebruik en zwaardere proof.

--- a/frontend/tests/e2e/.real-usage-wave.json
+++ b/frontend/tests/e2e/.real-usage-wave.json
@@ -1,5 +1,5 @@
 {
-  "seededAt": "2026-04-27T08:07:05.261Z",
+  "seededAt": "2026-04-27T10:47:00.080Z",
   "organizations": [
     {
       "id": "26b85e72-2f92-4995-b995-2f435830ebcf",
@@ -28,8 +28,8 @@
   "telemetryCount": 20,
   "proofCount": 4,
   "storageMode": {
-    "billing": "fallback_only",
-    "telemetry": "fallback_only",
-    "proof": "fallback_only"
+    "billing": "supabase+fallback",
+    "telemetry": "supabase+fallback",
+    "proof": "supabase+fallback"
   }
 }

--- a/migrations/2026_04_27_add_real_usage_registry_tables.sql
+++ b/migrations/2026_04_27_add_real_usage_registry_tables.sql
@@ -1,0 +1,155 @@
+-- Real usage registry tables for assisted billing, telemetry, and proof.
+-- Keeps the RU wave DB-backed in the linked Supabase environment while
+-- preserving bounded shapes that match the current app layer.
+
+create table if not exists public.billing_registry (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid not null unique references public.organizations(id) on delete cascade,
+  legal_customer_name text not null,
+  contract_state text not null default 'draft'
+    check (contract_state in ('draft', 'pending_signature', 'signed')),
+  billing_state text not null default 'draft'
+    check (billing_state in ('draft', 'active_manual', 'paused', 'closed')),
+  payment_method_confirmed boolean not null default false,
+  notes text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists billing_registry_billing_state_idx
+  on public.billing_registry (billing_state);
+
+create index if not exists billing_registry_updated_at_idx
+  on public.billing_registry (updated_at desc);
+
+create or replace function public.set_billing_registry_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists billing_registry_set_updated_at on public.billing_registry;
+create trigger billing_registry_set_updated_at
+before update on public.billing_registry
+for each row execute function public.set_billing_registry_updated_at();
+
+create table if not exists public.suite_telemetry_events (
+  id uuid primary key default gen_random_uuid(),
+  event_type text not null
+    check (
+      event_type in (
+        'owner_access_confirmed',
+        'first_value_confirmed',
+        'first_management_use_confirmed',
+        'manager_denied_insights',
+        'action_center_review_scheduled',
+        'action_center_closeout_recorded'
+      )
+    ),
+  org_id uuid references public.organizations(id) on delete set null,
+  campaign_id uuid references public.campaigns(id) on delete set null,
+  actor_id uuid references auth.users(id) on delete set null,
+  payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists suite_telemetry_events_org_idx
+  on public.suite_telemetry_events (org_id, created_at desc);
+
+create index if not exists suite_telemetry_events_campaign_idx
+  on public.suite_telemetry_events (campaign_id, created_at desc);
+
+create index if not exists suite_telemetry_events_type_idx
+  on public.suite_telemetry_events (event_type, created_at desc);
+
+create table if not exists public.case_proof_registry (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid references public.organizations(id) on delete set null,
+  campaign_id uuid references public.campaigns(id) on delete set null,
+  route text not null,
+  proof_state text not null default 'lesson_only'
+    check (proof_state in ('lesson_only', 'internal_proof_only', 'sales_usable', 'public_usable', 'rejected')),
+  approval_state text not null default 'draft'
+    check (approval_state in ('draft', 'internal_review', 'claim_check', 'customer_permission', 'approved', 'rejected')),
+  summary text not null,
+  claimable_observation text,
+  supporting_artifacts jsonb not null default '[]'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists case_proof_registry_org_idx
+  on public.case_proof_registry (org_id, created_at desc);
+
+create index if not exists case_proof_registry_campaign_idx
+  on public.case_proof_registry (campaign_id, created_at desc);
+
+create index if not exists case_proof_registry_state_idx
+  on public.case_proof_registry (proof_state, approval_state, created_at desc);
+
+alter table public.billing_registry enable row level security;
+alter table public.suite_telemetry_events enable row level security;
+alter table public.case_proof_registry enable row level security;
+
+drop policy if exists "billing_registry_org_owner_or_admin_select" on public.billing_registry;
+drop policy if exists "billing_registry_org_owner_or_admin_insert" on public.billing_registry;
+drop policy if exists "billing_registry_org_owner_or_admin_update" on public.billing_registry;
+drop policy if exists "billing_registry_org_owner_or_admin_delete" on public.billing_registry;
+
+create policy "billing_registry_org_owner_or_admin_select"
+  on public.billing_registry for select
+  using (public.is_verisight_admin_user() or public.is_org_owner(org_id));
+
+create policy "billing_registry_org_owner_or_admin_insert"
+  on public.billing_registry for insert
+  with check (public.is_verisight_admin_user() or public.is_org_owner(org_id));
+
+create policy "billing_registry_org_owner_or_admin_update"
+  on public.billing_registry for update
+  using (public.is_verisight_admin_user() or public.is_org_owner(org_id))
+  with check (public.is_verisight_admin_user() or public.is_org_owner(org_id));
+
+create policy "billing_registry_org_owner_or_admin_delete"
+  on public.billing_registry for delete
+  using (public.is_verisight_admin_user() or public.is_org_owner(org_id));
+
+drop policy if exists "suite_telemetry_org_owner_or_admin_select" on public.suite_telemetry_events;
+drop policy if exists "suite_telemetry_org_owner_or_admin_insert" on public.suite_telemetry_events;
+drop policy if exists "suite_telemetry_admin_delete" on public.suite_telemetry_events;
+
+create policy "suite_telemetry_org_owner_or_admin_select"
+  on public.suite_telemetry_events for select
+  using (public.is_verisight_admin_user() or (org_id is not null and public.is_org_owner(org_id)));
+
+create policy "suite_telemetry_org_owner_or_admin_insert"
+  on public.suite_telemetry_events for insert
+  with check (public.is_verisight_admin_user() or (org_id is not null and public.is_org_owner(org_id)));
+
+create policy "suite_telemetry_admin_delete"
+  on public.suite_telemetry_events for delete
+  using (public.is_verisight_admin_user());
+
+drop policy if exists "case_proof_org_owner_or_admin_select" on public.case_proof_registry;
+drop policy if exists "case_proof_org_owner_or_admin_insert" on public.case_proof_registry;
+drop policy if exists "case_proof_org_owner_or_admin_update" on public.case_proof_registry;
+drop policy if exists "case_proof_admin_delete" on public.case_proof_registry;
+
+create policy "case_proof_org_owner_or_admin_select"
+  on public.case_proof_registry for select
+  using (public.is_verisight_admin_user() or (org_id is not null and public.is_org_owner(org_id)));
+
+create policy "case_proof_org_owner_or_admin_insert"
+  on public.case_proof_registry for insert
+  with check (public.is_verisight_admin_user() or (org_id is not null and public.is_org_owner(org_id)));
+
+create policy "case_proof_org_owner_or_admin_update"
+  on public.case_proof_registry for update
+  using (public.is_verisight_admin_user() or (org_id is not null and public.is_org_owner(org_id)))
+  with check (public.is_verisight_admin_user() or (org_id is not null and public.is_org_owner(org_id)));
+
+create policy "case_proof_admin_delete"
+  on public.case_proof_registry for delete
+  using (public.is_verisight_admin_user());


### PR DESCRIPTION
## Summary
- add the RU registry migration for billing, telemetry, and proof tables with bounded indexes and RLS
- provision the three RU tables in the linked Supabase project and rerun the semireal RU seed against live storage
- update the RU closeout and seed artifact to reflect live DB-backed storage instead of fallback-only mode

## Verification
- apply `migrations/2026_04_27_add_real_usage_registry_tables.sql` against the current `DATABASE_URL`
- `node scripts/seed-real-usage-proof-wave.mjs`
- `python` live DB count check for `billing_registry`, `suite_telemetry_events`, `case_proof_registry`
- `npm run test -- lib/billing-registry.test.ts lib/telemetry/events.test.ts lib/proof-registry.test.ts lib/public-proof-feed.test.ts "app/(dashboard)/beheer/billing/page.test.ts" "app/(dashboard)/beheer/health/page.test.ts" "app/(dashboard)/beheer/proof/page.test.ts" "app/api/internal/telemetry/route.test.ts"`
- `npm run build`

## Important nuance
- fallback registries still remain in place as bounded safety rails
- the primary runtime truth is now the live Supabase tables in the current linked environment
