### PR TITLE
[codex] Enrich Action Center review decisions and result progression

### DIFF
--- a/docs/superpowers/plans/2026-04-29-action-center-action-quality.md
+++ b/docs/superpowers/plans/2026-04-29-action-center-action-quality.md
@@ -1,0 +1,20 @@
+## Action Center Stronger Action Quality Plan
+
+### Task 1: add action-quality tests and shared rules
+- add tests for authored step/effect validation
+- add shared helpers for step-like versus effect-like text
+- keep rules small and decision-aware
+
+### Task 2: enforce stronger action quality in authored write input
+- reject clearly weak authored combinations
+- improve admin guidance for `currentStep`, `nextStep`, `expectedEffect`
+
+### Task 3: tighten Action Center projection
+- keep actionProgress and actionFrame aligned with stronger quality rules
+- ensure closing decisions do not regress into open action phrasing
+
+### Task 4: verify and checkpoint
+- run focused tests
+- lint changed files
+- run build
+- commit as phase 2 checkpoint

--- a/docs/superpowers/plans/2026-04-29-action-center-result-loop-over-time.md
+++ b/docs/superpowers/plans/2026-04-29-action-center-result-loop-over-time.md
@@ -1,0 +1,20 @@
+## Action Center Result Loop Over Time Plan
+
+### Task 1: add result-progression projection tests
+- cover authored history with multiple review moments
+- verify chronological ordering and follow-through fallback
+- keep existing latest-decision semantics intact
+
+### Task 2: add shared result-progression projection
+- project compact over-time entries from canonical decision history
+- expose the new layer through shared Action Center semantics
+
+### Task 3: render richer detail progression
+- add `Resultaat over tijd` to the Action Center detail surface
+- keep landing compact and unchanged in density
+
+### Task 4: verify and checkpoint
+- run focused tests
+- lint changed files
+- run build
+- commit as phase 3 checkpoint

--- a/docs/superpowers/plans/2026-04-29-action-center-richer-review-decisions.md
+++ b/docs/superpowers/plans/2026-04-29-action-center-richer-review-decisions.md
@@ -1,0 +1,22 @@
+## Action Center Richer Review Decisions Plan
+
+### Task 1: add decision-profile rules and tests
+- extend authored decision tests with decision-specific requirements
+- add shared helpers that classify decisions into open vs closing behavior
+- add validation rules for `doorgaan`, `bijstellen`, `afronden`, `stoppen`
+
+### Task 2: project richer review-decision semantics into Action Center
+- add shared projection for `decisionSummary`, `decisionGuidance`, `nextCheckVisibility`
+- apply it in core semantics and decision history rendering
+- ensure closeout decisions do not render open follow-up fields
+
+### Task 3: strengthen beheer write-surface
+- surface decision-specific guidance in the authored admin editor
+- enforce decision-specific behavior in the editor payload
+- keep manager-facing Action Center read-only
+
+### Task 4: verify and publish
+- run focused tests
+- lint changed files
+- run build with local env parity if needed
+- commit, push, PR, review, merge

--- a/docs/superpowers/specs/2026-04-29-action-center-action-quality-design.md
+++ b/docs/superpowers/specs/2026-04-29-action-center-action-quality-design.md
@@ -1,0 +1,74 @@
+## Action Center Stronger Action Quality
+
+### Doel
+Deze fase verdiept de authored actielaag zodat routes minder op generieke tekst en meer op echte managementinterventies leunen.
+
+De kern:
+- `currentStep`, `nextStep`, `expectedEffect` blijven de canonieke authored velden
+- de productlaag definieert nu explicieter wat een goede stap en een goed effect is
+- open routebesluiten moeten een geloofwaardige voortgangslijn tonen
+
+### Productgrens
+Wel:
+- sterkere kwaliteitsregels voor authored actievelden
+- betere guidance in de admin-write-surface
+- compacter en consistenter zichtbaar actieframe in Action Center
+
+Niet:
+- tasklists
+- meerdere parallelle steps
+- nieuwe managerinput
+- workflowuitbreiding
+
+### Canonieke actieregels
+
+#### CurrentStep
+- moet een concrete lopende managementhandeling beschrijven
+- hoort te lezen als interventie, niet als observatie of vraag
+- mag niet alleen een outcome-label of abstracte status zijn
+
+#### NextStep
+- is de eerstvolgende bounded stap na `currentStep`
+- hoort alleen zichtbaar te blijven bij open routebesluiten
+- moet verschillen van `currentStep`, tenzij het product expliciet een vervolgcheck zonder koerscorrectie projecteert
+
+#### ExpectedEffect
+- beschrijft wat deze stap zichtbaar moet maken
+- hoort als effect te lezen, niet als extra taak
+- blijft verplicht voor open routebesluiten
+
+### Kwaliteitsprojectie
+Deze fase introduceert een kleine gedeelde presentatielaag:
+- `actionQuality`
+- `actionGuidance`
+
+#### ActionQuality
+Geeft per authored decision aan of de actielaag:
+- concrete staptaal heeft
+- een logisch vervolg toont
+- een echt effect beschrijft
+
+Deze laag is intern productmatig en wordt niet als score naar eindgebruikers gevisualiseerd.
+
+#### ActionGuidance
+Korte interne guidance voor de beheer-editor:
+- wanneer een stap te vaag is
+- wanneer `expectedEffect` als taak leest
+- wanneer `nextStep` te veel op `currentStep` lijkt
+
+### Zichtbaar gedrag
+Action Center-detail moet daardoor sneller voelen als:
+- dit loopt nu
+- dit volgt daarna
+- dit moet het opleveren
+
+Landing blijft compact:
+- `Stap`
+- eventueel impliciet vervolg via decision-context
+
+### Succescriteria
+Geslaagd als:
+- minder authored stappen op observatie- of vraagtaal leunen
+- `expectedEffect` minder vaak een tweede taakzin is
+- `currentStep` en `nextStep` beter als kleine voortgangslijn voelen
+- managers nog steeds niets extra’s hoeven in te voeren

--- a/docs/superpowers/specs/2026-04-29-action-center-result-loop-over-time-design.md
+++ b/docs/superpowers/specs/2026-04-29-action-center-result-loop-over-time-design.md
@@ -1,0 +1,65 @@
+## Action Center Result Loop Over Time
+
+### Doel
+Deze fase maakt zichtbaar hoe een route zich over meerdere reviewmomenten ontwikkelt.
+
+De kern:
+- de bestaande `decisionHistory` blijft de canonieke bron
+- de productlaag projecteert daar nu een compacte `resultProgression` uit
+- detail laat daardoor niet alleen de laatste stand zien, maar ook de opeenvolging van stap -> observatie -> besluit -> vervolg
+
+### Productgrens
+Wel:
+- gedeelde result-progressie uit canonieke decision history
+- rijkere detailweergave van meerdere reviewmomenten
+- compacte, rustige landing zonder extra workflow
+
+Niet:
+- auditlog
+- extra managerinput
+- generieke eventtimeline
+- nieuwe statussen of decision-typen
+
+### Canonieke projectieregel
+`resultProgression` is geen aparte authored truth.
+
+Het is een gedeelde projectie uit `decisionHistory`, met per entry:
+- `resultEntryId`
+- `recordedAt`
+- `currentStep`
+- `observation`
+- `decision`
+- `followThrough`
+
+#### Ordering
+- detail toont de progressie chronologisch oud -> nieuw
+- de nieuwste entry blijft wel de bron voor `latestDecision` en de bestaande actuele result-loop
+
+#### FollowThrough
+`followThrough` komt primair uit:
+- `nextStepSnapshot`
+- anders `nextCheck`
+- anders `expectedEffectSnapshot`
+
+Daardoor blijft zichtbaar wat uit een besluit logisch volgde, ook als niet elk historisch moment exact dezelfde velden droeg.
+
+### Surfacegedrag
+#### Landing
+- blijft compact
+- toont geen volledige progression feed
+- mag hooguit de laatste actuele result-loop en laatste beslissing blijven samenvatten
+
+#### Detail
+- krijgt een expliciete sectie `Resultaat over tijd`
+- elke entry toont compact:
+  - wat liep
+  - wat zagen we
+  - wat besloten we
+  - wat volgde daarna
+
+### Succescriteria
+Geslaagd als:
+- authored routes met meerdere reviewmomenten als echte voortgangslijn leesbaar worden
+- resultaat niet alleen in de laatste update blijft hangen
+- detail inhoudelijk rijker voelt zonder logboekdrukte
+- landing rustig blijft

