### PR TITLE
Sharpen commercial portfolio truth and report policy

### DIFF
--- a/docs/active/ACTION_CENTER_PROPOSITION_CONTRACT.md
+++ b/docs/active/ACTION_CENTER_PROPOSITION_CONTRACT.md
@@ -66,7 +66,9 @@ Dashboard blijft:
 Rapport blijft:
 
 - de compacte management read en handofflaag
-- de formele output die gedeeld, besproken en doorverteld kan worden
+- de formele output die vooral bij ExitScan en RetentieScan standaard gedeeld, besproken en doorverteld kan worden
+
+Bij bounded peer- en vervolgroutes kan de suite wel een managementread of outputlaag dragen, zonder dat iedere route dezelfde formele reportzwaarte opent.
 
 ### Action Center
 
@@ -78,7 +80,7 @@ Action Center blijft:
 De commerciële suitewaarheid is dus:
 
 - dashboard = zien
-- rapport = samenvatten en overdragen
+- rapport = formeel samenvatten en overdragen waar de route dat draagt
 - Action Center = opvolging organiseren en bewaken
 
 ## 4. Strong propositional framing

--- a/docs/active/CASE_EVIDENCE_AND_PROOF_POLICY_2026-04-27.md
+++ b/docs/active/CASE_EVIDENCE_AND_PROOF_POLICY_2026-04-27.md
@@ -1,0 +1,104 @@
+# CASE_EVIDENCE_AND_PROOF_POLICY_2026-04-27.md
+
+Last updated: 2026-04-27  
+Status: active  
+Scope: `TD-5` case evidence and proof upgrade
+
+## 1. Summary
+
+Deze policy legt vast hoe Verisight bewijs nu commercieel mag gebruiken.
+
+Niet elk bewijsfragment is automatisch:
+
+- salesproof
+- publieke proof
+- of klantclaim
+
+De prooflaag volgt daarom bewust een ladder.
+
+## 2. Proof ladder
+
+- `lesson_only`
+- `internal_proof_only`
+- `sales_usable`
+- `public_usable`
+
+## 3. Betekenis per niveau
+
+### lesson_only
+
+Interne les over wat werkte, blokkeerde of verschoof.
+
+Niet gebruiken als:
+
+- salesclaim
+- publieke case
+- marketingproof
+
+### internal_proof_only
+
+Interne bewijslaag die al sterker is dan een losse les, maar nog niet buyer-safe.
+
+Wel bruikbaar voor:
+
+- productverbetering
+- operatorplaybooks
+- interne salesvoorbereiding
+
+### sales_usable
+
+Buyer-safe in directe salescontext, mits:
+
+- claim check is gedaan
+- context bounded is gehouden
+- geen publieke case-sprong wordt gemaakt
+
+### public_usable
+
+Pas geschikt voor publieke inzet als:
+
+- provenance klopt
+- klanttoestemming of andere vereiste approval expliciet is vastgelegd
+- de claim geen grotere volwassenheid suggereert dan de suite echt draagt
+
+## 4. Harde scheiding
+
+Bewust scheiden:
+
+- interne lessons
+- sales-usable proof
+- publieke proof
+
+Dat betekent:
+
+- geen seeded semireële runs verkopen als echte klantcase
+- geen publieke claims opvoeren op basis van interne of semireële data
+- geen public proof zonder expliciete approval trail
+
+## 5. Huidige basis
+
+De huidige registry- en RU-basis is nu sterk genoeg voor:
+
+- semireële evidence
+- bounded salesproof
+- eerste proof-governance
+
+Maar nog niet automatisch voor:
+
+- brede publieke effectclaims
+- generieke ROI-beloften
+- volledige portfolio-evidence voor alle routes
+
+## 6. Wat hierna pas logisch is
+
+Versterk pas publieke claims nadat:
+
+- echte live cases door de registrylaag lopen
+- klanttoestemming expliciet vastligt
+- dezelfde uitkomst intern, salesmatig en publiek hetzelfde verhaal kan dragen
+
+## 7. Validation
+
+- Sluit aan op de live proof registry, billing registry en telemetrybasis.
+- Sluit aan op de bestaande RU-closeout en proof execution contracten.
+- Houdt de commerciële claimlaag bewust eerlijker dan de infrastructuur alleen.

