### PR TITLE
[codex] Add authored Action Center review decisions

### DIFF
--- a/docs/superpowers/plans/2026-04-29-action-center-review-decisions.md
+++ b/docs/superpowers/plans/2026-04-29-action-center-review-decisions.md
@@ -1,0 +1,169 @@
+# Action Center Review Decisions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an authored internal review-decision layer for Action Center so richer decisions, step progression, and result loops over time come from one canonical write-path instead of legacy projection alone.
+
+**Architecture:** Introduce one small `action_center_review_decisions` persistence layer tied to existing learning dossiers/checkpoints, consume it through one shared server/lib pipeline, and keep Action Center itself read-only while an internal beheer write-surface manages the new records. Preserve legacy fallback only for routes that do not yet have any authored decisions.
+
+**Tech Stack:** Supabase/Postgres, Next.js App Router, TypeScript, React, Vitest, ESLint
+
+---
+
+## File structure
+
+### Existing files to modify
+
+- `supabase/schema.sql`
+  - Add the new `action_center_review_decisions` table, indexes, and RLS/policies.
+- `frontend/lib/pilot-learning.ts`
+  - Add types and helpers for authored review decisions.
+- `frontend/lib/action-center-route-contract.ts`
+  - Add hooks for authored review decisions alongside existing route truth.
+- `frontend/lib/action-center-decision-history.ts`
+  - Make authored decisions the primary source, with legacy fallback only when no authored decision exists.
+- `frontend/lib/action-center-core-semantics.ts`
+  - Consume authored `latestDecision`, `actionProgress`, and `decisionHistory`.
+- `frontend/lib/action-center-live.ts`
+  - Pipe authored review decisions into preview items and shared semantics.
+- `frontend/components/dashboard/action-center-preview.tsx`
+  - Render the richer authored semantics without adding manager input.
+- `frontend/app/(dashboard)/beheer/klantlearnings/page.tsx`
+  - Surface a small internal authored decision editor/readout in the existing beheer flow.
+- `frontend/app/api/learning-dossiers/[id]/route.ts`
+  - Optionally expose authored decision summaries in dossier fetch/update flows when needed.
+- `frontend/app/api/learning-checkpoints/[id]/route.ts`
+  - Validate coupling to `follow_up_review` / `first_management_use` as needed.
+- `frontend/lib/action-center-core-semantics.test.ts`
+- `frontend/lib/action-center-decision-history.test.ts`
+- `frontend/lib/action-center-live.test.ts`
+- `frontend/lib/action-center-preview-display.test.ts`
+- `frontend/lib/action-center-preview-route-fields-render.test.ts`
+- `frontend/app/(dashboard)/action-center/page.route-shell.test.ts`
+
+### New files to create
+
+- `frontend/lib/action-center-review-decisions.ts`
+  - Server/client-safe shared types, validation helpers, and mappers for authored review decisions.
+- `frontend/app/api/action-center-review-decisions/route.ts`
+  - Create endpoint for new authored decision records.
+- `frontend/app/api/action-center-review-decisions/[id]/route.ts`
+  - Update endpoint for authored decision records.
+- `frontend/lib/action-center-review-decisions.test.ts`
+  - Unit tests for authored decision coercion, selection, and fallback cutover rules.
+
+### Boundaries to preserve
+
+- Do not add manager write flows.
+- Do not move review decision authoring into Action Center.
+- Do not introduce a broad event timeline or task system.
+
+---
+
+### Task 1: Add the authored review decision schema and shared types
+
+**Files:**
+- Modify: `supabase/schema.sql`
+- Modify: `frontend/lib/pilot-learning.ts`
+- Create: `frontend/lib/action-center-review-decisions.ts`
+- Test: `frontend/lib/action-center-review-decisions.test.ts`
+
+- [ ] **Step 1: Add failing tests for authored decision shape and fallback cutover**
+- [ ] **Step 2: Run `npm test -- "lib/action-center-review-decisions.test.ts"` and confirm failure**
+- [ ] **Step 3: Add `action_center_review_decisions` schema, indexes, and admin-only policies in `supabase/schema.sql`**
+- [ ] **Step 4: Add `ActionCenterReviewDecision` types plus small validation helpers in `pilot-learning.ts` and the new review-decisions lib**
+- [ ] **Step 5: Re-run `npm test -- "lib/action-center-review-decisions.test.ts"` and make it pass**
+- [ ] **Step 6: Commit with `feat: add authored action center review decision contract`**
+
+### Task 2: Add internal admin APIs for authored decisions
+
+**Files:**
+- Create: `frontend/app/api/action-center-review-decisions/route.ts`
+- Create: `frontend/app/api/action-center-review-decisions/[id]/route.ts`
+- Modify: `frontend/lib/action-center-review-decisions.ts`
+- Test: `frontend/lib/action-center-review-decisions.test.ts`
+
+- [ ] **Step 1: Write failing tests for create/update validation and coupling to review checkpoints**
+- [ ] **Step 2: Run the targeted test file and confirm failure**
+- [ ] **Step 3: Implement create API with admin auth, required `routeSourceId`, `checkpointId`, `decision`, `decisionReason`, `nextCheck`, `currentStep`, `nextStep`, `expectedEffect`**
+- [ ] **Step 4: Implement update API with the same validation and no manager access**
+- [ ] **Step 5: Re-run the targeted API/mapper tests**
+- [ ] **Step 6: Commit with `feat: add action center review decision admin apis`**
+
+### Task 3: Make authored decisions the primary Action Center source
+
+**Files:**
+- Modify: `frontend/lib/action-center-route-contract.ts`
+- Modify: `frontend/lib/action-center-decision-history.ts`
+- Modify: `frontend/lib/action-center-core-semantics.ts`
+- Modify: `frontend/lib/action-center-live.ts`
+- Test: `frontend/lib/action-center-core-semantics.test.ts`
+- Test: `frontend/lib/action-center-decision-history.test.ts`
+- Test: `frontend/lib/action-center-live.test.ts`
+
+- [ ] **Step 1: Add failing tests for “authored decisions win fully over legacy fallback”**
+- [ ] **Step 2: Run the three targeted semantic/history/live tests and confirm failure**
+- [ ] **Step 3: Thread authored review decisions into route projection**
+- [ ] **Step 4: Update decision-history logic so authored history is primary and legacy fallback only applies when zero authored decisions exist**
+- [ ] **Step 5: Update core semantics and live preview builders to use authored `latestDecision`, `actionProgress`, and `decisionHistory`**
+- [ ] **Step 6: Re-run the three targeted test files and make them pass**
+- [ ] **Step 7: Commit with `feat: consume authored review decisions in action center semantics`**
+
+### Task 4: Add the internal beheer write-surface
+
+**Files:**
+- Modify: `frontend/app/(dashboard)/beheer/klantlearnings/page.tsx`
+- Modify: `frontend/lib/action-center-live.ts`
+- Modify: `frontend/lib/action-center-preview-display.test.ts`
+- Modify: `frontend/lib/action-center-preview-route-fields-render.test.ts`
+
+- [ ] **Step 1: Add failing render tests for authored decision visibility and compact admin write context**
+- [ ] **Step 2: Run the targeted render tests and confirm failure**
+- [ ] **Step 3: Add a small authored review-decision editor/readout in klantlearnings tied to the review checkpoint context**
+- [ ] **Step 4: Keep Action Center read-only and consume the authored output only through shared semantics**
+- [ ] **Step 5: Re-run the targeted render tests and make them pass**
+- [ ] **Step 6: Commit with `feat: add internal authored review decision surface`**
+
+### Task 5: Final verification and documentation closeout
+
+**Files:**
+- Modify only if verification exposes drift
+
+- [ ] **Step 1: Run the authored decision test set**
+
+Run:
+
+```bash
+npm test -- "lib/action-center-review-decisions.test.ts" "lib/action-center-decision-history.test.ts" "lib/action-center-core-semantics.test.ts" "lib/action-center-live.test.ts" "lib/action-center-preview-display.test.ts" "lib/action-center-preview-route-fields-render.test.ts" "app/(dashboard)/action-center/page.route-shell.test.ts"
+```
+
+- [ ] **Step 2: Run lint on the touched files**
+
+Run:
+
+```bash
+npx eslint "lib/action-center-review-decisions.ts" "lib/action-center-route-contract.ts" "lib/action-center-decision-history.ts" "lib/action-center-core-semantics.ts" "lib/action-center-live.ts" "components/dashboard/action-center-preview.tsx" "app/(dashboard)/beheer/klantlearnings/page.tsx" "app/api/action-center-review-decisions/route.ts" "app/api/action-center-review-decisions/[id]/route.ts"
+```
+
+- [ ] **Step 3: Run production build**
+
+Run:
+
+```bash
+npm run build
+```
+
+- [ ] **Step 4: Commit verification fixes if needed**
+
+```bash
+git add .
+git commit -m "test: verify authored action center review decisions"
+```
+
+- [ ] **Step 5: Prepare PR summary**
+
+Include:
+- canonical authored review decision write-path
+- authored step progression and result loop over time
+- managers still read-only
+- legacy fallback only for zero-authored-decision routes