--- a/docs/superpowers/specs/2026-04-29-action-center-richer-review-decisions-design.md
+++ b/docs/superpowers/specs/2026-04-29-action-center-richer-review-decisions-design.md
@@ -1,0 +1,104 @@
+## Action Center Richer Review Decisions
+
+### Doel
+Deze fase verdiept `review decisions` zonder nieuwe managerinput of bredere workflow. De kern is:
+- authored decisions blijven de canonieke write-path
+- reviewbesluiten krijgen sterkere beslisregels per `decision`
+- zichtbare Action Center-semantiek gaat minder op losse vrije tekst leunen
+
+### Productgrens
+Wel:
+- sterkere beslisregels rond `doorgaan`, `bijstellen`, `afronden`, `stoppen`
+- decision-specifieke zichtbare semantics in detail en history
+- interne admin-begeleiding in de bestaande beheer-write-surface
+
+Niet:
+- nieuwe managerinteractie
+- uitbreiding naar task management
+- brede statusmachine
+- auditlog of extra reviewworkflow
+
+### Canonieke beslissingstypen
+De bestaande authored `decision`-set blijft canoniek:
+- `doorgaan`
+- `bijstellen`
+- `afronden`
+- `stoppen`
+
+Deze fase voegt geen extra decision-values toe. In plaats daarvan krijgt elke value een vaste productregel:
+
+#### Doorgaan
+- huidige stap blijft inhoudelijk geldig
+- `nextStep` mag leeg zijn of hetzelfde spoor volgen
+- `nextCheck` moet bevestigen wat nog moet blijken voordat de route weer reviewt
+
+#### Bijstellen
+- de review heeft expliciet een koerscorrectie opgeleverd
+- `nextStep` moet aanwezig zijn en inhoudelijk verschillen van alleen een herhaling van de huidige stap
+- `observationSnapshot` moet gevuld zijn, zodat zichtbaar is wat de bijstelling triggerde
+
+#### Afronden
+- de route kan inhoudelijk sluiten
+- `nextStep` hoort leeg te zijn
+- `nextCheck` hoort leeg te zijn
+- zichtbare semantics moeten dit als sluitbesluit tonen, niet als open vervolg
+
+#### Stoppen
+- de route wordt bewust beëindigd
+- `nextStep` hoort leeg te zijn
+- `nextCheck` hoort leeg te zijn
+- de stopreden moet zichtbaar blijven in `decisionReason`
+
+### Canonieke projectielaag
+Deze fase introduceert een kleine gedeelde presentatielaag bovenop bestaande authored truth:
+- `decisionSummary`
+- `decisionGuidance`
+- `nextCheckVisibility`
+
+Dit zijn expliciet geen losse component-heuristieken. Ze worden uit authored decision-truth geprojecteerd.
+
+#### DecisionSummary
+Korte zichtbare samenvatting van de beslisrichting:
+- doorgaan = huidige spoor loopt door
+- bijstellen = koerscorrectie nodig
+- afronden = route inhoudelijk klaar
+- stoppen = route bewust beëindigd
+
+#### DecisionGuidance
+Korte, decision-gebonden UI-hulp in de admin write-surface:
+- welke velden nu verplicht of logisch zijn
+- welke velden juist niet meer horen te vullen
+
+#### NextCheckVisibility
+Vaste zichtbaarheidregel:
+- alleen tonen als het besluit nog open vervolg heeft
+- dus wel bij `doorgaan` en `bijstellen`
+- niet bij `afronden` en `stoppen`
+
+### Action Center detail
+Detailweergave moet hierdoor sterker en consistenter worden:
+- `Laatste beslissing` blijft
+- `Waarom dit besluit` blijft
+- `Volgende toets` verdwijnt automatisch bij afsluitende besluiten
+- detail maakt zichtbaar of het besluit een open vervolg of sluiting betekent
+
+### Decision history
+Decision history blijft compact, maar volgt nu dezelfde regels:
+- afsluitende entries tonen geen synthetische next check
+- bijstelentries tonen expliciet dat het om koerscorrectie gaat
+- doorloopentries blijven zichtbaar als voortzettingsbesluit
+
+### Beheer-write-surface
+De bestaande authored decision-editor blijft de enige write-surface.
+Deze fase scherpt hem aan met:
+- decision-specifieke guidance
+- decision-specifieke validatie
+- duidelijker gedrag rond open versus afsluitende besluiten
+
+### Succescriteria
+Geslaagd als:
+- authored review decisions inhoudelijk consistenter worden ingevuld
+- Action Center minder open velden toont die niet bij het besluittype passen
+- afsluitende besluiten duidelijker als sluiting voelen
+- bijstelbesluiten zichtbaarder koerscorrectie tonen
+- managers nog steeds read-only blijven

--- a/frontend/components/dashboard/action-center-preview.tsx
+++ b/frontend/components/dashboard/action-center-preview.tsx
@@ -1324,6 +1324,19 @@ export function ActionCenterPreview({
                           </div>
 
                           <div>
+                            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/48">Resultaat over tijd</p>
+                            <div className="mt-3 space-y-3">
+                              {selectedItem.coreSemantics.resultProgression.length === 0 ? (
+                                <EmptyBlock text="Nog geen opeenvolgende resultaatmomenten zichtbaar in deze route." />
+                              ) : (
+                                selectedItem.coreSemantics.resultProgression.map((entry) => (
+                                  <ResultProgressionEntry key={entry.resultEntryId} entry={entry} />
+                                ))
+                              )}
+                            </div>
+                          </div>
+
+                          <div>
                             <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/48">Beslisgeschiedenis</p>
                             <div className="mt-3 space-y-3">
                               {selectedItem.coreSemantics.decisionHistory.length === 0 ? (
@@ -2267,6 +2280,39 @@ function DecisionHistoryEntry({ entry }: { entry: ActionCenterDecisionRecord }) 
           ))}
         </div>
       ) : null}
+    </div>
+  )
+}
+
+function ResultProgressionEntry({
+  entry,
+}: {
+  entry: ActionCenterPreviewItem['coreSemantics']['resultProgression'][number]
+}) {
+  const rows = [
+    entry.currentStep ? { label: 'Liep', value: entry.currentStep } : null,
+    entry.observation ? { label: 'Teruggezien', value: entry.observation } : null,
+    { label: 'Besloten', value: getDecisionLabel(entry.decision) },
+    entry.followThrough ? { label: 'Volgde daarna', value: entry.followThrough } : null,
+  ].filter((row): row is { label: string; value: string } => Boolean(row))
+
+  return (
+    <div className="rounded-[18px] border border-white/10 bg-white/[0.04] px-4 py-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <span className="inline-flex items-center rounded-xl border border-white/10 bg-white/[0.06] px-3 py-1.5 text-sm font-semibold text-white/88">
+          {formatLongDate(entry.recordedAt)}
+        </span>
+        <span className="text-xs uppercase tracking-[0.16em] text-white/40">Resultaatmoment</span>
+      </div>
+
+      <div className="mt-4 space-y-2.5">
+        {rows.map((row) => (
+          <div key={`${entry.resultEntryId}-${row.label}`} className="flex items-start justify-between gap-3 text-sm">
+            <span className="shrink-0 font-semibold text-white/46">{row.label}</span>
+            <span className="text-right leading-6 text-white/82">{row.value}</span>
+          </div>
+        ))}
+      </div>
     </div>
   )
 }