--- a/docs/active/COMMERCIAL_PORTFOLIO_TRUTH_CONTRACT_2026-04-27.md
+++ b/docs/active/COMMERCIAL_PORTFOLIO_TRUTH_CONTRACT_2026-04-27.md
@@ -1,0 +1,139 @@
+# COMMERCIAL_PORTFOLIO_TRUTH_CONTRACT_2026-04-27.md
+
+Last updated: 2026-04-27  
+Status: active  
+Scope: `TD-0` portfolio commercial truth contract
+
+## 1. Summary
+
+Dit contract legt vast hoe het commerciële portfolio van Verisight nu eerlijk en scherp verkocht moet worden.
+
+De suite is niet:
+
+- een losse surveybibliotheek
+- een generieke HR-tool
+- of een bundel waar elke route dezelfde outputzwaarte draagt
+
+De suite is nu wel:
+
+- een people suite met duidelijke eerste routes
+- een gedeelde dashboardlaag voor managementread
+- een formele reportlaag waar dat echt past
+- en een Action Center-laag voor expliciete opvolging
+
+## 2. Wat Verisight nu verkoopt
+
+Verisight verkoopt nu in de kern:
+
+- ExitScan
+- RetentieScan
+
+Deze twee routes dragen het eerste koopgewicht.
+
+Daarnaast verkoopt Verisight bewust kleiner:
+
+- Onboarding 30-60-90 als bounded peer
+- Pulse als compacte vervolgroute
+- Leadership Scan als bounded managementcontext-route
+- Combinatie als portfolioroute tussen twee bestaande kernvragen
+
+## 3. Wat de suite-onderdelen doen
+
+### Scan / route
+
+De route opent de managementvraag:
+
+- waarom vertrekken mensen?
+- waar staat behoud onder druk?
+- waar lopen nieuwe medewerkers vroeg vast?
+- waar is een compacte review of bounded managementcontext logisch?
+
+### Dashboard
+
+Dashboard is de gedeelde readlaag van de suite.
+
+Dashboard helpt:
+
+- signalen zien
+- patronen prioriteren
+- managementread openen
+
+Dashboard hoort dus niet alleen bij formele reportroutes, maar bij meerdere productroutes.
+
+### Formele reportlaag
+
+De formele reportlaag draagt nu standaard kerngewicht bij:
+
+- ExitScan
+- RetentieScan
+
+Dat zijn de twee routes waar publieke en productmatige waarheid nu zwaar genoeg is voor:
+
+- formeel deelbaar managementrapport
+- bestuurlijke handoff
+- expliciete report-read als standaard onderdeel van de route
+
+Andere routes kunnen wel een managementread, snapshot of bounded output hebben, maar dragen niet automatisch dezelfde formele reportbelofte.
+
+### Action Center
+
+Action Center is:
+
+- geen losse productlijn
+- geen derde kerninstap
+- geen generieke taaktool
+
+Action Center is de gedeelde follow-through laag van de suite.
+
+Die laag helpt:
+
+- prioriteiten zichtbaar maken
+- een eigenaar vastleggen
+- eerste acties expliciet maken
+- reviewmomenten bewaken
+
+## 4. Commerciële hiërarchie
+
+### Primaire commerciële dragers
+
+- ExitScan
+- RetentieScan
+
+### Bewust kleinere peers of vervolgroutes
+
+- Onboarding 30-60-90
+- Pulse
+- Leadership Scan
+
+### Portfolioroute
+
+- Combinatie
+
+Combinatie is geen derde hoofdproduct, maar een route voor organisaties die beide kernvragen tegelijk moeten adresseren.
+
+## 5. Harde verkoopregels
+
+Wel doen:
+
+- ExitScan en RetentieScan als twee duidelijke eerste routes verkopen
+- dashboard als gedeelde managementread neerzetten
+- Action Center als scherpe opvolglaag neerzetten
+- bounded vervolg- en peerroutes kleiner en eerlijker positioneren
+
+Niet doen:
+
+- alle routes verkopen alsof ze dezelfde reportzwaarte hebben
+- Action Center als los derde product framen
+- Pulse of Leadership Scan als brede eerste wedge verkopen
+- Combinatie als bundel of pakketproduct behandelen
+
+## 6. Aanbevolen korte hoofdzin
+
+> Verisight helpt HR en management signalen zien, bepalen wat eerst telt en opvolging expliciet organiseren.
+
+## 7. Validation
+
+- Sluit aan op de huidige suite shell, reportlaag en Action Center runtime.
+- Sluit aan op de bestaande productfamilie- en manager-access-truth.
+- Maakt scherper wat al impliciet waar was: niet elke route draagt dezelfde formele outputlaag.
+

--- a/docs/active/REPORT_POLICY_AND_OUTPUT_TRUTH_2026-04-27.md
+++ b/docs/active/REPORT_POLICY_AND_OUTPUT_TRUTH_2026-04-27.md
@@ -1,0 +1,118 @@
+# REPORT_POLICY_AND_OUTPUT_TRUTH_2026-04-27.md
+
+Last updated: 2026-04-27  
+Status: active  
+Scope: `TD-3` report policy and output truth
+
+## 1. Summary
+
+Deze policy legt vast wanneer Verisight een formele reportbelofte draagt en wanneer een route bewust lichter blijft.
+
+Het uitgangspunt is:
+
+- niet elke route heeft dezelfde outputzwaarte
+- dashboard is breder dan de formele reportlaag
+- Action Center volgt pas nadat de readlaag is geland
+
+## 2. Routegroepen
+
+### Standaard formele reportroutes
+
+- ExitScan
+- RetentieScan
+
+Deze routes dragen nu standaard:
+
+- dashboard
+- formele managementread
+- deelbaar rapport
+- bestuurlijke handoff
+
+### Bounded output-routes
+
+- Onboarding 30-60-90
+- Pulse
+- Leadership Scan
+
+Deze routes dragen nu standaard:
+
+- dashboard of managementsurface
+- bounded outputread
+- eerste vervolgrichting
+
+Niet standaard:
+
+- een even zwaar formeel rapport als ExitScan of RetentieScan
+
+### Portfolioroute
+
+- Combinatie
+
+Deze route leunt op de twee kernroutes en opent geen aparte derde reportstructuur.
+
+## 3. Wat "managementread" per route betekent
+
+### ExitScan / RetentieScan
+
+Managementread betekent:
+
+- formele bestuurlijke samenvatting
+- prioriteiten
+- duiding
+- formele handoff voor HR, MT en directie
+
+### Onboarding 30-60-90
+
+Managementread betekent:
+
+- bounded checkpoint-read
+- vroege frictie of borging
+- eerste eigenaar en eerste actie
+
+### Pulse
+
+Managementread betekent:
+
+- compacte reviewlaag
+- ritmesignaal
+- beperkte vergelijkingsduiding
+- hercheckmoment
+
+### Leadership Scan
+
+Managementread betekent:
+
+- bounded leadership-context
+- eerste verificatievraag
+- geen named leader output
+- geen brede formele reportbelofte
+
+## 4. Producttaal die hierbij hoort
+
+Gebruik bij ExitScan en RetentieScan:
+
+- rapport
+- managementrapport
+- bestuurlijke handoff
+
+Gebruik bij de andere routes liever:
+
+- output
+- managementread
+- samenvatting
+- bounded handoff
+
+## 5. Dashboard-, report- en Action Center-relatie
+
+- dashboard = signalen en prioriteiten lezen
+- rapport = formele handoff waar de route dat draagt
+- Action Center = opvolging expliciet houden
+
+Action Center mag dus nooit impliceren dat iedere route eerst een zwaar formeel rapport nodig heeft.
+
+## 6. Validation
+
+- Sluit aan op de huidige runtime, waarin Pulse al expliciet zonder formeel PDF-rapport wordt behandeld.
+- Sluit aan op bestaande UI-logica die Exit en Retentie al zwaarder behandelt dan andere routes.
+- Begrenst reportclaims zonder de bredere suitepropositie zwakker te maken.
+