--- a/docs/superpowers/specs/2026-04-29-action-center-review-decisions-design.md
+++ b/docs/superpowers/specs/2026-04-29-action-center-review-decisions-design.md
@@ -1,0 +1,348 @@
+# Action Center Review Decisions Design
+
+Date: 2026-04-29  
+Scope: Eerstvolgende schone Action Center-fase na de gemergede decision-history port op `main`  
+Status: Draft spec
+
+## 1. Doel
+
+Deze fase maakt de decision-history laag echt authored en bruikbaar over tijd.
+
+De vorige fase heeft Action Center semantisch rijker gemaakt in presentatie:
+- `latestDecision`
+- `actionProgress`
+- `decisionHistory`
+
+Maar die laag leunt nog grotendeels op legacy dossier- en checkpointtruth. Daardoor is de UI sterker geworden dan de onderliggende bestuurlijke write-path.
+
+Het doel van deze fase is daarom:
+- reviewbeslissingen canoniek vastleggen
+- actiekwaliteit explicieter vastleggen
+- resultaatlus over meerdere beslismomenten laten leven
+- zonder managers extra invoerlast te geven
+
+Na deze fase moet een route niet alleen beter tonen wat er besloten lijkt te zijn, maar ook echt gedragen worden door een kleine interne truth-laag die meerdere reviewmomenten kan opslaan.
+
+## 2. Productgrens
+
+Wel in scope:
+- een kleine authored review-decision truth
+- authored `currentStep`, `nextStep`, `expectedEffect`
+- authored `decisionReason` en `nextCheck`
+- een compacte decision history over meerdere momenten
+- een interne Verisight/HR write-path
+- Action Center landing/detail die primair uit die waarheid projecteren
+
+Niet in scope:
+- managerinput in Action Center
+- nieuwe managerformulieren
+- brede workflow of task-management
+- uitgebreide timeline van alle events
+- nieuwe HR-suite work buiten Action Center en de interne beheerlaag
+- escalatie- of governancevarianten zoals `opschalen`, `borgen`, `archiveren`
+
+De kernregel blijft:
+- rijkere bestuurlijke waarheid
+- niet meer eindgebruikersbediening
+
+## 3. Gekozen aanpak
+
+De juiste aanpak voor deze fase is `authored-decision-first`.
+
+Niet:
+- nog meer legacy projectie maken uit dossiers/checkpoints
+- of meteen managerinteractie toevoegen
+
+Wel:
+1. één kleine canonieke `review decision` recordlaag toevoegen
+2. die recordlaag koppelen aan een route en een reviewmoment
+3. authored actieprogressie aan dezelfde recordlaag hangen
+4. Action Center laten lezen uit die recordlaag, met legacy fallback alleen voor oudere routes
+5. de interne write-path onderbrengen in bestaande Verisight-beheerflows, niet in manager-UI
+
+Dat maakt de volgende stap inhoudelijk sterk, maar houdt de UX nog steeds rustig.
+
+## 4. Canonieke truth-laag
+
+### 4.1 Nieuw record
+
+Deze fase introduceert één nieuwe canonieke entiteit:
+- `ActionCenterReviewDecision`
+
+Per record leggen we vast:
+- `id`
+- `routeSourceType`
+- `routeSourceId`
+- `checkpointId`
+- `decision`
+- `decisionReason`
+- `nextCheck`
+- `currentStep`
+- `nextStep`
+- `expectedEffect`
+- `observationSnapshot`
+- `decisionRecordedAt`
+- `reviewCompletedAt`
+- `createdBy`
+- `updatedBy`
+- `createdAt`
+- `updatedAt`
+
+### 4.2 Canonieke betekenis
+
+`decision`
+- bestuurlijk besluit van dit reviewmoment
+- waarden in deze fase:
+  - `doorgaan`
+  - `bijstellen`
+  - `afronden`
+  - `stoppen`
+
+`decisionReason`
+- de compacte reden waarom juist dit besluit nu logisch is
+
+`nextCheck`
+- wat bij de volgende toets zichtbaar of duidelijker moet zijn
+
+`currentStep`
+- welke stap nu de actieve route-interventie is
+
+`nextStep`
+- welke volgende kleine stap daarna logisch volgt
+
+`expectedEffect`
+- welk effect of welke verduidelijking deze stap moet opleveren
+
+`observationSnapshot`
+- de relevante observatie op dit beslismoment
+- compact en routegericht, niet een volledige notulenlaag
+
+### 4.3 Identity en ordering
+
+Deze laag moet stabiel identificeerbaar en sorteerbaar zijn.
+
+Canonieke identity:
+- `id` is de enige primaire identity
+
+Canonieke ordering:
+1. `decisionRecordedAt` descending
+2. `reviewCompletedAt` descending
+3. `createdAt` descending
+4. `id` ascending als laatste tie-breaker
+
+Dus:
+- decision history wordt nooit meer gebouwd op impliciete updatevolgorde
+- en ook niet op dossiertekst alleen
+
+## 5. Canonieke source- en write-regel
+
+### 5.1 Enige write-path
+
+Voor nieuwe reviewbeslissingen geldt één harde regel:
+- nieuwe decision/history truth wordt uitsluitend geschreven via `ActionCenterReviewDecision`
+
+Dus niet:
+- soms via dossiervelden
+- soms via checkpointvelden
+- soms via componentlocal state
+
+Bestaande dossiervelden zoals:
+- `first_action_taken`
+- `first_management_value`
+- `management_action_outcome`
+- `expected_first_value`
+
+blijven bestaan als legacy/seedinput, maar zijn niet langer de canonieke write-path voor nieuwe reviewbesluiten.
+
+### 5.2 Interne owner
+
+Deze write-path is in deze fase alleen beschikbaar voor:
+- Verisight admin / interne HR-operatie
+
+Managers:
+- blijven read-only
+- zien de rijkere waarheid wel
+- schrijven er nog niet naar
+
+### 5.3 Write-surface
+
+De authored decision-truth wordt in deze fase niet direct in Action Center geschreven.
+
+De write-surface komt in de bestaande interne beheerlaag rond learning dossiers/checkpoints, specifiek:
+- gekoppeld aan `follow_up_review`
+- en waar nodig aan `first_management_use` voor de eerste authored stapkwaliteit
+
+Dat houdt Action Center zelf schoon als consumptielaag.
+
+## 6. Relatie met bestaande learning truth
+
+De nieuwe truth-laag vervangt de learning dossiers/checkpoints niet.
+
+De rolverdeling wordt:
+
+`PilotLearningDossier`
+- blijft de bredere context, oorsprong en legacy carrier
+
+`PilotLearningCheckpoint`
+- blijft het reviewanker en operationele checkpoint
+
+`ActionCenterReviewDecision`
+- wordt de canonieke bestuurlijke besluit- en voortgangslaag voor Action Center
+
+Dus:
+- dossiers en checkpoints beschrijven de context
+- review decisions beschrijven wat bestuurlijk is besloten en hoe de route vooruitgaat
+
+## 7. Projectieregels
+
+### 7.1 Primair
+
+Action Center projecteert vanaf nu primair uit authored decisions.
+
+Per route:
+- `latestDecision` = meest recente authored decision
+- `decisionHistory` = alle authored decisions volgens de vaste ordering
+- `actionProgress.currentStep` = `currentStep` van de laatste authored decision
+- `actionProgress.nextStep` = `nextStep` van de laatste authored decision
+- `actionProgress.expectedEffect` = `expectedEffect` van de laatste authored decision
+- `resultLoop.whatWeObserved` = `observationSnapshot` van de laatste authored decision
+- `resultLoop.whatWasDecided` = zichtbare label van `decision`
+
+### 7.2 Legacy fallback
+
+Voor routes zonder authored decisions blijft één tijdelijke fallback bestaan:
+- projecteer uit de bestaande decision-history helpers en dossier/checkpointtruth
+
+Regel:
+- zodra een route minstens één authored decision heeft, wint authored truth volledig
+- we mengen authored en legacy entries niet door elkaar binnen dezelfde history
+
+Dus:
+- zero authored decisions = legacy fallback toegestaan
+- one or more authored decisions = alleen authored history zichtbaar
+
+Dat voorkomt half gemengde routeverhalen.
+
+## 8. UI-gedrag
+
+### 8.1 Action Center landing
+
+Landing blijft compact.
+
+Laat alleen zien:
+- laatste beslissing
+- huidige stap
+- eventueel een compacte volgende toets als dat helpt
+
+Geen uitgebreide history op landing.
+
+### 8.2 Action Center detail
+
+Detail wordt de plek waar de authored truth volledig zichtbaar wordt:
+- laatste beslissing
+- reden van het besluit
+- volgende toets
+- huidige stap
+- hierna
+- verwacht effect
+- kernobservatie
+- compacte beslisgeschiedenis
+
+### 8.3 Managers
+
+Managers blijven read-only.
+
+Zij zien:
+- duidelijker waarom iets doorloopt, bijgesteld wordt, afgerond of gestopt is
+- beter welke stap nu geldt
+- beter hoe de route zich ontwikkelt
+
+Maar zij voeren in deze fase niets in.
+
+### 8.4 Verisight / interne HR
+
+De interne beheerlaag krijgt een beperkte authored write-capability:
+- nieuwe review decision toevoegen
+- bestaande review decision bijwerken
+
+Niet:
+- uitgebreide bulkbewerkingen
+- matrixschermen
+- multi-actor review approvals
+
+## 9. Resultaatlus over tijd
+
+De kernwinst van deze fase is dat resultaat niet meer alleen de laatste projectie is, maar authored over meerdere momenten.
+
+Een goede decision history laat dan compact zien:
+- welke stap toen liep
+- wat toen zichtbaar werd
+- wat toen besloten werd
+- wat daarna de volgende toets werd
+
+Dat maakt de route:
+- minder impressionistisch
+- minder afhankelijk van losse updatecopy
+- en veel sterker als intern managementdossier
+
+## 10. Telemetry en bewijs
+
+Omdat review decisions nu authored worden, kunnen telemetry-events ook scherper worden.
+
+Minimaal willen we kunnen onderscheiden:
+- authored review decision created
+- authored review decision updated
+- route consumed with authored decision history present
+
+Deze fase hoeft nog geen groot analyticsdashboard te bouwen.
+
+Maar we willen wel dat de nieuwe waarheid bewijsbaar gebruikt en onderscheiden kan worden.
+
+## 11. Guardrails
+
+Niet doen in deze fase:
+- authored decisions in manager-UI stoppen
+- meerdere open current steps tegelijk ondersteunen
+- decision history combineren met alle update-events
+- authored truth in verschillende tabellen dupliceren
+- Action Center ombouwen tot taskboard
+
+De juiste zwaarte is:
+- één kleine decision-table
+- één kleine interne write-surface
+- één veel sterkere read-model in Action Center
+
+## 12. Succescriteria
+
+Deze fase is geslaagd als:
+
+### Truth
+- nieuwe reviewbesluiten hebben één duidelijke canonieke write-path
+- action progression is authored en niet meer half projectie / half legacy
+
+### UI
+- Action Center detail laat duidelijk authored bestuurlijke voortgang zien
+- managers begrijpen de route beter zonder extra handelingen
+
+### History
+- routes met meerdere reviewmomenten tonen een compacte, stabiele authored history
+- ordering en identity zijn consistent over surfaces en tests
+
+### Scope-discipline
+- managerinteractie is nog steeds afwezig
+- de module blijft rustig
+- de write-path blijft intern en beperkt
+
+## 13. Volgende logische stap hierna
+
+Pas na deze fase wordt het gezond om te beoordelen:
+- welke beperkte managerinteractie echt nuttig is
+- of managers één stap, reviewuitkomst of update zelf moeten kunnen bevestigen
+
+Dus eerst:
+- authored review decisions
+- authored actieprogressie
+- authored resultaatlus
+
+Daarna pas:
+- minimale manager write-interactie