--- a/frontend/components/dashboard/action-center-review-decision-editor.tsx
+++ b/frontend/components/dashboard/action-center-review-decision-editor.tsx
@@ -8,6 +8,7 @@ import {
   toIsoDateTimeString,
   type ActionCenterReviewDecisionFormState,
 } from '@/lib/action-center-review-decision-editor-state'
+import { getActionCenterDecisionGuidance, getActionCenterDecisionProfile } from '@/lib/action-center-review-decisions'
 import type {
   ActionCenterReviewDecision,
   AuthoredActionCenterDecision,
@@ -97,6 +98,8 @@ export function ActionCenterReviewDecisionEditor({ dossier, checkpoint, decision
   }, [checkpoint, decision, dossier])
 
   const routeUnavailable = !form.route_source_id
+  const decisionProfile = getActionCenterDecisionProfile(form.decision)
+  const decisionGuidance = getActionCenterDecisionGuidance(form.decision)
 
   async function handleSave() {
     setError(null)
@@ -136,7 +139,7 @@ export function ActionCenterReviewDecisionEditor({ dossier, checkpoint, decision
         <div>
           <p className="text-sm font-semibold text-slate-950">Action Center review decision</p>
           <p className="mt-1 text-xs leading-5 text-slate-600">
-            Gebruik deze authored laag om de canonieke reviewbeslissing, actuele stap en volgende toets expliciet vast te leggen zonder managers extra invoer te geven.
+            {decisionGuidance}
           </p>
         </div>
         <div className="flex flex-wrap gap-2">
@@ -212,6 +215,8 @@ export function ActionCenterReviewDecisionEditor({ dossier, checkpoint, decision
           id={`next-check-${checkpoint.id}`}
           value={form.next_check}
           onChange={(value) => setForm((current) => ({ ...current, next_check: value }))}
+          disabled={decisionProfile.hidesNextCheck}
+          placeholder={decisionProfile.hidesNextCheck ? 'Niet van toepassing bij een afsluitend besluit.' : undefined}
         />
         <TextAreaField
           label="Huidige stap"
@@ -224,6 +229,8 @@ export function ActionCenterReviewDecisionEditor({ dossier, checkpoint, decision
           id={`next-step-${checkpoint.id}`}
           value={form.next_step}
           onChange={(value) => setForm((current) => ({ ...current, next_step: value }))}
+          disabled={decisionProfile.hidesNextStep}
+          placeholder={decisionProfile.hidesNextStep ? 'Laat leeg bij een afsluitend besluit.' : undefined}
         />
         <TextAreaField
           label="Verwacht effect"
@@ -259,11 +266,15 @@ function TextAreaField({
   label,
   value,
   onChange,
+  disabled = false,
+  placeholder,
 }: {
   id: string
   label: string
   value: string
   onChange: (value: string) => void
+  disabled?: boolean
+  placeholder?: string
 }) {
   return (
     <div>
@@ -272,6 +283,8 @@ function TextAreaField({
         id={id}
         value={value}
         onChange={(event) => onChange(event.target.value)}
+        disabled={disabled}
+        placeholder={placeholder}
         rows={4}
         className={`${FIELD_CLASS} min-h-[112px]`}
       />

--- a/frontend/components/dashboard/action-center-review-decision-editor.tsx
+++ b/frontend/components/dashboard/action-center-review-decision-editor.tsx
@@ -8,7 +8,11 @@ import {
   toIsoDateTimeString,
   type ActionCenterReviewDecisionFormState,
 } from '@/lib/action-center-review-decision-editor-state'
-import { getActionCenterDecisionGuidance, getActionCenterDecisionProfile } from '@/lib/action-center-review-decisions'
+import {
+  getActionCenterActionGuidance,
+  getActionCenterDecisionGuidance,
+  getActionCenterDecisionProfile,
+} from '@/lib/action-center-review-decisions'
 import type {
   ActionCenterReviewDecision,
   AuthoredActionCenterDecision,
@@ -100,6 +104,11 @@ export function ActionCenterReviewDecisionEditor({ dossier, checkpoint, decision
   const routeUnavailable = !form.route_source_id
   const decisionProfile = getActionCenterDecisionProfile(form.decision)
   const decisionGuidance = getActionCenterDecisionGuidance(form.decision)
+  const actionGuidance = getActionCenterActionGuidance({
+    currentStep: form.current_step,
+    nextStep: form.next_step,
+    expectedEffect: form.expected_effect,
+  })
 
   async function handleSave() {
     setError(null)
@@ -244,6 +253,10 @@ export function ActionCenterReviewDecisionEditor({ dossier, checkpoint, decision
           value={form.observation_snapshot}
           onChange={(value) => setForm((current) => ({ ...current, observation_snapshot: value }))}
         />
+      </div>
+
+      <div className="mt-4 rounded-2xl border border-white/80 bg-white/80 px-4 py-3 text-sm text-slate-700">
+        <span className="font-semibold text-slate-900">Actiekwaliteit:</span> {actionGuidance}
       </div>
 
       {error ? <p className="mt-4 text-sm text-red-700">{error}</p> : null}

--- a/frontend/lib/action-center-core-semantics.test.ts
+++ b/frontend/lib/action-center-core-semantics.test.ts
@@ -271,6 +271,80 @@ describe('action center core semantics', () => {
       expect(semantics.decisionHistory[0]?.decisionEntryId).toBe('authored-decision-1')
     })
 
+    it('projects a chronological result progression from multiple authored decision moments', () => {
+      const semantics = projectActionCenterCoreSemantics({
+        ...buildContext({
+          dossier: buildDossier({
+            management_action_outcome: 'bijstellen',
+            first_action_taken: 'Voer deze week een gerichte managercheck uit.',
+            expected_first_value: 'Binnen twee weken moet zichtbaar zijn of de correctie smaller werkt.',
+          }),
+          reviewDecisions: [
+            {
+              id: 'authored-decision-2',
+              route_source_type: 'campaign',
+              route_source_id: 'campaign-1',
+              checkpoint_id: 'checkpoint-2',
+              decision: 'bijstellen',
+              decision_reason: 'Dezelfde frictie bleef in twee teams zichtbaar.',
+              next_check: 'Toets volgende week of de bijgestelde stap tractie geeft.',
+              current_step: 'Voer deze week een gerichte managercheck uit.',
+              next_step: 'Leg de bijgestelde route vast in het MT-overleg.',
+              expected_effect: 'Binnen twee weken moet zichtbaar zijn of de correctie smaller werkt.',
+              observation_snapshot: 'Dezelfde frictie bleef in twee teams zichtbaar.',
+              decision_recorded_at: '2026-04-28T09:00:00.000Z',
+              review_completed_at: '2026-04-28T08:30:00.000Z',
+              created_by: null,
+              updated_by: null,
+              created_at: '2026-04-28T09:00:00.000Z',
+              updated_at: '2026-04-28T09:00:00.000Z',
+            },
+            {
+              id: 'authored-decision-1',
+              route_source_type: 'campaign',
+              route_source_id: 'campaign-1',
+              checkpoint_id: 'checkpoint-1',
+              decision: 'doorgaan',
+              decision_reason: 'De eerste stap liep nog binnen de afgesproken termijn.',
+              next_check: 'Toets over een week of de eerste stap tractie geeft.',
+              current_step: 'Plan een eerste teamreview met de manager.',
+              next_step: 'Bevestig de route in het MT-overleg.',
+              expected_effect: 'Binnen twee weken moet zichtbaar zijn of de eerste review de frictie smaller maakt.',
+              observation_snapshot: 'De eerste signalen bleven nog breed verdeeld.',
+              decision_recorded_at: '2026-04-25T09:00:00.000Z',
+              review_completed_at: '2026-04-25T08:30:00.000Z',
+              created_by: null,
+              updated_by: null,
+              created_at: '2026-04-25T09:00:00.000Z',
+              updated_at: '2026-04-25T09:00:00.000Z',
+            },
+          ],
+        }),
+        campaign: { id: 'campaign-1', name: 'ExitScan april' } as never,
+        route: baseRoute,
+      })
+
+      expect(semantics.resultProgression).toEqual([
+        {
+          resultEntryId: 'authored-decision-1',
+          recordedAt: '2026-04-25T08:30:00.000Z',
+          currentStep: 'Plan een eerste teamreview met de manager.',
+          observation: 'De eerste signalen bleven nog breed verdeeld.',
+          decision: 'doorgaan',
+          followThrough: 'Bevestig de route in het MT-overleg.',
+        },
+        {
+          resultEntryId: 'authored-decision-2',
+          recordedAt: '2026-04-28T08:30:00.000Z',
+          currentStep: 'Voer deze week een gerichte managercheck uit.',
+          observation: 'Dezelfde frictie bleef in twee teams zichtbaar.',
+          decision: 'bijstellen',
+          followThrough: 'Leg de bijgestelde route vast in het MT-overleg.',
+        },
+      ])
+      expect(semantics.latestDecision?.decisionEntryId).toBe('authored-decision-2')
+    })
+
     it('falls back to legacy truth when no canonical decision records exist', () => {
       const semantics = projectActionCenterCoreSemantics({
         campaign: { id: 'campaign-1', name: 'ExitScan april' } as never,

--- a/frontend/lib/action-center-core-semantics.ts
+++ b/frontend/lib/action-center-core-semantics.ts
@@ -7,8 +7,10 @@ import type { LiveActionCenterCampaignContext } from './action-center-live-conte
 import type { ActionCenterReviewDecision, PilotLearningCheckpoint } from './pilot-learning'
 import {
   compareDecisionHistoryEntries,
+  projectResultProgression,
   projectAuthoredDecisionHistory,
   projectLegacyDecisionRecord,
+  type ActionCenterResultProgressEntry,
 } from './action-center-decision-history'
 import { getActionCenterDecisionProfile } from './action-center-review-decisions'
 
@@ -40,6 +42,7 @@ export interface ActionCenterCoreSemantics {
     whatWeObserved: string | null
     whatWasDecided: string | null
   }
+  resultProgression: ActionCenterResultProgressEntry[]
   decisionHistory: ActionCenterDecisionRecord[]
   closingSemantics: {
     status: ActionCenterClosingStatus
@@ -468,6 +471,7 @@ export function projectActionCenterPreviewCoreSemantics(
     managementActionOutcome: input.reviewOutcome,
   })
   const latestDecision = decisionHistory[0] ?? null
+  const resultProgression = projectResultProgression(decisionHistory)
   const latestDecisionProfile = latestDecision ? getActionCenterDecisionProfile(latestDecision.decision) : null
   const actionProgress = projectActionProgress({
     route,
@@ -514,6 +518,7 @@ export function projectActionCenterPreviewCoreSemantics(
       whatWeObserved,
       whatWasDecided,
     },
+    resultProgression,
     decisionHistory,
     closingSemantics: {
       status: closingStatus,
@@ -611,6 +616,7 @@ export function projectActionCenterCoreSemantics(
     decisionRecords: context.decisionRecords,
   })
   const latestDecision = decisionHistory[0] ?? null
+  const resultProgression = projectResultProgression(decisionHistory)
   const latestDecisionProfile = latestDecision ? getActionCenterDecisionProfile(latestDecision.decision) : null
   const actionProgress = projectActionProgress({
     route,
@@ -658,6 +664,7 @@ export function projectActionCenterCoreSemantics(
         latestVisibleUpdateNote: normalizeText(context.latestVisibleUpdateNote),
       }),
     },
+    resultProgression,
     decisionHistory,
     closingSemantics: {
       status: closingStatus,

--- a/frontend/lib/action-center-core-semantics.ts
+++ b/frontend/lib/action-center-core-semantics.ts
@@ -10,6 +10,7 @@ import {
   projectAuthoredDecisionHistory,
   projectLegacyDecisionRecord,
 } from './action-center-decision-history'
+import { getActionCenterDecisionProfile } from './action-center-review-decisions'
 
 export type ActionCenterVisibleReviewOutcome = Exclude<ActionCenterReviewOutcome, 'opschalen'>
 export type ActionCenterClosingStatus = 'lopend' | 'afgerond' | 'gestopt'
@@ -327,9 +328,12 @@ function projectActionProgress(args: {
   firstActionTaken: string | null | undefined
   reviewQuestion: string | null
   expectedEffectFallback: string | null
+  suppressNextStepFallback?: boolean
 }) {
   const currentStep = pickFirst([args.firstActionTaken, args.route.intervention])
-  const nextStep = pickFirst([args.deliveryNextStep, args.reviewQuestion])
+  const nextStep = args.suppressNextStepFallback
+    ? normalizeText(args.deliveryNextStep)
+    : pickFirst([args.deliveryNextStep, args.reviewQuestion])
   const expectedEffect = pickFirst([
     args.route.expectedEffect,
     args.expectedEffectFallback,
@@ -464,12 +468,14 @@ export function projectActionCenterPreviewCoreSemantics(
     managementActionOutcome: input.reviewOutcome,
   })
   const latestDecision = decisionHistory[0] ?? null
+  const latestDecisionProfile = latestDecision ? getActionCenterDecisionProfile(latestDecision.decision) : null
   const actionProgress = projectActionProgress({
     route,
     deliveryNextStep: input.nextStep,
     firstActionTaken: route.intervention,
     reviewQuestion,
     expectedEffectFallback: expectedEffectFromReason,
+    suppressNextStepFallback: latestDecisionProfile?.hidesNextStep ?? false,
   })
   const whatWasDecided = getDecisionText({
     reviewOutcomeVisible,
@@ -605,12 +611,14 @@ export function projectActionCenterCoreSemantics(
     decisionRecords: context.decisionRecords,
   })
   const latestDecision = decisionHistory[0] ?? null
+  const latestDecisionProfile = latestDecision ? getActionCenterDecisionProfile(latestDecision.decision) : null
   const actionProgress = projectActionProgress({
     route,
     deliveryNextStep: latestDecision?.nextStepSnapshot ?? context.deliveryRecord?.next_step,
     firstActionTaken: latestDecision?.currentStepSnapshot ?? context.learningDossier?.first_action_taken,
     reviewQuestion,
     expectedEffectFallback: latestDecision?.expectedEffectSnapshot ?? derivedExpectedEffect,
+    suppressNextStepFallback: latestDecisionProfile?.hidesNextStep ?? false,
   })
 
   return {

--- a/frontend/lib/action-center-decision-history.test.ts
+++ b/frontend/lib/action-center-decision-history.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   buildLegacyDecisionEntryId,
   compareDecisionHistoryEntries,
+  projectResultProgression,
   projectLegacyDecisionRecord,
   type ActionCenterDecisionRecord,
 } from './action-center-decision-history'
@@ -73,5 +74,52 @@ describe('action-center decision history contract', () => {
     })
 
     expect(record).toBeNull()
+  })
+
+  it('projects compact result progression entries in chronological order with bounded follow-through fallback', () => {
+    const entries: ActionCenterDecisionRecord[] = [
+      {
+        decisionEntryId: 'decision-2',
+        sourceRouteId: 'route-1',
+        decision: 'bijstellen',
+        decisionReason: 'De eerste stap vroeg een koerscorrectie.',
+        nextCheck: 'Toets volgende week of de aangepaste route tractie geeft.',
+        decisionRecordedAt: '2026-04-28T09:00:00.000Z',
+        reviewCompletedAt: '2026-04-28T08:00:00.000Z',
+        currentStepSnapshot: 'Plan een tweede teamreview met de manager.',
+        nextStepSnapshot: 'Leg de bijgestelde route vast in het MT-overleg.',
+        observationSnapshot: 'Dezelfde frictie bleef in twee teams zichtbaar.',
+      },
+      {
+        decisionEntryId: 'decision-1',
+        sourceRouteId: 'route-1',
+        decision: 'doorgaan',
+        decisionReason: 'De eerste stap liep nog.',
+        nextCheck: 'Toets volgende week of de frictie daalt.',
+        decisionRecordedAt: '2026-04-25T09:00:00.000Z',
+        reviewCompletedAt: '2026-04-25T08:00:00.000Z',
+        currentStepSnapshot: 'Plan een eerste teamreview met de manager.',
+        expectedEffectSnapshot: 'Binnen twee weken moet zichtbaar zijn of de eerste review de frictie smaller maakt.',
+      },
+    ]
+
+    expect(projectResultProgression(entries)).toEqual([
+      {
+        resultEntryId: 'decision-1',
+        recordedAt: '2026-04-25T08:00:00.000Z',
+        currentStep: 'Plan een eerste teamreview met de manager.',
+        observation: null,
+        decision: 'doorgaan',
+        followThrough: 'Toets volgende week of de frictie daalt.',
+      },
+      {
+        resultEntryId: 'decision-2',
+        recordedAt: '2026-04-28T08:00:00.000Z',
+        currentStep: 'Plan een tweede teamreview met de manager.',
+        observation: 'Dezelfde frictie bleef in twee teams zichtbaar.',
+        decision: 'bijstellen',
+        followThrough: 'Leg de bijgestelde route vast in het MT-overleg.',
+      },
+    ])
   })
 })

--- a/frontend/lib/action-center-decision-history.ts
+++ b/frontend/lib/action-center-decision-history.ts
@@ -6,6 +6,15 @@ import type {
 import type { ActionCenterReviewDecision } from './pilot-learning'
 import { getActionCenterDecisionProfile } from './action-center-review-decisions'
 
+export interface ActionCenterResultProgressEntry {
+  resultEntryId: string
+  recordedAt: string
+  currentStep: string | null
+  observation: string | null
+  decision: ActionCenterDecision
+  followThrough: string | null
+}
+
 function normalizeText(value: string | null | undefined) {
   const trimmed = value?.trim() ?? ''
   return trimmed.length > 0 ? trimmed : null
@@ -120,4 +129,21 @@ export function projectLegacyDecisionRecord(args: {
     decisionRecordedAt: reviewCompletedAt,
     reviewCompletedAt: args.reviewCompletedAt,
   }
+}
+
+export function projectResultProgression(decisionHistory: ActionCenterDecisionRecord[]) {
+  return [...decisionHistory]
+    .sort(compareDecisionHistoryEntries)
+    .reverse()
+    .map<ActionCenterResultProgressEntry>((entry) => ({
+      resultEntryId: entry.decisionEntryId,
+      recordedAt: entry.reviewCompletedAt ?? entry.decisionRecordedAt,
+      currentStep: normalizeText(entry.currentStepSnapshot),
+      observation: normalizeText(entry.observationSnapshot),
+      decision: entry.decision,
+      followThrough:
+        normalizeText(entry.nextStepSnapshot) ??
+        normalizeText(entry.nextCheck) ??
+        normalizeText(entry.expectedEffectSnapshot),
+    }))
 }

--- a/frontend/lib/action-center-decision-history.ts
+++ b/frontend/lib/action-center-decision-history.ts
@@ -4,6 +4,7 @@ import type {
   ActionCenterReviewOutcome,
 } from './action-center-route-contract'
 import type { ActionCenterReviewDecision } from './pilot-learning'
+import { getActionCenterDecisionProfile } from './action-center-review-decisions'
 
 function normalizeText(value: string | null | undefined) {
   const trimmed = value?.trim() ?? ''
@@ -65,16 +66,17 @@ export function compareDecisionHistoryEntries(left: ActionCenterDecisionRecord, 
 }
 
 export function projectAuthoredDecisionRecord(record: ActionCenterReviewDecision): ActionCenterDecisionRecord {
+  const profile = getActionCenterDecisionProfile(record.decision)
   return {
     decisionEntryId: record.id,
     sourceRouteId: record.route_source_id,
     decision: record.decision,
     decisionReason: normalizeText(record.decision_reason),
-    nextCheck: normalizeText(record.next_check),
+    nextCheck: profile.hidesNextCheck ? null : normalizeText(record.next_check),
     decisionRecordedAt: record.decision_recorded_at,
     reviewCompletedAt: record.review_completed_at,
     currentStepSnapshot: normalizeText(record.current_step),
-    nextStepSnapshot: normalizeText(record.next_step),
+    nextStepSnapshot: profile.hidesNextStep ? null : normalizeText(record.next_step),
     expectedEffectSnapshot: normalizeText(record.expected_effect),
     observationSnapshot: normalizeText(record.observation_snapshot),
   }

--- a/frontend/lib/action-center-preview-display.test.ts
+++ b/frontend/lib/action-center-preview-display.test.ts
@@ -92,6 +92,16 @@ describe('action center preview display helpers', () => {
           whatWeObserved: 'MT kiest een eerste leiderschapsspoor.',
           whatWasDecided: null,
         },
+        resultProgression: [
+          {
+            resultEntryId: 'decision-1',
+            recordedAt: '2026-04-22T09:00:00.000Z',
+            currentStep: 'Leg eigenaar en eerste correctie in het MT-overleg vast.',
+            observation: 'MT kiest een eerste leiderschapsspoor.',
+            decision: 'bijstellen',
+            followThrough: 'Toets of het eerste gesprek is gevoerd en of het knelpunt specifieker is geworden.',
+          },
+        ],
         decisionHistory: [
           {
             decisionEntryId: 'decision-1',

--- a/frontend/lib/action-center-preview-route-fields-render.test.ts
+++ b/frontend/lib/action-center-preview-route-fields-render.test.ts
@@ -91,6 +91,24 @@ describe('action center preview route fields render', () => {
           whatWeObserved: 'MT kiest een eerste leiderschapsspoor.',
           whatWasDecided: 'Bijstellen',
         },
+        resultProgression: [
+          {
+            resultEntryId: 'decision-0',
+            recordedAt: '2026-04-21T09:00:00.000Z',
+            currentStep: 'Plan een eerste teamgesprek met de manager.',
+            observation: 'De eerste signalen bleven breed verdeeld.',
+            decision: 'doorgaan',
+            followThrough: 'Bevestig de route in het MT-overleg.',
+          },
+          {
+            resultEntryId: 'decision-1',
+            recordedAt: '2026-04-24T09:00:00.000Z',
+            currentStep: 'Leg eigenaar en eerste correctie in het MT-overleg vast.',
+            observation: 'MT kiest een eerste leiderschapsspoor.',
+            decision: 'bijstellen',
+            followThrough: 'Binnen twee weken moet het eerste teamgesprek zijn gevoerd.',
+          },
+        ],
         decisionHistory: [
           {
             decisionEntryId: 'decision-1',
@@ -131,6 +149,9 @@ describe('action center preview route fields render', () => {
     expect(html).toContain('Leg eigenaar en eerste correctie in het MT-overleg vast.')
     expect(html).toContain('Hierna')
     expect(html).toContain('Verwacht effect')
+    expect(html).toContain('Resultaat over tijd')
+    expect(html).toContain('Plan een eerste teamgesprek met de manager.')
+    expect(html).toContain('MT kiest een eerste leiderschapsspoor.')
   })
 
   it('builds compact landing summary lines from latest decision and current step', () => {
@@ -191,6 +212,7 @@ describe('action center preview route fields render', () => {
           whatWeObserved: 'Werkdruk bleef zichtbaar in hetzelfde team.',
           whatWasDecided: 'Bijstellen',
         },
+        resultProgression: [],
         decisionHistory: [],
         closingSemantics: {
           status: 'lopend',
@@ -285,6 +307,16 @@ describe('action center preview route fields render', () => {
           whatWeObserved: 'De lokale correctie hield zichtbaar stand.',
           whatWasDecided: 'Afronden',
         },
+        resultProgression: [
+          {
+            resultEntryId: 'decision-2',
+            recordedAt: '2026-04-28T09:00:00.000Z',
+            currentStep: 'Rond de route af en borg de les.',
+            observation: 'De lokale correctie hield zichtbaar stand.',
+            decision: 'afronden',
+            followThrough: null,
+          },
+        ],
         decisionHistory: [
           {
             decisionEntryId: 'decision-2',

--- a/frontend/lib/action-center-preview-route-fields-render.test.ts
+++ b/frontend/lib/action-center-preview-route-fields-render.test.ts
@@ -205,4 +205,119 @@ describe('action center preview route fields render', () => {
       { label: 'Stap', value: 'Plan een gerichte teamreview met de manager.' },
     ])
   })
+
+  it('hides next-check and next-step detail blocks for closing decisions', () => {
+    const item = finalizeActionCenterPreviewItem({
+      id: 'route-2',
+      code: 'ACT-1002',
+      title: 'Exit follow-through sluit af',
+      summary: 'De route kan inhoudelijk sluiten.',
+      reason: 'Het effect bleef zichtbaar na de laatste check.',
+      sourceLabel: 'ExitScan',
+      orgId: 'org-1',
+      scopeType: 'department',
+      teamId: 'operations',
+      teamLabel: 'Operations',
+      ownerId: 'manager-1',
+      ownerName: 'Manager Operations',
+      ownerRole: 'Manager - Operations',
+      ownerSubtitle: 'Operations',
+      reviewOwnerName: 'HR lead',
+      priority: 'laag',
+      status: 'afgerond',
+      reviewDate: null,
+      expectedEffect: 'Borging is bevestigd.',
+      reviewReason: 'Het effect bleef zichtbaar na de laatste check.',
+      reviewOutcome: 'afronden',
+      reviewDateLabel: 'Nog niet gepland',
+      reviewRhythm: 'Maandelijks',
+      signalLabel: 'ExitScan - Exit voorjaar',
+      signalBody: 'De lokale correctie hield zichtbaar stand.',
+      nextStep: 'Nog niet van toepassing',
+      peopleCount: 38,
+      updates: [],
+      coreSemantics: {
+        route: {
+          campaignId: 'campaign-exit',
+          entryStage: 'active',
+          routeOpenedAt: '2026-04-20T09:00:00.000Z',
+          ownerAssignedAt: '2026-04-21T08:00:00.000Z',
+          routeStatus: 'afgerond',
+          reviewOutcome: 'afronden',
+          reviewCompletedAt: '2026-04-28T09:00:00.000Z',
+          outcomeRecordedAt: '2026-04-28T09:00:00.000Z',
+          outcomeSummary: 'De lokale correctie hield zichtbaar stand.',
+          intervention: 'Rond de route af en borg de les.',
+          owner: 'Manager Operations',
+          expectedEffect: 'Borging is bevestigd.',
+          reviewScheduledFor: null,
+          reviewReason: 'Het effect bleef zichtbaar na de laatste check.',
+          blockedBy: null,
+        },
+        latestDecision: {
+          decisionEntryId: 'decision-2',
+          sourceRouteId: 'campaign-exit',
+          decision: 'afronden',
+          decisionReason: 'Het effect bleef zichtbaar na de laatste check.',
+          nextCheck: null,
+          decisionRecordedAt: '2026-04-28T09:00:00.000Z',
+          reviewCompletedAt: '2026-04-28T09:00:00.000Z',
+        },
+        actionProgress: {
+          currentStep: 'Rond de route af en borg de les.',
+          nextStep: null,
+          expectedEffect: 'Borging is bevestigd.',
+        },
+        reviewSemantics: {
+          reviewReason: 'Het effect bleef zichtbaar na de laatste check.',
+          reviewQuestion: 'Welke uitkomst van deze route verdient nu de eerste review?',
+          reviewOutcomeRaw: 'afronden',
+          reviewOutcomeVisible: 'afronden',
+        },
+        actionFrame: {
+          whyNow: 'Het effect bleef zichtbaar na de laatste check.',
+          firstStep: 'Rond de route af en borg de les.',
+          owner: 'Manager Operations',
+          expectedEffect: 'Borging is bevestigd.',
+        },
+        resultLoop: {
+          whatWasTried: 'Rond de route af en borg de les.',
+          whatWeObserved: 'De lokale correctie hield zichtbaar stand.',
+          whatWasDecided: 'Afronden',
+        },
+        decisionHistory: [
+          {
+            decisionEntryId: 'decision-2',
+            sourceRouteId: 'campaign-exit',
+            decision: 'afronden',
+            decisionReason: 'Het effect bleef zichtbaar na de laatste check.',
+            nextCheck: null,
+            decisionRecordedAt: '2026-04-28T09:00:00.000Z',
+            reviewCompletedAt: '2026-04-28T09:00:00.000Z',
+          },
+        ],
+        closingSemantics: {
+          status: 'afgerond',
+          summary: 'De lokale correctie hield zichtbaar stand.',
+          historicalSummary: null,
+        },
+      },
+    })
+
+    const html = renderToStaticMarkup(
+      React.createElement(ActionCenterPreview, {
+        initialItems: [item],
+        initialView: 'actions',
+        fallbackOwnerName: 'Verisight gebruiker',
+        ownerOptions: ['Manager Operations'],
+        workbenchHref: '/dashboard',
+        readOnly: true,
+      }),
+    )
+
+    expect(html).toContain('Laatste beslissing')
+    expect(html).toContain('Afronden')
+    expect(html).not.toContain('Volgende toets')
+    expect(html).not.toContain('Hierna')
+  })
 })

--- a/frontend/lib/action-center-review-decisions.test.ts
+++ b/frontend/lib/action-center-review-decisions.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
+  getActionCenterDecisionGuidance,
+  getActionCenterDecisionProfile,
   isActionCenterDecisionCheckpointKey,
   normalizeActionCenterReviewDecision,
   validateActionCenterReviewDecisionWriteInput,
@@ -135,5 +137,74 @@ describe('action center review decisions', () => {
         review_completed_at: '',
       }),
     ).toThrowError('Ongeldige authored review decision input.')
+  })
+
+  it('requires a distinct next step and observation snapshot for bijstellen decisions', () => {
+    expect(() =>
+      validateActionCenterReviewDecisionWriteInput({
+        route_source_type: 'campaign',
+        route_source_id: 'campaign-1',
+        checkpoint_id: 'checkpoint-1',
+        decision: 'bijstellen',
+        decision_reason: 'De eerste stap gaf nog geen stabiele verbetering.',
+        next_check: 'Toets volgende week of de frictie daalt.',
+        current_step: 'Plan een eerste teamgesprek.',
+        next_step: 'Plan een eerste teamgesprek.',
+        expected_effect: 'Maak zichtbaar of de eerste stap tractie geeft.',
+        observation_snapshot: null,
+        decision_recorded_at: '2026-04-25T09:00:00.000Z',
+        review_completed_at: '2026-04-25T08:30:00.000Z',
+      }),
+    ).toThrowError('Ongeldige authored review decision input.')
+  })
+
+  it('rejects closing decisions that still carry open follow-up fields', () => {
+    expect(() =>
+      validateActionCenterReviewDecisionWriteInput({
+        route_source_type: 'campaign',
+        route_source_id: 'campaign-1',
+        checkpoint_id: 'checkpoint-1',
+        decision: 'afronden',
+        decision_reason: 'Het effect is bevestigd.',
+        next_check: 'Toets volgende maand of dit stabiel blijft.',
+        current_step: 'Rond het traject af.',
+        next_step: 'Plan een extra review.',
+        expected_effect: 'Borging aantonen.',
+        observation_snapshot: 'De verbetering hield drie weken stand.',
+        decision_recorded_at: '2026-04-25T09:00:00.000Z',
+        review_completed_at: '2026-04-25T08:30:00.000Z',
+      }),
+    ).toThrowError('Ongeldige authored review decision input.')
+  })
+
+  it('classifies open versus closing decisions into one shared profile', () => {
+    expect(getActionCenterDecisionProfile('doorgaan')).toEqual({
+      isClosing: false,
+      requiresDistinctNextStep: false,
+      requiresObservationSnapshot: false,
+      hidesNextCheck: false,
+      hidesNextStep: false,
+    })
+
+    expect(getActionCenterDecisionProfile('bijstellen')).toEqual({
+      isClosing: false,
+      requiresDistinctNextStep: true,
+      requiresObservationSnapshot: true,
+      hidesNextCheck: false,
+      hidesNextStep: false,
+    })
+
+    expect(getActionCenterDecisionProfile('afronden')).toEqual({
+      isClosing: true,
+      requiresDistinctNextStep: false,
+      requiresObservationSnapshot: false,
+      hidesNextCheck: true,
+      hidesNextStep: true,
+    })
+  })
+
+  it('returns decision-specific guidance for the internal write surface', () => {
+    expect(getActionCenterDecisionGuidance('bijstellen')).toContain('koerscorrectie')
+    expect(getActionCenterDecisionGuidance('stoppen')).toContain('stopreden')
   })
 })

--- a/frontend/lib/action-center-review-decisions.test.ts
+++ b/frontend/lib/action-center-review-decisions.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import {
+  getActionCenterActionGuidance,
   getActionCenterDecisionGuidance,
   getActionCenterDecisionProfile,
   isActionCenterDecisionCheckpointKey,
+  looksLikeActionCenterExpectedEffect,
+  looksLikeActionCenterStep,
   normalizeActionCenterReviewDecision,
   validateActionCenterReviewDecisionWriteInput,
   shouldUseLegacyDecisionFallback,
@@ -98,7 +101,7 @@ describe('action center review decisions', () => {
       next_check: ' Toets volgende week of de frictie daalt. ',
       current_step: ' Plan een eerste teamgesprek. ',
       next_step: ' Check of het teamgesprek plaatsvond. ',
-      expected_effect: ' Maak zichtbaar of de eerste stap tractie geeft. ',
+      expected_effect: ' Binnen twee weken moet zichtbaar zijn of de eerste stap tractie geeft. ',
       observation_snapshot: ' Werkdruk bleef zichtbaar in hetzelfde team. ',
       decision_recorded_at: '2026-04-25T09:00:00.000Z',
       review_completed_at: '2026-04-25T08:30:00.000Z',
@@ -113,7 +116,7 @@ describe('action center review decisions', () => {
       next_check: 'Toets volgende week of de frictie daalt.',
       current_step: 'Plan een eerste teamgesprek.',
       next_step: 'Check of het teamgesprek plaatsvond.',
-      expected_effect: 'Maak zichtbaar of de eerste stap tractie geeft.',
+      expected_effect: 'Binnen twee weken moet zichtbaar zijn of de eerste stap tractie geeft.',
       observation_snapshot: 'Werkdruk bleef zichtbaar in hetzelfde team.',
       decision_recorded_at: '2026-04-25T09:00:00.000Z',
       review_completed_at: '2026-04-25T08:30:00.000Z',
@@ -206,5 +209,41 @@ describe('action center review decisions', () => {
   it('returns decision-specific guidance for the internal write surface', () => {
     expect(getActionCenterDecisionGuidance('bijstellen')).toContain('koerscorrectie')
     expect(getActionCenterDecisionGuidance('stoppen')).toContain('stopreden')
+  })
+
+  it('recognizes action-like steps and effect-like expected effects as separate semantics', () => {
+    expect(looksLikeActionCenterStep('Plan een eerste teamgesprek met de manager.')).toBe(true)
+    expect(looksLikeActionCenterStep('Werkdruk bleef zichtbaar in hetzelfde team.')).toBe(false)
+    expect(looksLikeActionCenterExpectedEffect('Binnen twee weken moet duidelijk zijn of de frictie daalt.')).toBe(true)
+    expect(looksLikeActionCenterExpectedEffect('Plan een eerste teamgesprek met de manager.')).toBe(false)
+  })
+
+  it('rejects open decisions when the current step is not action-like or the expected effect is task-like', () => {
+    expect(() =>
+      validateActionCenterReviewDecisionWriteInput({
+        route_source_type: 'campaign',
+        route_source_id: 'campaign-1',
+        checkpoint_id: 'checkpoint-1',
+        decision: 'doorgaan',
+        decision_reason: 'De eerste stap loopt nog.',
+        next_check: 'Toets volgende week of de frictie daalt.',
+        current_step: 'Werkdruk bleef zichtbaar in hetzelfde team.',
+        next_step: 'Plan een eerste teamgesprek met de manager.',
+        expected_effect: 'Plan een eerste teamgesprek met de manager.',
+        observation_snapshot: 'Werkdruk bleef zichtbaar in hetzelfde team.',
+        decision_recorded_at: '2026-04-25T09:00:00.000Z',
+        review_completed_at: '2026-04-25T08:30:00.000Z',
+      }),
+    ).toThrowError('Ongeldige authored review decision input.')
+  })
+
+  it('returns action guidance that points out weak step or effect phrasing', () => {
+    expect(
+      getActionCenterActionGuidance({
+        currentStep: 'Werkdruk bleef zichtbaar in hetzelfde team.',
+        nextStep: 'Plan een eerste teamgesprek met de manager.',
+        expectedEffect: 'Plan een eerste teamgesprek met de manager.',
+      }),
+    ).toContain('huidige stap')
   })
 })

--- a/frontend/lib/action-center-review-decisions.ts
+++ b/frontend/lib/action-center-review-decisions.ts
@@ -11,6 +11,34 @@ const AUTHORED_DECISION_VALUES = new Set<AuthoredActionCenterDecision>([
   'afronden',
   'stoppen',
 ])
+const ACTION_STEP_PREFIXES = new Set([
+  'plan',
+  'leg',
+  'bevestig',
+  'kies',
+  'maak',
+  'zet',
+  'start',
+  'bespreek',
+  'neem',
+  'stem',
+  'deel',
+  'werk',
+  'rond',
+  'stop',
+  'onderzoek',
+  'borg',
+  'vraag',
+  'mail',
+  'bel',
+  'organiseer',
+  'herplan',
+  'corrigeer',
+  'check',
+  'koppel',
+  'vervolg',
+  'voer',
+])
 
 const ACTION_CENTER_DECISION_CHECKPOINT_KEYS = new Set<LearningCheckpointKey>([
   'first_management_use',
@@ -125,6 +153,56 @@ export function getActionCenterDecisionGuidance(decision: AuthoredActionCenterDe
   }
 }
 
+export function looksLikeActionCenterStep(value: string | null | undefined) {
+  const normalized = normalizeText(value)
+  if (!normalized) return false
+
+  const lower = normalized.toLocaleLowerCase('nl-NL')
+  if (lower.endsWith('?')) return false
+
+  const firstWord = lower.split(/\s+/, 1)[0] ?? ''
+  return ACTION_STEP_PREFIXES.has(firstWord)
+}
+
+export function looksLikeActionCenterExpectedEffect(value: string | null | undefined) {
+  const normalized = normalizeText(value)
+  if (!normalized) return false
+
+  const lower = normalized.toLocaleLowerCase('nl-NL')
+  if (looksLikeActionCenterStep(lower)) return false
+
+  return (
+    lower.includes('moet ') ||
+    lower.includes('zichtbaar') ||
+    lower.includes('duidelijk') ||
+    lower.includes('blijken') ||
+    lower.includes('bevestigd') ||
+    lower.includes('effect') ||
+    lower.includes('toename') ||
+    lower.includes('afname')
+  )
+}
+
+export function getActionCenterActionGuidance(args: {
+  currentStep: string | null | undefined
+  nextStep: string | null | undefined
+  expectedEffect: string | null | undefined
+}) {
+  if (!looksLikeActionCenterStep(args.currentStep)) {
+    return 'De huidige stap leest nog niet als concrete managementhandeling. Maak hem actiever en bounded.'
+  }
+
+  if (normalizeText(args.nextStep) && !looksLikeActionCenterStep(args.nextStep)) {
+    return 'De volgende stap leest nog niet als echte vervolghandeling. Scherp hem aan als bounded interventie.'
+  }
+
+  if (!looksLikeActionCenterExpectedEffect(args.expectedEffect)) {
+    return 'Het verwacht effect leest nog te veel als taakzin. Beschrijf wat de stap zichtbaar of duidelijker moet maken.'
+  }
+
+  return 'De actie-opbouw is scherp genoeg: huidige stap, vervolgstap en verwacht effect vormen samen een geloofwaardige voortgangslijn.'
+}
+
 export function isActionCenterDecisionCheckpointKey(
   value: LearningCheckpointKey | string | null | undefined,
 ): value is 'first_management_use' | 'follow_up_review' {
@@ -178,6 +256,20 @@ export function validateActionCenterReviewDecisionWriteInput(
 
   if (decisionProfile?.hidesNextStep && nextStep) {
     throw new Error('Ongeldige authored review decision input.')
+  }
+
+  if (!decisionProfile?.isClosing) {
+    if (!expectedEffect || !looksLikeActionCenterExpectedEffect(expectedEffect)) {
+      throw new Error('Ongeldige authored review decision input.')
+    }
+
+    if (!looksLikeActionCenterStep(currentStep)) {
+      throw new Error('Ongeldige authored review decision input.')
+    }
+
+    if (nextStep && !looksLikeActionCenterStep(nextStep)) {
+      throw new Error('Ongeldige authored review decision input.')
+    }
   }
 
   return {

--- a/frontend/lib/action-center-review-decisions.ts
+++ b/frontend/lib/action-center-review-decisions.ts
@@ -38,6 +38,14 @@ export interface ActionCenterReviewDecisionWriteInput {
   review_completed_at: string
 }
 
+export interface ActionCenterDecisionProfile {
+  isClosing: boolean
+  requiresDistinctNextStep: boolean
+  requiresObservationSnapshot: boolean
+  hidesNextCheck: boolean
+  hidesNextStep: boolean
+}
+
 function normalizeText(value: string | null | undefined) {
   const trimmed = value?.trim() ?? ''
   return trimmed.length > 0 ? trimmed : null
@@ -66,6 +74,57 @@ function isIsoTimestamp(value: string | null | undefined) {
   return parseTimestamp(value) !== Number.NEGATIVE_INFINITY
 }
 
+function areSameStep(left: string | null | undefined, right: string | null | undefined) {
+  const normalizedLeft = normalizeText(left)?.toLocaleLowerCase('nl-NL') ?? null
+  const normalizedRight = normalizeText(right)?.toLocaleLowerCase('nl-NL') ?? null
+  return Boolean(normalizedLeft && normalizedRight && normalizedLeft === normalizedRight)
+}
+
+export function getActionCenterDecisionProfile(decision: AuthoredActionCenterDecision): ActionCenterDecisionProfile {
+  switch (decision) {
+    case 'bijstellen':
+      return {
+        isClosing: false,
+        requiresDistinctNextStep: true,
+        requiresObservationSnapshot: true,
+        hidesNextCheck: false,
+        hidesNextStep: false,
+      }
+    case 'afronden':
+    case 'stoppen':
+      return {
+        isClosing: true,
+        requiresDistinctNextStep: false,
+        requiresObservationSnapshot: false,
+        hidesNextCheck: true,
+        hidesNextStep: true,
+      }
+    case 'doorgaan':
+    default:
+      return {
+        isClosing: false,
+        requiresDistinctNextStep: false,
+        requiresObservationSnapshot: false,
+        hidesNextCheck: false,
+        hidesNextStep: false,
+      }
+  }
+}
+
+export function getActionCenterDecisionGuidance(decision: AuthoredActionCenterDecision) {
+  switch (decision) {
+    case 'bijstellen':
+      return 'Bijstellen vraagt een zichtbare koerscorrectie: leg vast wat je zag, welke volgende stap nu verandert en wat je daarna opnieuw wilt toetsen.'
+    case 'afronden':
+      return 'Afronden sluit de route inhoudelijk: beschrijf waarom deze route klaar is en laat vervolgvelden leeg zodat geen open follow-through zichtbaar blijft.'
+    case 'stoppen':
+      return 'Stoppen vraagt een expliciete stopreden: leg uit waarom vervolg niet zinvol is en laat open volgende stappen of toetsen leeg.'
+    case 'doorgaan':
+    default:
+      return 'Doorgaan bevestigt het huidige spoor: houd de huidige stap en volgende toets scherp zodat de route bounded reviewbaar blijft.'
+  }
+}
+
 export function isActionCenterDecisionCheckpointKey(
   value: LearningCheckpointKey | string | null | undefined,
 ): value is 'first_management_use' | 'follow_up_review' {
@@ -87,6 +146,7 @@ export function validateActionCenterReviewDecisionWriteInput(
   const observationSnapshot = normalizeText(input?.observation_snapshot)
   const decisionRecordedAt = normalizeText(input?.decision_recorded_at)
   const reviewCompletedAt = normalizeText(input?.review_completed_at)
+  const decisionProfile = decision ? getActionCenterDecisionProfile(decision) : null
 
   if (
     routeSourceType !== 'campaign' ||
@@ -101,6 +161,22 @@ export function validateActionCenterReviewDecisionWriteInput(
     !isIsoTimestamp(decisionRecordedAt) ||
     !isIsoTimestamp(reviewCompletedAt)
   ) {
+    throw new Error('Ongeldige authored review decision input.')
+  }
+
+  if (decisionProfile?.requiresDistinctNextStep && (!nextStep || areSameStep(currentStep, nextStep))) {
+    throw new Error('Ongeldige authored review decision input.')
+  }
+
+  if (decisionProfile?.requiresObservationSnapshot && !observationSnapshot) {
+    throw new Error('Ongeldige authored review decision input.')
+  }
+
+  if (decisionProfile?.hidesNextCheck && nextCheck) {
+    throw new Error('Ongeldige authored review decision input.')
+  }
+
+  if (decisionProfile?.hidesNextStep && nextStep) {
     throw new Error('Ongeldige authored review decision input.')
   }
 

--- a/frontend/lib/dashboard/shell-navigation.ts
+++ b/frontend/lib/dashboard/shell-navigation.ts
@@ -142,7 +142,7 @@ export function buildDashboardShellNavigation({
     }
   }
 
-  const modules = MODULE_LABELS.flatMap((item) => {
+  const modules: DashboardModuleNavItem[] = MODULE_LABELS.flatMap<DashboardModuleNavItem>((item) => {
     if (item.key === 'overview') {
       return [
         {


### PR DESCRIPTION
## Summary
- enrich authored Action Center review decisions with stronger decision-specific guidance and validation
- strengthen authored action quality for current step, next step, and expected effect
- deepen Action Center result progression over time with a shared chronological progression layer on detail

## What changed
- adds decision profiles and guidance for `doorgaan`, `bijstellen`, `afronden`, and `stoppen`
- enforces better authored action phrasing in the internal review-decision editor
- projects a shared `resultProgression` from canonical decision history
- renders `Resultaat over tijd` on Action Center detail while keeping landing compact
- includes phase docs for richer review decisions, action quality, and result progression

## Verification
- `npm test -- "lib/action-center-review-decisions.test.ts" "lib/action-center-decision-history.test.ts" "lib/action-center-core-semantics.test.ts" "lib/action-center-live.test.ts" "lib/action-center-preview-display.test.ts" "lib/action-center-preview-route-fields-render.test.ts" "app/(dashboard)/action-center/page.route-shell.test.ts"`
- `npx eslint "lib/action-center-review-decisions.ts" "lib/action-center-review-decisions.test.ts" "lib/action-center-decision-history.ts" "lib/action-center-decision-history.test.ts" "lib/action-center-core-semantics.ts" "lib/action-center-core-semantics.test.ts" "components/dashboard/action-center-review-decision-editor.tsx" "components/dashboard/action-center-preview.tsx" "lib/action-center-preview-display.test.ts" "lib/action-center-preview-route-fields-render.test.ts" "lib/dashboard/shell-navigation.ts"`
- `npm run build`

## Notes
- managers remain read-only in this phase
- the new result progression is projected from canonical decision history, not from a new workflow layer