--- a/docs/active/SUITE_PRODUCT_FAMILY_MODEL.md
+++ b/docs/active/SUITE_PRODUCT_FAMILY_MODEL.md
@@ -64,7 +64,14 @@ Pas daarna zijn logisch:
 
 ### Shared module logic
 
-Dashboard en report volgen de productroute.
+Dashboard volgt de productroute als gedeelde readlaag.
+
+De formele reportlaag draagt nu standaard kerngewicht bij:
+
+- ExitScan
+- RetentieScan
+
+Andere routes kunnen wel een bounded outputread of managementsamenvatting dragen, maar niet automatisch dezelfde formele reportbelofte.
 
 Action Center volgt de follow-through behoefte, niet de first-buy status.
 

--- a/docs/superpowers/plans/2026-04-27-commercial-todo-truth-proof-wave.md
+++ b/docs/superpowers/plans/2026-04-27-commercial-todo-truth-proof-wave.md
@@ -1,0 +1,101 @@
+# Commercial TODO Truth & Proof Wave Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the non-design-dependent commercial TODO chain by hardening portfolio truth, formal report policy, case-evidence rules, and Action Center proposition truth without colliding with the active homepage and dashboard design threads.
+
+**Architecture:** Treat this wave as a truth-contract and bounded copy/runtime alignment pass. New active docs become the explicit policy source; small, safe copy and categorization updates in marketing and dashboard surfaces make that truth visible without reopening homepage or dashboard design implementation.
+
+**Tech Stack:** Markdown docs, Next.js/React marketing surfaces, dashboard report library helpers, workbook follow-up.
+
+---
+
+## File map
+
+- Create: `docs/active/COMMERCIAL_PORTFOLIO_TRUTH_CONTRACT_2026-04-27.md`
+- Create: `docs/active/REPORT_POLICY_AND_OUTPUT_TRUTH_2026-04-27.md`
+- Create: `docs/active/CASE_EVIDENCE_AND_PROOF_POLICY_2026-04-27.md`
+- Modify: `docs/active/SUITE_PRODUCT_FAMILY_MODEL.md`
+- Modify: `docs/active/ACTION_CENTER_PROPOSITION_CONTRACT.md`
+- Modify: `frontend/lib/dashboard/report-library.ts`
+- Modify: `frontend/app/(dashboard)/reports/page.tsx`
+- Modify: `frontend/components/marketing/producten-content.tsx`
+- Modify: `frontend/components/marketing/aanpak-content.tsx`
+- Modify: `frontend/components/marketing/contact-form.tsx`
+- Modify: `frontend/app/vertrouwen/page.tsx`
+
+### Task 1: TD-0 portfolio commercial truth
+
+**Files:**
+- Create: `docs/active/COMMERCIAL_PORTFOLIO_TRUTH_CONTRACT_2026-04-27.md`
+- Modify: `docs/active/SUITE_PRODUCT_FAMILY_MODEL.md`
+
+- [ ] Write the commercial portfolio truth contract that answers:
+  - what Verisight sells now
+  - which routes are primary
+  - how scan, dashboard, report/output, and Action Center relate
+  - why only ExitScan and RetentieScan carry standard report weight
+- [ ] Update `SUITE_PRODUCT_FAMILY_MODEL.md` so the shared module logic explicitly distinguishes:
+  - dashboard as shared read layer
+  - formal report as standard for Exit/Retentie
+  - Action Center as shared follow-through layer
+- [ ] Review the new contract and model for contradiction with the current portfolio truth.
+
+### Task 2: TD-3 report policy and output truth
+
+**Files:**
+- Create: `docs/active/REPORT_POLICY_AND_OUTPUT_TRUTH_2026-04-27.md`
+- Modify: `frontend/lib/dashboard/report-library.ts`
+- Modify: `frontend/app/(dashboard)/reports/page.tsx`
+- Modify: `frontend/components/marketing/producten-content.tsx`
+- Modify: `frontend/components/marketing/aanpak-content.tsx`
+- Modify: `frontend/components/marketing/contact-form.tsx`
+- Modify: `frontend/app/vertrouwen/page.tsx`
+
+- [ ] Write the report/output policy doc that defines:
+  - standard formal report carriers
+  - bounded output routes
+  - what "management read" means per route type
+- [ ] Update the report library helper so only ExitScan and RetentieScan are treated as formal management-report routes by default.
+- [ ] Tighten `/reports` copy so the page explains formal reports as primary for Exit/Retentie and bounded output for other routes.
+- [ ] Tighten safe marketing copy so broad route pages say "dashboard, managementread/output and Action Center" instead of implying every route carries the same formal report layer.
+- [ ] Review all touched strings for consistency with the new report policy.
+
+### Task 3: TD-5 case evidence and proof upgrade
+
+**Files:**
+- Create: `docs/active/CASE_EVIDENCE_AND_PROOF_POLICY_2026-04-27.md`
+
+- [ ] Write a proof policy doc that distinguishes:
+  - lesson_only
+  - internal_proof_only
+  - sales_usable
+  - public_usable
+- [ ] Make the doc explicit about:
+  - semireal seeded usage vs true customer proof
+  - public-proof approval requirements
+  - when claims may be strengthened after real usage
+- [ ] Cross-check the new policy against the already landed RU closeout and proof execution contract.
+
+### Task 4: TD-4 Action Center proposition sharpening
+
+**Files:**
+- Modify: `docs/active/ACTION_CENTER_PROPOSITION_CONTRACT.md`
+- Optionally adjust safe supporting copy in files already touched above if needed for consistency
+
+- [ ] Update the Action Center proposition contract so it explicitly fits the sharpened portfolio truth:
+  - Action Center as shared follow-through layer
+  - not every route starts with the same report weight
+  - Action Center remains commercially strongest after insight/output has landed
+- [ ] Recheck that no language turns Action Center into a separate product line or generic workflow suite.
+
+### Task 5: Verification and handoff
+
+**Files:**
+- Modify: workbook later in canonical output path
+
+- [ ] Run targeted tests or build checks for any changed frontend code.
+- [ ] Review git diff for accidental homepage/dashboard design collisions.
+- [ ] Commit the wave on the dedicated branch.
+- [ ] Update the workbook rows for `TD-0`, `TD-3`, `TD-5`, and `TD-4` in the canonical `.xlsx`.
+

