### PR TITLE
Action Center decision history on current main

### DIFF
--- a/docs/superpowers/plans/2026-04-29-action-center-decision-history.md
+++ b/docs/superpowers/plans/2026-04-29-action-center-decision-history.md
@@ -1,0 +1,885 @@
+# Action Center Decision History Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a canonical internal decision layer, shared action progression projection, and stable decision history so Action Center routes become more decision-driven without adding manager input.
+
+**Architecture:** Extend the existing route/core-semantics pipeline rather than creating a separate workflow. Add one small decision/history contract adjacent to the route contract, build one shared projector that composes legacy fallback and new truth into stable detail semantics, and then update Action Center detail and landing to read from that single layer.
+
+**Tech Stack:** Next.js App Router, React, TypeScript, Vitest, ESLint
+
+---
+
+## File structure
+
+### Existing files to modify
+
+- `frontend/lib/action-center-route-contract.ts`
+  - Extend route-adjacent canonical types with the minimal decision-history record contract and any shared enums/helpers needed by projectors.
+- `frontend/lib/action-center-core-semantics.ts`
+  - Replace the current Core V1-only route semantics with the new decision-first projection model.
+- `frontend/lib/action-center-live.ts`
+  - Feed live Action Center preview items from the new semantics, including landing-safe compact decision summaries.
+- `frontend/components/dashboard/action-center-preview.tsx`
+  - Render richer detail semantics and compact landing summaries without adding new manager input.
+- `frontend/lib/action-center-core-semantics.test.ts`
+  - Cover the new truth/projection rules, legacy fallback behavior, and stable history ordering.
+- `frontend/lib/action-center-live.test.ts`
+  - Cover live projection, telemetry-safe semantics, and landing/detail summary behavior.
+- `frontend/lib/action-center-preview-display.test.ts`
+  - Guard detail rendering and compact landing rendering against regressions.
+- `frontend/lib/action-center-preview-route-fields-render.test.ts`
+  - Assert the route field surface now reads from decision/history semantics instead of older first-step-only semantics.
+- `frontend/app/(dashboard)/action-center/page.route-shell.test.ts`
+  - Guard the read-only Action Center shell against regressions in the new detail/landing language.
+
+### New files to create
+
+- `frontend/lib/action-center-decision-history.ts`
+  - Canonical decision-layer types, shared migration/projector helpers, and stable ordering logic.
+- `frontend/lib/action-center-decision-history.test.ts`
+  - Unit tests for identity, ordering, legacy migration, and currentStep/nextStep projection rules.
+
+### Boundaries to preserve
+
+- Do not add new manager write flows.
+- Do not add new dashboard/reports/campaign-detail work in this plan.
+- Do not introduce a broad audit log model or event timeline UI.
+
+---
+
+### Task 1: Add the canonical decision/history contract
+
+**Files:**
+- Create: `frontend/lib/action-center-decision-history.ts`
+- Modify: `frontend/lib/action-center-route-contract.ts`
+- Test: `frontend/lib/action-center-decision-history.test.ts`
+
+- [ ] **Step 1: Write the failing tests for identity, ordering, and legacy migration**
+
+```ts
+import { describe, expect, it } from 'vitest'
+import {
+  buildLegacyDecisionEntryId,
+  compareDecisionHistoryEntries,
+  projectLegacyDecisionRecord,
+  type ActionCenterDecisionRecord,
+} from './action-center-decision-history'
+
+describe('action-center decision history contract', () => {
+  it('builds a stable legacy decision entry id from one legacy review moment', () => {
+    const id = buildLegacyDecisionEntryId({
+      routeId: 'route-1',
+      reviewCompletedAt: '2026-04-25T10:00:00.000Z',
+      reviewOutcome: 'bijstellen',
+    })
+
+    expect(id).toBe('legacy:route-1:2026-04-25T10:00:00.000Z:bijstellen')
+  })
+
+  it('orders decision entries by decisionRecordedAt descending before older fallback timestamps', () => {
+    const left: ActionCenterDecisionRecord = {
+      decisionEntryId: 'decision-2',
+      sourceRouteId: 'route-1',
+      decision: 'afronden',
+      decisionReason: 'Het effect is bevestigd.',
+      nextCheck: 'Geen nieuwe toets nodig.',
+      decisionRecordedAt: '2026-04-28T09:00:00.000Z',
+      reviewCompletedAt: '2026-04-28T08:00:00.000Z',
+    }
+    const right: ActionCenterDecisionRecord = {
+      decisionEntryId: 'decision-1',
+      sourceRouteId: 'route-1',
+      decision: 'doorgaan',
+      decisionReason: 'De eerste stap loopt nog.',
+      nextCheck: 'Toets volgende week of de frictie daalt.',
+      decisionRecordedAt: '2026-04-25T09:00:00.000Z',
+      reviewCompletedAt: '2026-04-25T08:00:00.000Z',
+    }
+
+    expect(compareDecisionHistoryEntries(left, right)).toBeLessThan(0)
+    expect(compareDecisionHistoryEntries(right, left)).toBeGreaterThan(0)
+  })
+
+  it('projects one legacy decision record from legacy review truth using the canonical fallback order', () => {
+    const record = projectLegacyDecisionRecord({
+      sourceRouteId: 'route-1',
+      reviewOutcome: 'bijstellen',
+      reviewCompletedAt: '2026-04-25T10:00:00.000Z',
+      reviewReason: 'De eerste stap gaf nog geen stabiele verbetering.',
+      reviewQuestion: 'Moet de vervolgstap worden aangescherpt?',
+      managementActionOutcome: null,
+      latestObservation: 'Werkdruk bleef zichtbaar in hetzelfde team.',
+    })
+
+    expect(record).toMatchObject({
+      sourceRouteId: 'route-1',
+      decision: 'bijstellen',
+      decisionReason: 'De eerste stap gaf nog geen stabiele verbetering.',
+      nextCheck: 'Moet de vervolgstap worden aangescherpt?',
+      decisionRecordedAt: '2026-04-25T10:00:00.000Z',
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run:
+
+```bash
+npm test -- "lib/action-center-decision-history.test.ts"
+```
+
+Expected:
+- FAIL because `action-center-decision-history.ts` does not exist yet
+
+- [ ] **Step 3: Add the minimal contract to `action-center-route-contract.ts`**
+
+```ts
+export type ActionCenterDecision =
+  | 'doorgaan'
+  | 'bijstellen'
+  | 'afronden'
+  | 'stoppen'
+
+export interface ActionCenterDecisionRecord {
+  decisionEntryId: string
+  sourceRouteId: string
+  decision: ActionCenterDecision
+  decisionReason: string | null
+  nextCheck: string | null
+  decisionRecordedAt: string
+  reviewCompletedAt: string | null
+  currentStepSnapshot?: string | null
+  observationSnapshot?: string | null
+}
+```
+
+- [ ] **Step 4: Create `action-center-decision-history.ts` with stable helpers**
+
+```ts
+import type { ActionCenterDecision, ActionCenterDecisionRecord, ActionCenterReviewOutcome } from './action-center-route-contract'
+
+function normalizeText(value: string | null | undefined) {
+  const trimmed = value?.trim() ?? ''
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function coerceDecision(
+  reviewOutcome: ActionCenterReviewOutcome | null | undefined,
+  managementActionOutcome: string | null | undefined,
+): ActionCenterDecision | null {
+  if (reviewOutcome === 'doorgaan' || reviewOutcome === 'bijstellen' || reviewOutcome === 'afronden' || reviewOutcome === 'stoppen') {
+    return reviewOutcome
+  }
+
+  const fallback = normalizeText(managementActionOutcome)
+  if (fallback === 'doorgaan' || fallback === 'bijstellen' || fallback === 'afronden' || fallback === 'stoppen') {
+    return fallback
+  }
+
+  return null
+}
+
+export function buildLegacyDecisionEntryId(args: {
+  routeId: string
+  reviewCompletedAt: string | null
+  reviewOutcome: ActionCenterReviewOutcome | null | undefined
+}) {
+  return `legacy:${args.routeId}:${args.reviewCompletedAt ?? 'unknown-review'}:${args.reviewOutcome ?? 'geen-uitkomst'}`
+}
+
+export function compareDecisionHistoryEntries(left: ActionCenterDecisionRecord, right: ActionCenterDecisionRecord) {
+  const leftPrimary = new Date(left.decisionRecordedAt).getTime()
+  const rightPrimary = new Date(right.decisionRecordedAt).getTime()
+
+  if (leftPrimary !== rightPrimary) {
+    return rightPrimary - leftPrimary
+  }
+
+  const leftFallback = left.reviewCompletedAt ? new Date(left.reviewCompletedAt).getTime() : Number.NEGATIVE_INFINITY
+  const rightFallback = right.reviewCompletedAt ? new Date(right.reviewCompletedAt).getTime() : Number.NEGATIVE_INFINITY
+
+  if (leftFallback !== rightFallback) {
+    return rightFallback - leftFallback
+  }
+
+  return left.decisionEntryId.localeCompare(right.decisionEntryId)
+}
+
+export function projectLegacyDecisionRecord(args: {
+  sourceRouteId: string
+  reviewOutcome: ActionCenterReviewOutcome | null | undefined
+  reviewCompletedAt: string | null
+  reviewReason: string | null | undefined
+  reviewQuestion: string | null | undefined
+  managementActionOutcome: string | null | undefined
+  latestObservation: string | null | undefined
+}): ActionCenterDecisionRecord | null {
+  const decision = coerceDecision(args.reviewOutcome, args.managementActionOutcome)
+  if (!decision) return null
+
+  const reviewCompletedAt = args.reviewCompletedAt ?? new Date(0).toISOString()
+
+  return {
+    decisionEntryId: buildLegacyDecisionEntryId({
+      routeId: args.sourceRouteId,
+      reviewCompletedAt: args.reviewCompletedAt,
+      reviewOutcome: args.reviewOutcome,
+    }),
+    sourceRouteId: args.sourceRouteId,
+    decision,
+    decisionReason: normalizeText(args.reviewReason) ?? normalizeText(args.latestObservation),
+    nextCheck: normalizeText(args.reviewQuestion),
+    decisionRecordedAt: reviewCompletedAt,
+    reviewCompletedAt: args.reviewCompletedAt,
+  }
+}
+```
+
+- [ ] **Step 5: Run the decision-history tests again**
+
+Run:
+
+```bash
+npm test -- "lib/action-center-decision-history.test.ts"
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 6: Commit Task 1**
+
+```bash
+git add frontend/lib/action-center-route-contract.ts frontend/lib/action-center-decision-history.ts frontend/lib/action-center-decision-history.test.ts
+git commit -m "feat: add action center decision history contract"
+```
+
+---
+
+### Task 2: Replace the core semantics projector with decision-first semantics
+
+**Files:**
+- Modify: `frontend/lib/action-center-core-semantics.ts`
+- Modify: `frontend/lib/action-center-route-contract.ts`
+- Test: `frontend/lib/action-center-core-semantics.test.ts`
+- Test: `frontend/lib/action-center-decision-history.test.ts`
+
+- [ ] **Step 1: Write failing tests for decision truth precedence and action progression projection**
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { projectActionCenterCoreSemantics } from './action-center-core-semantics'
+import type { ActionCenterRouteContract } from './action-center-route-contract'
+
+describe('action-center core semantics decision-first projection', () => {
+  const baseRoute: ActionCenterRouteContract = {
+    campaignId: 'campaign-1',
+    entryStage: 'active',
+    routeOpenedAt: '2026-04-20T10:00:00.000Z',
+    ownerAssignedAt: '2026-04-20T11:00:00.000Z',
+    routeStatus: 'in-uitvoering',
+    reviewOutcome: 'bijstellen',
+    reviewCompletedAt: '2026-04-25T10:00:00.000Z',
+    outcomeRecordedAt: null,
+    outcomeSummary: 'Werkdruk bleef zichtbaar in hetzelfde team.',
+    intervention: 'Plan een gerichte teamreview met de manager.',
+    owner: 'Sanne de Vries',
+    expectedEffect: 'Zichtbaar maken of de werkdruk lokaal afneemt.',
+    reviewScheduledFor: '2026-05-02',
+    reviewReason: 'De eerste stap gaf nog geen stabiele verbetering.',
+    blockedBy: null,
+  }
+
+  it('prefers canonical decision truth over legacy review outcome when both exist', () => {
+    const semantics = projectActionCenterCoreSemantics({
+      campaign: { id: 'campaign-1', name: 'ExitScan april' } as never,
+      assignedManager: { displayName: 'Sanne de Vries' } as never,
+      deliveryRecord: { next_step: 'Herplan de teamreview voor volgende week.' } as never,
+      learningDossier: {
+        management_action_outcome: 'doorgaan',
+        first_action_taken: 'Plan een gerichte teamreview met de manager.',
+        expected_first_value: 'Werkdruktrend moet dalen.',
+      } as never,
+      learningCheckpoints: [],
+      route: baseRoute,
+      latestVisibleUpdateNote: 'De manager bevestigde dat de frictie nog niet daalt.',
+      decisionRecords: [
+        {
+          decisionEntryId: 'decision-1',
+          sourceRouteId: 'campaign-1',
+          decision: 'bijstellen',
+          decisionReason: 'De eerste teamreview gaf nog geen stabiele verbetering.',
+          nextCheck: 'Toets over een week of de teamdruk zichtbaar daalt.',
+          decisionRecordedAt: '2026-04-25T10:00:00.000Z',
+          reviewCompletedAt: '2026-04-25T09:30:00.000Z',
+        },
+      ],
+    })
+
+    expect(semantics.latestDecision?.decision).toBe('bijstellen')
+    expect(semantics.latestDecision?.decisionReason).toBe('De eerste teamreview gaf nog geen stabiele verbetering.')
+    expect(semantics.actionProgress.currentStep).toBe('Plan een gerichte teamreview met de manager.')
+    expect(semantics.actionProgress.nextStep).toBe('Herplan de teamreview voor volgende week.')
+  })
+
+  it('falls back to legacy truth when no canonical decision records exist', () => {
+    const semantics = projectActionCenterCoreSemantics({
+      campaign: { id: 'campaign-1', name: 'ExitScan april' } as never,
+      assignedManager: { displayName: 'Sanne de Vries' } as never,
+      deliveryRecord: { next_step: null } as never,
+      learningDossier: {
+        management_action_outcome: null,
+        first_action_taken: 'Plan een gerichte teamreview met de manager.',
+        expected_first_value: 'Werkdruktrend moet dalen.',
+      } as never,
+      learningCheckpoints: [],
+      route: baseRoute,
+      latestVisibleUpdateNote: 'De manager bevestigde dat de frictie nog niet daalt.',
+      decisionRecords: [],
+    })
+
+    expect(semantics.latestDecision?.decision).toBe('bijstellen')
+    expect(semantics.latestDecision?.nextCheck).toBeTruthy()
+    expect(semantics.decisionHistory).toHaveLength(1)
+  })
+})
+```
+
+- [ ] **Step 2: Run the semantics tests to verify they fail**
+
+Run:
+
+```bash
+npm test -- "lib/action-center-core-semantics.test.ts"
+```
+
+Expected:
+- FAIL because `decisionRecords`, `latestDecision`, `actionProgress`, or `decisionHistory` do not exist yet
+
+- [ ] **Step 3: Extend the semantics interfaces in `action-center-core-semantics.ts`**
+
+```ts
+import type { ActionCenterDecisionRecord } from './action-center-route-contract'
+
+export interface ActionCenterCoreSemantics {
+  route: ActionCenterRouteContract
+  reviewSemantics: {
+    reviewReason: string
+    reviewQuestion: string
+    reviewOutcomeRaw: ActionCenterReviewOutcome
+    reviewOutcomeVisible: ActionCenterVisibleReviewOutcome
+  }
+  latestDecision: ActionCenterDecisionRecord | null
+  actionProgress: {
+    currentStep: string | null
+    nextStep: string | null
+    expectedEffect: string | null
+  }
+  actionFrame: {
+    whyNow: string
+    firstStep: string
+    owner: string
+    expectedEffect: string
+  }
+  resultLoop: {
+    whatWasTried: string | null
+    whatWeObserved: string | null
+    whatWasDecided: string | null
+  }
+  decisionHistory: ActionCenterDecisionRecord[]
+  closingSemantics: {
+    status: ActionCenterClosingStatus
+    summary: string | null
+    historicalSummary: string | null
+  }
+}
+```
+
+- [ ] **Step 4: Add decision-record input support and shared projection helpers**
+
+```ts
+import {
+  compareDecisionHistoryEntries,
+  projectLegacyDecisionRecord,
+} from './action-center-decision-history'
+
+export type ActionCenterCoreSemanticsProjectionInput = Pick<
+  LiveActionCenterCampaignContext,
+  'campaign' | 'assignedManager' | 'deliveryRecord' | 'learningDossier' | 'learningCheckpoints'
+> & {
+  route: ActionCenterRouteContract
+  latestVisibleUpdateNote?: string | null
+  decisionRecords?: ActionCenterDecisionRecord[]
+}
+
+function buildDecisionHistory(input: ActionCenterCoreSemanticsProjectionInput, reviewQuestion: string | null, latestObservation: string | null) {
+  const canonical = [...(input.decisionRecords ?? [])]
+    .filter((record) => record.sourceRouteId === input.route.campaignId)
+    .sort(compareDecisionHistoryEntries)
+
+  if (canonical.length > 0) {
+    return canonical
+  }
+
+  const legacy = projectLegacyDecisionRecord({
+    sourceRouteId: input.route.campaignId,
+    reviewOutcome: input.route.reviewOutcome,
+    reviewCompletedAt: input.route.reviewCompletedAt,
+    reviewReason: input.route.reviewReason,
+    reviewQuestion,
+    managementActionOutcome: input.learningDossier?.management_action_outcome,
+    latestObservation,
+  })
+
+  return legacy ? [legacy] : []
+}
+```
+
+- [ ] **Step 5: Project action progression from one shared source order**
+
+```ts
+function projectActionProgress(args: {
+  route: ActionCenterRouteContract
+  deliveryNextStep: string | null | undefined
+  firstActionTaken: string | null | undefined
+  reviewQuestion: string | null
+  expectedEffectFallback: string | null
+}) {
+  const currentStep = pickFirst([
+    args.firstActionTaken,
+    args.route.intervention,
+  ])
+
+  const nextStep = pickFirst([
+    args.deliveryNextStep,
+    args.reviewQuestion,
+  ])
+
+  const expectedEffect = pickFirst([
+    args.route.expectedEffect,
+    args.expectedEffectFallback,
+    args.reviewQuestion,
+  ])
+
+  return {
+    currentStep,
+    nextStep,
+    expectedEffect,
+  }
+}
+```
+
+- [ ] **Step 6: Return `latestDecision`, `actionProgress`, and `decisionHistory` from the live semantics projector**
+
+```ts
+  const latestObservation = getLatestObservation(context, route)
+  const decisionHistory = buildDecisionHistory(context, reviewQuestion, latestObservation)
+  const latestDecision = decisionHistory[0] ?? null
+  const actionProgress = projectActionProgress({
+    route,
+    deliveryNextStep: context.deliveryRecord?.next_step,
+    firstActionTaken: context.learningDossier?.first_action_taken,
+    reviewQuestion,
+    expectedEffectFallback: derivedExpectedEffect,
+  })
+
+  return {
+    route,
+    reviewSemantics: { ... },
+    latestDecision,
+    actionProgress,
+    actionFrame: {
+      whyNow: whyNow ?? ACTION_FRAME_FALLBACK,
+      firstStep: actionProgress.currentStep ?? ACTION_FRAME_FALLBACK,
+      owner: owner ?? UNASSIGNED_OWNER_LABEL,
+      expectedEffect: actionProgress.expectedEffect ?? ACTION_FRAME_FALLBACK,
+    },
+    resultLoop: {
+      whatWasTried: pickFirst([
+        normalizeAttemptText(context.latestVisibleUpdateNote),
+        actionProgress.currentStep,
+      ]),
+      whatWeObserved: pickFirst([latestObservation, observationFallback]),
+      whatWasDecided: latestDecision?.decisionReason ?? getDecisionText({ ... }),
+    },
+    decisionHistory,
+    closingSemantics: { ... },
+  }
+```
+
+- [ ] **Step 7: Re-run the semantics tests**
+
+Run:
+
+```bash
+npm test -- "lib/action-center-core-semantics.test.ts" "lib/action-center-decision-history.test.ts"
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 8: Commit Task 2**
+
+```bash
+git add frontend/lib/action-center-route-contract.ts frontend/lib/action-center-core-semantics.ts frontend/lib/action-center-core-semantics.test.ts frontend/lib/action-center-decision-history.test.ts
+git commit -m "feat: project decision-first action center semantics"
+```
+
+---
+
+### Task 3: Wire live Action Center items and compact landing summaries to the new semantics
+
+**Files:**
+- Modify: `frontend/lib/action-center-live.ts`
+- Test: `frontend/lib/action-center-live.test.ts`
+- Test: `frontend/lib/action-center-preview-route-fields-render.test.ts`
+
+- [ ] **Step 1: Write failing tests for live item projection and compact landing summaries**
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { buildCompactLandingSummaryLines, finalizeActionCenterPreviewItem } from '@/components/dashboard/action-center-preview'
+
+describe('action-center live summary projection', () => {
+  it('uses current step and latest decision on landing instead of only first-step semantics', () => {
+    const item = finalizeActionCenterPreviewItem({
+      id: 'route-1',
+      code: 'ACT-1001',
+      title: 'Werkdruk blijft hoog in Operations',
+      summary: 'De route vraagt een nieuwe lokale stap.',
+      reason: 'Werkdruk bleef zichtbaar na de eerste interventie.',
+      sourceLabel: 'ExitScan',
+      teamId: 'team-1',
+      teamLabel: 'Operations',
+      ownerId: 'manager-1',
+      ownerName: 'Sanne de Vries',
+      ownerRole: 'Manager - Operations',
+      ownerSubtitle: 'Operations',
+      reviewOwnerName: 'Sanne de Vries',
+      priority: 'hoog',
+      status: 'in-uitvoering',
+      reviewDate: '2026-05-02',
+      reviewDateLabel: '2 mei',
+      reviewRhythm: 'Wekelijks',
+      signalLabel: 'ExitScan - Operations',
+      signalBody: 'Werkdruk bleef zichtbaar in hetzelfde team.',
+      nextStep: 'Herplan de teamreview voor volgende week.',
+      expectedEffect: 'Zichtbaar maken of de werkdruk lokaal afneemt.',
+      reviewReason: 'De eerste teamreview gaf nog geen stabiele verbetering.',
+      reviewOutcome: 'bijstellen',
+      peopleCount: 14,
+      updates: [],
+      coreSemantics: {
+        route: {} as never,
+        reviewSemantics: {} as never,
+        latestDecision: {
+          decisionEntryId: 'decision-1',
+          sourceRouteId: 'route-1',
+          decision: 'bijstellen',
+          decisionReason: 'De eerste teamreview gaf nog geen stabiele verbetering.',
+          nextCheck: 'Toets over een week of de teamdruk zichtbaar daalt.',
+          decisionRecordedAt: '2026-04-25T10:00:00.000Z',
+          reviewCompletedAt: '2026-04-25T09:30:00.000Z',
+        },
+        actionProgress: {
+          currentStep: 'Plan een gerichte teamreview met de manager.',
+          nextStep: 'Herplan de teamreview voor volgende week.',
+          expectedEffect: 'Zichtbaar maken of de werkdruk lokaal afneemt.',
+        },
+        actionFrame: {
+          whyNow: 'Werkdruk bleef zichtbaar na de eerste interventie.',
+          firstStep: 'Plan een gerichte teamreview met de manager.',
+          owner: 'Sanne de Vries',
+          expectedEffect: 'Zichtbaar maken of de werkdruk lokaal afneemt.',
+        },
+        resultLoop: {
+          whatWasTried: 'Plan een gerichte teamreview met de manager.',
+          whatWeObserved: 'Werkdruk bleef zichtbaar in hetzelfde team.',
+          whatWasDecided: 'Bijstellen',
+        },
+        decisionHistory: [],
+        closingSemantics: {
+          status: 'lopend',
+          summary: null,
+          historicalSummary: null,
+        },
+      },
+    })
+
+    expect(buildCompactLandingSummaryLines(item)).toEqual([
+      { label: 'Besluit', value: 'bijstellen' },
+      { label: 'Stap', value: 'Plan een gerichte teamreview met de manager.' },
+    ])
+  })
+})
+```
+
+- [ ] **Step 2: Run the live tests to verify they fail**
+
+Run:
+
+```bash
+npm test -- "lib/action-center-live.test.ts" "lib/action-center-preview-route-fields-render.test.ts"
+```
+
+Expected:
+- FAIL because the compact summaries still read from the older first-step-only semantics
+
+- [ ] **Step 3: Update the landing summary builder in `action-center-preview.tsx`**
+
+```ts
+export function buildCompactLandingSummaryLines(item: ActionCenterPreviewItem) {
+  const latestDecision = item.coreSemantics.latestDecision
+  const currentStep = item.coreSemantics.actionProgress.currentStep
+
+  return [
+    latestDecision ? { label: 'Besluit', value: latestDecision.decision } : null,
+    currentStep ? { label: 'Stap', value: currentStep } : null,
+  ]
+    .filter((entry): entry is { label: string; value: string } => Boolean(entry?.value))
+    .filter((entry, index, entries) => entries.findIndex((candidate) => candidate.value === entry.value) === index)
+    .slice(0, 2)
+}
+```
+
+- [ ] **Step 4: Pass decision records through the live item builder**
+
+```ts
+      const coreSemantics = projectActionCenterCoreSemantics({
+        ...context,
+        route,
+        latestVisibleUpdateNote: latestUpdate,
+        decisionRecords: [],
+      })
+```
+
+Use `[]` explicitly in this phase if no live store exists yet, so the projector always follows the same signature and legacy fallback path.
+
+- [ ] **Step 5: Re-run the live projection tests**
+
+Run:
+
+```bash
+npm test -- "lib/action-center-live.test.ts" "lib/action-center-preview-route-fields-render.test.ts"
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 6: Commit Task 3**
+
+```bash
+git add frontend/lib/action-center-live.ts frontend/lib/action-center-live.test.ts frontend/components/dashboard/action-center-preview.tsx frontend/lib/action-center-preview-route-fields-render.test.ts
+git commit -m "feat: wire decision-first summaries into action center items"
+```
+
+---
+
+### Task 4: Render decision-first detail UI without adding manager input
+
+**Files:**
+- Modify: `frontend/components/dashboard/action-center-preview.tsx`
+- Test: `frontend/lib/action-center-preview-display.test.ts`
+- Test: `frontend/app/(dashboard)/action-center/page.route-shell.test.ts`
+
+- [ ] **Step 1: Write failing display tests for detail-first decision blocks**
+
+```ts
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { ActionCenterPreview } from '@/components/dashboard/action-center-preview'
+
+describe('action center detail decision-first rendering', () => {
+  it('shows latest decision, reason, next check, and compact decision history on detail', () => {
+    render(
+      <ActionCenterPreview
+        initialItems={[buildDecisionHistoryItemFixture()]}
+        initialSelectedItemId="route-1"
+        fallbackOwnerName="Verisight"
+        ownerOptions={[]}
+        workbenchHref="/beheer/klantlearnings"
+        readOnly
+      />,
+    )
+
+    expect(screen.getByText('Laatste beslissing')).toBeInTheDocument()
+    expect(screen.getByText('De eerste teamreview gaf nog geen stabiele verbetering.')).toBeInTheDocument()
+    expect(screen.getByText('Toets over een week of de teamdruk zichtbaar daalt.')).toBeInTheDocument()
+    expect(screen.getByText('Beslisgeschiedenis')).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: Run the display tests to verify they fail**
+
+Run:
+
+```bash
+npm test -- "lib/action-center-preview-display.test.ts" "app/(dashboard)/action-center/page.route-shell.test.ts"
+```
+
+Expected:
+- FAIL because the detail UI still only renders Core V1 review/action/result blocks
+
+- [ ] **Step 3: Add a compact decision panel and decision history block in `action-center-preview.tsx`**
+
+```tsx
+function DecisionSummaryCard({ item }: { item: ActionCenterPreviewItem }) {
+  const latestDecision = item.coreSemantics.latestDecision
+  if (!latestDecision) return null
+
+  return (
+    <div className="rounded-[18px] border border-[#eadfce] bg-[#fcfaf6] px-4 py-4">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Laatste beslissing</p>
+      <p className="mt-3 text-sm font-semibold text-[#132033]">{latestDecision.decision}</p>
+      {latestDecision.decisionReason ? (
+        <p className="mt-2 text-sm leading-7 text-[#32465d]">{latestDecision.decisionReason}</p>
+      ) : null}
+      {latestDecision.nextCheck ? (
+        <p className="mt-2 text-sm leading-7 text-[#5d6f84]">Volgende toets: {latestDecision.nextCheck}</p>
+      ) : null}
+    </div>
+  )
+}
+
+function DecisionHistoryCard({ item }: { item: ActionCenterPreviewItem }) {
+  if (item.coreSemantics.decisionHistory.length === 0) return null
+
+  return (
+    <div className="rounded-[18px] border border-[#eadfce] bg-[#fcfaf6] px-4 py-4">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Beslisgeschiedenis</p>
+      <div className="mt-3 space-y-3">
+        {item.coreSemantics.decisionHistory.map((entry) => (
+          <div key={entry.decisionEntryId} className="rounded-[14px] border border-[#efe7dc] bg-white px-3 py-3">
+            <p className="text-sm font-semibold text-[#132033]">{entry.decision}</p>
+            {entry.decisionReason ? <p className="mt-1 text-sm text-[#42556b]">{entry.decisionReason}</p> : null}
+            {entry.nextCheck ? <p className="mt-1 text-sm text-[#6d6458]">Volgende toets: {entry.nextCheck}</p> : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Show the action progression in detail instead of only `firstStep`**
+
+```tsx
+<RouteFieldCard
+  label="Huidige stap"
+  value={selectedItem.coreSemantics.actionProgress.currentStep ?? selectedItem.coreSemantics.actionFrame.firstStep}
+/>
+{selectedItem.coreSemantics.actionProgress.nextStep ? (
+  <RouteFieldCard
+    label="Volgende stap"
+    value={selectedItem.coreSemantics.actionProgress.nextStep}
+  />
+) : null}
+<RouteFieldCard
+  label="Verwacht effect"
+  value={selectedItem.coreSemantics.actionProgress.expectedEffect ?? selectedItem.coreSemantics.actionFrame.expectedEffect}
+/>
+```
+
+- [ ] **Step 5: Re-run the display/shell tests**
+
+Run:
+
+```bash
+npm test -- "lib/action-center-preview-display.test.ts" "app/(dashboard)/action-center/page.route-shell.test.ts"
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 6: Commit Task 4**
+
+```bash
+git add frontend/components/dashboard/action-center-preview.tsx frontend/lib/action-center-preview-display.test.ts frontend/app/(dashboard)/action-center/page.route-shell.test.ts
+git commit -m "feat: render decision-first action center detail"
+```
+
+---
+
+### Task 5: Full targeted verification and documentation alignment
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-04-29-action-center-decision-history-design.md` (only if implementation forces a naming correction)
+- Test: `frontend/lib/action-center-decision-history.test.ts`
+- Test: `frontend/lib/action-center-core-semantics.test.ts`
+- Test: `frontend/lib/action-center-live.test.ts`
+- Test: `frontend/lib/action-center-preview-display.test.ts`
+- Test: `frontend/lib/action-center-preview-route-fields-render.test.ts`
+- Test: `frontend/app/(dashboard)/action-center/page.route-shell.test.ts`
+
+- [ ] **Step 1: Run the full targeted decision-history slice**
+
+Run:
+
+```bash
+npm test -- "lib/action-center-decision-history.test.ts" "lib/action-center-core-semantics.test.ts" "lib/action-center-live.test.ts" "lib/action-center-preview-display.test.ts" "lib/action-center-preview-route-fields-render.test.ts" "app/(dashboard)/action-center/page.route-shell.test.ts"
+```
+
+Expected:
+- PASS for the full decision-history slice
+
+- [ ] **Step 2: Run ESLint on the touched files**
+
+Run:
+
+```bash
+npx eslint "lib/action-center-decision-history.ts" "lib/action-center-decision-history.test.ts" "lib/action-center-core-semantics.ts" "lib/action-center-core-semantics.test.ts" "lib/action-center-live.ts" "lib/action-center-live.test.ts" "components/dashboard/action-center-preview.tsx" "lib/action-center-preview-display.test.ts" "lib/action-center-preview-route-fields-render.test.ts" "app/(dashboard)/action-center/page.route-shell.test.ts"
+```
+
+Expected:
+- no lint errors
+
+- [ ] **Step 3: Run a production build for the frontend**
+
+Run:
+
+```bash
+npm run build
+```
+
+Expected:
+- successful Next.js production build
+
+- [ ] **Step 4: If naming drift appears, update the spec to match the implemented contract**
+
+```md
+- keep `decisionEntryId`, `decisionRecordedAt`, `currentStep`, `nextStep`, and `expectedEffect` aligned between spec and code
+- do not leave any old Core V1-only names as the primary API if the implementation changed
+```
+
+- [ ] **Step 5: Commit Task 5**
+
+```bash
+git add frontend/lib/action-center-decision-history.ts frontend/lib/action-center-decision-history.test.ts frontend/lib/action-center-core-semantics.ts frontend/lib/action-center-core-semantics.test.ts frontend/lib/action-center-live.ts frontend/lib/action-center-live.test.ts frontend/components/dashboard/action-center-preview.tsx frontend/lib/action-center-preview-display.test.ts frontend/lib/action-center-preview-route-fields-render.test.ts frontend/app/(dashboard)/action-center/page.route-shell.test.ts docs/superpowers/specs/2026-04-29-action-center-decision-history-design.md
+git commit -m "test: verify action center decision history slice"
+```
+
+---
+
+## Self-review
+
+### Spec coverage
+
+- Small canonical decision-truth: covered in Task 1 and Task 2
+- Stronger action contract (`currentStep`, `nextStep`, `expectedEffect`): covered in Task 2 and Task 4
+- Decision history with identity/ordering: covered in Task 1 and Task 2
+- Read-only manager experience: preserved in Task 4 by detail rendering only, with no new write flow
+- Truth-first then presentation: task order enforces contract -> projector -> landing/detail rendering
+
+### Placeholder scan
+
+- No `TODO`, `TBD`, or “appropriate handling” placeholders remain
+- Every task includes explicit file paths, code, commands, and expected results
+
+### Type consistency
+
+- `decisionEntryId`, `decisionRecordedAt`, `reviewCompletedAt`, `currentStep`, `nextStep`, `expectedEffect`, `decision`, `decisionReason`, and `nextCheck` are used consistently across tasks
+- The plan keeps `reviewOutcome` as a separate existing field and does not conflate it with `decision`
+

--- a/docs/superpowers/specs/2026-04-29-action-center-decision-history-design.md
+++ b/docs/superpowers/specs/2026-04-29-action-center-decision-history-design.md
@@ -1,0 +1,561 @@
+# Action Center Decision History Design
+
+Date: 2026-04-29
+Scope: Ingelogde Verisight suite, volgende schone verdiepingsslag binnen Action Center na Route Contract, HR Bridge, Core V1 en HR demo hardening
+Status: Revised draft spec after review hardening
+
+## 1. Doel
+
+Deze fase maakt Action Center inhoudelijk volwassener op drie plekken tegelijk:
+- reviewbeslissingen
+- actiekwaliteit
+- resultaatlus over tijd
+
+Het doel is niet om de module interactiever te maken, maar om hem besluitvaardiger en geloofwaardiger te maken.
+
+Na deze fase moet een route niet alleen zeggen:
+- wat speelt hier
+- wat doen we nu
+
+maar ook:
+- wat is in review besloten
+- waarom juist dat
+- wat moet daarna opnieuw blijken
+- welke stap loopt nu
+- welke stap volgt daarna
+- hoe ontwikkelt deze route zich over meerdere beslismomenten
+
+## 2. Productgrens
+
+Deze fase blijft bewust begrensd.
+
+Wel in scope:
+- kleine canonieke decision-truth
+- sterker actiecontract
+- compacte decision history
+- rijkere read-only presentatie voor HR en managers
+
+Niet in scope:
+- extra managerinput
+- nieuwe managerformulieren
+- brede reviewworkflow
+- veel nieuwe statussen
+- zware governance- of case-managementlagen
+- uitgebreide eventtimeline voor alles
+
+De kernregel blijft:
+- meer besliskwaliteit
+- niet meer bedieningslast
+
+## 3. Gewenst Eindbeeld
+
+Na deze fase moet Action Center-detail veel sterker aanvoelen als:
+- een plek waar opvolging niet alleen wordt bijgehouden
+- maar waar een route echt bestuurlijk te volgen is
+
+Dat betekent concreet:
+- reviewmomenten hebben niet alleen een reden, maar ook een expliciete beslissing
+- beslissingen dragen een korte reden en een volgende toets
+- acties voelen niet meer als één losse stap, maar als een kleine voortgangslijn
+- resultaat leeft niet alleen in de laatste update, maar in een compacte beslisgeschiedenis
+- routes voelen daardoor minder als kaarten met tekst en meer als kleine managementdossiers
+
+Voor HR:
+- meer grip op kwaliteit van opvolging
+- sneller zien of een route inhoudelijk sterk of zwak is
+- duidelijker wat al besloten is en wat nog moet blijken
+
+Voor managers:
+- nog steeds weinig interactielast
+- maar wel veel beter te begrijpen waarom de route eruitziet zoals hij eruitziet
+
+## 4. Hoofdaanpak
+
+De juiste aanpak voor deze fase is `decision-first`.
+
+Dus niet:
+- alleen presentatie verrijken
+- of direct nieuwe workflowinteractie toevoegen
+
+Maar wel:
+1. een kleine canonieke decision-truth toevoegen
+2. het actiecontract versterken naar een kleine voortgangslijn
+3. een compacte decision history uit die waarheid opbouwen
+4. daarna pas detail en landing op die gedeelde laag laten spreken
+
+Dit houdt de stap groot genoeg om productmatig echt iets te veranderen, maar klein genoeg om managers niet te belasten en de module niet in workflowsoftware te laten kantelen.
+
+## 5. Kleine Canonieke Decision-Truth
+
+### 5.1 Doel
+
+Per betekenisvol reviewmoment krijgt een route een kleine canonieke decision-truth met drie onderdelen:
+- `decision`
+- `decisionReason`
+- `nextCheck`
+
+### 5.2 Betekenis
+
+`decision`
+- wat is hier bestuurlijk besloten
+
+Compacte set waarden in deze fase:
+- `doorgaan`
+- `bijstellen`
+- `afronden`
+- `stoppen`
+
+`decisionReason`
+- waarom dit besluit op dit reviewmoment logisch is
+- kort, compact en expliciet
+
+`nextCheck`
+- wat bij de volgende toets duidelijker, zichtbaar of bevestigd moet zijn
+
+### 5.3 Productregel
+
+Deze laag moet klein blijven:
+- één decision per betekenisvol reviewmoment
+- één compacte reden
+- één compacte vervolgtoets
+
+Niet in deze fase:
+- meerdere parallelle beslissingen per review
+- uitgebreide reviewnotulen
+- actor-specifieke subbesluiten
+- brede escalatie- of borgtypes
+
+### 5.4 Canoniek source model
+
+Deze fase kiest nu expliciet één source model.
+
+Voor nieuwe reviewbeslissingen geldt:
+- `decision`, `decisionReason` en `nextCheck` worden geschreven naar één interne HR-/Verisight-managed decision layer
+- die decision layer is de enige canonieke write-path voor nieuwe besluitmomenten
+- managers schrijven hier in deze fase niet naar
+
+Dus niet:
+- soms authored decision truth
+- soms alleen afgeleide componentcopy
+- of per route een andere write-source
+
+### 5.5 Legacy migratieregel
+
+Voor routes die deze nieuwe decision layer nog niet dragen, geldt één expliciete migratieregel:
+1. projecteer tijdelijk uit legacy review truth
+2. toon dat resultaat exact alsof het uit de decision layer komt
+3. schrijf niet terug naar component-state of losse routepresentatie
+
+De migratievolgorde is:
+
+`decision`
+1. primair uit bestaande `reviewOutcome`
+2. anders uit bestaande `management_action_outcome`
+
+`decisionReason`
+1. primair uit bestaande review-/update-truth die al een expliciete besluitreden draagt
+2. anders uit bestaande review reason + kernobservatie via één gedeelde templatemap
+3. anders leeg laten in plaats van vrije reason-copy genereren
+
+`nextCheck`
+1. primair uit bestaande review question of equivalent
+2. anders uit bestaande expected-effect truth
+3. anders uit gedeelde Core V1 review-question projectie
+
+Dus:
+- één canonieke write-source voor nieuwe decisions
+- één canonieke migratieprojectie voor legacy-routes
+- geen gemengd model per route of per surface
+
+### 5.6 Relatie met bestaande reviewOutcome
+
+`reviewOutcome` verdwijnt niet direct.
+
+De rolverdeling in deze fase wordt:
+- `reviewOutcome` = compacte zichtbare route-uitkomsttaal
+- `decision` = expliciet reviewbesluit dat de history voedt
+
+Vaak zullen die dicht bij elkaar liggen, maar ze mogen productmatig niet langer alles in één veld proberen te dragen.
+
+### 5.7 Zichtbaarheid
+
+Op route-detail:
+- volledig zichtbaar
+- inclusief `decision`, `decisionReason` en `nextCheck`
+
+Op landing:
+- alleen compacte samenvatting
+- bijvoorbeeld laatste beslissing of eerstvolgende toets
+
+## 6. Sterker Actiecontract
+
+### 6.1 Doel
+
+Reviewbeslissingen moeten gekoppeld worden aan een duidelijkere routevoortgang.
+
+Daarom krijgt elke route in deze fase een compacter maar sterker actiecontract met:
+- `currentStep`
+- `nextStep`
+- `expectedEffect`
+
+### 6.2 Betekenis
+
+`currentStep`
+- wat nu feitelijk de actieve werkstap is
+
+`nextStep`
+- wat daarna logisch volgt
+
+`expectedEffect`
+- wat die stap of stapovergang duidelijker, beter of toetsbaar moet maken
+
+### 6.3 Productregel
+
+Deze laag blijft klein:
+- geen tasklists
+- geen meerdere parallelle stappen
+- geen checklists
+- geen projectboard-gedrag
+
+Er is per route steeds:
+- één huidige stap
+- één volgende stap
+- één verwacht effect
+
+### 6.4 Truth versus projectie
+
+Deze fase kiest dit nu expliciet:
+- `currentStep`, `nextStep` en `expectedEffect` worden in deze fase geen nieuwe authored datastorevelden
+- ze zijn één gedeelde canonieke projectielaag bovenop bestaande route-, review- en update-truth
+- elke surface moet exact dezelfde projectie gebruiken
+
+Dus niet:
+- één routepad waar deze velden al als nieuwe truth bestaan
+- en een tweede routepad waar dezelfde velden lokaal uit presentatie worden afgeleid
+
+Wel:
+- één gedeelde projector die voor elke route tot dezelfde actieprogressie leidt
+
+### 6.5 Projectievolgorde
+
+De inputvolgorde voor deze gedeelde projectie wordt:
+
+`currentStep`
+1. primair uit de meest recente open of actuele interventiestap in bestaande route/update-truth
+2. anders uit bestaande interventie- of `nextStep`-truth van de huidige route
+3. anders uit Core V1 `firstStep`-projectie
+
+`nextStep`
+1. primair uit de eerstvolgende expliciete vervolgstap in bestaande route/review-truth
+2. anders uit `nextCheck` als die al een concrete vervolgstap impliceert
+3. anders leeg laten in plaats van vrije UI-copy genereren
+
+`expectedEffect`
+1. primair uit bestaande canonieke expected-effect truth
+2. anders uit de bestaande route-reviewvraag of verwachte toets
+3. anders uit de gedeelde Core V1 expected-effect projectie
+
+`firstStep` uit Core V1 mag dus opgaan in `currentStep`, maar alleen via deze gedeelde projector en niet via lokale componentlogica.
+
+## 7. Decision History en Resultaatlus Over Tijd
+
+### 7.1 Doel
+
+Een route moet niet alleen de laatste stand tonen, maar compact laten zien hoe deze zich ontwikkelt.
+
+Niet als volledig logboek, maar als samengevatte reeks van betekenisvolle beslismomenten:
+- wat liep
+- wat zagen we
+- wat besloten we
+- wat volgde daarna
+
+### 7.2 Vorm
+
+De juiste vorm in deze fase is een compacte `decision history`, geen brede eventtimeline.
+
+Elke history-entry bevat idealiter:
+- `currentStep`
+- kernobservatie
+- `decision`
+- `decisionReason`
+- `nextCheck`
+
+### 7.3 Waarom geen ruwe timeline
+
+Een ruwe timeline heeft drie risico's:
+- te veel ruis
+- te weinig managementbetekenis
+- te veel logboekgevoel
+
+Een compacte decision history is beter omdat die:
+- samenvat in plaats van ophoopt
+- focust op betekenisvolle review- en besluitmomenten
+- direct aansluit op HR- en managergebruik
+
+### 7.4 Productgrens
+
+Niet in deze fase:
+- onbeperkte event history
+- audit log
+- uitgebreide notulenlaag
+- multi-actor governance feed
+
+Alleen de betekenisvolle beslismomenten worden zichtbaar gemaakt.
+
+### 7.5 Identity en ordering contract
+
+De decision history krijgt één expliciet identity- en ordering-contract.
+
+Elke history-entry wordt canoniek geïdentificeerd door:
+- één `decisionEntryId` uit de nieuwe decision layer
+- anders één stabiele migratie-id afgeleid uit het legacy reviewmoment dat de entry voortbrengt
+
+De orderingregel is:
+1. primair `decisionRecordedAt`
+2. anders `reviewCompletedAt`
+3. anders het canonieke checkpoint-/update-timestamp van hetzelfde reviewmoment
+
+De zichtbare history wordt aflopend gesorteerd op die canonieke orderingbron, zodat detail, landing, tests en browser-QA steeds dezelfde volgorde zien.
+
+Niet toegestaan:
+- array-volgorde uit een API-response als impliciete truth
+- vrije sortering op tekst
+- verschillende fallback-timestamps per surface
+
+## 8. Rollen en Grenzen
+
+### 8.1 Managers blijven read-only
+
+Managers mogen in deze fase:
+- rijkere routekwaliteit zien
+- beter begrijpen wat is besloten
+- beter zien wat nu loopt en wat daarna volgt
+- beter zien hoe de route zich ontwikkelt
+
+Managers doen in deze fase nog niet:
+- decisions vastleggen
+- decision reasons invullen
+- next checks vastleggen
+- current/next step bewerken
+- history aanvullen
+
+### 8.2 HR / Verisight als truth-drager
+
+De nieuwe decision-truth en het sterkere actiecontract mogen in deze fase wel productmatig bestaan, maar worden nog niet manager-gedreven.
+
+De decision layer is:
+- intern
+- HR-/Verisight-managed
+- de enige write-source voor nieuwe reviewbeslissingen
+
+De action progression layer is:
+- niet authored
+- maar wel één gedeelde canonieke projectie
+
+### 8.3 Geen brede reviewworkflow
+
+Niet in deze fase:
+- aparte reviewschermen
+- reviewwizards
+- reviewformulierflows
+- multi-step review completion flows
+
+De reviewbeslissing wordt rijker, maar de workflow blijft klein.
+
+## 9. Architectuurprincipe
+
+Deze fase moet opnieuw `semantics-first` zijn.
+
+Dus niet:
+- eerst UI-blokken ontwerpen
+- daarna kijken hoe ze gevuld worden
+
+Maar:
+1. kleine decision-truth
+2. sterker actiecontract
+3. compacte decision history
+4. daarna surface-projectie
+
+De UI mag alleen spreken vanuit die gedeelde laag.
+
+## 10. Canonieke Lagen
+
+De nieuwe productkern bestaat uit drie niveaus:
+
+### 10.1 Review Decision Layer
+
+Per betekenisvol reviewmoment:
+- `decision`
+- `decisionReason`
+- `nextCheck`
+
+### 10.2 Action Progression Layer
+
+Per actieve route:
+- `currentStep`
+- `nextStep`
+- `expectedEffect`
+
+### 10.3 Decision History Layer
+
+Per route:
+- compacte reeks van de belangrijkste review-/beslismomenten
+
+Deze drie samen vormen de ruggengraat van deze fase.
+
+## 11. Projectieregels
+
+### 11.1 Gedeelde waarheid
+
+Landing, detail, previewweergave en persona-varianten moeten allemaal projecteren uit dezelfde canonieke lagen.
+
+Niet toegestaan:
+- `decisionReason` per surface anders formuleren
+- `nextCheck` op detail anders afleiden dan op landing
+- `currentStep` op kaartniveau uit andere bron halen dan op detail
+- decision history in de ene component uit losse updates bouwen en in de andere uit review-items
+
+### 11.2 Truth versus projectie
+
+Deze fase kiest nu expliciet:
+- `decision`, `decisionReason`, `nextCheck` worden kleine canonieke truth met één interne HR-/Verisight-managed write-path
+- `currentStep`, `nextStep`, `expectedEffect` worden in deze fase geen nieuwe authored truth, maar één gedeelde canonieke projectie
+- decision history wordt canoniek opgebouwd uit decision-truth plus de expliciete orderingbron, niet uit willekeurige updates
+
+### 11.3 Gevolg voor bestaande Core V1-semantiek
+
+De bestaande Core V1-semantiek blijft relevant, maar wordt in deze fase opnieuw geordend:
+- review-semantiek blijft de leeslaag
+- decision-truth wordt de nieuwe bestuurlijke kern
+- `whyNow` blijft nuttig als aanleiding
+- `firstStep` mag opgaan in `currentStep`
+- de mini-resultaatlus wordt deels opgeslokt door decision history
+
+Dus:
+- geen parallelle dubbele semantische lagen laten bestaan als ze hetzelfde proberen te zeggen
+- wel een gecontroleerde migratie van Core V1-presentatie naar een rijkere decision-first structuur
+
+### 11.4 Beslisrecord contract
+
+Voor implementatie geldt het volgende minimale contract per decision-history-entry:
+- `decisionEntryId`
+- `decision`
+- `decisionReason`
+- `nextCheck`
+- `decisionRecordedAt`
+- `sourceRouteId`
+
+Optioneel, maar toegestaan als de bestaande truth dit al netjes draagt:
+- `reviewCompletedAt`
+- `currentStepSnapshot`
+- `observationSnapshot`
+
+Dit contract hoeft in deze fase nog geen brede workflow of multi-actor auditstructuur te worden, maar moet wel stabiel genoeg zijn om:
+- browsermatig dezelfde progression te tonen
+- tests op vaste ordering te kunnen schrijven
+- latere managerinteractie niet opnieuw te laten herontwerpen
+
+## 12. Surface-verdeling
+
+### 12.1 Landing
+
+Landing blijft compact.
+
+Toont vooral:
+- huidige stap
+- laatste beslissing
+- eventueel volgende toets in compacte vorm
+
+### 12.2 Detail
+
+Detail draagt de volledige verdieping:
+- reviewbeslissing
+- besluitreden
+- volgende toets
+- `currentStep`
+- `nextStep`
+- `expectedEffect`
+- decision history
+
+### 12.3 Managers
+
+Managers zien dezelfde truth, maar in smallere presentatie.
+Geen extra bediening.
+
+### 12.4 HR / Verisight
+
+HR en Verisight zien dezelfde truth, maar met rijkere interpretatie en meer zichtbaarheid van kwaliteit en geschiedenis.
+
+## 13. Succescriteria
+
+Deze fase is geslaagd als:
+
+### 13.1 Reviewkwaliteit
+- routes tonen niet alleen reviewuitkomst, maar ook een duidelijke beslisreden en vervolgvraag
+
+### 13.2 Actiekwaliteit
+- routes maken zichtbaar wat nu loopt en wat daarna volgt
+- acties voelen minder statisch en concreter bestuurlijk bruikbaar
+
+### 13.3 Resultaatlus
+- een route laat niet alleen de laatste stand zien, maar ook hoe die daar gekomen is
+
+### 13.4 Rust in gebruik
+- managers ervaren meer duidelijkheid zonder extra invoerdruk
+- HR ervaart meer grip zonder dat het product bureaucratisch voelt
+
+### 13.5 Architectuurkwaliteit
+- de nieuwe lagen zijn canoniek en gedeeld
+- niet lokaal per surface opgebouwd
+
+## 14. UX-risico's
+
+De belangrijkste risico's in deze fase zijn:
+
+1. Te veel truth toevoegen zonder duidelijke productvorm
+- dan voelt het als interne administratie in plaats van productverdieping
+
+2. Decision history wordt toch logboek
+- dan verliezen we bestuurlijke scherpte
+
+3. `currentStep` en `nextStep` gaan dezelfde inhoud dragen
+- dan voegen we semantisch niets toe
+
+4. `decisionReason` wordt te vrij en te lang
+- dan wordt de laag inconsistent en moeilijk herbruikbaar
+
+5. Managers krijgen indirect toch bedieningsverwachting
+- dan sluipt interactielast te vroeg binnen
+
+## 15. Visuele Richting Voor Deze Fase
+
+Dezelfde regel als in de vorige Action Center-fase blijft gelden:
+
+Wel ok:
+- detailblokken compacter of helderder maken
+- betere typografische hiërarchie
+- compactere history-presentatie
+- rustigere kaartsamenvattingen op landing
+
+Nog terughoudend mee zijn:
+- grote structurele redesign van de hele module
+- brede informatie-architectuurvervanging
+- interactiepatronen die al vooruitlopen op managerinput
+
+Dus:
+- semantische verdieping: ja
+- grote structurele visual redesign: nog even niet
+
+## 16. Eerstvolgende Implementatieslag
+
+De eerstvolgende bouwstap na deze spec moet:
+1. eerst de decision-truth en historylaag neerzetten
+2. daarna het actiecontract migreren naar `currentStep` / `nextStep`
+3. daarna route-detail op die waarheid laten landen
+4. landing pas als compacte tweede projectie meenemen
+
+Nog niet:
+- managerinputflows
+- nieuwe route-editing voor managers
+- brede reviewmodule
+- rijkere escalatie- of afsluittypes

--- a/frontend/app/(dashboard)/action-center/page.route-shell.test.ts
+++ b/frontend/app/(dashboard)/action-center/page.route-shell.test.ts
@@ -95,7 +95,7 @@ function buildDossier(overrides: Partial<PilotLearningDossier> = {}): PilotLearn
     first_action_taken: "Leg eigenaar en eerste correctie in het MT-overleg vast.",
     review_moment: "2026-05-12",
     adoption_outcome: null,
-    management_action_outcome: "opschalen",
+    management_action_outcome: "bijstellen",
     next_route: null,
     stop_reason: null,
     case_evidence_closure_status: "lesson_only",
@@ -188,20 +188,84 @@ describe("action center landing shell", () => {
       }),
     );
 
-    expect(markup).toContain("Waarom we opnieuw kijken");
-    expect(markup).toContain(item.coreSemantics.reviewSemantics.reviewReason);
-    expect(markup).toContain("Wat we dan toetsen");
-    expect(markup).toContain(item.coreSemantics.reviewSemantics.reviewQuestion);
-    expect(markup).toContain("Laatste reviewuitkomst");
+    expect(markup).toContain("Laatste beslissing");
     expect(markup).toContain("Bijstellen");
-    expect(markup).toContain("Waarom nu");
-    expect(markup).toContain(item.coreSemantics.actionFrame.whyNow);
-    expect(markup).toContain("Eerste stap");
-    expect(markup).toContain(item.coreSemantics.actionFrame.firstStep);
-    expect(markup).toContain("Eigenaar");
-    expect(markup).toContain(item.coreSemantics.actionFrame.owner);
+    expect(markup).toContain("Waarom dit besluit");
+    expect(markup).toContain(item.coreSemantics.latestDecision?.decisionReason ?? "");
+    expect(markup).toContain("Volgende toets");
+    expect(markup).toContain(item.coreSemantics.latestDecision?.nextCheck ?? "");
+    expect(markup).toContain("Huidige stap");
+    expect(markup).toContain(item.coreSemantics.actionProgress.currentStep ?? "");
+    expect(markup).toContain("Hierna");
+    expect(markup).toContain(item.coreSemantics.actionProgress.nextStep ?? "");
     expect(markup).toContain("Verwacht effect");
-    expect(markup).toContain(item.coreSemantics.actionFrame.expectedEffect);
+    expect(markup).toContain(item.coreSemantics.actionProgress.expectedEffect ?? "");
+  });
+
+  it("renders compact decision history from shared semantics on route detail", () => {
+    const context = buildLiveContext();
+    const [baseItem] = buildLiveActionCenterItems([context]);
+    const item = {
+      ...baseItem,
+      coreSemantics: {
+        ...baseItem.coreSemantics,
+        latestDecision: {
+          decisionEntryId: "decision-latest",
+          sourceRouteId: baseItem.id,
+          decision: "bijstellen" as const,
+          decisionReason: "De eerste teamread gaf genoeg richting om de route kleiner en concreter te maken.",
+          nextCheck: "Toets of de managercheck het knelpunt binnen twee weken specifieker maakt.",
+          decisionRecordedAt: "2026-04-23T10:00:00.000Z",
+          reviewCompletedAt: "2026-04-23T10:00:00.000Z",
+          currentStepSnapshot: "Voer de managercheck met operations deze week uit.",
+          observationSnapshot: "Dezelfde frictie kwam in twee teams terug.",
+        },
+        decisionHistory: [
+          {
+            decisionEntryId: "decision-latest",
+            sourceRouteId: baseItem.id,
+            decision: "bijstellen" as const,
+            decisionReason: "De eerste teamread gaf genoeg richting om de route kleiner en concreter te maken.",
+            nextCheck: "Toets of de managercheck het knelpunt binnen twee weken specifieker maakt.",
+            decisionRecordedAt: "2026-04-23T10:00:00.000Z",
+            reviewCompletedAt: "2026-04-23T10:00:00.000Z",
+            currentStepSnapshot: "Voer de managercheck met operations deze week uit.",
+            observationSnapshot: "Dezelfde frictie kwam in twee teams terug.",
+          },
+          {
+            decisionEntryId: "decision-earlier",
+            sourceRouteId: baseItem.id,
+            decision: "doorgaan" as const,
+            decisionReason: "De eerste signalen waren sterk genoeg voor een bounded vervolgstap.",
+            nextCheck: "Kijk of het eerste teamgesprek daadwerkelijk gepland is.",
+            decisionRecordedAt: "2026-04-18T10:00:00.000Z",
+            reviewCompletedAt: "2026-04-18T10:00:00.000Z",
+            currentStepSnapshot: "Plan een eerste teamgesprek met operations.",
+            observationSnapshot: "Het patroon werd in meerdere exits bevestigd.",
+          },
+        ],
+      },
+    };
+
+    const markup = renderToStaticMarkup(
+      createElement(ActionCenterPreview, {
+        initialItems: [item],
+        initialSelectedItemId: item.id,
+        initialView: "actions",
+        fallbackOwnerName: "Admin",
+        ownerOptions: ["Manager Operations"],
+        workbenchHref: "/action-center/dossier",
+        hideSidebar: true,
+        readOnly: true,
+      }),
+    );
+
+    expect(markup).toContain("Beslisgeschiedenis");
+    expect(markup).toContain("De eerste teamread gaf genoeg richting om de route kleiner en concreter te maken.");
+    expect(markup).toContain("Toets of de managercheck het knelpunt binnen twee weken specifieker maakt.");
+    expect(markup).toContain("Voer de managercheck met operations deze week uit.");
+    expect(markup).toContain("Dezelfde frictie kwam in twee teams terug.");
+    expect(markup).toContain("Plan een eerste teamgesprek met operations.");
   });
 
   it("renders the compact result loop on route detail from grouped result semantics", () => {
@@ -428,19 +492,19 @@ describe("action center landing shell", () => {
     );
 
     expect(markup).toContain("Laatste route-read");
-    expect(markup).toContain("Uitkomst");
+    expect(markup).toContain("Besluit");
     expect(markup).toContain("Bijstellen");
     expect(markup).toContain("Stap");
-    expect(markup).toContain(item.coreSemantics.actionFrame.firstStep);
-    expect(markup).not.toContain("Besluit");
+    expect(markup).toContain(item.coreSemantics.actionProgress.currentStep ?? "");
+    expect(markup).not.toContain("Laatste beslissing");
+    expect(markup).not.toContain("Waarom dit besluit");
+    expect(markup).not.toContain("Volgende toets");
     expect(markup).not.toContain("Signaal");
-    expect(markup).not.toContain("Waarom we opnieuw kijken");
-    expect(markup).not.toContain("Wat we dan toetsen");
-    expect(markup).not.toContain("Wat is geprobeerd");
-    expect(markup).not.toContain("Wat zagen we terug");
-    expect(markup).not.toContain("Wat is besloten");
+    expect(markup).not.toContain("Huidige stap");
+    expect(markup).not.toContain("Hierna");
+    expect(markup).not.toContain("Beslisgeschiedenis");
     expect((markup.match(/>Stap</g) ?? []).length).toBe(1);
-    expect((markup.match(/>Uitkomst</g) ?? []).length).toBe(1);
+    expect((markup.match(/>Besluit</g) ?? []).length).toBe(1);
   });
 
   it("shows team Review < 7 dagen for upcoming reviews within the next week", () => {

--- a/frontend/app/(dashboard)/action-center/page.route-shell.test.ts
+++ b/frontend/app/(dashboard)/action-center/page.route-shell.test.ts
@@ -153,7 +153,16 @@ function buildLiveContext(): LiveActionCenterCampaignContext {
     deliveryRecord: buildDeliveryRecord(),
     deliveryCheckpoints: [],
     learningDossier: buildDossier(),
-    learningCheckpoints: [],
+    learningCheckpoints: [
+      buildCheckpoint({
+        id: "checkpoint-follow-up-review",
+        checkpoint_key: "follow_up_review",
+        owner_label: "HR lead",
+        status: "uitgevoerd",
+        confirmed_lesson: "De eerste review liet zien dat dezelfde frictie in twee teams terugkomt.",
+        updated_at: "2026-04-24T09:00:00.000Z",
+      }),
+    ],
   };
 }
 
@@ -547,7 +556,7 @@ describe("action center landing shell", () => {
       deliveryRecord: context.deliveryRecord,
       learningDossier: context.learningDossier,
       learningCheckpoints: context.learningCheckpoints,
-      latestVisibleUpdateNote: null,
+      latestVisibleUpdateNote: item.updates[0]?.note ?? null,
       route,
     }));
     expect(item.coreSemantics).toMatchObject({
@@ -567,7 +576,7 @@ describe("action center landing shell", () => {
         expectedEffect: item.expectedEffect,
       },
       resultLoop: {
-        whatWasTried: "Leg eigenaar en eerste correctie in het MT-overleg vast.",
+        whatWasTried: item.updates[0]?.note ?? null,
       },
       closingSemantics: {
         status: "lopend",

--- a/frontend/app/(dashboard)/beheer/klantlearnings/page.tsx
+++ b/frontend/app/(dashboard)/beheer/klantlearnings/page.tsx
@@ -19,8 +19,6 @@ import {
 import { finalizeActionCenterPreviewItem } from '@/lib/action-center-live'
 import { getContactRequestsForAdmin } from '@/lib/contact-requests'
 import { createClient } from '@/lib/supabase/server'
-import { finalizeActionCenterPreviewItem } from '@/lib/action-center-live'
-import type { ActionCenterReviewOutcome } from '@/lib/action-center-route-contract'
 import type {
   ContactRequestRecord,
   PilotLearningCheckpoint,
@@ -78,20 +76,6 @@ function formatPreviewDate(value: string | null) {
   const parsed = new Date(value)
   if (Number.isNaN(parsed.getTime())) return value
   return DUTCH_SHORT_DATE.format(parsed).replace('.', '')
-}
-
-function normalizePreviewReviewOutcome(value: string | null | undefined): ActionCenterReviewOutcome {
-  switch (value) {
-    case 'doorgaan':
-    case 'bijstellen':
-    case 'opschalen':
-    case 'afronden':
-    case 'stoppen':
-    case 'geen-uitkomst':
-      return value
-    default:
-      return 'geen-uitkomst'
-  }
 }
 
 function inferPreviewRhythm(reviewMoment: string | null) {
@@ -407,9 +391,6 @@ export default async function KlantLearningsPage({ searchParams }: Props) {
       ownerRole: ownerName ? 'Manager' : 'Nog niet toegewezen',
       ownerSubtitle: teamLabel,
       reviewOwnerName: reviewCheckpoint?.owner_label?.trim() || ownerName,
-      expectedEffect: dossier.expected_first_value ?? null,
-      reviewReason: dossier.first_management_value ?? null,
-      reviewOutcome: normalizePreviewReviewOutcome(dossier.management_action_outcome),
       priority,
       status,
       reviewDate: reviewMoment?.state === 'scheduled' ? reviewMoment.scheduledFor : null,

--- a/frontend/app/(dashboard)/beheer/klantlearnings/page.tsx
+++ b/frontend/app/(dashboard)/beheer/klantlearnings/page.tsx
@@ -19,6 +19,8 @@ import {
 import { finalizeActionCenterPreviewItem } from '@/lib/action-center-live'
 import { getContactRequestsForAdmin } from '@/lib/contact-requests'
 import { createClient } from '@/lib/supabase/server'
+import { finalizeActionCenterPreviewItem } from '@/lib/action-center-live'
+import type { ActionCenterReviewOutcome } from '@/lib/action-center-route-contract'
 import type {
   ContactRequestRecord,
   PilotLearningCheckpoint,
@@ -108,6 +110,19 @@ function inferPreviewRhythm(reviewMoment: string | null) {
 function estimateHeadcount(value: string | null) {
   const match = value?.match(/\d+/)
   return match ? Number.parseInt(match[0], 10) : 0
+}
+
+function normalizePreviewReviewOutcome(value: string | null | undefined): ActionCenterReviewOutcome {
+  switch (value?.trim()) {
+    case 'doorgaan':
+    case 'bijstellen':
+    case 'opschalen':
+    case 'afronden':
+    case 'stoppen':
+      return value.trim() as ActionCenterReviewOutcome
+    default:
+      return 'geen-uitkomst'
+  }
 }
 
 export default async function KlantLearningsPage({ searchParams }: Props) {
@@ -384,6 +399,7 @@ export default async function KlantLearningsPage({ searchParams }: Props) {
       title: dossier.title,
       summary,
       reason,
+      orgId: organization?.id ?? dossier.organization_id ?? campaign?.organization_id ?? null,
       sourceLabel,
       teamId: organization?.id ?? campaign?.organization_id ?? `team-${dossier.id}`,
       teamLabel,
@@ -397,6 +413,9 @@ export default async function KlantLearningsPage({ searchParams }: Props) {
       priority,
       status,
       reviewDate: reviewMoment?.state === 'scheduled' ? reviewMoment.scheduledFor : null,
+      expectedEffect: dossier.expected_first_value ?? null,
+      reviewReason: reason,
+      reviewOutcome: normalizePreviewReviewOutcome(dossier.management_action_outcome),
       reviewDateLabel: formatPreviewDate(reviewMoment?.state === 'scheduled' ? reviewMoment.scheduledFor : null),
       reviewRhythm: inferPreviewRhythm(reviewMoment?.state === 'scheduled' ? reviewMoment.scheduledFor : null),
       signalLabel: `${sourceLabel} - ${teamLabel}`,

--- a/frontend/components/dashboard/action-center-preview.tsx
+++ b/frontend/components/dashboard/action-center-preview.tsx
@@ -1,7 +1,7 @@
 ﻿'use client'
 
 import Link from 'next/link'
-import type { ActionCenterReviewOutcome } from '@/lib/action-center-route-contract'
+import type { ActionCenterDecision, ActionCenterDecisionRecord, ActionCenterReviewOutcome } from '@/lib/action-center-route-contract'
 import { finalizeActionCenterPreviewItem } from '@/lib/action-center-live'
 import type {
   ActionCenterPreviewItem,
@@ -11,6 +11,15 @@ import type {
   ActionCenterPreviewView,
 } from '@/lib/action-center-preview-model'
 import React, { useDeferredValue, useEffect, useMemo, useState } from 'react'
+
+export type {
+  ActionCenterPreviewItem,
+  ActionCenterPreviewManagerOption,
+  ActionCenterPreviewPriority,
+  ActionCenterPreviewStatus,
+  ActionCenterPreviewUpdate,
+  ActionCenterPreviewView,
+} from '@/lib/action-center-preview-model'
 
 interface Props {
   initialItems: ActionCenterPreviewItem[]
@@ -191,14 +200,18 @@ function getReviewOutcomeMeta(outcome: ActionCenterReviewOutcome) {
   }
 }
 
-function getClosingStatusLabel(status: 'lopend' | 'afgerond' | 'gestopt') {
-  switch (status) {
-    case 'afgerond':
-      return 'Afgerond voor nu'
-    case 'gestopt':
-      return 'Bewust gestopt'
+function getDecisionLabel(decision: ActionCenterDecision) {
+  switch (decision) {
+    case 'doorgaan':
+      return 'Doorgaan'
+    case 'bijstellen':
+      return 'Bijstellen'
+    case 'afronden':
+      return 'Afronden'
+    case 'stoppen':
+      return 'Stoppen'
     default:
-      return null
+      return decision
   }
 }
 
@@ -1238,39 +1251,51 @@ export function ActionCenterPreview({
 
                         <div className="mt-6 space-y-5">
                           <div>
-                            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/48">Reviewbetekenis</p>
-                            <div className="mt-3 grid gap-3 md:grid-cols-3">
-                              <RouteFieldCard
-                                label="Waarom we opnieuw kijken"
-                                value={selectedItem.coreSemantics.reviewSemantics.reviewReason}
-                              />
-                              <RouteFieldCard
-                                label="Wat we dan toetsen"
-                                value={selectedItem.coreSemantics.reviewSemantics.reviewQuestion}
-                              />
-                              <RouteOutcomeCard outcome={selectedItem.coreSemantics.reviewSemantics.reviewOutcomeVisible} />
-                            </div>
+                            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/48">Beslissing</p>
+                            {selectedItem.coreSemantics.latestDecision ? (
+                              <div className="mt-3 grid gap-3 md:grid-cols-3">
+                                <DecisionOutcomeCard decision={selectedItem.coreSemantics.latestDecision.decision} />
+                                {selectedItem.coreSemantics.latestDecision.decisionReason ? (
+                                  <RouteFieldCard
+                                    label="Waarom dit besluit"
+                                    value={selectedItem.coreSemantics.latestDecision.decisionReason}
+                                  />
+                                ) : null}
+                                {selectedItem.coreSemantics.latestDecision.nextCheck ? (
+                                  <RouteFieldCard
+                                    label="Volgende toets"
+                                    value={selectedItem.coreSemantics.latestDecision.nextCheck}
+                                  />
+                                ) : null}
+                              </div>
+                            ) : (
+                              <div className="mt-3">
+                                <EmptyBlock text="Nog geen expliciete reviewbeslissing vastgelegd in deze route." />
+                              </div>
+                            )}
                           </div>
 
                           <div>
-                            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/48">Actiekader</p>
-                            <div className="mt-3 grid gap-3 md:grid-cols-2">
-                              <RouteFieldCard
-                                label="Waarom nu"
-                                value={selectedItem.coreSemantics.actionFrame.whyNow}
-                              />
-                              <RouteFieldCard
-                                label="Eerste stap"
-                                value={selectedItem.coreSemantics.actionFrame.firstStep}
-                              />
-                              <RouteFieldCard
-                                label="Eigenaar"
-                                value={selectedItem.coreSemantics.actionFrame.owner}
-                              />
-                              <RouteFieldCard
-                                label="Verwacht effect"
-                                value={selectedItem.coreSemantics.actionFrame.expectedEffect}
-                              />
+                            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/48">Actievoortgang</p>
+                            <div className="mt-3 grid gap-3 md:grid-cols-3">
+                              {selectedItem.coreSemantics.actionProgress.currentStep ? (
+                                <RouteFieldCard
+                                  label="Huidige stap"
+                                  value={selectedItem.coreSemantics.actionProgress.currentStep}
+                                />
+                              ) : null}
+                              {selectedItem.coreSemantics.actionProgress.nextStep ? (
+                                <RouteFieldCard
+                                  label="Hierna"
+                                  value={selectedItem.coreSemantics.actionProgress.nextStep}
+                                />
+                              ) : null}
+                              {selectedItem.coreSemantics.actionProgress.expectedEffect ? (
+                                <RouteFieldCard
+                                  label="Verwacht effect"
+                                  value={selectedItem.coreSemantics.actionProgress.expectedEffect}
+                                />
+                              ) : null}
                             </div>
                           </div>
 
@@ -1295,6 +1320,19 @@ export function ActionCenterPreview({
                                   value={selectedItem.coreSemantics.resultLoop.whatWasDecided}
                                 />
                               ) : null}
+                            </div>
+                          </div>
+
+                          <div>
+                            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/48">Beslisgeschiedenis</p>
+                            <div className="mt-3 space-y-3">
+                              {selectedItem.coreSemantics.decisionHistory.length === 0 ? (
+                                <EmptyBlock text="Nog geen expliciete beslismomenten zichtbaar in deze route." />
+                              ) : (
+                                selectedItem.coreSemantics.decisionHistory.map((entry) => (
+                                  <DecisionHistoryEntry key={entry.decisionEntryId} entry={entry} />
+                                ))
+                              )}
                             </div>
                           </div>
                         </div>
@@ -2138,13 +2176,12 @@ function EmptySection({ title, body }: { title: string; body: string }) {
 }
 
 export function buildCompactLandingSummaryLines(item: ActionCenterPreviewItem) {
-  const outcomeLabel = getReviewOutcomeMeta(item.coreSemantics.reviewSemantics.reviewOutcomeVisible).label
-  const supportingLine =
-    { label: 'Stap', value: item.coreSemantics.actionFrame.firstStep }
+  const latestDecision = item.coreSemantics.latestDecision
+  const currentStep = item.coreSemantics.actionProgress.currentStep
 
   return [
-    { label: 'Uitkomst', value: outcomeLabel },
-    supportingLine,
+    latestDecision ? { label: 'Besluit', value: getDecisionLabel(latestDecision.decision) } : null,
+    currentStep ? { label: 'Stap', value: currentStep } : null,
   ]
     .filter((entry): entry is { label: string; value: string } => Boolean(entry?.value))
     .filter((entry, index, entries) => entries.findIndex((candidate) => candidate.value === entry.value) === index)
@@ -2182,17 +2219,54 @@ function RouteFieldCard({ label, value }: { label: string; value: string }) {
   )
 }
 
-function RouteOutcomeCard({ outcome }: { outcome: ActionCenterReviewOutcome }) {
-  const meta = getReviewOutcomeMeta(outcome)
+function DecisionOutcomeCard({ decision }: { decision: ActionCenterDecision }) {
+  const label = getDecisionLabel(decision)
+  const meta = getReviewOutcomeMeta(decision)
 
   return (
     <div className="rounded-[18px] border border-[#eadfce] bg-[#fcfaf6] px-4 py-4">
-      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Laatste reviewuitkomst</p>
+      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Laatste beslissing</p>
       <div className="mt-3">
         <span className={`inline-flex items-center rounded-xl border px-3 py-2 text-sm font-semibold ${meta.className}`}>
-          {meta.label}
+          {label}
         </span>
       </div>
+    </div>
+  )
+}
+
+function DecisionHistoryEntry({ entry }: { entry: ActionCenterDecisionRecord }) {
+  const summaryBits = [
+    entry.currentStepSnapshot ? { label: 'Stap', value: entry.currentStepSnapshot } : null,
+    entry.observationSnapshot ? { label: 'Gezien', value: entry.observationSnapshot } : null,
+    entry.nextCheck ? { label: 'Hierna toetsen', value: entry.nextCheck } : null,
+  ].filter((bit): bit is { label: string; value: string } => Boolean(bit))
+
+  return (
+    <div className="rounded-[18px] border border-white/10 bg-white/[0.04] px-4 py-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <span className="inline-flex items-center rounded-xl border border-white/10 bg-white/[0.06] px-3 py-1.5 text-sm font-semibold text-white/88">
+          {getDecisionLabel(entry.decision)}
+        </span>
+        <span className="text-xs uppercase tracking-[0.16em] text-white/40">
+          {formatLongDate(entry.reviewCompletedAt ?? entry.decisionRecordedAt)}
+        </span>
+      </div>
+
+      {entry.decisionReason ? (
+        <p className="mt-3 text-sm leading-7 text-white/78">{entry.decisionReason}</p>
+      ) : null}
+
+      {summaryBits.length > 0 ? (
+        <div className="mt-4 space-y-2.5">
+          {summaryBits.map((bit) => (
+            <div key={`${entry.decisionEntryId}-${bit.label}`} className="flex items-start justify-between gap-3 text-sm">
+              <span className="shrink-0 font-semibold text-white/46">{bit.label}</span>
+              <span className="text-right leading-6 text-white/82">{bit.value}</span>
+            </div>
+          ))}
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/frontend/lib/action-center-core-semantics.test.ts
+++ b/frontend/lib/action-center-core-semantics.test.ts
@@ -241,6 +241,71 @@ describe('action center core semantics', () => {
       expect(semantics.latestDecision?.nextCheck).toBeTruthy()
       expect(semantics.decisionHistory).toHaveLength(1)
     })
+
+    it('does not synthesize a legacy decision history when completion truth is missing', () => {
+      const semantics = projectActionCenterCoreSemantics({
+        campaign: { id: 'campaign-1', name: 'ExitScan april' } as never,
+        assignedManager: { displayName: 'Sanne de Vries' } as never,
+        deliveryRecord: { next_step: null } as never,
+        learningDossier: {
+          management_action_outcome: 'bijstellen',
+          first_action_taken: 'Plan een gerichte teamreview met de manager.',
+          expected_first_value: 'Werkdruktrend moet dalen.',
+        } as never,
+        learningCheckpoints: [],
+        route: {
+          ...baseRoute,
+          reviewCompletedAt: null,
+        },
+        latestVisibleUpdateNote: 'De manager bevestigde dat de frictie nog niet daalt.',
+        decisionRecords: [],
+      })
+
+      expect(semantics.latestDecision).toBeNull()
+      expect(semantics.decisionHistory).toEqual([])
+    })
+  })
+
+  it('derives route completion truth from a completed follow-up review checkpoint', () => {
+    const route = projectActionCenterRoute({
+      campaign: buildCampaign(),
+      stats: buildStats(),
+      organizationName: 'Acme BV',
+      memberRole: 'owner',
+      scopeType: 'department',
+      scopeValue: 'operations',
+      scopeLabel: 'Operations',
+      peopleCount: 38,
+      assignedManager: {
+        userId: 'manager-1',
+        displayName: 'Manager Operations',
+        assignedAt: '2026-04-21T08:00:00.000Z',
+      },
+      deliveryRecord: buildDeliveryRecord({
+        first_management_use_confirmed_at: '2026-04-20T09:00:00.000Z',
+      }),
+      deliveryCheckpoints: [],
+      learningDossier: buildDossier({
+        first_management_value: 'Welke vertrekduiding vraagt nu als eerste managementeigenaarschap?',
+        expected_first_value: 'Maak zichtbaar welk vertrekpatroon nu eerst bestuurlijke aandacht vraagt.',
+        first_action_taken: 'Leg eigenaar en eerste correctie in het MT-overleg vast.',
+        review_moment: '2026-05-12',
+        management_action_outcome: 'bijstellen',
+        adoption_outcome: 'De eerste review liet zien dat dezelfde frictie in twee teams terugkomt.',
+      }),
+      learningCheckpoints: [
+        buildCheckpoint({
+          id: 'checkpoint-review',
+          checkpoint_key: 'follow_up_review',
+          status: 'uitgevoerd',
+          updated_at: '2026-04-26T10:15:00.000Z',
+          confirmed_lesson: 'De frictie bleef terugkomen in elk vervolggesprek.',
+        }),
+      ],
+    })
+
+    expect(route.reviewCompletedAt).toBe('2026-04-26T10:15:00.000Z')
+    expect(route.outcomeRecordedAt).toBe('2026-04-26T10:15:00.000Z')
   })
 
   it('keeps reviewReason and reviewQuestion distinct while preserving the visible outcome mapping', () => {

--- a/frontend/lib/action-center-core-semantics.test.ts
+++ b/frontend/lib/action-center-core-semantics.test.ts
@@ -9,6 +9,7 @@ import type { Campaign, CampaignStats } from '@/lib/types'
 import type { CampaignDeliveryRecord } from '@/lib/ops-delivery'
 import type { PilotLearningCheckpoint, PilotLearningDossier } from '@/lib/pilot-learning'
 import type { LiveActionCenterCampaignContext } from './action-center-live-context'
+import type { ActionCenterRouteContract } from './action-center-route-contract'
 
 function buildCampaign(overrides: Partial<Campaign> = {}): Campaign {
   return {
@@ -167,6 +168,81 @@ function buildContext(args: {
 }
 
 describe('action center core semantics', () => {
+  describe('decision-first projection', () => {
+    const baseRoute: ActionCenterRouteContract = {
+      campaignId: 'campaign-1',
+      entryStage: 'active',
+      routeOpenedAt: '2026-04-20T10:00:00.000Z',
+      ownerAssignedAt: '2026-04-20T11:00:00.000Z',
+      routeStatus: 'in-uitvoering',
+      reviewOutcome: 'bijstellen',
+      reviewCompletedAt: '2026-04-25T10:00:00.000Z',
+      outcomeRecordedAt: null,
+      outcomeSummary: 'Werkdruk bleef zichtbaar in hetzelfde team.',
+      intervention: 'Plan een gerichte teamreview met de manager.',
+      owner: 'Sanne de Vries',
+      expectedEffect: 'Zichtbaar maken of de werkdruk lokaal afneemt.',
+      reviewScheduledFor: '2026-05-02',
+      reviewReason: 'De eerste stap gaf nog geen stabiele verbetering.',
+      blockedBy: null,
+    }
+
+    it('prefers canonical decision truth over legacy review outcome when both exist', () => {
+      const semantics = projectActionCenterCoreSemantics({
+        campaign: { id: 'campaign-1', name: 'ExitScan april' } as never,
+        assignedManager: { displayName: 'Sanne de Vries' } as never,
+        deliveryRecord: { next_step: 'Herplan de teamreview voor volgende week.' } as never,
+        learningDossier: {
+          management_action_outcome: 'doorgaan',
+          first_action_taken: 'Plan een gerichte teamreview met de manager.',
+          expected_first_value: 'Werkdruktrend moet dalen.',
+        } as never,
+        learningCheckpoints: [],
+        route: baseRoute,
+        latestVisibleUpdateNote: 'De manager bevestigde dat de frictie nog niet daalt.',
+        decisionRecords: [
+          {
+            decisionEntryId: 'decision-1',
+            sourceRouteId: 'campaign-1',
+            decision: 'bijstellen',
+            decisionReason: 'De eerste teamreview gaf nog geen stabiele verbetering.',
+            nextCheck: 'Toets over een week of de teamdruk zichtbaar daalt.',
+            decisionRecordedAt: '2026-04-25T10:00:00.000Z',
+            reviewCompletedAt: '2026-04-25T09:30:00.000Z',
+          },
+        ],
+      })
+
+      expect(semantics.latestDecision?.decision).toBe('bijstellen')
+      expect(semantics.latestDecision?.decisionReason).toBe(
+        'De eerste teamreview gaf nog geen stabiele verbetering.',
+      )
+      expect(semantics.actionProgress.currentStep).toBe('Plan een gerichte teamreview met de manager.')
+      expect(semantics.actionProgress.nextStep).toBe('Herplan de teamreview voor volgende week.')
+    })
+
+    it('falls back to legacy truth when no canonical decision records exist', () => {
+      const semantics = projectActionCenterCoreSemantics({
+        campaign: { id: 'campaign-1', name: 'ExitScan april' } as never,
+        assignedManager: { displayName: 'Sanne de Vries' } as never,
+        deliveryRecord: { next_step: null } as never,
+        learningDossier: {
+          management_action_outcome: null,
+          first_action_taken: 'Plan een gerichte teamreview met de manager.',
+          expected_first_value: 'Werkdruktrend moet dalen.',
+        } as never,
+        learningCheckpoints: [],
+        route: baseRoute,
+        latestVisibleUpdateNote: 'De manager bevestigde dat de frictie nog niet daalt.',
+        decisionRecords: [],
+      })
+
+      expect(semantics.latestDecision?.decision).toBe('bijstellen')
+      expect(semantics.latestDecision?.nextCheck).toBeTruthy()
+      expect(semantics.decisionHistory).toHaveLength(1)
+    })
+  })
+
   it('keeps reviewReason and reviewQuestion distinct while preserving the visible outcome mapping', () => {
     const context = buildContext({
       assignedManager: {

--- a/frontend/lib/action-center-core-semantics.ts
+++ b/frontend/lib/action-center-core-semantics.ts
@@ -1,6 +1,11 @@
-import type { ActionCenterReviewOutcome, ActionCenterRouteContract } from './action-center-route-contract'
+import type {
+  ActionCenterDecisionRecord,
+  ActionCenterReviewOutcome,
+  ActionCenterRouteContract,
+} from './action-center-route-contract'
 import type { LiveActionCenterCampaignContext } from './action-center-live-context'
 import type { PilotLearningCheckpoint } from './pilot-learning'
+import { compareDecisionHistoryEntries, projectLegacyDecisionRecord } from './action-center-decision-history'
 
 export type ActionCenterVisibleReviewOutcome = Exclude<ActionCenterReviewOutcome, 'opschalen'>
 export type ActionCenterClosingStatus = 'lopend' | 'afgerond' | 'gestopt'
@@ -13,6 +18,12 @@ export interface ActionCenterCoreSemantics {
     reviewOutcomeRaw: ActionCenterReviewOutcome
     reviewOutcomeVisible: ActionCenterVisibleReviewOutcome
   }
+  latestDecision: ActionCenterDecisionRecord | null
+  actionProgress: {
+    currentStep: string | null
+    nextStep: string | null
+    expectedEffect: string | null
+  }
   actionFrame: {
     whyNow: string
     firstStep: string
@@ -24,6 +35,7 @@ export interface ActionCenterCoreSemantics {
     whatWeObserved: string | null
     whatWasDecided: string | null
   }
+  decisionHistory: ActionCenterDecisionRecord[]
   closingSemantics: {
     status: ActionCenterClosingStatus
     summary: string | null
@@ -37,6 +49,7 @@ export type ActionCenterCoreSemanticsProjectionInput = Pick<
 > & {
   route: ActionCenterRouteContract
   latestVisibleUpdateNote?: string | null
+  decisionRecords?: ActionCenterDecisionRecord[]
 }
 
 export interface ActionCenterPreviewCoreSemanticsProjectionInput {
@@ -265,6 +278,57 @@ function getLatestObservation(context: ActionCenterCoreSemanticsProjectionInput,
   ])
 }
 
+function buildDecisionHistory(args: {
+  route: ActionCenterRouteContract
+  reviewQuestion: string | null
+  latestObservation: string | null
+  reviewReason?: string | null
+  managementActionOutcome?: string | null
+  decisionRecords?: ActionCenterDecisionRecord[]
+}) {
+  const canonical = [...(args.decisionRecords ?? [])]
+    .filter((record) => record.sourceRouteId === args.route.campaignId)
+    .sort(compareDecisionHistoryEntries)
+
+  if (canonical.length > 0) {
+    return canonical
+  }
+
+  const legacy = projectLegacyDecisionRecord({
+    sourceRouteId: args.route.campaignId,
+    reviewOutcome: args.route.reviewOutcome,
+    reviewCompletedAt: args.route.reviewCompletedAt,
+    reviewReason: args.reviewReason ?? args.route.reviewReason,
+    reviewQuestion: args.reviewQuestion,
+    managementActionOutcome: args.managementActionOutcome,
+    latestObservation: args.latestObservation,
+  })
+
+  return legacy ? [legacy] : []
+}
+
+function projectActionProgress(args: {
+  route: ActionCenterRouteContract
+  deliveryNextStep: string | null | undefined
+  firstActionTaken: string | null | undefined
+  reviewQuestion: string | null
+  expectedEffectFallback: string | null
+}) {
+  const currentStep = pickFirst([args.firstActionTaken, args.route.intervention])
+  const nextStep = pickFirst([args.deliveryNextStep, args.reviewQuestion])
+  const expectedEffect = pickFirst([
+    args.route.expectedEffect,
+    args.expectedEffectFallback,
+    args.reviewQuestion,
+  ])
+
+  return {
+    currentStep,
+    nextStep,
+    expectedEffect,
+  }
+}
+
 function getPreviewClosingStatus(status: ActionCenterRouteContract['routeStatus']): ActionCenterClosingStatus {
   if (status === 'afgerond') return 'afgerond'
   if (status === 'gestopt') return 'gestopt'
@@ -378,6 +442,21 @@ export function projectActionCenterPreviewCoreSemantics(
     input.signalBody,
     route.expectedEffect,
   ])
+  const decisionHistory = buildDecisionHistory({
+    route,
+    reviewQuestion,
+    latestObservation: whatWeObserved,
+    reviewReason,
+    managementActionOutcome: input.reviewOutcome,
+  })
+  const latestDecision = decisionHistory[0] ?? null
+  const actionProgress = projectActionProgress({
+    route,
+    deliveryNextStep: input.nextStep,
+    firstActionTaken: route.intervention,
+    reviewQuestion,
+    expectedEffectFallback: expectedEffectFromReason,
+  })
   const whatWasDecided = getDecisionText({
     reviewOutcomeVisible,
     managementActionOutcomeText: getRawManagementActionOutcomeText(input.reviewOutcome),
@@ -394,6 +473,8 @@ export function projectActionCenterPreviewCoreSemantics(
       reviewOutcomeRaw: route.reviewOutcome,
       reviewOutcomeVisible,
     },
+    latestDecision,
+    actionProgress,
     actionFrame: {
       whyNow: whyNow ?? ACTION_FRAME_FALLBACK,
       firstStep,
@@ -413,6 +494,7 @@ export function projectActionCenterPreviewCoreSemantics(
       whatWeObserved,
       whatWasDecided,
     },
+    decisionHistory,
     closingSemantics: {
       status: closingStatus,
       summary: getClosingSummary(closingStatus, getPreviewClosingSummaryValues(route, closingStatus)),
@@ -499,6 +581,22 @@ export function projectActionCenterCoreSemantics(
   const latestObservation = getLatestObservation(context, route)
   const latestActionUpdate = getLatestActionUpdate(context)
   const closingStatus = getClosingStatus(context, route)
+  const decisionHistory = buildDecisionHistory({
+    route,
+    reviewQuestion,
+    latestObservation,
+    reviewReason,
+    managementActionOutcome: context.learningDossier?.management_action_outcome,
+    decisionRecords: context.decisionRecords,
+  })
+  const latestDecision = decisionHistory[0] ?? null
+  const actionProgress = projectActionProgress({
+    route,
+    deliveryNextStep: context.deliveryRecord?.next_step,
+    firstActionTaken: context.learningDossier?.first_action_taken,
+    reviewQuestion,
+    expectedEffectFallback: derivedExpectedEffect,
+  })
 
   return {
     route,
@@ -508,6 +606,8 @@ export function projectActionCenterCoreSemantics(
       reviewOutcomeRaw: route.reviewOutcome,
       reviewOutcomeVisible,
     },
+    latestDecision,
+    actionProgress,
     actionFrame: {
       whyNow: whyNow ?? ACTION_FRAME_FALLBACK,
       firstStep: firstStep ?? ACTION_FRAME_FALLBACK,
@@ -534,6 +634,7 @@ export function projectActionCenterCoreSemantics(
         latestVisibleUpdateNote: normalizeText(context.latestVisibleUpdateNote),
       }),
     },
+    decisionHistory,
     closingSemantics: {
       status: closingStatus,
       summary: getClosingSummary(closingStatus, getLiveClosingSummaryValues(context, route, closingStatus)),

--- a/frontend/lib/action-center-decision-history.test.ts
+++ b/frontend/lib/action-center-decision-history.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildLegacyDecisionEntryId,
+  compareDecisionHistoryEntries,
+  projectLegacyDecisionRecord,
+  type ActionCenterDecisionRecord,
+} from './action-center-decision-history'
+
+describe('action-center decision history contract', () => {
+  it('builds a stable legacy decision entry id from one legacy review moment', () => {
+    const id = buildLegacyDecisionEntryId({
+      routeId: 'route-1',
+      reviewCompletedAt: '2026-04-25T10:00:00.000Z',
+      reviewOutcome: 'bijstellen',
+    })
+
+    expect(id).toBe('legacy:route-1:2026-04-25T10:00:00.000Z:bijstellen')
+  })
+
+  it('orders decision entries by decisionRecordedAt descending before older fallback timestamps', () => {
+    const left: ActionCenterDecisionRecord = {
+      decisionEntryId: 'decision-2',
+      sourceRouteId: 'route-1',
+      decision: 'afronden',
+      decisionReason: 'Het effect is bevestigd.',
+      nextCheck: 'Geen nieuwe toets nodig.',
+      decisionRecordedAt: '2026-04-28T09:00:00.000Z',
+      reviewCompletedAt: '2026-04-28T08:00:00.000Z',
+    }
+    const right: ActionCenterDecisionRecord = {
+      decisionEntryId: 'decision-1',
+      sourceRouteId: 'route-1',
+      decision: 'doorgaan',
+      decisionReason: 'De eerste stap loopt nog.',
+      nextCheck: 'Toets volgende week of de frictie daalt.',
+      decisionRecordedAt: '2026-04-25T09:00:00.000Z',
+      reviewCompletedAt: '2026-04-25T08:00:00.000Z',
+    }
+
+    expect(compareDecisionHistoryEntries(left, right)).toBeLessThan(0)
+    expect(compareDecisionHistoryEntries(right, left)).toBeGreaterThan(0)
+  })
+
+  it('projects one legacy decision record from legacy review truth using the canonical fallback order', () => {
+    const record = projectLegacyDecisionRecord({
+      sourceRouteId: 'route-1',
+      reviewOutcome: 'bijstellen',
+      reviewCompletedAt: '2026-04-25T10:00:00.000Z',
+      reviewReason: 'De eerste stap gaf nog geen stabiele verbetering.',
+      reviewQuestion: 'Moet de vervolgstap worden aangescherpt?',
+      managementActionOutcome: null,
+      latestObservation: 'Werkdruk bleef zichtbaar in hetzelfde team.',
+    })
+
+    expect(record).toMatchObject({
+      sourceRouteId: 'route-1',
+      decision: 'bijstellen',
+      decisionReason: 'De eerste stap gaf nog geen stabiele verbetering.',
+      nextCheck: 'Moet de vervolgstap worden aangescherpt?',
+      decisionRecordedAt: '2026-04-25T10:00:00.000Z',
+    })
+  })
+})

--- a/frontend/lib/action-center-decision-history.test.ts
+++ b/frontend/lib/action-center-decision-history.test.ts
@@ -60,4 +60,18 @@ describe('action-center decision history contract', () => {
       decisionRecordedAt: '2026-04-25T10:00:00.000Z',
     })
   })
+
+  it('does not project a legacy decision record without a real review completion timestamp', () => {
+    const record = projectLegacyDecisionRecord({
+      sourceRouteId: 'route-1',
+      reviewOutcome: 'bijstellen',
+      reviewCompletedAt: null,
+      reviewReason: 'De eerste stap gaf nog geen stabiele verbetering.',
+      reviewQuestion: 'Moet de vervolgstap worden aangescherpt?',
+      managementActionOutcome: null,
+      latestObservation: 'Werkdruk bleef zichtbaar in hetzelfde team.',
+    })
+
+    expect(record).toBeNull()
+  })
 })

--- a/frontend/lib/action-center-decision-history.ts
+++ b/frontend/lib/action-center-decision-history.ts
@@ -1,0 +1,93 @@
+import type {
+  ActionCenterDecision,
+  ActionCenterDecisionRecord,
+  ActionCenterReviewOutcome,
+} from './action-center-route-contract'
+
+function normalizeText(value: string | null | undefined) {
+  const trimmed = value?.trim() ?? ''
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function coerceDecision(
+  reviewOutcome: ActionCenterReviewOutcome | null | undefined,
+  managementActionOutcome: string | null | undefined,
+): ActionCenterDecision | null {
+  if (
+    reviewOutcome === 'doorgaan' ||
+    reviewOutcome === 'bijstellen' ||
+    reviewOutcome === 'afronden' ||
+    reviewOutcome === 'stoppen'
+  ) {
+    return reviewOutcome
+  }
+
+  const fallback = normalizeText(managementActionOutcome)
+  if (
+    fallback === 'doorgaan' ||
+    fallback === 'bijstellen' ||
+    fallback === 'afronden' ||
+    fallback === 'stoppen'
+  ) {
+    return fallback
+  }
+
+  return null
+}
+
+export function buildLegacyDecisionEntryId(args: {
+  routeId: string
+  reviewCompletedAt: string | null
+  reviewOutcome: ActionCenterReviewOutcome | null | undefined
+}) {
+  return `legacy:${args.routeId}:${args.reviewCompletedAt ?? 'unknown-review'}:${args.reviewOutcome ?? 'geen-uitkomst'}`
+}
+
+export function compareDecisionHistoryEntries(left: ActionCenterDecisionRecord, right: ActionCenterDecisionRecord) {
+  const leftPrimary = new Date(left.decisionRecordedAt).getTime()
+  const rightPrimary = new Date(right.decisionRecordedAt).getTime()
+
+  if (leftPrimary !== rightPrimary) {
+    return rightPrimary - leftPrimary
+  }
+
+  const leftFallback = left.reviewCompletedAt ? new Date(left.reviewCompletedAt).getTime() : Number.NEGATIVE_INFINITY
+  const rightFallback = right.reviewCompletedAt
+    ? new Date(right.reviewCompletedAt).getTime()
+    : Number.NEGATIVE_INFINITY
+
+  if (leftFallback !== rightFallback) {
+    return rightFallback - leftFallback
+  }
+
+  return left.decisionEntryId.localeCompare(right.decisionEntryId)
+}
+
+export function projectLegacyDecisionRecord(args: {
+  sourceRouteId: string
+  reviewOutcome: ActionCenterReviewOutcome | null | undefined
+  reviewCompletedAt: string | null
+  reviewReason: string | null | undefined
+  reviewQuestion: string | null | undefined
+  managementActionOutcome: string | null | undefined
+  latestObservation: string | null | undefined
+}): ActionCenterDecisionRecord | null {
+  const decision = coerceDecision(args.reviewOutcome, args.managementActionOutcome)
+  if (!decision) return null
+
+  const reviewCompletedAt = args.reviewCompletedAt ?? new Date(0).toISOString()
+
+  return {
+    decisionEntryId: buildLegacyDecisionEntryId({
+      routeId: args.sourceRouteId,
+      reviewCompletedAt: args.reviewCompletedAt,
+      reviewOutcome: args.reviewOutcome,
+    }),
+    sourceRouteId: args.sourceRouteId,
+    decision,
+    decisionReason: normalizeText(args.reviewReason) ?? normalizeText(args.latestObservation),
+    nextCheck: normalizeText(args.reviewQuestion),
+    decisionRecordedAt: reviewCompletedAt,
+    reviewCompletedAt: args.reviewCompletedAt,
+  }
+}

--- a/frontend/lib/action-center-decision-history.ts
+++ b/frontend/lib/action-center-decision-history.ts
@@ -75,7 +75,8 @@ export function projectLegacyDecisionRecord(args: {
   const decision = coerceDecision(args.reviewOutcome, args.managementActionOutcome)
   if (!decision) return null
 
-  const reviewCompletedAt = args.reviewCompletedAt ?? new Date(0).toISOString()
+  const reviewCompletedAt = normalizeText(args.reviewCompletedAt)
+  if (!reviewCompletedAt) return null
 
   return {
     decisionEntryId: buildLegacyDecisionEntryId({

--- a/frontend/lib/action-center-live.test.ts
+++ b/frontend/lib/action-center-live.test.ts
@@ -683,4 +683,49 @@ describe('live action center builder', () => {
       ]),
     )
   })
+
+  it('projects latest decision and shared action progress into live items', () => {
+    const items = buildLiveActionCenterItems([
+      {
+        campaign: buildCampaign(),
+        stats: buildStats(),
+        organizationName: 'Acme BV',
+        memberRole: 'owner',
+        scopeType: 'department',
+        scopeValue: 'operations',
+        scopeLabel: 'Operations',
+        peopleCount: 38,
+        assignedManager: {
+          userId: 'manager-1',
+          displayName: 'Sanne de Vries',
+          assignedAt: '2026-04-21T08:00:00.000Z',
+        },
+        deliveryRecord: buildDeliveryRecord({
+          lifecycle_stage: 'first_management_use',
+          first_management_use_confirmed_at: '2026-04-20T09:00:00.000Z',
+          next_step: 'Plan de vervolgcheck met HR en operations.',
+        }),
+        deliveryCheckpoints: [],
+        learningDossier: buildDossier({
+          expected_first_value: 'Maak zichtbaar of de werkdruk lokaal daalt.',
+          first_action_taken: 'Plan een gerichte teamreview met de manager.',
+          review_moment: '2026-05-12',
+          management_action_outcome: 'bijstellen',
+        }),
+        learningCheckpoints: [],
+      },
+    ])
+
+    expect(items).toHaveLength(1)
+    expect(items[0]?.coreSemantics.latestDecision).toMatchObject({
+      decision: 'bijstellen',
+      decisionReason: 'Maak zichtbaar of de werkdruk lokaal daalt.',
+      nextCheck: 'Maak zichtbaar of de werkdruk lokaal daalt.',
+    })
+    expect(items[0]?.coreSemantics.actionProgress).toMatchObject({
+      currentStep: 'Plan een gerichte teamreview met de manager.',
+      nextStep: 'Plan de vervolgcheck met HR en operations.',
+      expectedEffect: 'Maak zichtbaar of de werkdruk lokaal daalt.',
+    })
+  })
 })

--- a/frontend/lib/action-center-live.test.ts
+++ b/frontend/lib/action-center-live.test.ts
@@ -641,6 +641,61 @@ describe('live action center builder', () => {
     ])
   })
 
+  it('records review completion and outcome telemetry only when follow-up review completion truth exists', () => {
+    const campaign = buildCampaign()
+    const deliveryRecord = buildDeliveryRecord({
+      lifecycle_stage: 'follow_up_decided',
+      first_management_use_confirmed_at: '2026-04-20T09:00:00.000Z',
+    })
+    const dossier = buildDossier({
+      review_moment: '2026-05-12',
+      triage_status: 'bevestigd',
+      management_action_outcome: 'bijstellen',
+      adoption_outcome: 'Team koos een aangepaste follow-through na de eerste MT-review.',
+    })
+
+    const events = buildActionCenterTelemetryEvents([
+      {
+        campaign,
+        stats: null,
+        organizationName: 'Acme BV',
+        memberRole: 'owner',
+        scopeType: 'department',
+        scopeValue: 'operations',
+        scopeLabel: 'Operations',
+        peopleCount: 12,
+        assignedManager: {
+          userId: 'manager-1',
+          displayName: 'Manager Operations',
+          assignedAt: '2026-04-21T08:00:00.000Z',
+        } as NonNullable<Parameters<typeof buildActionCenterTelemetryEvents>[0][number]['assignedManager']>,
+        deliveryRecord,
+        deliveryCheckpoints: [],
+        learningDossier: dossier,
+        learningCheckpoints: [
+          {
+            id: 'checkpoint-review',
+            dossier_id: 'dossier-exit',
+            checkpoint_key: 'follow_up_review',
+            owner_label: 'HR lead',
+            status: 'uitgevoerd',
+            objective_signal_notes: null,
+            qualitative_notes: null,
+            interpreted_observation: null,
+            confirmed_lesson: 'De eerste review liet zien dat dezelfde frictie in twee teams terugkomt.',
+            lesson_strength: 'terugkerend_patroon',
+            destination_areas: ['operations'],
+            updated_at: '2026-04-26T10:15:00.000Z',
+            created_at: '2026-04-15T10:00:00.000Z',
+          } as PilotLearningCheckpoint,
+        ],
+      },
+    ])
+
+    expect(events.map((event) => event.eventType)).toContain('action_center_review_completed')
+    expect(events.map((event) => event.eventType)).toContain('action_center_outcome_recorded')
+  })
+
   it('records closeout telemetry for intentionally stopped routes too', () => {
     const events = buildActionCenterTelemetryEvents([
       {
@@ -712,7 +767,23 @@ describe('live action center builder', () => {
           review_moment: '2026-05-12',
           management_action_outcome: 'bijstellen',
         }),
-        learningCheckpoints: [],
+        learningCheckpoints: [
+          {
+            id: 'checkpoint-review',
+            dossier_id: 'dossier-exit',
+            checkpoint_key: 'follow_up_review',
+            owner_label: 'HR lead',
+            status: 'uitgevoerd',
+            objective_signal_notes: null,
+            qualitative_notes: null,
+            interpreted_observation: null,
+            confirmed_lesson: 'De eerste review liet zien dat de werkdruk nog niet daalt.',
+            lesson_strength: 'terugkerend_patroon',
+            destination_areas: ['operations'],
+            updated_at: '2026-04-26T10:15:00.000Z',
+            created_at: '2026-04-15T10:00:00.000Z',
+          } as PilotLearningCheckpoint,
+        ],
       },
     ])
 

--- a/frontend/lib/action-center-live.ts
+++ b/frontend/lib/action-center-live.ts
@@ -340,6 +340,7 @@ export function buildLiveActionCenterItems(contexts: LiveActionCenterCampaignCon
         ...context,
         route,
         latestVisibleUpdateNote: latestUpdate,
+        decisionRecords: [],
       })
       const priority = getPriorityFromSignals({
         exceptionStatus: context.deliveryRecord?.exception_status,

--- a/frontend/lib/action-center-preview-display.test.ts
+++ b/frontend/lib/action-center-preview-display.test.ts
@@ -61,6 +61,20 @@ describe('action center preview display helpers', () => {
           reviewReason: 'Welke vertrekduiding vraagt nu als eerste managementeigenaarschap?',
           blockedBy: null,
         },
+        latestDecision: {
+          decisionEntryId: 'decision-1',
+          sourceRouteId: 'campaign-exit',
+          decision: 'bijstellen',
+          decisionReason: 'Binnen twee weken moet het eerste teamgesprek zijn gevoerd.',
+          nextCheck: 'Toets of het eerste gesprek is gevoerd en of het knelpunt specifieker is geworden.',
+          decisionRecordedAt: '2026-04-22T09:00:00.000Z',
+          reviewCompletedAt: '2026-04-22T09:00:00.000Z',
+        },
+        actionProgress: {
+          currentStep: 'Leg eigenaar en eerste correctie in het MT-overleg vast.',
+          nextStep: 'Plan het vervolggesprek met HR en operations.',
+          expectedEffect: 'Binnen twee weken moet het eerste teamgesprek zijn gevoerd.',
+        },
         reviewSemantics: {
           reviewReason: 'Welke vertrekduiding vraagt nu als eerste managementeigenaarschap?',
           reviewQuestion: 'Binnen twee weken moet het eerste teamgesprek zijn gevoerd.',
@@ -78,15 +92,27 @@ describe('action center preview display helpers', () => {
           whatWeObserved: 'MT kiest een eerste leiderschapsspoor.',
           whatWasDecided: null,
         },
+        decisionHistory: [
+          {
+            decisionEntryId: 'decision-1',
+            sourceRouteId: 'campaign-exit',
+            decision: 'bijstellen',
+            decisionReason: 'Binnen twee weken moet het eerste teamgesprek zijn gevoerd.',
+            nextCheck: 'Toets of het eerste gesprek is gevoerd en of het knelpunt specifieker is geworden.',
+            decisionRecordedAt: '2026-04-22T09:00:00.000Z',
+            reviewCompletedAt: '2026-04-22T09:00:00.000Z',
+          },
+        ],
         closingSemantics: {
           status: 'lopend',
           summary: null,
+          historicalSummary: null,
         },
       },
     } satisfies ActionCenterPreviewItem
 
     expect(buildCompactLandingSummaryLines(item)).toEqual([
-      { label: 'Uitkomst', value: 'Bijstellen' },
+      { label: 'Besluit', value: 'Bijstellen' },
       { label: 'Stap', value: 'Leg eigenaar en eerste correctie in het MT-overleg vast.' },
     ])
   })

--- a/frontend/lib/action-center-preview-route-fields-render.test.ts
+++ b/frontend/lib/action-center-preview-route-fields-render.test.ts
@@ -42,6 +42,72 @@ describe('action center preview route fields render', () => {
           note: 'MT kiest een eerste leiderschapsspoor.',
         },
       ],
+      coreSemantics: {
+        route: {
+          campaignId: 'campaign-exit',
+          entryStage: 'active',
+          routeOpenedAt: '2026-04-20T09:00:00.000Z',
+          ownerAssignedAt: '2026-04-21T08:00:00.000Z',
+          routeStatus: 'in-uitvoering',
+          reviewOutcome: 'bijstellen',
+          reviewCompletedAt: '2026-04-24T09:00:00.000Z',
+          outcomeRecordedAt: '2026-04-24T09:00:00.000Z',
+          outcomeSummary: 'De eerste review liet zien dat dezelfde frictie in twee teams terugkomt.',
+          intervention: 'Leg eigenaar en eerste correctie in het MT-overleg vast.',
+          owner: 'Manager Operations',
+          expectedEffect: 'Binnen twee weken moet het eerste teamgesprek zijn gevoerd.',
+          reviewScheduledFor: '2026-05-12',
+          reviewReason: 'Toets of het eerste gesprek is gevoerd en of het knelpunt specifieker is geworden.',
+          blockedBy: null,
+        },
+        latestDecision: {
+          decisionEntryId: 'decision-1',
+          sourceRouteId: 'campaign-exit',
+          decision: 'bijstellen',
+          decisionReason: 'Toets of het eerste gesprek is gevoerd en of het knelpunt specifieker is geworden.',
+          nextCheck: 'Binnen twee weken moet het eerste teamgesprek zijn gevoerd.',
+          decisionRecordedAt: '2026-04-24T09:00:00.000Z',
+          reviewCompletedAt: '2026-04-24T09:00:00.000Z',
+        },
+        actionProgress: {
+          currentStep: 'Leg eigenaar en eerste correctie in het MT-overleg vast.',
+          nextStep: 'Leg eigenaar en eerste correctie in het MT-overleg vast.',
+          expectedEffect: 'Binnen twee weken moet het eerste teamgesprek zijn gevoerd.',
+        },
+        reviewSemantics: {
+          reviewReason: 'Toets of het eerste gesprek is gevoerd en of het knelpunt specifieker is geworden.',
+          reviewQuestion: 'Binnen twee weken moet het eerste teamgesprek zijn gevoerd.',
+          reviewOutcomeRaw: 'bijstellen',
+          reviewOutcomeVisible: 'bijstellen',
+        },
+        actionFrame: {
+          whyNow: 'Toets of het eerste gesprek is gevoerd en of het knelpunt specifieker is geworden.',
+          firstStep: 'Leg eigenaar en eerste correctie in het MT-overleg vast.',
+          owner: 'Manager Operations',
+          expectedEffect: 'Binnen twee weken moet het eerste teamgesprek zijn gevoerd.',
+        },
+        resultLoop: {
+          whatWasTried: 'MT kiest een eerste leiderschapsspoor.',
+          whatWeObserved: 'MT kiest een eerste leiderschapsspoor.',
+          whatWasDecided: 'Bijstellen',
+        },
+        decisionHistory: [
+          {
+            decisionEntryId: 'decision-1',
+            sourceRouteId: 'campaign-exit',
+            decision: 'bijstellen',
+            decisionReason: 'Toets of het eerste gesprek is gevoerd en of het knelpunt specifieker is geworden.',
+            nextCheck: 'Binnen twee weken moet het eerste teamgesprek zijn gevoerd.',
+            decisionRecordedAt: '2026-04-24T09:00:00.000Z',
+            reviewCompletedAt: '2026-04-24T09:00:00.000Z',
+          },
+        ],
+        closingSemantics: {
+          status: 'lopend',
+          summary: null,
+          historicalSummary: null,
+        },
+      },
     })
 
     const html = renderToStaticMarkup(

--- a/frontend/lib/action-center-preview-route-fields-render.test.ts
+++ b/frontend/lib/action-center-preview-route-fields-render.test.ts
@@ -1,11 +1,11 @@
 import React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
-import { ActionCenterPreview } from '@/components/dashboard/action-center-preview'
+import { ActionCenterPreview, buildCompactLandingSummaryLines } from '@/components/dashboard/action-center-preview'
 import { finalizeActionCenterPreviewItem } from '@/lib/action-center-live'
 
 describe('action center preview route fields render', () => {
-  it('renders expected effect, review reason, and review outcome in the detail experience', () => {
+  it('renders decision-first review meaning and action progression in the detail experience', () => {
     const item = finalizeActionCenterPreviewItem({
       id: 'route-1',
       code: 'ACT-1001',
@@ -55,11 +55,88 @@ describe('action center preview route fields render', () => {
       }),
     )
 
-    expect(html).toContain('Verwacht effect')
-    expect(html).toContain('Binnen twee weken moet het eerste teamgesprek zijn gevoerd.')
-    expect(html).toContain('Waarom we opnieuw kijken')
-    expect(html).toContain('Toets of het eerste gesprek is gevoerd en of het knelpunt specifieker is geworden.')
-    expect(html).toContain('Laatste reviewuitkomst')
+    expect(html).toContain('Laatste beslissing')
     expect(html).toContain('Bijstellen')
+    expect(html).toContain('Waarom dit besluit')
+    expect(html).toContain('Toets of het eerste gesprek is gevoerd en of het knelpunt specifieker is geworden.')
+    expect(html).toContain('Volgende toets')
+    expect(html).toContain('Binnen twee weken moet het eerste teamgesprek zijn gevoerd.')
+    expect(html).toContain('Huidige stap')
+    expect(html).toContain('Leg eigenaar en eerste correctie in het MT-overleg vast.')
+    expect(html).toContain('Hierna')
+    expect(html).toContain('Verwacht effect')
+  })
+
+  it('builds compact landing summary lines from latest decision and current step', () => {
+    const item = finalizeActionCenterPreviewItem({
+      id: 'route-1',
+      code: 'ACT-1001',
+      title: 'Werkdruk blijft hoog in Operations',
+      summary: 'De route vraagt een nieuwe lokale stap.',
+      reason: 'Werkdruk bleef zichtbaar na de eerste interventie.',
+      sourceLabel: 'ExitScan',
+      orgId: 'org-1',
+      scopeType: 'department',
+      teamId: 'operations',
+      teamLabel: 'Operations',
+      ownerId: 'manager-1',
+      ownerName: 'Sanne de Vries',
+      ownerRole: 'Manager - Operations',
+      ownerSubtitle: 'Operations',
+      reviewOwnerName: 'Sanne de Vries',
+      priority: 'hoog',
+      status: 'in-uitvoering',
+      reviewDate: '2026-05-02',
+      expectedEffect: 'Zichtbaar maken of de werkdruk lokaal afneemt.',
+      reviewReason: 'De eerste teamreview gaf nog geen stabiele verbetering.',
+      reviewOutcome: 'bijstellen',
+      reviewDateLabel: '2 mei',
+      reviewRhythm: 'Wekelijks',
+      signalLabel: 'ExitScan - Operations',
+      signalBody: 'Werkdruk bleef zichtbaar in hetzelfde team.',
+      nextStep: 'Herplan de teamreview voor volgende week.',
+      peopleCount: 14,
+      updates: [],
+      coreSemantics: {
+        route: {} as never,
+        reviewSemantics: {} as never,
+        latestDecision: {
+          decisionEntryId: 'decision-1',
+          sourceRouteId: 'route-1',
+          decision: 'bijstellen',
+          decisionReason: 'De eerste teamreview gaf nog geen stabiele verbetering.',
+          nextCheck: 'Toets over een week of de teamdruk zichtbaar daalt.',
+          decisionRecordedAt: '2026-04-25T10:00:00.000Z',
+          reviewCompletedAt: '2026-04-25T09:30:00.000Z',
+        },
+        actionProgress: {
+          currentStep: 'Plan een gerichte teamreview met de manager.',
+          nextStep: 'Herplan de teamreview voor volgende week.',
+          expectedEffect: 'Zichtbaar maken of de werkdruk lokaal afneemt.',
+        },
+        actionFrame: {
+          whyNow: 'Werkdruk bleef zichtbaar na de eerste interventie.',
+          firstStep: 'Plan een gerichte teamreview met de manager.',
+          owner: 'Sanne de Vries',
+          expectedEffect: 'Zichtbaar maken of de werkdruk lokaal afneemt.',
+        },
+        resultLoop: {
+          whatWasTried: 'Plan een gerichte teamreview met de manager.',
+          whatWeObserved: 'Werkdruk bleef zichtbaar in hetzelfde team.',
+          whatWasDecided: 'Bijstellen',
+        },
+        decisionHistory: [],
+        closingSemantics: {
+          status: 'lopend',
+          summary: null,
+          historicalSummary: null,
+        },
+      },
+    })
+
+    expect(buildCompactLandingSummaryLines(item)).toEqual([
+      { label: 'Besluit', value: 'Bijstellen' },
+      { label: 'Stap', value: 'Plan een gerichte teamreview met de manager.' },
+    ])
   })
 })

--- a/frontend/lib/action-center-route-contract.ts
+++ b/frontend/lib/action-center-route-contract.ts
@@ -1,5 +1,6 @@
 import type { DeliveryExceptionStatus } from '@/lib/ops-delivery'
 import type { LiveActionCenterCampaignContext } from './action-center-live'
+import type { PilotLearningCheckpoint } from './pilot-learning'
 
 export type ActionCenterEntryStage = 'attention' | 'candidate' | 'active'
 
@@ -101,6 +102,20 @@ function getOutcomeSummary(context: LiveActionCenterCampaignContext) {
   return normalizeText(context.learningDossier?.case_public_summary) ?? normalizeText(context.learningDossier?.adoption_outcome)
 }
 
+function getLearningCheckpoint(context: LiveActionCenterCampaignContext, key: PilotLearningCheckpoint['checkpoint_key']) {
+  return context.learningCheckpoints.find((checkpoint) => checkpoint.checkpoint_key === key) ?? null
+}
+
+function isCompletedReviewCheckpoint(checkpoint: PilotLearningCheckpoint | null) {
+  if (!checkpoint) return false
+
+  return (
+    checkpoint.status === 'bevestigd' ||
+    checkpoint.status === 'uitgevoerd' ||
+    checkpoint.status === 'verworpen'
+  )
+}
+
 function hasCandidateTruth(context: LiveActionCenterCampaignContext) {
   return Boolean(
     getOwner(context) ??
@@ -143,7 +158,13 @@ export function projectActionCenterRoute(context: LiveActionCenterCampaignContex
   const reviewScheduledFor = getReviewScheduledFor(context)
   const reviewReason = getReviewReason(context)
   const reviewOutcome = getReviewOutcome(context)
+  const followUpReviewCheckpoint = getLearningCheckpoint(context, 'follow_up_review')
+  const reviewCompletedAt =
+    reviewOutcome !== 'geen-uitkomst' && isCompletedReviewCheckpoint(followUpReviewCheckpoint)
+      ? normalizeText(followUpReviewCheckpoint?.updated_at)
+      : null
   const outcomeSummary = getOutcomeSummary(context)
+  const outcomeRecordedAt = reviewCompletedAt && outcomeSummary ? reviewCompletedAt : null
   const blockedBy =
     context.deliveryRecord?.exception_status && context.deliveryRecord.exception_status !== 'none'
       ? context.deliveryRecord.exception_status
@@ -172,8 +193,8 @@ export function projectActionCenterRoute(context: LiveActionCenterCampaignContex
     ownerAssignedAt,
     routeStatus,
     reviewOutcome,
-    reviewCompletedAt: null,
-    outcomeRecordedAt: null,
+    reviewCompletedAt,
+    outcomeRecordedAt,
     outcomeSummary,
     intervention,
     owner,

--- a/frontend/lib/action-center-route-contract.ts
+++ b/frontend/lib/action-center-route-contract.ts
@@ -18,6 +18,24 @@ export type ActionCenterReviewOutcome =
   | 'afronden'
   | 'stoppen'
 
+export type ActionCenterDecision =
+  | 'doorgaan'
+  | 'bijstellen'
+  | 'afronden'
+  | 'stoppen'
+
+export interface ActionCenterDecisionRecord {
+  decisionEntryId: string
+  sourceRouteId: string
+  decision: ActionCenterDecision
+  decisionReason: string | null
+  nextCheck: string | null
+  decisionRecordedAt: string
+  reviewCompletedAt: string | null
+  currentStepSnapshot?: string | null
+  observationSnapshot?: string | null
+}
+
 export interface ActionCenterRouteContract {
   campaignId: string
   entryStage: ActionCenterEntryStage

--- a/frontend/lib/telemetry/events.ts
+++ b/frontend/lib/telemetry/events.ts
@@ -3,9 +3,9 @@ export type SuiteTelemetryEventType =
   | 'first_value_confirmed'
   | 'first_management_use_confirmed'
   | 'manager_denied_insights'
-  | 'action_center_review_scheduled'
   | 'action_center_route_opened'
   | 'action_center_owner_assigned'
+  | 'action_center_review_scheduled'
   | 'action_center_review_completed'
   | 'action_center_outcome_recorded'
   | 'action_center_closeout_recorded'
@@ -34,9 +34,9 @@ export function isSuiteTelemetryEventType(value: string): value is SuiteTelemetr
     value === 'first_value_confirmed' ||
     value === 'first_management_use_confirmed' ||
     value === 'manager_denied_insights' ||
-    value === 'action_center_review_scheduled' ||
     value === 'action_center_route_opened' ||
     value === 'action_center_owner_assigned' ||
+    value === 'action_center_review_scheduled' ||
     value === 'action_center_review_completed' ||
     value === 'action_center_outcome_recorded' ||
     value === 'action_center_closeout_recorded'
@@ -67,9 +67,9 @@ export function countSuiteTelemetryEvents(events: SuiteTelemetryEvent[]) {
       first_value_confirmed: 0,
       first_management_use_confirmed: 0,
       manager_denied_insights: 0,
-      action_center_review_scheduled: 0,
       action_center_route_opened: 0,
       action_center_owner_assigned: 0,
+      action_center_review_scheduled: 0,
       action_center_review_completed: 0,
       action_center_outcome_recorded: 0,
       action_center_closeout_recorded: 0,
@@ -91,12 +91,12 @@ export function getSuiteTelemetryEventLabel(eventType: SuiteTelemetryEventType) 
       return 'First management use confirmed'
     case 'manager_denied_insights':
       return 'Manager denied insights'
-    case 'action_center_review_scheduled':
-      return 'Action Center review scheduled'
     case 'action_center_route_opened':
       return 'Action Center route opened'
     case 'action_center_owner_assigned':
       return 'Action Center owner assigned'
+    case 'action_center_review_scheduled':
+      return 'Action Center review scheduled'
     case 'action_center_review_completed':
       return 'Action Center review completed'
     case 'action_center_outcome_recorded':


### PR DESCRIPTION
## Summary
- port the verified Action Center decision-history phase onto current `main`
- add the canonical decision-history contract and shared decision-first semantics projection
- upgrade Action Center landing/detail to show compact decision summaries on landing and richer decision/action/result semantics on detail
- keep managers read-only in this phase while strengthening HR/Verisight route truth
- bring the admin customer-learnings preview onto the same shared Action Center finalizer
- include the phase spec and implementation plan on the clean branch

## Scope
This phase adds:
- canonical `decision`, `decisionReason`, `nextCheck` decision-history records
- shared projection for `latestDecision`, `actionProgress`, `decisionHistory`
- decision-first Action Center detail rendering
- compact landing summaries for `Besluit` and `Stap`
- supporting telemetry event types used by the ported live semantics

This phase does not add:
- manager input flows
- broader workflow forms
- multi-step task management

## Verification
- `npm test -- "lib/action-center-decision-history.test.ts" "lib/action-center-core-semantics.test.ts" "lib/action-center-live.test.ts" "lib/action-center-preview-display.test.ts" "lib/action-center-preview-route-fields-render.test.ts" "app/(dashboard)/action-center/page.route-shell.test.ts"`
- `npx eslint "app/(dashboard)/beheer/klantlearnings/page.tsx" "components/dashboard/action-center-preview.tsx" "lib/telemetry/events.ts" "lib/action-center-route-contract.ts" "lib/action-center-decision-history.ts" "lib/action-center-core-semantics.ts" "lib/action-center-live.ts" "app/(dashboard)/action-center/page.tsx"`
- `npm run build`

## Notes
- this PR is the clean follow-up after closing the earlier broad decision-history PR attempt
- the port is aligned to current `main`'s file layout rather than the older feature-line branch structure