--- a/frontend/app/(dashboard)/action-center/page.tsx
+++ b/frontend/app/(dashboard)/action-center/page.tsx
@@ -9,7 +9,11 @@ import {
 import { loadSuiteAccessContext } from '@/lib/suite-access-server'
 import { createClient } from '@/lib/supabase/server'
 import type { CampaignDeliveryCheckpoint, CampaignDeliveryRecord } from '@/lib/ops-delivery'
-import type { PilotLearningCheckpoint, PilotLearningDossier } from '@/lib/pilot-learning'
+import type {
+  ActionCenterReviewDecision,
+  PilotLearningCheckpoint,
+  PilotLearningDossier,
+} from '@/lib/pilot-learning'
 import type { Campaign, CampaignStats, Organization } from '@/lib/types'
 
 type RespondentDepartmentRow = {
@@ -143,7 +147,7 @@ export default async function ActionCenterPage({
 
   const respondentsWithDepartments = (respondentsWithDepartmentsRaw ?? []) as RespondentDepartmentRow[]
 
-  const [{ data: deliveryCheckpointsRaw }, { data: learningCheckpointsRaw }] = await Promise.all([
+  const [{ data: deliveryCheckpointsRaw }, { data: learningCheckpointsRaw }, { data: reviewDecisionsRaw }] = await Promise.all([
     deliveryRecords.length > 0
       ? dataClient
           .from('campaign_delivery_checkpoints')
@@ -162,10 +166,18 @@ export default async function ActionCenterPage({
             dossiers.map((dossier) => dossier.id),
           )
       : Promise.resolve({ data: [] }),
+    campaignIds.length > 0
+      ? dataClient
+          .from('action_center_review_decisions')
+          .select('*')
+          .eq('route_source_type', 'campaign')
+          .in('route_source_id', campaignIds)
+      : Promise.resolve({ data: [] }),
   ])
 
   const deliveryCheckpoints = (deliveryCheckpointsRaw ?? []) as CampaignDeliveryCheckpoint[]
   const learningCheckpoints = (learningCheckpointsRaw ?? []) as PilotLearningCheckpoint[]
+  const reviewDecisions = (reviewDecisionsRaw ?? []) as ActionCenterReviewDecision[]
 
   const organizationById = new Map(organizations.map((organization) => [organization.id, organization]))
   const roleByOrgId = orgMemberships.reduce<Record<string, 'owner' | 'member' | 'viewer'>>((acc, membership) => {
@@ -185,6 +197,11 @@ export default async function ActionCenterPage({
   const learningCheckpointMap = learningCheckpoints.reduce<Record<string, PilotLearningCheckpoint[]>>((acc, checkpoint) => {
     acc[checkpoint.dossier_id] ??= []
     acc[checkpoint.dossier_id].push(checkpoint)
+    return acc
+  }, {})
+  const reviewDecisionMap = reviewDecisions.reduce<Record<string, ActionCenterReviewDecision[]>>((acc, record) => {
+    acc[record.route_source_id] ??= []
+    acc[record.route_source_id].push(record)
     return acc
   }, {})
   const respondentDepartmentsByCampaign = respondentsWithDepartments.reduce<Record<string, string[]>>((acc, row) => {
@@ -246,6 +263,7 @@ export default async function ActionCenterPage({
           deliveryCheckpoints: deliveryRecord ? (deliveryCheckpointMap[deliveryRecord.id] ?? []) : [],
           learningDossier,
           learningCheckpoints: learningDossier ? (learningCheckpointMap[learningDossier.id] ?? []) : [],
+          reviewDecisions: reviewDecisionMap[campaign.id] ?? [],
         }
       })
   })

--- a/frontend/app/(dashboard)/beheer/klantlearnings/page.tsx
+++ b/frontend/app/(dashboard)/beheer/klantlearnings/page.tsx
@@ -3,6 +3,7 @@ import type { ActionCenterReviewOutcome } from '@/lib/action-center-route-contra
 import {
   ActionCenterPreview,
 } from '@/components/dashboard/action-center-preview'
+import { projectActionCenterCoreSemantics } from '@/lib/action-center-core-semantics'
 import type {
   ActionCenterPreviewItem,
   ActionCenterPreviewView,
@@ -20,6 +21,7 @@ import { finalizeActionCenterPreviewItem } from '@/lib/action-center-live'
 import { getContactRequestsForAdmin } from '@/lib/contact-requests'
 import { createClient } from '@/lib/supabase/server'
 import type {
+  ActionCenterReviewDecision,
   ContactRequestRecord,
   PilotLearningCheckpoint,
   PilotLearningDossier,
@@ -148,6 +150,7 @@ export default async function KlantLearningsPage({ searchParams }: Props) {
     { data: campaignStatsRaw },
     { data: dossiersRaw },
     { data: checkpointsRaw },
+    { data: reviewDecisionsRaw },
     { data: clientAccessRaw },
     { data: pendingInvitesRaw },
   ] = await Promise.all([
@@ -173,6 +176,11 @@ export default async function KlantLearningsPage({ searchParams }: Props) {
       .from('pilot_learning_checkpoints')
       .select('*')
       .order('updated_at', { ascending: false }),
+    supabase
+      .from('action_center_review_decisions')
+      .select('*')
+      .eq('route_source_type', 'campaign')
+      .order('decision_recorded_at', { ascending: false }),
     orgIds.length
       ? supabase
           .from('org_members')
@@ -193,6 +201,7 @@ export default async function KlantLearningsPage({ searchParams }: Props) {
   const campaignStats = (campaignStatsRaw ?? []) as CampaignStats[]
   const dossiers = (dossiersRaw ?? []) as PilotLearningDossier[]
   const checkpoints = (checkpointsRaw ?? []) as PilotLearningCheckpoint[]
+  const reviewDecisions = (reviewDecisionsRaw ?? []) as ActionCenterReviewDecision[]
   const activeClientAccessByOrg = (clientAccessRaw ?? []).reduce<Record<string, number>>((acc, membership) => {
     acc[membership.org_id] = (acc[membership.org_id] ?? 0) + 1
     return acc
@@ -255,6 +264,11 @@ export default async function KlantLearningsPage({ searchParams }: Props) {
   const exitCampaignStatsById = new Map(exitCampaignStats.map((stats) => [stats.campaign_id, stats]))
   const exitLeadById = new Map(exitLeads.map((lead) => [lead.id, lead]))
   const exitOrgById = new Map(exitOrgs.map((org) => [org.id, org]))
+  const reviewDecisionsByRouteId = reviewDecisions.reduce<Record<string, ActionCenterReviewDecision[]>>((acc, decision) => {
+    acc[decision.route_source_id] ??= []
+    acc[decision.route_source_id].push(decision)
+    return acc
+  }, {})
   const invitedCountByOrgId = exitCampaignStats.reduce<Record<string, number>>((acc, stats) => {
     acc[stats.organization_id] = (acc[stats.organization_id] ?? 0) + stats.total_invited
     return acc
@@ -377,7 +391,7 @@ export default async function KlantLearningsPage({ searchParams }: Props) {
           `${checkpoint.checkpoint_key.replace(/_/g, ' ')} bijgewerkt in dossierbron.`,
       }))
 
-    return finalizeActionCenterPreviewItem({
+    const previewItem = finalizeActionCenterPreviewItem({
       id: dossier.id,
       code: `ACT-${1041 + index}`,
       title: dossier.title,
@@ -418,6 +432,39 @@ export default async function KlantLearningsPage({ searchParams }: Props) {
               },
             ],
     })
+
+    if (!campaign) {
+      return previewItem
+    }
+
+    const authoredReviewDecisions = reviewDecisionsByRouteId[campaign.id] ?? []
+    if (authoredReviewDecisions.length === 0) {
+      return previewItem
+    }
+
+    const coreSemantics = projectActionCenterCoreSemantics({
+      campaign,
+      assignedManager: null,
+      deliveryRecord: null,
+      learningDossier: dossier,
+      learningCheckpoints: dossierCheckpoints,
+      reviewDecisions: authoredReviewDecisions,
+      route: {
+        ...previewItem.coreSemantics.route,
+        campaignId: campaign.id,
+      },
+      latestVisibleUpdateNote: previewItem.updates[0]?.note ?? null,
+      decisionRecords: [],
+    })
+
+    return finalizeActionCenterPreviewItem(
+      {
+        ...previewItem,
+        reviewOutcome: coreSemantics.route.reviewOutcome,
+        coreSemantics,
+      },
+      { recomputeCoreSemantics: false },
+    )
   })
   const ownerOptions = Array.from(
     new Set(previewItems.map((item) => item.ownerName).filter((value): value is string => Boolean(value))),
@@ -471,6 +518,7 @@ export default async function KlantLearningsPage({ searchParams }: Props) {
           leads={exitLeads as ContactRequestRecord[]}
           dossiers={exitDossiers}
           checkpoints={exitCheckpoints}
+          reviewDecisions={reviewDecisions}
           activeClientAccessByOrg={exitActiveClientAccessByOrg}
           pendingClientInvitesByOrg={exitPendingClientInvitesByOrg}
           initialLeadId={initialExitLeadId}

--- a/frontend/app/api/action-center-review-decisions/[id]/route.ts
+++ b/frontend/app/api/action-center-review-decisions/[id]/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import {
+  isActionCenterDecisionCheckpointKey,
+  validateActionCenterReviewDecisionWriteInput,
+} from '@/lib/action-center-review-decisions'
+
+interface Context {
+  params: Promise<{ id: string }>
+}
+
+async function requireVerisightAdmin() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return { supabase, user: null, error: NextResponse.json({ detail: 'Niet ingelogd.' }, { status: 401 }) }
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('is_verisight_admin')
+    .eq('id', user.id)
+    .single()
+
+  if (profile?.is_verisight_admin !== true) {
+    return {
+      supabase,
+      user: null,
+      error: NextResponse.json(
+        { detail: 'Alleen Verisight-beheerders kunnen authored review decisions beheren.' },
+        { status: 403 },
+      ),
+    }
+  }
+
+  return { supabase, user, error: null }
+}
+
+export async function PATCH(request: Request, context: Context) {
+  const { id } = await context.params
+  const admin = await requireVerisightAdmin()
+  if (admin.error || !admin.user) {
+    return admin.error
+  }
+
+  const body = await request.json().catch(() => null)
+
+  let parsed
+  try {
+    parsed = validateActionCenterReviewDecisionWriteInput(body)
+  } catch {
+    return NextResponse.json({ detail: 'Ongeldige authored review decision input.' }, { status: 400 })
+  }
+
+  const { data: existing } = await admin.supabase
+    .from('action_center_review_decisions')
+    .select('id')
+    .eq('id', id)
+    .maybeSingle()
+
+  if (!existing) {
+    return NextResponse.json({ detail: 'Authored review decision niet gevonden.' }, { status: 404 })
+  }
+
+  const { data: checkpoint } = await admin.supabase
+    .from('pilot_learning_checkpoints')
+    .select('id, checkpoint_key')
+    .eq('id', parsed.checkpoint_id)
+    .maybeSingle()
+
+  if (!checkpoint) {
+    return NextResponse.json({ detail: 'Learningcheckpoint niet gevonden.' }, { status: 404 })
+  }
+
+  if (!isActionCenterDecisionCheckpointKey(checkpoint.checkpoint_key)) {
+    return NextResponse.json(
+      { detail: 'Authored review decisions zijn alleen toegestaan op reviewcheckpoints.' },
+      { status: 400 },
+    )
+  }
+
+  const { error } = await admin.supabase
+    .from('action_center_review_decisions')
+    .update({
+      ...parsed,
+      updated_by: admin.user.id,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', id)
+
+  if (error) {
+    return NextResponse.json({ detail: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ message: 'Authored review decision bijgewerkt.' })
+}

--- a/frontend/app/api/action-center-review-decisions/route.ts
+++ b/frontend/app/api/action-center-review-decisions/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import {
+  isActionCenterDecisionCheckpointKey,
+  validateActionCenterReviewDecisionWriteInput,
+} from '@/lib/action-center-review-decisions'
+
+async function requireVerisightAdmin() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return { supabase, user: null, error: NextResponse.json({ detail: 'Niet ingelogd.' }, { status: 401 }) }
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('is_verisight_admin')
+    .eq('id', user.id)
+    .single()
+
+  if (profile?.is_verisight_admin !== true) {
+    return {
+      supabase,
+      user: null,
+      error: NextResponse.json(
+        { detail: 'Alleen Verisight-beheerders kunnen authored review decisions beheren.' },
+        { status: 403 },
+      ),
+    }
+  }
+
+  return { supabase, user, error: null }
+}
+
+export async function POST(request: Request) {
+  const admin = await requireVerisightAdmin()
+  if (admin.error || !admin.user) {
+    return admin.error
+  }
+
+  const body = await request.json().catch(() => null)
+
+  let parsed
+  try {
+    parsed = validateActionCenterReviewDecisionWriteInput(body)
+  } catch {
+    return NextResponse.json({ detail: 'Ongeldige authored review decision input.' }, { status: 400 })
+  }
+
+  const { data: checkpoint } = await admin.supabase
+    .from('pilot_learning_checkpoints')
+    .select('id, checkpoint_key')
+    .eq('id', parsed.checkpoint_id)
+    .maybeSingle()
+
+  if (!checkpoint) {
+    return NextResponse.json({ detail: 'Learningcheckpoint niet gevonden.' }, { status: 404 })
+  }
+
+  if (!isActionCenterDecisionCheckpointKey(checkpoint.checkpoint_key)) {
+    return NextResponse.json(
+      { detail: 'Authored review decisions zijn alleen toegestaan op reviewcheckpoints.' },
+      { status: 400 },
+    )
+  }
+
+  const { data, error } = await admin.supabase
+    .from('action_center_review_decisions')
+    .insert({
+      ...parsed,
+      created_by: admin.user.id,
+      updated_by: admin.user.id,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .select('id')
+    .single()
+
+  if (error || !data) {
+    return NextResponse.json({ detail: error?.message ?? 'Authored review decision opslaan mislukt.' }, { status: 500 })
+  }
+
+  return NextResponse.json({ id: data.id, message: 'Authored review decision opgeslagen.' }, { status: 201 })
+}

--- a/frontend/components/dashboard/action-center-review-decision-editor.tsx
+++ b/frontend/components/dashboard/action-center-review-decision-editor.tsx
@@ -1,0 +1,280 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { DashboardChip } from '@/components/dashboard/dashboard-primitives'
+import {
+  buildActionCenterReviewDecisionFormState,
+  toIsoDateTimeString,
+  type ActionCenterReviewDecisionFormState,
+} from '@/lib/action-center-review-decision-editor-state'
+import type {
+  ActionCenterReviewDecision,
+  AuthoredActionCenterDecision,
+  PilotLearningCheckpoint,
+  PilotLearningDossier,
+} from '@/lib/pilot-learning'
+
+const FIELD_CLASS =
+  'w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 shadow-sm outline-none transition focus:border-blue-300 focus:ring-4 focus:ring-blue-100'
+const PRIMARY_BUTTON_CLASS =
+  'inline-flex items-center rounded-full bg-[#0d6a7c] px-4 py-3 text-sm font-semibold text-white transition hover:bg-[#0b5b6a] disabled:cursor-not-allowed disabled:opacity-60'
+const DECISION_OPTIONS: Array<{ value: AuthoredActionCenterDecision; label: string }> = [
+  { value: 'doorgaan', label: 'Doorgaan' },
+  { value: 'bijstellen', label: 'Bijstellen' },
+  { value: 'afronden', label: 'Afronden' },
+  { value: 'stoppen', label: 'Stoppen' },
+]
+
+interface Props {
+  dossier: PilotLearningDossier
+  checkpoint: PilotLearningCheckpoint
+  decision: ActionCenterReviewDecision | null
+}
+
+function FieldLabel({ htmlFor, children }: { htmlFor: string; children: React.ReactNode }) {
+  return (
+    <label htmlFor={htmlFor} className="mb-2 block text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+      {children}
+    </label>
+  )
+}
+
+function getDecisionTone(value: AuthoredActionCenterDecision | null) {
+  switch (value) {
+    case 'doorgaan':
+      return 'emerald' as const
+    case 'bijstellen':
+      return 'amber' as const
+    case 'afronden':
+      return 'blue' as const
+    case 'stoppen':
+      return 'slate' as const
+    default:
+      return 'slate' as const
+  }
+}
+
+function getDecisionLabel(value: AuthoredActionCenterDecision | null) {
+  return DECISION_OPTIONS.find((option) => option.value === value)?.label ?? 'Nog niet vastgelegd'
+}
+
+function buildPayload(state: ActionCenterReviewDecisionFormState) {
+  const decisionRecordedAt = toIsoDateTimeString(state.decision_recorded_at_local)
+  const reviewCompletedAt = toIsoDateTimeString(state.review_completed_at_local)
+
+  if (!state.route_source_id || !decisionRecordedAt || !reviewCompletedAt) {
+    return null
+  }
+
+  return {
+    route_source_type: state.route_source_type,
+    route_source_id: state.route_source_id,
+    checkpoint_id: state.checkpoint_id,
+    decision: state.decision,
+    decision_reason: state.decision_reason,
+    next_check: state.next_check,
+    current_step: state.current_step,
+    next_step: state.next_step || null,
+    expected_effect: state.expected_effect || null,
+    observation_snapshot: state.observation_snapshot || null,
+    decision_recorded_at: decisionRecordedAt,
+    review_completed_at: reviewCompletedAt,
+  }
+}
+
+export function ActionCenterReviewDecisionEditor({ dossier, checkpoint, decision }: Props) {
+  const router = useRouter()
+  const [form, setForm] = useState<ActionCenterReviewDecisionFormState>(() =>
+    buildActionCenterReviewDecisionFormState({ dossier, checkpoint, decision }),
+  )
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [message, setMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    setForm(buildActionCenterReviewDecisionFormState({ dossier, checkpoint, decision }))
+  }, [checkpoint, decision, dossier])
+
+  const routeUnavailable = !form.route_source_id
+
+  async function handleSave() {
+    setError(null)
+    setMessage(null)
+
+    const payload = buildPayload(form)
+    if (!payload) {
+      setError('Koppel eerst een campaign en vul beide reviewmomenten in om deze decision vast te leggen.')
+      return
+    }
+
+    setSaving(true)
+    const response = await fetch(
+      form.id ? `/api/action-center-review-decisions/${form.id}` : '/api/action-center-review-decisions',
+      {
+        method: form.id ? 'PATCH' : 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      },
+    )
+    const result = (await response.json().catch(() => null)) as { id?: string; detail?: string; message?: string } | null
+    if (!response.ok) {
+      setError(result?.detail ?? 'Authored review decision opslaan mislukt.')
+      setSaving(false)
+      return
+    }
+
+    setForm((current) => ({ ...current, id: result?.id ?? current.id }))
+    setMessage(result?.message ?? 'Authored review decision opgeslagen.')
+    router.refresh()
+    setSaving(false)
+  }
+
+  return (
+    <div className="mt-4 rounded-[22px] border border-blue-100 bg-blue-50/70 p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold text-slate-950">Action Center review decision</p>
+          <p className="mt-1 text-xs leading-5 text-slate-600">
+            Gebruik deze authored laag om de canonieke reviewbeslissing, actuele stap en volgende toets expliciet vast te leggen zonder managers extra invoer te geven.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <DashboardChip label={getDecisionLabel(form.decision)} tone={getDecisionTone(form.decision)} />
+          <DashboardChip label={routeUnavailable ? 'Campaign ontbreekt' : 'Campaign-route'} tone={routeUnavailable ? 'amber' : 'blue'} />
+        </div>
+      </div>
+
+      {routeUnavailable ? (
+        <div className="mt-4 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+          Deze decision write-path werkt alleen voor campaign-gekoppelde dossiers. Koppel eerst een campaign op dossierniveau.
+        </div>
+      ) : null}
+
+      <div className="mt-4 grid gap-4 xl:grid-cols-2">
+        <div>
+          <FieldLabel htmlFor={`decision-${checkpoint.id}`}>Besluit</FieldLabel>
+          <select
+            id={`decision-${checkpoint.id}`}
+            value={form.decision}
+            onChange={(event) =>
+              setForm((current) => ({
+                ...current,
+                decision: event.target.value as AuthoredActionCenterDecision,
+              }))
+            }
+            className={FIELD_CLASS}
+          >
+            {DECISION_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div>
+            <FieldLabel htmlFor={`decision-completed-${checkpoint.id}`}>Review afgerond op</FieldLabel>
+            <input
+              id={`decision-completed-${checkpoint.id}`}
+              type="datetime-local"
+              value={form.review_completed_at_local}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, review_completed_at_local: event.target.value }))
+              }
+              className={FIELD_CLASS}
+            />
+          </div>
+          <div>
+            <FieldLabel htmlFor={`decision-recorded-${checkpoint.id}`}>Besluit vastgelegd op</FieldLabel>
+            <input
+              id={`decision-recorded-${checkpoint.id}`}
+              type="datetime-local"
+              value={form.decision_recorded_at_local}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, decision_recorded_at_local: event.target.value }))
+              }
+              className={FIELD_CLASS}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-4 grid gap-4 xl:grid-cols-2">
+        <TextAreaField
+          label="Waarom dit besluit"
+          id={`decision-reason-${checkpoint.id}`}
+          value={form.decision_reason}
+          onChange={(value) => setForm((current) => ({ ...current, decision_reason: value }))}
+        />
+        <TextAreaField
+          label="Volgende toets"
+          id={`next-check-${checkpoint.id}`}
+          value={form.next_check}
+          onChange={(value) => setForm((current) => ({ ...current, next_check: value }))}
+        />
+        <TextAreaField
+          label="Huidige stap"
+          id={`current-step-${checkpoint.id}`}
+          value={form.current_step}
+          onChange={(value) => setForm((current) => ({ ...current, current_step: value }))}
+        />
+        <TextAreaField
+          label="Hierna"
+          id={`next-step-${checkpoint.id}`}
+          value={form.next_step}
+          onChange={(value) => setForm((current) => ({ ...current, next_step: value }))}
+        />
+        <TextAreaField
+          label="Verwacht effect"
+          id={`expected-effect-${checkpoint.id}`}
+          value={form.expected_effect}
+          onChange={(value) => setForm((current) => ({ ...current, expected_effect: value }))}
+        />
+        <TextAreaField
+          label="Observatie snapshot"
+          id={`observation-snapshot-${checkpoint.id}`}
+          value={form.observation_snapshot}
+          onChange={(value) => setForm((current) => ({ ...current, observation_snapshot: value }))}
+        />
+      </div>
+
+      {error ? <p className="mt-4 text-sm text-red-700">{error}</p> : null}
+      {message ? <p className="mt-4 text-sm text-emerald-700">{message}</p> : null}
+
+      <div className="mt-4 flex flex-wrap items-center gap-3">
+        <button type="button" onClick={() => void handleSave()} disabled={saving || routeUnavailable} className={PRIMARY_BUTTON_CLASS}>
+          {saving ? 'Decision wordt opgeslagen...' : form.id ? 'Decision bijwerken' : 'Decision vastleggen'}
+        </button>
+        <span className="text-xs text-slate-500">
+          Deze laag voedt authored review decisions, action progression en decision history in Action Center.
+        </span>
+      </div>
+    </div>
+  )
+}
+
+function TextAreaField({
+  id,
+  label,
+  value,
+  onChange,
+}: {
+  id: string
+  label: string
+  value: string
+  onChange: (value: string) => void
+}) {
+  return (
+    <div>
+      <FieldLabel htmlFor={id}>{label}</FieldLabel>
+      <textarea
+        id={id}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        rows={4}
+        className={`${FIELD_CLASS} min-h-[112px]`}
+      />
+    </div>
+  )
+}

--- a/frontend/components/dashboard/pilot-learning-workbench.tsx
+++ b/frontend/components/dashboard/pilot-learning-workbench.tsx
@@ -32,6 +32,7 @@ import {
   LEARNING_ROUTE_OPTIONS,
   LEARNING_STRENGTH_OPTIONS,
   LEARNING_TRIAGE_STATUS_OPTIONS,
+  type ActionCenterReviewDecision,
   type ContactRequestRecord,
   type LearningCheckpointKey,
   type LearningDestinationArea,
@@ -41,6 +42,8 @@ import {
   type PilotLearningDossier,
 } from '@/lib/pilot-learning'
 import type { Campaign, CampaignStats, Organization } from '@/lib/types'
+import { isActionCenterDecisionCheckpointKey } from '@/lib/action-center-review-decisions'
+import { ActionCenterReviewDecisionEditor } from '@/components/dashboard/action-center-review-decision-editor'
 
 type DossierDraft = Pick<
   PilotLearningDossier,
@@ -114,6 +117,7 @@ interface Props {
   leads: ContactRequestRecord[]
   dossiers: PilotLearningDossier[]
   checkpoints: PilotLearningCheckpoint[]
+  reviewDecisions: ActionCenterReviewDecision[]
   activeClientAccessByOrg: Record<string, number>
   pendingClientInvitesByOrg: Record<string, number>
   initialLeadId?: string | null
@@ -250,6 +254,7 @@ export function PilotLearningWorkbench({
   leads,
   dossiers,
   checkpoints,
+  reviewDecisions,
   activeClientAccessByOrg,
   pendingClientInvitesByOrg,
   initialLeadId = null,
@@ -268,6 +273,10 @@ export function PilotLearningWorkbench({
     }
     return grouped
   }, [checkpoints])
+  const reviewDecisionByCheckpointId = useMemo(
+    () => Object.fromEntries(reviewDecisions.map((decision) => [decision.checkpoint_id, decision])),
+    [reviewDecisions],
+  ) as Record<string, ActionCenterReviewDecision>
 
   const [selectedLeadId, setSelectedLeadId] = useState(initialLeadId ?? '')
   const [selectedCampaignId, setSelectedCampaignId] = useState(initialCampaignId ?? '')
@@ -824,6 +833,7 @@ export function PilotLearningWorkbench({
                   <div className="space-y-4">
                     {dossierCheckpoints.map((checkpoint) => {
                       const checkpointDraft = checkpointDrafts[checkpoint.id]
+                      const authoredDecision = reviewDecisionByCheckpointId[checkpoint.id] ?? null
                       const definition = getCheckpointDefinition(checkpoint.checkpoint_key)
                       const objectiveSignals = buildLearningObjectiveSignals({
                         checkpointKey: checkpoint.checkpoint_key,
@@ -939,6 +949,14 @@ export function PilotLearningWorkbench({
                             </button>
                             <span className="text-xs text-slate-500">Laatst bijgewerkt op {formatAmsterdamDate(checkpoint.updated_at)}.</span>
                           </div>
+
+                          {isActionCenterDecisionCheckpointKey(checkpoint.checkpoint_key) ? (
+                            <ActionCenterReviewDecisionEditor
+                              dossier={dossier}
+                              checkpoint={checkpoint}
+                              decision={authoredDecision}
+                            />
+                          ) : null}
                         </div>
                       )
                     })}

--- a/frontend/lib/action-center-core-semantics.test.ts
+++ b/frontend/lib/action-center-core-semantics.test.ts
@@ -7,7 +7,11 @@ import {
 import { projectActionCenterRoute } from './action-center-route-contract'
 import type { Campaign, CampaignStats } from '@/lib/types'
 import type { CampaignDeliveryRecord } from '@/lib/ops-delivery'
-import type { PilotLearningCheckpoint, PilotLearningDossier } from '@/lib/pilot-learning'
+import type {
+  ActionCenterReviewDecision,
+  PilotLearningCheckpoint,
+  PilotLearningDossier,
+} from '@/lib/pilot-learning'
 import type { LiveActionCenterCampaignContext } from './action-center-live-context'
 import type { ActionCenterRouteContract } from './action-center-route-contract'
 
@@ -140,6 +144,7 @@ function buildContext(args: {
   deliveryRecord?: CampaignDeliveryRecord | null
   assignedManager?: LiveActionCenterCampaignContext['assignedManager']
   learningCheckpoints?: PilotLearningCheckpoint[]
+  reviewDecisions?: ActionCenterReviewDecision[]
 } = {}): ActionCenterCoreSemanticsProjectionInput {
   const liveContext: LiveActionCenterCampaignContext = {
     campaign: buildCampaign(),
@@ -155,6 +160,7 @@ function buildContext(args: {
     deliveryCheckpoints: [],
     learningDossier: args.dossier ?? buildDossier(),
     learningCheckpoints: args.learningCheckpoints ?? [],
+    reviewDecisions: args.reviewDecisions ?? [],
   }
 
   return {
@@ -163,6 +169,7 @@ function buildContext(args: {
     deliveryRecord: liveContext.deliveryRecord,
     learningDossier: liveContext.learningDossier,
     learningCheckpoints: liveContext.learningCheckpoints,
+    reviewDecisions: liveContext.reviewDecisions,
     route: projectActionCenterRoute(liveContext),
   }
 }
@@ -219,6 +226,49 @@ describe('action center core semantics', () => {
       )
       expect(semantics.actionProgress.currentStep).toBe('Plan een gerichte teamreview met de manager.')
       expect(semantics.actionProgress.nextStep).toBe('Herplan de teamreview voor volgende week.')
+    })
+
+    it('cuts over fully to authored review decisions once any authored decision exists', () => {
+      const semantics = projectActionCenterCoreSemantics({
+        ...buildContext({
+          dossier: buildDossier({
+            management_action_outcome: 'stoppen',
+            first_action_taken: 'Legacy route stap die niet meer zichtbaar mag zijn.',
+            expected_first_value: 'Legacy effect dat niet meer zichtbaar mag zijn.',
+          }),
+          reviewDecisions: [
+            {
+              id: 'authored-decision-1',
+              route_source_type: 'campaign',
+              route_source_id: 'campaign-1',
+              checkpoint_id: 'checkpoint-1',
+              decision: 'bijstellen',
+              decision_reason: 'Authored decision wint volledig zodra hij bestaat.',
+              next_check: 'Toets volgende week of de bijgestelde stap tractie geeft.',
+              current_step: 'Voer deze week een gerichte managercheck uit.',
+              next_step: 'Bevestig in review of de frictie specifieker is geworden.',
+              expected_effect: 'Maak zichtbaar of de managercheck de frictie smaller maakt.',
+              observation_snapshot: 'Dezelfde frictie bleef in twee teams zichtbaar.',
+              decision_recorded_at: '2026-04-28T09:00:00.000Z',
+              review_completed_at: '2026-04-28T08:30:00.000Z',
+              created_by: null,
+              updated_by: null,
+              created_at: '2026-04-28T09:00:00.000Z',
+              updated_at: '2026-04-28T09:00:00.000Z',
+            },
+          ],
+        }),
+        campaign: { id: 'campaign-1', name: 'ExitScan april' } as never,
+        route: baseRoute,
+      })
+
+      expect(semantics.latestDecision?.decisionReason).toBe(
+        'Authored decision wint volledig zodra hij bestaat.',
+      )
+      expect(semantics.actionProgress.currentStep).toBe('Voer deze week een gerichte managercheck uit.')
+      expect(semantics.resultLoop.whatWasDecided).toBe('Bijstellen')
+      expect(semantics.decisionHistory).toHaveLength(1)
+      expect(semantics.decisionHistory[0]?.decisionEntryId).toBe('authored-decision-1')
     })
 
     it('falls back to legacy truth when no canonical decision records exist', () => {

--- a/frontend/lib/action-center-core-semantics.ts
+++ b/frontend/lib/action-center-core-semantics.ts
@@ -4,8 +4,12 @@ import type {
   ActionCenterRouteContract,
 } from './action-center-route-contract'
 import type { LiveActionCenterCampaignContext } from './action-center-live-context'
-import type { PilotLearningCheckpoint } from './pilot-learning'
-import { compareDecisionHistoryEntries, projectLegacyDecisionRecord } from './action-center-decision-history'
+import type { ActionCenterReviewDecision, PilotLearningCheckpoint } from './pilot-learning'
+import {
+  compareDecisionHistoryEntries,
+  projectAuthoredDecisionHistory,
+  projectLegacyDecisionRecord,
+} from './action-center-decision-history'
 
 export type ActionCenterVisibleReviewOutcome = Exclude<ActionCenterReviewOutcome, 'opschalen'>
 export type ActionCenterClosingStatus = 'lopend' | 'afgerond' | 'gestopt'
@@ -45,7 +49,7 @@ export interface ActionCenterCoreSemantics {
 
 export type ActionCenterCoreSemanticsProjectionInput = Pick<
   LiveActionCenterCampaignContext,
-  'campaign' | 'assignedManager' | 'deliveryRecord' | 'learningDossier' | 'learningCheckpoints'
+  'campaign' | 'assignedManager' | 'deliveryRecord' | 'learningDossier' | 'learningCheckpoints' | 'reviewDecisions'
 > & {
   route: ActionCenterRouteContract
   latestVisibleUpdateNote?: string | null
@@ -284,8 +288,18 @@ function buildDecisionHistory(args: {
   latestObservation: string | null
   reviewReason?: string | null
   managementActionOutcome?: string | null
+  reviewDecisions?: ActionCenterReviewDecision[] | null
   decisionRecords?: ActionCenterDecisionRecord[]
 }) {
+  const authored = projectAuthoredDecisionHistory({
+    routeId: args.route.campaignId,
+    reviewDecisions: args.reviewDecisions,
+  })
+
+  if (authored.length > 0) {
+    return authored
+  }
+
   const canonical = [...(args.decisionRecords ?? [])]
     .filter((record) => record.sourceRouteId === args.route.campaignId)
     .sort(compareDecisionHistoryEntries)
@@ -587,15 +601,16 @@ export function projectActionCenterCoreSemantics(
     latestObservation,
     reviewReason,
     managementActionOutcome: context.learningDossier?.management_action_outcome,
+    reviewDecisions: context.reviewDecisions,
     decisionRecords: context.decisionRecords,
   })
   const latestDecision = decisionHistory[0] ?? null
   const actionProgress = projectActionProgress({
     route,
-    deliveryNextStep: context.deliveryRecord?.next_step,
-    firstActionTaken: context.learningDossier?.first_action_taken,
+    deliveryNextStep: latestDecision?.nextStepSnapshot ?? context.deliveryRecord?.next_step,
+    firstActionTaken: latestDecision?.currentStepSnapshot ?? context.learningDossier?.first_action_taken,
     reviewQuestion,
-    expectedEffectFallback: derivedExpectedEffect,
+    expectedEffectFallback: latestDecision?.expectedEffectSnapshot ?? derivedExpectedEffect,
   })
 
   return {
@@ -616,6 +631,7 @@ export function projectActionCenterCoreSemantics(
     },
     resultLoop: {
       whatWasTried: pickFirst([
+        latestDecision?.currentStepSnapshot,
         normalizeAttemptText(context.latestVisibleUpdateNote),
         latestActionUpdate,
         nextStep,

--- a/frontend/lib/action-center-decision-history.ts
+++ b/frontend/lib/action-center-decision-history.ts
@@ -3,6 +3,7 @@ import type {
   ActionCenterDecisionRecord,
   ActionCenterReviewOutcome,
 } from './action-center-route-contract'
+import type { ActionCenterReviewDecision } from './pilot-learning'
 
 function normalizeText(value: string | null | undefined) {
   const trimmed = value?.trim() ?? ''
@@ -61,6 +62,32 @@ export function compareDecisionHistoryEntries(left: ActionCenterDecisionRecord, 
   }
 
   return left.decisionEntryId.localeCompare(right.decisionEntryId)
+}
+
+export function projectAuthoredDecisionRecord(record: ActionCenterReviewDecision): ActionCenterDecisionRecord {
+  return {
+    decisionEntryId: record.id,
+    sourceRouteId: record.route_source_id,
+    decision: record.decision,
+    decisionReason: normalizeText(record.decision_reason),
+    nextCheck: normalizeText(record.next_check),
+    decisionRecordedAt: record.decision_recorded_at,
+    reviewCompletedAt: record.review_completed_at,
+    currentStepSnapshot: normalizeText(record.current_step),
+    nextStepSnapshot: normalizeText(record.next_step),
+    expectedEffectSnapshot: normalizeText(record.expected_effect),
+    observationSnapshot: normalizeText(record.observation_snapshot),
+  }
+}
+
+export function projectAuthoredDecisionHistory(args: {
+  routeId: string
+  reviewDecisions?: ActionCenterReviewDecision[] | null
+}) {
+  return (args.reviewDecisions ?? [])
+    .filter((record) => record.route_source_id === args.routeId)
+    .map(projectAuthoredDecisionRecord)
+    .sort(compareDecisionHistoryEntries)
 }
 
 export function projectLegacyDecisionRecord(args: {

--- a/frontend/lib/action-center-live-context.ts
+++ b/frontend/lib/action-center-live-context.ts
@@ -1,6 +1,10 @@
 import type { Campaign, CampaignStats, MemberRole } from '@/lib/types'
 import type { CampaignDeliveryCheckpoint, CampaignDeliveryRecord } from '@/lib/ops-delivery'
-import type { PilotLearningCheckpoint, PilotLearningDossier } from './pilot-learning'
+import type {
+  ActionCenterReviewDecision,
+  PilotLearningCheckpoint,
+  PilotLearningDossier,
+} from './pilot-learning'
 
 export interface LiveActionCenterCampaignContext {
   campaign: Campaign
@@ -20,4 +24,5 @@ export interface LiveActionCenterCampaignContext {
   deliveryCheckpoints: CampaignDeliveryCheckpoint[]
   learningDossier: PilotLearningDossier | null
   learningCheckpoints: PilotLearningCheckpoint[]
+  reviewDecisions?: ActionCenterReviewDecision[]
 }

--- a/frontend/lib/action-center-live.test.ts
+++ b/frontend/lib/action-center-live.test.ts
@@ -8,7 +8,11 @@ import {
 import { projectActionCenterRoute } from './action-center-route-contract'
 import type { Campaign, CampaignStats } from '@/lib/types'
 import type { CampaignDeliveryRecord } from '@/lib/ops-delivery'
-import type { PilotLearningCheckpoint, PilotLearningDossier } from '@/lib/pilot-learning'
+import type {
+  ActionCenterReviewDecision,
+  PilotLearningCheckpoint,
+  PilotLearningDossier,
+} from '@/lib/pilot-learning'
 
 function buildCampaign(overrides: Partial<Campaign> = {}): Campaign {
   return {
@@ -193,6 +197,7 @@ describe('live action center builder', () => {
       deliveryCheckpoints: [],
       learningDossier: exitDossier,
       learningCheckpoints: exitLearningCheckpoints,
+      reviewDecisions: [] as ActionCenterReviewDecision[],
     }
     const candidateContext = {
       campaign: pulseCampaign,
@@ -225,6 +230,7 @@ describe('live action center builder', () => {
         review_moment: '2026-05-19',
       }),
       learningCheckpoints: [],
+      reviewDecisions: [] as ActionCenterReviewDecision[],
     }
     const route = projectActionCenterRoute(activeContext)
 
@@ -798,5 +804,84 @@ describe('live action center builder', () => {
       nextStep: 'Plan de vervolgcheck met HR en operations.',
       expectedEffect: 'Maak zichtbaar of de werkdruk lokaal daalt.',
     })
+  })
+
+  it('uses authored review decisions as the only visible history once they exist on a route', () => {
+    const context = {
+      campaign: buildCampaign(),
+      stats: buildStats(),
+      organizationName: 'Acme BV',
+      memberRole: 'owner' as const,
+      scopeType: 'department' as const,
+      scopeValue: 'operations',
+      scopeLabel: 'Operations',
+      peopleCount: 38,
+      assignedManager: {
+        userId: 'manager-1',
+        displayName: 'Manager Operations',
+        assignedAt: '2026-04-21T08:00:00.000Z',
+      },
+      deliveryRecord: buildDeliveryRecord({
+        lifecycle_stage: 'first_management_use',
+        first_management_use_confirmed_at: '2026-04-20T09:00:00.000Z',
+        next_step: 'Legacy vervolgstap die niet meer zichtbaar mag zijn.',
+      }),
+      deliveryCheckpoints: [],
+      learningDossier: buildDossier({
+        expected_first_value: 'Legacy effect dat niet meer zichtbaar mag zijn.',
+        first_management_value: 'Legacy reviewreden die niet meer zichtbaar mag zijn.',
+        first_action_taken: 'Legacy stap die niet meer zichtbaar mag zijn.',
+        management_action_outcome: 'stoppen',
+      }),
+      learningCheckpoints: [
+        {
+          id: 'checkpoint-follow-up-review',
+          dossier_id: 'dossier-exit',
+          checkpoint_key: 'follow_up_review',
+          owner_label: 'HR lead',
+          status: 'uitgevoerd',
+          objective_signal_notes: null,
+          qualitative_notes: null,
+          interpreted_observation: null,
+          confirmed_lesson: 'Legacy checkpointobservatie.',
+          lesson_strength: 'terugkerend_patroon',
+          destination_areas: ['operations'],
+          updated_at: '2026-04-24T09:00:00.000Z',
+          created_at: '2026-04-15T10:00:00.000Z',
+        } as PilotLearningCheckpoint,
+      ],
+      reviewDecisions: [
+        {
+          id: 'authored-decision-1',
+          route_source_type: 'campaign',
+          route_source_id: 'campaign-exit',
+          checkpoint_id: 'checkpoint-follow-up-review',
+          decision: 'bijstellen',
+          decision_reason: 'Authored review decision bepaalt nu de zichtbare besluitrichting.',
+          next_check: 'Toets volgende week of de managercheck de frictie smaller maakt.',
+          current_step: 'Voer deze week een gerichte managercheck uit.',
+          next_step: 'Bevestig in review of de frictie specifieker is geworden.',
+          expected_effect: 'Maak zichtbaar of de managercheck het knelpunt versmalt.',
+          observation_snapshot: 'Dezelfde frictie bleef zichtbaar in twee teams.',
+          decision_recorded_at: '2026-04-28T09:00:00.000Z',
+          review_completed_at: '2026-04-28T08:30:00.000Z',
+          created_by: null,
+          updated_by: null,
+          created_at: '2026-04-28T09:00:00.000Z',
+          updated_at: '2026-04-28T09:00:00.000Z',
+        },
+      ] satisfies ActionCenterReviewDecision[],
+    }
+
+    const [item] = buildLiveActionCenterItems([context])
+
+    expect(item?.coreSemantics.latestDecision?.decisionReason).toBe(
+      'Authored review decision bepaalt nu de zichtbare besluitrichting.',
+    )
+    expect(item?.coreSemantics.actionProgress.currentStep).toBe(
+      'Voer deze week een gerichte managercheck uit.',
+    )
+    expect(item?.coreSemantics.decisionHistory).toHaveLength(1)
+    expect(item?.coreSemantics.decisionHistory[0]?.decisionEntryId).toBe('authored-decision-1')
   })
 })

--- a/frontend/lib/action-center-live.ts
+++ b/frontend/lib/action-center-live.ts
@@ -12,7 +12,11 @@ import { getScanDefinition } from '@/lib/scan-definitions'
 import type { MemberRole, ScanType } from '@/lib/types'
 import type { CampaignDeliveryCheckpoint, CampaignDeliveryRecord, DeliveryExceptionStatus } from '@/lib/ops-delivery'
 import { getDeliveryExceptionLabel } from '@/lib/ops-delivery'
-import type { PilotLearningCheckpoint, PilotLearningDossier } from '@/lib/pilot-learning'
+import type {
+  ActionCenterReviewDecision,
+  PilotLearningCheckpoint,
+  PilotLearningDossier,
+} from '@/lib/pilot-learning'
 import { projectActionCenterRoute } from '@/lib/action-center-route-contract'
 import { buildSuiteTelemetryEvent, type SuiteTelemetryEvent } from '@/lib/telemetry/events'
 import type { LiveActionCenterCampaignContext } from './action-center-live-context'
@@ -340,6 +344,7 @@ export function buildLiveActionCenterItems(contexts: LiveActionCenterCampaignCon
         ...context,
         route,
         latestVisibleUpdateNote: latestUpdate,
+        reviewDecisions: context.reviewDecisions ?? ([] as ActionCenterReviewDecision[]),
         decisionRecords: [],
       })
       const priority = getPriorityFromSignals({

--- a/frontend/lib/action-center-review-decision-editor-state.test.ts
+++ b/frontend/lib/action-center-review-decision-editor-state.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import { buildActionCenterReviewDecisionFormState, formatDateTimeLocalValue, toIsoDateTimeString } from './action-center-review-decision-editor-state'
+import type { ActionCenterReviewDecision, PilotLearningCheckpoint, PilotLearningDossier } from './pilot-learning'
+
+describe('action center review decision editor state', () => {
+  it('prefills the form from an existing authored decision', () => {
+    const dossier = {
+      id: 'dossier-1',
+      campaign_id: 'campaign-1',
+      first_action_taken: 'Voer het eerste teamgesprek.',
+      next_route: 'Plan een vervolggesprek met HR.',
+      expected_first_value: 'Meer scherpte over het lokale vertrekpatroon.',
+      management_action_outcome: 'bijstellen',
+      updated_at: '2026-04-29T09:15:00.000Z',
+    } as Partial<PilotLearningDossier> as PilotLearningDossier
+    const checkpoint = {
+      id: 'checkpoint-1',
+      updated_at: '2026-04-28T15:00:00.000Z',
+    } as Partial<PilotLearningCheckpoint> as PilotLearningCheckpoint
+    const decision = {
+      id: 'decision-1',
+      route_source_type: 'campaign',
+      route_source_id: 'campaign-1',
+      checkpoint_id: 'checkpoint-1',
+      decision: 'doorgaan',
+      decision_reason: 'Het eerste gesprek gaf genoeg scherpte.',
+      next_check: 'Toets over twee weken of het patroon stabiel blijft.',
+      current_step: 'Voer het eerste teamgesprek.',
+      next_step: 'Plan een vervolggesprek met HR.',
+      expected_effect: 'Meer scherpte over het lokale vertrekpatroon.',
+      observation_snapshot: 'Dezelfde frictie kwam in twee teams terug.',
+      decision_recorded_at: '2026-04-29T10:15:00.000Z',
+      review_completed_at: '2026-04-29T10:00:00.000Z',
+    } as Partial<ActionCenterReviewDecision> as ActionCenterReviewDecision
+
+    expect(buildActionCenterReviewDecisionFormState({ dossier, checkpoint, decision })).toEqual({
+      id: 'decision-1',
+      route_source_type: 'campaign',
+      route_source_id: 'campaign-1',
+      checkpoint_id: 'checkpoint-1',
+      decision: 'doorgaan',
+      decision_reason: 'Het eerste gesprek gaf genoeg scherpte.',
+      next_check: 'Toets over twee weken of het patroon stabiel blijft.',
+      current_step: 'Voer het eerste teamgesprek.',
+      next_step: 'Plan een vervolggesprek met HR.',
+      expected_effect: 'Meer scherpte over het lokale vertrekpatroon.',
+      observation_snapshot: 'Dezelfde frictie kwam in twee teams terug.',
+      decision_recorded_at_local: formatDateTimeLocalValue('2026-04-29T10:15:00.000Z'),
+      review_completed_at_local: formatDateTimeLocalValue('2026-04-29T10:00:00.000Z'),
+    })
+  })
+
+  it('falls back to dossier and checkpoint truth when no authored decision exists', () => {
+    const dossier = {
+      id: 'dossier-2',
+      campaign_id: 'campaign-2',
+      first_management_value: 'Welke teamfrictie vraagt nu als eerste eigenaarschap?',
+      expected_first_value: 'Binnen twee weken moet het eerste gesprek zijn gevoerd.',
+      first_action_taken: 'Leg de eerste managementreactie vast.',
+      next_route: 'Hercheck het team na de correctie.',
+      management_action_outcome: 'stoppen',
+      updated_at: '2026-04-29T11:05:00.000Z',
+    } as Partial<PilotLearningDossier> as PilotLearningDossier
+    const checkpoint = {
+      id: 'checkpoint-2',
+      confirmed_lesson: 'Het eerste gesprek maakte het vertrekpatroon scherper.',
+      updated_at: '2026-04-28T16:45:00.000Z',
+    } as Partial<PilotLearningCheckpoint> as PilotLearningCheckpoint
+
+    expect(buildActionCenterReviewDecisionFormState({ dossier, checkpoint, decision: null })).toEqual({
+      id: null,
+      route_source_type: 'campaign',
+      route_source_id: 'campaign-2',
+      checkpoint_id: 'checkpoint-2',
+      decision: 'stoppen',
+      decision_reason: 'Welke teamfrictie vraagt nu als eerste eigenaarschap?',
+      next_check: 'Binnen twee weken moet het eerste gesprek zijn gevoerd.',
+      current_step: 'Leg de eerste managementreactie vast.',
+      next_step: 'Hercheck het team na de correctie.',
+      expected_effect: 'Binnen twee weken moet het eerste gesprek zijn gevoerd.',
+      observation_snapshot: 'Het eerste gesprek maakte het vertrekpatroon scherper.',
+      decision_recorded_at_local: formatDateTimeLocalValue('2026-04-28T16:45:00.000Z'),
+      review_completed_at_local: formatDateTimeLocalValue('2026-04-28T16:45:00.000Z'),
+    })
+  })
+
+  it('formats and normalizes datetime-local values consistently', () => {
+    expect(formatDateTimeLocalValue('2026-04-29T13:05:00.000Z')).toMatch(/^2026-04-29T\d{2}:05$/)
+    expect(toIsoDateTimeString('2026-04-29T13:05')).toBeTruthy()
+    expect(toIsoDateTimeString('')).toBeNull()
+  })
+})

--- a/frontend/lib/action-center-review-decision-editor-state.ts
+++ b/frontend/lib/action-center-review-decision-editor-state.ts
@@ -1,0 +1,132 @@
+import {
+  normalizeActionCenterReviewDecision,
+  type ActionCenterReviewDecisionWriteInput,
+} from './action-center-review-decisions'
+import type {
+  ActionCenterReviewDecision,
+  AuthoredActionCenterDecision,
+  PilotLearningCheckpoint,
+  PilotLearningDossier,
+} from './pilot-learning'
+
+export interface ActionCenterReviewDecisionFormState {
+  id: string | null
+  route_source_type: ActionCenterReviewDecisionWriteInput['route_source_type']
+  route_source_id: string | null
+  checkpoint_id: string
+  decision: AuthoredActionCenterDecision
+  decision_reason: string
+  next_check: string
+  current_step: string
+  next_step: string
+  expected_effect: string
+  observation_snapshot: string
+  decision_recorded_at_local: string
+  review_completed_at_local: string
+}
+
+function normalizeText(value: string | null | undefined) {
+  const trimmed = value?.trim() ?? ''
+  return trimmed
+}
+
+function pickFirst(values: Array<string | null | undefined>) {
+  for (const value of values) {
+    const normalized = normalizeText(value)
+    if (normalized.length > 0) {
+      return normalized
+    }
+  }
+
+  return ''
+}
+
+function toDate(value: string | null | undefined) {
+  if (!value) return null
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}
+
+export function formatDateTimeLocalValue(value: string | null | undefined) {
+  const parsed = toDate(value)
+  if (!parsed) return ''
+
+  const year = parsed.getFullYear()
+  const month = `${parsed.getMonth() + 1}`.padStart(2, '0')
+  const day = `${parsed.getDate()}`.padStart(2, '0')
+  const hours = `${parsed.getHours()}`.padStart(2, '0')
+  const minutes = `${parsed.getMinutes()}`.padStart(2, '0')
+  return `${year}-${month}-${day}T${hours}:${minutes}`
+}
+
+export function toIsoDateTimeString(value: string) {
+  const trimmed = value.trim()
+  if (!trimmed) return null
+
+  const normalized = trimmed.length === 16 ? `${trimmed}:00` : trimmed
+  const parsed = new Date(normalized)
+  if (Number.isNaN(parsed.getTime())) {
+    return null
+  }
+
+  return parsed.toISOString()
+}
+
+export function buildActionCenterReviewDecisionFormState(args: {
+  dossier: PilotLearningDossier
+  checkpoint: PilotLearningCheckpoint
+  decision: ActionCenterReviewDecision | null
+}) {
+  const { dossier, checkpoint, decision } = args
+  const fallbackTimestamp = checkpoint.updated_at ?? dossier.updated_at ?? new Date().toISOString()
+  const fallbackDecision =
+    normalizeActionCenterReviewDecision(dossier.management_action_outcome) ?? ('bijstellen' satisfies AuthoredActionCenterDecision)
+
+  return {
+    id: decision?.id ?? null,
+    route_source_type: 'campaign',
+    route_source_id: dossier.campaign_id ?? null,
+    checkpoint_id: checkpoint.id,
+    decision: decision?.decision ?? fallbackDecision,
+    decision_reason: pickFirst([
+      decision?.decision_reason,
+      dossier.first_management_value,
+      dossier.buyer_question,
+      dossier.buying_reason,
+      checkpoint.confirmed_lesson,
+      checkpoint.interpreted_observation,
+    ]),
+    next_check: pickFirst([
+      decision?.next_check,
+      dossier.expected_first_value,
+      dossier.review_moment,
+      checkpoint.qualitative_notes,
+      checkpoint.objective_signal_notes,
+    ]),
+    current_step: pickFirst([
+      decision?.current_step,
+      dossier.first_action_taken,
+      dossier.next_route,
+    ]),
+    next_step: pickFirst([
+      decision?.next_step,
+      dossier.next_route,
+      dossier.stop_reason,
+    ]),
+    expected_effect: pickFirst([
+      decision?.expected_effect,
+      dossier.expected_first_value,
+      dossier.adoption_outcome,
+    ]),
+    observation_snapshot: pickFirst([
+      decision?.observation_snapshot,
+      checkpoint.confirmed_lesson,
+      checkpoint.interpreted_observation,
+      checkpoint.qualitative_notes,
+      dossier.management_action_outcome,
+      dossier.case_public_summary,
+    ]),
+    decision_recorded_at_local: formatDateTimeLocalValue(decision?.decision_recorded_at ?? fallbackTimestamp),
+    review_completed_at_local: formatDateTimeLocalValue(decision?.review_completed_at ?? fallbackTimestamp),
+  } satisfies ActionCenterReviewDecisionFormState
+}

--- a/frontend/lib/action-center-review-decisions.test.ts
+++ b/frontend/lib/action-center-review-decisions.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import {
+  normalizeActionCenterReviewDecision,
+  shouldUseLegacyDecisionFallback,
+  sortActionCenterReviewDecisions,
+  type ActionCenterReviewDecision,
+} from './action-center-review-decisions'
+
+describe('action center review decisions', () => {
+  it('normalizes only the canonical authored decision values', () => {
+    expect(normalizeActionCenterReviewDecision('doorgaan')).toBe('doorgaan')
+    expect(normalizeActionCenterReviewDecision(' bijstellen ')).toBe('bijstellen')
+    expect(normalizeActionCenterReviewDecision('opschalen')).toBeNull()
+    expect(normalizeActionCenterReviewDecision('')).toBeNull()
+  })
+
+  it('sorts authored review decisions by decisionRecordedAt descending before reviewCompletedAt', () => {
+    const older: ActionCenterReviewDecision = {
+      id: 'decision-1',
+      route_source_type: 'campaign',
+      route_source_id: 'campaign-1',
+      checkpoint_id: 'checkpoint-1',
+      decision: 'doorgaan',
+      decision_reason: 'De eerste stap loopt nog.',
+      next_check: 'Toets volgende week of de frictie daalt.',
+      current_step: 'Plan een eerste teamgesprek.',
+      next_step: 'Check of het teamgesprek plaatsvond.',
+      expected_effect: 'Maak zichtbaar of de eerste stap tractie geeft.',
+      observation_snapshot: 'Het patroon was bevestigd in meerdere exits.',
+      decision_recorded_at: '2026-04-20T09:00:00.000Z',
+      review_completed_at: '2026-04-20T08:30:00.000Z',
+      created_by: null,
+      updated_by: null,
+      created_at: '2026-04-20T09:00:00.000Z',
+      updated_at: '2026-04-20T09:00:00.000Z',
+    }
+    const newer: ActionCenterReviewDecision = {
+      ...older,
+      id: 'decision-2',
+      decision: 'bijstellen',
+      decision_reason: 'De eerste stap gaf nog geen stabiele verbetering.',
+      decision_recorded_at: '2026-04-25T09:00:00.000Z',
+      review_completed_at: '2026-04-25T08:30:00.000Z',
+      created_at: '2026-04-25T09:00:00.000Z',
+      updated_at: '2026-04-25T09:00:00.000Z',
+    }
+
+    expect(sortActionCenterReviewDecisions([older, newer]).map((entry) => entry.id)).toEqual([
+      'decision-2',
+      'decision-1',
+    ])
+  })
+
+  it('disables legacy fallback as soon as one authored review decision exists', () => {
+    expect(shouldUseLegacyDecisionFallback([])).toBe(true)
+    expect(
+      shouldUseLegacyDecisionFallback([
+        {
+          id: 'decision-1',
+          route_source_type: 'campaign',
+          route_source_id: 'campaign-1',
+          checkpoint_id: 'checkpoint-1',
+          decision: 'bijstellen',
+          decision_reason: 'De eerste stap gaf nog geen stabiele verbetering.',
+          next_check: 'Toets volgende week of de frictie daalt.',
+          current_step: 'Plan een eerste teamgesprek.',
+          next_step: 'Check of het teamgesprek plaatsvond.',
+          expected_effect: 'Maak zichtbaar of de eerste stap tractie geeft.',
+          observation_snapshot: 'Werkdruk bleef zichtbaar in hetzelfde team.',
+          decision_recorded_at: '2026-04-25T09:00:00.000Z',
+          review_completed_at: '2026-04-25T08:30:00.000Z',
+          created_by: null,
+          updated_by: null,
+          created_at: '2026-04-25T09:00:00.000Z',
+          updated_at: '2026-04-25T09:00:00.000Z',
+        },
+      ]),
+    ).toBe(false)
+  })
+})

--- a/frontend/lib/action-center-review-decisions.test.ts
+++ b/frontend/lib/action-center-review-decisions.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
+  isActionCenterDecisionCheckpointKey,
   normalizeActionCenterReviewDecision,
+  validateActionCenterReviewDecisionWriteInput,
   shouldUseLegacyDecisionFallback,
   sortActionCenterReviewDecisions,
   type ActionCenterReviewDecision,
@@ -76,5 +78,62 @@ describe('action center review decisions', () => {
         },
       ]),
     ).toBe(false)
+  })
+
+  it('allows authored review decisions only on supported review checkpoints', () => {
+    expect(isActionCenterDecisionCheckpointKey('first_management_use')).toBe(true)
+    expect(isActionCenterDecisionCheckpointKey('follow_up_review')).toBe(true)
+    expect(isActionCenterDecisionCheckpointKey('launch_output')).toBe(false)
+  })
+
+  it('validates and normalizes authored review decision write input', () => {
+    const parsed = validateActionCenterReviewDecisionWriteInput({
+      route_source_type: 'campaign',
+      route_source_id: 'campaign-1',
+      checkpoint_id: 'checkpoint-1',
+      decision: ' bijstellen ',
+      decision_reason: ' De eerste stap gaf nog geen stabiele verbetering. ',
+      next_check: ' Toets volgende week of de frictie daalt. ',
+      current_step: ' Plan een eerste teamgesprek. ',
+      next_step: ' Check of het teamgesprek plaatsvond. ',
+      expected_effect: ' Maak zichtbaar of de eerste stap tractie geeft. ',
+      observation_snapshot: ' Werkdruk bleef zichtbaar in hetzelfde team. ',
+      decision_recorded_at: '2026-04-25T09:00:00.000Z',
+      review_completed_at: '2026-04-25T08:30:00.000Z',
+    })
+
+    expect(parsed).toEqual({
+      route_source_type: 'campaign',
+      route_source_id: 'campaign-1',
+      checkpoint_id: 'checkpoint-1',
+      decision: 'bijstellen',
+      decision_reason: 'De eerste stap gaf nog geen stabiele verbetering.',
+      next_check: 'Toets volgende week of de frictie daalt.',
+      current_step: 'Plan een eerste teamgesprek.',
+      next_step: 'Check of het teamgesprek plaatsvond.',
+      expected_effect: 'Maak zichtbaar of de eerste stap tractie geeft.',
+      observation_snapshot: 'Werkdruk bleef zichtbaar in hetzelfde team.',
+      decision_recorded_at: '2026-04-25T09:00:00.000Z',
+      review_completed_at: '2026-04-25T08:30:00.000Z',
+    })
+  })
+
+  it('rejects authored review decision input when required fields or decision values are invalid', () => {
+    expect(() =>
+      validateActionCenterReviewDecisionWriteInput({
+        route_source_type: 'campaign',
+        route_source_id: 'campaign-1',
+        checkpoint_id: 'checkpoint-1',
+        decision: 'opschalen',
+        decision_reason: '',
+        next_check: '',
+        current_step: '',
+        next_step: null,
+        expected_effect: null,
+        observation_snapshot: null,
+        decision_recorded_at: 'not-a-date',
+        review_completed_at: '',
+      }),
+    ).toThrowError('Ongeldige authored review decision input.')
   })
 })

--- a/frontend/lib/action-center-review-decisions.ts
+++ b/frontend/lib/action-center-review-decisions.ts
@@ -2,6 +2,7 @@ import type {
   ActionCenterReviewDecision,
   ActionCenterRouteSourceType,
   AuthoredActionCenterDecision,
+  LearningCheckpointKey,
 } from './pilot-learning'
 
 const AUTHORED_DECISION_VALUES = new Set<AuthoredActionCenterDecision>([
@@ -11,11 +12,31 @@ const AUTHORED_DECISION_VALUES = new Set<AuthoredActionCenterDecision>([
   'stoppen',
 ])
 
+const ACTION_CENTER_DECISION_CHECKPOINT_KEYS = new Set<LearningCheckpointKey>([
+  'first_management_use',
+  'follow_up_review',
+])
+
 export type {
   ActionCenterReviewDecision,
   ActionCenterRouteSourceType,
   AuthoredActionCenterDecision,
 } from './pilot-learning'
+
+export interface ActionCenterReviewDecisionWriteInput {
+  route_source_type: ActionCenterRouteSourceType
+  route_source_id: string
+  checkpoint_id: string
+  decision: AuthoredActionCenterDecision
+  decision_reason: string
+  next_check: string
+  current_step: string
+  next_step: string | null
+  expected_effect: string | null
+  observation_snapshot: string | null
+  decision_recorded_at: string
+  review_completed_at: string
+}
 
 function normalizeText(value: string | null | undefined) {
   const trimmed = value?.trim() ?? ''
@@ -39,6 +60,64 @@ export function normalizeActionCenterReviewDecision(
   return AUTHORED_DECISION_VALUES.has(normalized as AuthoredActionCenterDecision)
     ? (normalized as AuthoredActionCenterDecision)
     : null
+}
+
+function isIsoTimestamp(value: string | null | undefined) {
+  return parseTimestamp(value) !== Number.NEGATIVE_INFINITY
+}
+
+export function isActionCenterDecisionCheckpointKey(
+  value: LearningCheckpointKey | string | null | undefined,
+): value is 'first_management_use' | 'follow_up_review' {
+  return ACTION_CENTER_DECISION_CHECKPOINT_KEYS.has(value as LearningCheckpointKey)
+}
+
+export function validateActionCenterReviewDecisionWriteInput(
+  input: Partial<ActionCenterReviewDecisionWriteInput> | null | undefined,
+): ActionCenterReviewDecisionWriteInput {
+  const routeSourceType = input?.route_source_type
+  const routeSourceId = normalizeText(input?.route_source_id)
+  const checkpointId = normalizeText(input?.checkpoint_id)
+  const decision = normalizeActionCenterReviewDecision(input?.decision)
+  const decisionReason = normalizeText(input?.decision_reason)
+  const nextCheck = normalizeText(input?.next_check)
+  const currentStep = normalizeText(input?.current_step)
+  const nextStep = normalizeText(input?.next_step)
+  const expectedEffect = normalizeText(input?.expected_effect)
+  const observationSnapshot = normalizeText(input?.observation_snapshot)
+  const decisionRecordedAt = normalizeText(input?.decision_recorded_at)
+  const reviewCompletedAt = normalizeText(input?.review_completed_at)
+
+  if (
+    routeSourceType !== 'campaign' ||
+    !routeSourceId ||
+    !checkpointId ||
+    !decision ||
+    !decisionReason ||
+    !nextCheck ||
+    !currentStep ||
+    !decisionRecordedAt ||
+    !reviewCompletedAt ||
+    !isIsoTimestamp(decisionRecordedAt) ||
+    !isIsoTimestamp(reviewCompletedAt)
+  ) {
+    throw new Error('Ongeldige authored review decision input.')
+  }
+
+  return {
+    route_source_type: routeSourceType,
+    route_source_id: routeSourceId,
+    checkpoint_id: checkpointId,
+    decision,
+    decision_reason: decisionReason,
+    next_check: nextCheck,
+    current_step: currentStep,
+    next_step: nextStep,
+    expected_effect: expectedEffect,
+    observation_snapshot: observationSnapshot,
+    decision_recorded_at: decisionRecordedAt,
+    review_completed_at: reviewCompletedAt,
+  }
 }
 
 export function sortActionCenterReviewDecisions(decisions: ActionCenterReviewDecision[]) {

--- a/frontend/lib/action-center-review-decisions.ts
+++ b/frontend/lib/action-center-review-decisions.ts
@@ -1,0 +1,69 @@
+import type {
+  ActionCenterReviewDecision,
+  ActionCenterRouteSourceType,
+  AuthoredActionCenterDecision,
+} from './pilot-learning'
+
+const AUTHORED_DECISION_VALUES = new Set<AuthoredActionCenterDecision>([
+  'doorgaan',
+  'bijstellen',
+  'afronden',
+  'stoppen',
+])
+
+export type {
+  ActionCenterReviewDecision,
+  ActionCenterRouteSourceType,
+  AuthoredActionCenterDecision,
+} from './pilot-learning'
+
+function normalizeText(value: string | null | undefined) {
+  const trimmed = value?.trim() ?? ''
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function parseTimestamp(value: string | null | undefined) {
+  const normalized = normalizeText(value)
+  if (!normalized) return Number.NEGATIVE_INFINITY
+
+  const timestamp = new Date(normalized).getTime()
+  return Number.isNaN(timestamp) ? Number.NEGATIVE_INFINITY : timestamp
+}
+
+export function normalizeActionCenterReviewDecision(
+  value: string | null | undefined,
+): AuthoredActionCenterDecision | null {
+  const normalized = normalizeText(value)
+  if (!normalized) return null
+
+  return AUTHORED_DECISION_VALUES.has(normalized as AuthoredActionCenterDecision)
+    ? (normalized as AuthoredActionCenterDecision)
+    : null
+}
+
+export function sortActionCenterReviewDecisions(decisions: ActionCenterReviewDecision[]) {
+  return [...decisions].sort((left, right) => {
+    const decisionRecordedDelta =
+      parseTimestamp(right.decision_recorded_at) - parseTimestamp(left.decision_recorded_at)
+    if (decisionRecordedDelta !== 0) {
+      return decisionRecordedDelta
+    }
+
+    const reviewCompletedDelta =
+      parseTimestamp(right.review_completed_at) - parseTimestamp(left.review_completed_at)
+    if (reviewCompletedDelta !== 0) {
+      return reviewCompletedDelta
+    }
+
+    const createdAtDelta = parseTimestamp(right.created_at) - parseTimestamp(left.created_at)
+    if (createdAtDelta !== 0) {
+      return createdAtDelta
+    }
+
+    return left.id.localeCompare(right.id)
+  })
+}
+
+export function shouldUseLegacyDecisionFallback(decisions: ActionCenterReviewDecision[]) {
+  return decisions.length === 0
+}

--- a/frontend/lib/action-center-route-contract.ts
+++ b/frontend/lib/action-center-route-contract.ts
@@ -34,6 +34,8 @@ export interface ActionCenterDecisionRecord {
   decisionRecordedAt: string
   reviewCompletedAt: string | null
   currentStepSnapshot?: string | null
+  nextStepSnapshot?: string | null
+  expectedEffectSnapshot?: string | null
   observationSnapshot?: string | null
 }
 

--- a/frontend/lib/pilot-learning.ts
+++ b/frontend/lib/pilot-learning.ts
@@ -35,6 +35,8 @@ export type LearningStrength =
   | 'incidentele_observatie'
   | 'terugkerend_patroon'
   | 'direct_uitvoerbare_verbetering'
+export type ActionCenterRouteSourceType = 'campaign'
+export type AuthoredActionCenterDecision = 'doorgaan' | 'bijstellen' | 'afronden' | 'stoppen'
 
 export interface ContactRequestRecord {
   id: string
@@ -124,6 +126,26 @@ export interface PilotLearningCheckpoint {
   confirmed_lesson: string | null
   lesson_strength: LearningStrength
   destination_areas: LearningDestinationArea[]
+  created_at: string
+  updated_at: string
+}
+
+export interface ActionCenterReviewDecision {
+  id: string
+  route_source_type: ActionCenterRouteSourceType
+  route_source_id: string
+  checkpoint_id: string
+  decision: AuthoredActionCenterDecision
+  decision_reason: string
+  next_check: string
+  current_step: string
+  next_step: string | null
+  expected_effect: string | null
+  observation_snapshot: string | null
+  decision_recorded_at: string
+  review_completed_at: string
+  created_by: string | null
+  updated_by: string | null
   created_at: string
   updated_at: string
 }

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -627,6 +627,28 @@ create table if not exists public.pilot_learning_checkpoints (
   unique (dossier_id, checkpoint_key)
 );
 
+create table if not exists public.action_center_review_decisions (
+  id uuid primary key default gen_random_uuid(),
+  route_source_type text not null
+    check (route_source_type in ('campaign')),
+  route_source_id uuid references public.campaigns(id) on delete cascade not null,
+  checkpoint_id uuid references public.pilot_learning_checkpoints(id) on delete cascade not null,
+  decision text not null
+    check (decision in ('doorgaan', 'bijstellen', 'afronden', 'stoppen')),
+  decision_reason text not null,
+  next_check text not null,
+  current_step text not null,
+  next_step text,
+  expected_effect text,
+  observation_snapshot text,
+  decision_recorded_at timestamptz not null,
+  review_completed_at timestamptz not null,
+  created_by uuid references auth.users(id) on delete set null,
+  updated_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
 -- ============================================================
 -- INDEXES
 -- ============================================================
@@ -645,6 +667,9 @@ create index if not exists idx_learning_dossiers_org on public.pilot_learning_do
 create index if not exists idx_learning_dossiers_campaign on public.pilot_learning_dossiers(campaign_id);
 create index if not exists idx_learning_dossiers_contact_request on public.pilot_learning_dossiers(contact_request_id);
 create index if not exists idx_learning_checkpoints_dossier on public.pilot_learning_checkpoints(dossier_id);
+create index if not exists idx_action_center_review_decisions_route on public.action_center_review_decisions(route_source_type, route_source_id);
+create index if not exists idx_action_center_review_decisions_checkpoint on public.action_center_review_decisions(checkpoint_id);
+create index if not exists idx_action_center_review_decisions_recorded_at on public.action_center_review_decisions(decision_recorded_at desc);
 create index if not exists idx_delivery_records_org on public.campaign_delivery_records(organization_id);
 create index if not exists idx_delivery_records_contact_request on public.campaign_delivery_records(contact_request_id);
 create index if not exists idx_delivery_records_lifecycle on public.campaign_delivery_records(lifecycle_stage);
@@ -666,6 +691,7 @@ alter table public.campaign_delivery_records enable row level security;
 alter table public.campaign_delivery_checkpoints enable row level security;
 alter table public.pilot_learning_dossiers enable row level security;
 alter table public.pilot_learning_checkpoints enable row level security;
+alter table public.action_center_review_decisions enable row level security;
 
 -- ── Hulpfuncties ─────────────────────────────────────────────────────────────
 
@@ -1036,6 +1062,23 @@ create policy "verisight_admins_can_update_learning_checkpoints"
         and public.is_verisight_admin_user()
     )
   );
+
+drop policy if exists "verisight_admins_can_select_action_center_review_decisions" on public.action_center_review_decisions;
+drop policy if exists "verisight_admins_can_insert_action_center_review_decisions" on public.action_center_review_decisions;
+drop policy if exists "verisight_admins_can_update_action_center_review_decisions" on public.action_center_review_decisions;
+
+create policy "verisight_admins_can_select_action_center_review_decisions"
+  on public.action_center_review_decisions for select
+  using (public.is_verisight_admin_user());
+
+create policy "verisight_admins_can_insert_action_center_review_decisions"
+  on public.action_center_review_decisions for insert
+  with check (public.is_verisight_admin_user());
+
+create policy "verisight_admins_can_update_action_center_review_decisions"
+  on public.action_center_review_decisions for update
+  using (public.is_verisight_admin_user())
+  with check (public.is_verisight_admin_user());
 
 -- ============================================================
 -- PROFILES: is_verisight_admin per gebruiker


### PR DESCRIPTION
## Summary
- add the authored Action Center review decision contract, schema, and admin APIs as the canonical write-path for `decision`, `decisionReason`, `nextCheck`, `currentStep`, `nextStep`, and `expectedEffect`
- make authored review decisions the primary Action Center semantics source and decision-history source whenever present, while keeping managers read-only
- add an internal beheer/klantlearnings write-surface so Verisight admins can author and update review decisions in the same dossier flow that feeds the preview and live Action Center projection

## Why
- the previous phase made decision history readable, but it was still largely derived from legacy review truth
- this phase moves the review/result loop onto an explicit authored truth layer without introducing new manager interaction
- the beheer surface keeps the write-path internal while making the Action Center projection more trustworthy and reviewable over time

## Validation
- `npm test -- "lib/action-center-review-decision-editor-state.test.ts" "lib/action-center-review-decisions.test.ts" "lib/action-center-decision-history.test.ts" "lib/action-center-core-semantics.test.ts" "lib/action-center-live.test.ts" "lib/action-center-preview-display.test.ts" "lib/action-center-preview-route-fields-render.test.ts" "app/(dashboard)/action-center/page.route-shell.test.ts"`
- `npx eslint "lib/action-center-review-decision-editor-state.ts" "lib/action-center-review-decision-editor-state.test.ts" "lib/action-center-review-decisions.ts" "lib/action-center-route-contract.ts" "lib/action-center-decision-history.ts" "lib/action-center-core-semantics.ts" "lib/action-center-live.ts" "components/dashboard/action-center-preview.tsx" "components/dashboard/action-center-review-decision-editor.tsx" "components/dashboard/pilot-learning-workbench.tsx" "app/(dashboard)/beheer/klantlearnings/page.tsx" "app/api/action-center-review-decisions/route.ts" "app/api/action-center-review-decisions/[id]/route.ts"`
- `npm run build`

## Notes
- `gh` is not available in this environment, so this PR was opened through the GitHub connector fallback
- the local worktree needed `.env.local` parity with the main dashboard worktree for `npm run build`; that env file was not added to git scope