--- a/frontend/app/(dashboard)/reports/page.tsx
+++ b/frontend/app/(dashboard)/reports/page.tsx
@@ -72,9 +72,9 @@ export default async function ReportsPage({
   return (
     <div className="space-y-6">
       <DashboardHero
-        eyebrow="Reports & Exports"
+        eyebrow="Reportlaag & output"
         title="Klaar voor het overleg."
-        description="Gebruik de rapportlaag als compacte managementread en handofflaag: eerst wat nu telt, daarna welke verificatie, eigenaar en opvolging logisch zijn. Geen ruwe data-dump, wel bestuurlijke output in dezelfde familie als dashboard en Action Center."
+        description="Gebruik de formele rapportlaag vooral voor ExitScan en RetentieScan: eerst wat nu telt, daarna welke verificatie, eigenaar en opvolging logisch zijn. Andere routes kunnen hier wel bounded outputreads tonen, maar dragen niet automatisch dezelfde reportzwaarte."
         tone="slate"
         meta={
           <>
@@ -129,9 +129,9 @@ export default async function ReportsPage({
           ) : (
             <div className="space-y-3">
               <p className="text-sm font-semibold text-[color:var(--dashboard-ink)]">Wanneer de rapportlaag opent</p>
-              <p className="text-sm leading-6 text-[color:var(--dashboard-text)]">
-                Rapporten verschijnen pas als een campaign genoeg respons en managementduiding heeft om een bounded handoff te dragen.
-              </p>
+                <p className="text-sm leading-6 text-[color:var(--dashboard-text)]">
+                  Formele rapporten openen pas als een campaign genoeg respons en managementduiding heeft om een bounded handoff te dragen. ExitScan en RetentieScan blijven daarin de primaire reportroutes.
+                </p>
             </div>
           )
         }
@@ -139,8 +139,8 @@ export default async function ReportsPage({
 
       <DashboardSection
         eyebrow="Bibliotheek"
-        title="Beschikbare rapporten"
-        description="Open alleen rapporten die al een echte managementread dragen. De rapportlaag blijft gekoppeld aan echte campaigns en volgt dezelfde bounded taal als dashboard en Action Center."
+        title="Beschikbare reports en outputreads"
+        description="Open alleen formele rapporten of bounded outputreads die al een echte managementread dragen. De formele reportlaag blijft primair gekoppeld aan ExitScan en RetentieScan; andere routes blijven bewust compacter."
         aside={
           <div className="flex flex-wrap justify-start gap-2 lg:justify-end">
             {CATEGORY_OPTIONS.map((option) => {
@@ -208,22 +208,22 @@ export default async function ReportsPage({
           </div>
         ) : (
           <div className="rounded-[24px] border border-dashed border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)] px-5 py-8 text-sm leading-7 text-[color:var(--dashboard-text)]">
-            Er zijn in deze categorie nog geen rapporten met voldoende respons en managementduiding. Gebruik eerst dashboard en campaignroute om de eerste read te laten landen.
+            Er zijn in deze categorie nog geen formele rapporten of bounded outputreads met voldoende respons en managementduiding. Gebruik eerst dashboard en campaignroute om de eerste read te laten landen.
           </div>
         )}
       </DashboardSection>
 
       <DashboardSection
         eyebrow="Handoff"
-        title="Van rapport naar opvolging"
-        description="De rapportlaag is geen eindpunt. Gebruik hem om managementduiding te bundelen en leg daarna in Action Center expliciet vast wie de eigenaar is, wat de eerste stap is en wanneer het reviewmoment terugkomt."
+        title="Van managementread naar opvolging"
+        description="De formele reportlaag of bounded outputread is geen eindpunt. Gebruik die read om managementduiding te bundelen en leg daarna in Action Center expliciet vast wie de eigenaar is, wat de eerste stap is en wanneer het reviewmoment terugkomt."
         tone="blue"
       >
         <div className="grid gap-4 lg:grid-cols-3">
           {[
-            ['1. Managementread', 'Gebruik dashboard en rapport samen om te bepalen welk patroon nu bestuurlijk telt en welke claim bewust nog niet hoort.'],
-            ['2. Eerste stap', 'Leg de eerste eigenaar en eerste stap vast zodra het rapport een echt managementgesprek opent. Zo blijft de output niet hangen in alleen inzicht.'],
-            ['3. Reviewmoment', 'Koppel het rapport altijd aan een reviewmoment in Action Center. Dan wordt opvolging zichtbaar, bounded en controleerbaar.'],
+            ['1. Managementread', 'Gebruik dashboard en formeel rapport of bounded outputread samen om te bepalen welk patroon nu bestuurlijk telt en welke claim bewust nog niet hoort.'],
+            ['2. Eerste stap', 'Leg de eerste eigenaar en eerste stap vast zodra de read een echt managementgesprek opent. Zo blijft de output niet hangen in alleen inzicht.'],
+            ['3. Reviewmoment', 'Koppel de read altijd aan een reviewmoment in Action Center. Dan wordt opvolging zichtbaar, bounded en controleerbaar.'],
           ].map(([title, body]) => (
             <div
               key={title}

--- a/frontend/app/(dashboard)/reports/page.tsx
+++ b/frontend/app/(dashboard)/reports/page.tsx
@@ -200,7 +200,11 @@ export default async function ReportsPage({
                     >
                       Open ↗
                     </Link>
-                    <PdfDownloadButton campaignId={entry.campaignId} campaignName={entry.campaignName} scanType={entry.scanType} />
+                    {entry.formalReport ? (
+                      <PdfDownloadButton campaignId={entry.campaignId} campaignName={entry.campaignName} scanType={entry.scanType} />
+                    ) : (
+                      <DashboardChip label="Bounded outputread" tone="blue" />
+                    )}
                   </div>
                 </div>
               </div>

--- a/frontend/app/vertrouwen/page.tsx
+++ b/frontend/app/vertrouwen/page.tsx
@@ -7,12 +7,12 @@ import { buildContactHref } from '@/lib/contact-funnel'
 export const metadata: Metadata = {
   title: 'Vertrouwen',
   description:
-    'Methodiek, privacy en rapportlezing van Verisight. Groepsinzichten met heldere claimsgrenzen voor ExitScan, RetentieScan, Onboarding 30-60-90, Pulse en Leadership Scan.',
+    'Methodiek, privacy en outputlezing van Verisight. Groepsinzichten met heldere claimsgrenzen voor ExitScan, RetentieScan, Onboarding 30-60-90, Pulse en Leadership Scan.',
   alternates: { canonical: '/vertrouwen' },
   openGraph: {
     title: 'Vertrouwen | Verisight',
     description:
-      'Methodiek, privacy en rapportlezing van Verisight. Groepsinzichten met heldere claimsgrenzen voor ExitScan, RetentieScan, Onboarding 30-60-90, Pulse en Leadership Scan.',
+      'Methodiek, privacy en outputlezing van Verisight. Groepsinzichten met heldere claimsgrenzen voor ExitScan, RetentieScan, Onboarding 30-60-90, Pulse en Leadership Scan.',
     url: 'https://www.verisight.nl/vertrouwen',
     images: ['/opengraph-image'],
   },
@@ -20,7 +20,7 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     title: 'Vertrouwen | Verisight',
     description:
-      'Methodiek, privacy en rapportlezing van Verisight. Groepsinzichten met heldere claimsgrenzen voor ExitScan, RetentieScan, Onboarding 30-60-90, Pulse en Leadership Scan.',
+      'Methodiek, privacy en outputlezing van Verisight. Groepsinzichten met heldere claimsgrenzen voor ExitScan, RetentieScan, Onboarding 30-60-90, Pulse en Leadership Scan.',
     images: ['/opengraph-image'],
   },
 }

--- a/frontend/components/marketing/aanpak-content.tsx
+++ b/frontend/components/marketing/aanpak-content.tsx
@@ -26,8 +26,8 @@ function HeroSection() {
               </h1>
             </div>
             <div style={{ animation: 'slideUpFade .8s cubic-bezier(.16,1,.3,1) .32s both' }}>
-              <p style={{ fontSize: 16.5, lineHeight: 1.72, color: T.inkSoft, maxWidth: '46ch', margin: '28px 0 36px' }}>
-                Verisight begeleidt het traject van intake en uitvoering naar dashboard, rapport, bestuurlijke handoff en
+            <p style={{ fontSize: 16.5, lineHeight: 1.72, color: T.inkSoft, maxWidth: '46ch', margin: '28px 0 36px' }}>
+                Verisight begeleidt het traject van intake en uitvoering naar dashboard, managementread, bestuurlijke handoff en
                 een eerste Action Center-opvolgafspraak, zonder losse eindes.
               </p>
             </div>
@@ -50,7 +50,7 @@ function HeroSection() {
               {[
                 { week: 'Week 1', label: 'Routekeuze, intake en setup' },
                 { week: 'Week 2', label: 'Uitnodiging, responses en opbouw' },
-                { week: 'Week 3', label: 'Dashboard, rapport en eerste read' },
+                { week: 'Week 3', label: 'Dashboard, eerste read en waar passend rapport' },
               ].map((item, i) => (
                 <div key={i} style={{ padding: '14px 0', borderBottom: i < 2 ? `1px solid ${T.rule}` : 'none', display: 'flex', gap: 16, alignItems: 'baseline' }}>
                   <span style={{ fontFamily: FF, fontSize: 11, color: T.inkFaint, minWidth: 52 }}>{item.week}</span>
@@ -124,7 +124,7 @@ function RolesSection() {
                 <em className="shimmer-text" style={{ fontStyle: 'italic' }}>Verisight regelt de uitvoering.</em>
               </h2>
               <p style={{ fontSize: 14, lineHeight: 1.72, color: T.inkSoft, marginBottom: 28 }}>
-                U bevestigt route en timing, levert het respondentbestand aan en ontvangt dashboard, rapport, toelichting
+                U bevestigt route en timing, levert het respondentbestand aan en ontvangt dashboard, managementread of rapport waar passend, toelichting
                 en de eerste bounded opvolglaag in Action Center.
               </p>
             </Reveal>
@@ -132,7 +132,7 @@ function RolesSection() {
               {[
                 { title: 'Route bevestigen', body: 'U bevestigt scan, variant, timing, doelgroep en contactpersoon na akkoord.' },
                 { title: 'Respondentbestand aanleveren', body: 'U levert het bestand aan; Verisight controleert de import en zet uitnodigingen klaar.' },
-                { title: 'Dashboard en rapport ontvangen', body: 'U ontvangt dashboard, managementrapport en toelichting in dezelfde leeslijn.' },
+                { title: 'Dashboard en output ontvangen', body: 'U ontvangt dashboard, managementread of rapport waar passend en toelichting in dezelfde leeslijn.' },
               ].map((item, i) => (
                 <Reveal key={i} delay={.1 + i * .08}>
                   <div style={{ display: 'flex', gap: 18, padding: '20px 0', borderTop: `1px solid ${T.rule}` }}>
@@ -188,7 +188,7 @@ function FirstValueSection() {
                 <em className="shimmer-text" style={{ fontStyle: 'italic' }}>grenzen.</em>
               </h2>
               <p style={{ fontSize: 13.5, lineHeight: 1.7, color: T.inkSoft }}>
-                First value is snel, maar nooit sneller dan de responsbasis toelaat. De route stopt niet bij het rapport, maar bij een eerste bestuurlijke vervolgbespreking.
+                First value is snel, maar nooit sneller dan de responsbasis toelaat. De route stopt niet bij output of rapport, maar bij een eerste bestuurlijke vervolgbespreking.
               </p>
             </div>
           </Reveal>

--- a/frontend/components/marketing/contact-form.tsx
+++ b/frontend/components/marketing/contact-form.tsx
@@ -215,7 +215,7 @@ export function ContactForm({
       >
         {isCompact
           ? 'Gebruik dit formulier om snel te bepalen welke eerste route nu het best past en welke suite-output daarna logisch wordt.'
-          : 'Gebruik dit formulier in de eerste plaats om te bepalen of ExitScan, RetentieScan of de combinatieroute nu de logische eerste stap is. Onboarding 30-60-90 behandelen we als bounded peer wanneer de vraag direct over nieuwe medewerkers gaat. Pulse en Leadership Scan blijven bounded vervolgroutes die pas logisch worden nadat een eerste signaal, baseline of managementread al staat. We gebruiken de intake ook om te bepalen wanneer dashboard, rapport of Action Center daarna logisch in dezelfde suite-omgeving landen en hoe een bounded suite-demo eruit moet zien. De informatie uit dit formulier gebruiken we alleen om jullie vraag te duiden en gericht op te volgen.'}
+          : 'Gebruik dit formulier in de eerste plaats om te bepalen of ExitScan, RetentieScan of de combinatieroute nu de logische eerste stap is. Onboarding 30-60-90 behandelen we als bounded peer wanneer de vraag direct over nieuwe medewerkers gaat. Pulse en Leadership Scan blijven bounded vervolgroutes die pas logisch worden nadat een eerste signaal, baseline of managementread al staat. We gebruiken de intake ook om te bepalen wanneer dashboard, managementread of rapport waar passend en Action Center daarna logisch in dezelfde suite-omgeving landen en hoe een bounded suite-demo eruit moet zien. De informatie uit dit formulier gebruiken we alleen om jullie vraag te duiden en gericht op te volgen.'}
         {!isCompact ? <span className={`mt-3 block text-xs ${helperClass}`}>{billingReadinessCopy}</span> : null}
       </div>
 

--- a/frontend/components/marketing/producten-content.tsx
+++ b/frontend/components/marketing/producten-content.tsx
@@ -88,7 +88,7 @@ function HeroSection() {
           </div>
           <div style={{ animation: 'slideUpFade .8s cubic-bezier(.16,1,.3,1) .3s both' }}>
             <p style={{ fontSize: 16.5, lineHeight: 1.72, color: T.inkSoft, margin: '28px 0 36px' }}>
-              ExitScan en RetentieScan zijn de twee hoofdinstappen. Daarna landen dashboard, rapport en Action Center in
+              ExitScan en RetentieScan zijn de twee hoofdinstappen. Daarna landen dashboard, formele managementread waar passend en Action Center in
               dezelfde suite-omgeving, zodat u niet alleen inzicht krijgt maar ook kunt prioriteren, toewijzen en opvolgen.
             </p>
           </div>
@@ -224,7 +224,7 @@ function ContactSection() {
         <MarketingInlineContactPanel
           eyebrow="Plan suite-demo"
           title="Twijfelt u tussen ExitScan, RetentieScan, onboarding of een vervolgronde?"
-          body="In een eerste gesprek bepalen we welke route nu echt logisch is, hoe dashboard, rapport en Action Center daarna in dezelfde suite-omgeving landen en welke vervolgstap bewust kleiner moet blijven."
+          body="In een eerste gesprek bepalen we welke route nu echt logisch is, hoe dashboard, managementread of rapport waar passend en Action Center daarna in dezelfde suite-omgeving landen en welke vervolgstap bewust kleiner moet blijven."
           defaultRouteInterest="exitscan"
           defaultCtaSource="products_form"
         />

--- a/frontend/lib/dashboard/report-library.test.ts
+++ b/frontend/lib/dashboard/report-library.test.ts
@@ -36,6 +36,22 @@ const campaigns: CampaignStats[] = [
     band_low: 3,
   },
   {
+    campaign_id: 'leadership-1',
+    campaign_name: 'Leadership read Q4',
+    scan_type: 'leadership',
+    organization_id: 'org-1',
+    is_active: true,
+    created_at: '2025-09-25T09:00:00Z',
+    total_invited: 42,
+    total_completed: 12,
+    completion_rate_pct: 29,
+    avg_risk_score: 4.9,
+    avg_signal_score: 5.0,
+    band_high: 3,
+    band_medium: 5,
+    band_low: 4,
+  },
+  {
     campaign_id: 'onboarding-1',
     campaign_name: 'Onboarding cohort sep 25',
     scan_type: 'onboarding',
@@ -73,7 +89,7 @@ describe('report library', () => {
   it('builds only report-ready entries and marks one featured management report', () => {
     const model = buildReportLibraryEntries(campaigns)
 
-    expect(model.entries.map((entry) => entry.campaignId)).toEqual(['exit-1', 'onboarding-1', 'pulse-1'])
+    expect(model.entries.map((entry) => entry.campaignId)).toEqual(['exit-1', 'onboarding-1', 'leadership-1', 'pulse-1'])
     expect(model.featured).toMatchObject({
       campaignId: 'exit-1',
       scanType: 'exit',
@@ -86,15 +102,16 @@ describe('report library', () => {
 
     expect(model.entries.find((entry) => entry.campaignId === 'exit-1')?.category).toBe('management')
     expect(model.entries.find((entry) => entry.campaignId === 'pulse-1')?.category).toBe('module')
+    expect(model.entries.find((entry) => entry.campaignId === 'leadership-1')?.category).toBe('module')
     expect(model.entries.find((entry) => entry.campaignId === 'onboarding-1')?.category).toBe('cohort')
   })
 
   it('filters cards per category without inventing an all-in-one export layer', () => {
     const model = buildReportLibraryEntries(campaigns)
 
-    expect(filterReportLibraryEntries(model.entries, 'all')).toHaveLength(3)
+    expect(filterReportLibraryEntries(model.entries, 'all')).toHaveLength(4)
     expect(filterReportLibraryEntries(model.entries, 'management').map((entry) => entry.campaignId)).toEqual(['exit-1'])
-    expect(filterReportLibraryEntries(model.entries, 'module').map((entry) => entry.campaignId)).toEqual(['pulse-1'])
+    expect(filterReportLibraryEntries(model.entries, 'module').map((entry) => entry.campaignId)).toEqual(['leadership-1', 'pulse-1'])
     expect(filterReportLibraryEntries(model.entries, 'cohort').map((entry) => entry.campaignId)).toEqual(['onboarding-1'])
   })
 })

--- a/frontend/lib/dashboard/report-library.test.ts
+++ b/frontend/lib/dashboard/report-library.test.ts
@@ -93,17 +93,23 @@ describe('report library', () => {
     expect(model.featured).toMatchObject({
       campaignId: 'exit-1',
       scanType: 'exit',
+      formalReport: true,
     })
     expect(model.entries.find((entry) => entry.campaignId === 'exit-1')?.recommended).toBe(true)
+    expect(model.entries.find((entry) => entry.campaignId === 'leadership-1')?.recommended).toBe(false)
   })
 
   it('maps management, module and cohort categories in a bounded way', () => {
     const model = buildReportLibraryEntries(campaigns)
 
     expect(model.entries.find((entry) => entry.campaignId === 'exit-1')?.category).toBe('management')
+    expect(model.entries.find((entry) => entry.campaignId === 'exit-1')?.formalReport).toBe(true)
     expect(model.entries.find((entry) => entry.campaignId === 'pulse-1')?.category).toBe('module')
+    expect(model.entries.find((entry) => entry.campaignId === 'pulse-1')?.formalReport).toBe(false)
     expect(model.entries.find((entry) => entry.campaignId === 'leadership-1')?.category).toBe('module')
+    expect(model.entries.find((entry) => entry.campaignId === 'leadership-1')?.formalReport).toBe(false)
     expect(model.entries.find((entry) => entry.campaignId === 'onboarding-1')?.category).toBe('cohort')
+    expect(model.entries.find((entry) => entry.campaignId === 'onboarding-1')?.formalReport).toBe(false)
   })
 
   it('filters cards per category without inventing an all-in-one export layer', () => {
@@ -113,6 +119,14 @@ describe('report library', () => {
     expect(filterReportLibraryEntries(model.entries, 'management').map((entry) => entry.campaignId)).toEqual(['exit-1'])
     expect(filterReportLibraryEntries(model.entries, 'module').map((entry) => entry.campaignId)).toEqual(['leadership-1', 'pulse-1'])
     expect(filterReportLibraryEntries(model.entries, 'cohort').map((entry) => entry.campaignId)).toEqual(['onboarding-1'])
+  })
+
+  it('keeps featured empty when only bounded output routes are report-ready', () => {
+    const boundedOnly = campaigns.filter((campaign) => campaign.scan_type !== 'exit' && campaign.scan_type !== 'retention')
+    const model = buildReportLibraryEntries(boundedOnly)
+
+    expect(model.entries).toHaveLength(3)
+    expect(model.featured).toBeNull()
   })
 })
 

--- a/frontend/lib/dashboard/report-library.ts
+++ b/frontend/lib/dashboard/report-library.ts
@@ -26,7 +26,7 @@ export interface FeaturedReportEntry {
   stats: Array<{ label: string; value: string }>
 }
 
-const MANAGEMENT_SCAN_TYPES: ScanType[] = ['exit', 'retention', 'leadership']
+const MANAGEMENT_SCAN_TYPES: ScanType[] = ['exit', 'retention']
 const MODULE_SCAN_TYPES: ScanType[] = ['pulse', 'team']
 
 function formatDutchDate(dateLike: string) {
@@ -55,10 +55,10 @@ function getCategoryLabel(category: Exclude<ReportLibraryCategory, 'all'>) {
     case 'management':
       return 'Managementsamenvatting'
     case 'cohort':
-      return 'Cohortrapport'
+      return 'Cohortread'
     case 'module':
     default:
-      return 'Modulerapport'
+      return 'Bounded output'
   }
 }
 
@@ -74,7 +74,7 @@ function getEntrySummary(campaign: CampaignStats, category: Exclude<ReportLibrar
     return `${SCAN_TYPE_LABELS[campaign.scan_type]} als bounded cohortread, met nadruk op checkpointduiding en opvolging.`
   }
 
-  return `${SCAN_TYPE_LABELS[campaign.scan_type]} als verdiepende modulelaag, met ${signalText.toLowerCase()}.`
+  return `${SCAN_TYPE_LABELS[campaign.scan_type]} als bounded outputlaag, met ${signalText.toLowerCase()}.`
 }
 
 function getEntryTitle(campaign: CampaignStats, category: Exclude<ReportLibraryCategory, 'all'>) {
@@ -143,7 +143,7 @@ export function buildReportLibraryEntries(campaigns: CampaignStats[]) {
           `${SCAN_TYPE_LABELS[featuredCandidate.scan_type]} ${formatDutchQuarter(featuredCandidate.created_at)}`,
         subtitle: `${SCAN_TYPE_LABELS[featuredCandidate.scan_type]} · ${formatDutchQuarter(featuredCandidate.created_at)}`,
         description:
-          'Gebruik dit rapport als eerste boardroom-ready handoff: wat speelt nu, wat vraagt verificatie en welke eigenaar, eerste stap en reviewmoment moeten daarna expliciet worden vastgelegd.',
+          'Gebruik deze formele reportlaag als eerste boardroom-ready handoff: wat speelt nu, wat vraagt verificatie en welke eigenaar, eerste stap en reviewmoment moeten daarna expliciet worden vastgelegd.',
         stats: [
           { label: 'Responses', value: String(featuredCandidate.total_completed) },
           {

--- a/frontend/lib/dashboard/report-library.ts
+++ b/frontend/lib/dashboard/report-library.ts
@@ -8,6 +8,7 @@ export interface ReportLibraryEntry {
   campaignName: string
   scanType: ScanType
   category: Exclude<ReportLibraryCategory, 'all'>
+  formalReport: boolean
   categoryLabel: string
   title: string
   summary: string
@@ -20,6 +21,7 @@ export interface FeaturedReportEntry {
   campaignId: string
   campaignName: string
   scanType: ScanType
+  formalReport: true
   title: string
   subtitle: string
   description: string
@@ -48,6 +50,10 @@ function getCategory(scanType: ScanType): Exclude<ReportLibraryCategory, 'all'> 
   if (MANAGEMENT_SCAN_TYPES.includes(scanType)) return 'management'
   if (MODULE_SCAN_TYPES.includes(scanType)) return 'module'
   return 'module'
+}
+
+function isFormalReportRoute(scanType: ScanType) {
+  return MANAGEMENT_SCAN_TYPES.includes(scanType)
 }
 
 function getCategoryLabel(category: Exclude<ReportLibraryCategory, 'all'>) {
@@ -113,7 +119,7 @@ export function buildReportLibraryEntries(campaigns: CampaignStats[]) {
 
   const featuredCandidate =
     [...readyCampaigns]
-      .filter((campaign) => campaign.total_completed >= 10)
+      .filter((campaign) => campaign.total_completed >= 10 && isFormalReportRoute(campaign.scan_type))
       .sort((left, right) => getPriority(right) - getPriority(left))[0] ?? null
 
   const entries: ReportLibraryEntry[] = readyCampaigns.map((campaign) => {
@@ -124,6 +130,7 @@ export function buildReportLibraryEntries(campaigns: CampaignStats[]) {
       campaignName: campaign.campaign_name,
       scanType: campaign.scan_type,
       category,
+      formalReport: isFormalReportRoute(campaign.scan_type),
       categoryLabel: getCategoryLabel(category),
       title: getEntryTitle(campaign, category),
       summary: getEntrySummary(campaign, category),
@@ -138,6 +145,7 @@ export function buildReportLibraryEntries(campaigns: CampaignStats[]) {
         campaignId: featuredCandidate.campaign_id,
         campaignName: featuredCandidate.campaign_name,
         scanType: featuredCandidate.scan_type,
+        formalReport: true,
         title:
           featuredCandidate.campaign_name ||
           `${SCAN_TYPE_LABELS[featuredCandidate.scan_type]} ${formatDutchQuarter(featuredCandidate.created_at)}`,


### PR DESCRIPTION
## Summary
- add active contracts for commercial portfolio truth, report/output policy, and case evidence proof policy
- sharpen the suite product family and Action Center proposition around a clearer report hierarchy
- align safe report, product, aanpak, contact, and trust copy with the new truth that ExitScan and RetentieScan carry the standard formal report weight

## Verification
- `npm run test -- lib/dashboard/report-library.test.ts`
- `npm run build` *(blocked by pre-existing homepage-thread type error in `frontend/components/marketing/home-page-content.tsx` on `origin/main`: `Reveal` receives unsupported `from="right"` prop)*