### PR TITLE
feat: add action center route reopen semantics

### DIFF
--- a/docs/superpowers/plans/2026-05-01-action-center-route-reopen.md
+++ b/docs/superpowers/plans/2026-05-01-action-center-route-reopen.md
@@ -1,0 +1,281 @@
+# Action Center Route Reopen Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add explicit Action Center route reopen and follow-up behavior so a previously closed route can either be reactivated through a canonical reopen event or be succeeded by a new follow-up route, with deterministic read-path precedence and compact lineage projection in overview/detail.
+
+**Architecture:** Use two distinct truth models. Reopen is a dedicated route event on the same route id. Follow-up is a route relation between a closed source route and a newly created target route. Read-path precedence for a single route id is determined strictly by event ordering between the latest closeout and the latest reopen event. Follow-up routes never reuse the old route id.
+
+**Tech Stack:** Next.js App Router, TypeScript, Vitest, Playwright, Supabase Postgres schema/RLS, existing Action Center route/closeout/action semantics, admin/HR dashboard surfaces.
+
+---
+
+### Task 1: Lock reopen-vs-follow-up semantics in tests
+
+**Files:**
+- Create: `frontend/lib/action-center-route-reopen.test.ts`
+- Modify: `frontend/lib/action-center-route-closeout.test.ts`
+- Modify: `frontend/lib/action-center-route-contract.test.ts`
+- Modify: `frontend/lib/action-center-live.test.ts`
+- Modify: `frontend/app/(dashboard)/action-center/page.route-shell.test.ts`
+
+- [ ] **Step 1: Add failing reopen truth tests**
+
+Test that:
+- reopen is accepted only as a dedicated event record
+- follow-up remains a separate relation type
+- reopen does not reuse relation semantics like `reopened-from`
+
+- [ ] **Step 2: Add failing precedence tests for closed -> reopened -> closed again**
+
+Test deterministic ordering:
+- closeout without later reopen = closed
+- reopen later than closeout = active again
+- second closeout later than reopen = closed again
+
+- [ ] **Step 3: Add failing follow-up projection tests**
+
+Test that:
+- source route remains closed
+- target route is active with its own route id
+- detail/overview can show compact `Vervolg op eerdere route` lineage
+
+- [ ] **Step 4: Add failing shell tests for compact lineage labels**
+
+Test that:
+- reopened route can show `Heropend traject`
+- follow-up route can show `Vervolg op eerdere route`
+- old route can show that vervolg later ontstond
+
+---
+
+### Task 2: Add canonical reopen truth + follow-up relation helpers
+
+**Files:**
+- Create: `frontend/lib/action-center-route-reopen.ts`
+- Modify: `frontend/lib/action-center-route-closeout.ts`
+- Modify: `frontend/lib/action-center-core-semantics.ts`
+- Modify: `frontend/lib/action-center-live-context.ts`
+
+- [ ] **Step 1: Implement reopen truth projector**
+
+Add:
+- `ActionCenterRouteReopenRecord`
+- `projectActionCenterRouteReopen(...)`
+- canonical validation for:
+  - `routeId`
+  - `reopenedAt`
+  - `reopenedByRole`
+  - `reopenReason`
+
+- [ ] **Step 2: Implement follow-up relation projector**
+
+Keep this intentionally small:
+- `routeRelationType = 'follow-up-from'`
+- `sourceRouteId`
+- `targetRouteId`
+- `recordedAt`
+- `recordedByRole`
+
+- [ ] **Step 3: Add shared derivation helpers**
+
+Introduce helpers for:
+- latest closeout timestamp
+- latest reopen timestamp
+- current route activity derived from event ordering
+- compact lineage badges/text for read surfaces
+
+---
+
+### Task 3: Extend route contract and live semantics
+
+**Files:**
+- Modify: `frontend/lib/action-center-route-contract.ts`
+- Modify: `frontend/lib/action-center-live.ts`
+- Modify: `frontend/lib/action-center-live-context.ts`
+
+- [ ] **Step 1: Add deterministic route precedence**
+
+Implement one status derivation contract:
+- no closeout -> live status from action aggregation
+- closeout with no later reopen -> closed
+- later reopen -> active again
+- later closeout again -> closed again
+
+- [ ] **Step 2: Add compact lineage projection**
+
+Project to route semantics:
+- `reopened`
+- `followUpFromRouteId`
+- `hasFollowUpTarget`
+- lightweight labels for overview/detail
+
+- [ ] **Step 3: Ensure closeout history stays visible**
+
+Do not remove prior closeout context when a route reopens.
+Instead:
+- route becomes active again
+- old closeout remains historical
+- reopen explains why it is active again
+
+---
+
+### Task 4: Add storage and write paths
+
+**Files:**
+- Modify: `supabase/schema.sql`
+- Create: `frontend/app/api/action-center-route-reopens/route.ts`
+- Create: `frontend/app/api/action-center-route-follow-ups/route.ts`
+- Create: `frontend/app/api/action-center-route-reopens/route.test.ts`
+- Create: `frontend/app/api/action-center-route-follow-ups/route.test.ts`
+
+- [ ] **Step 1: Add reopen-event table**
+
+Create canonical table for reopen events with:
+- route id
+- reopened at
+- reopened by role
+- reopen reason
+- audit fields
+
+RLS:
+- HR/Verisight write
+- route viewers read
+
+- [ ] **Step 2: Add follow-up relation table**
+
+Create canonical relation table for:
+- `follow-up-from`
+- source route id
+- target route id
+- recorded at
+- recorded by role
+
+RLS:
+- HR/Verisight write
+- route viewers read
+
+- [ ] **Step 3: Add HR-driven API routes**
+
+Route reopen API:
+- validates HR/admin authority
+- writes reopen event only
+- never mutates old closeout away
+
+Follow-up API:
+- validates HR/admin authority
+- creates a new route carrier
+- writes `follow-up-from` relation
+
+---
+
+### Task 5: Wire overview/detail UI
+
+**Files:**
+- Modify: `frontend/components/dashboard/action-center-preview.tsx`
+- Modify: `frontend/app/(dashboard)/action-center/page.tsx`
+- Modify: any closeout/admin wiring helpers needed for route actions
+
+- [ ] **Step 1: Add HR controls for reopen vs follow-up**
+
+Keep it small:
+- visible only to HR/Verisight
+- available on closed routes
+- explicit choice between:
+  - `Heropen traject`
+  - `Start vervolgroute`
+
+- [ ] **Step 2: Add compact read projection**
+
+Overview:
+- small label only
+
+Detail:
+- small context block with:
+  - prior closeout
+  - reopened on date
+  - or vervolg from route X
+
+- [ ] **Step 3: Preserve current calm UI**
+
+Do not introduce:
+- route trees
+- workflow wizards
+- deep ancestry panels
+
+Keep lineage compact and secondary to the active route story.
+
+---
+
+### Task 6: Seed and browser verification
+
+**Files:**
+- Modify: `frontend/scripts/seed-action-center-manager-pilot.mjs`
+- Modify: `frontend/tests/e2e/action-center-manager-access.spec.ts`
+- Create: `frontend/tests/e2e/action-center-route-reopen.spec.ts`
+
+- [ ] **Step 1: Seed both scenarios**
+
+Provide stable seeded routes for:
+- a closed route that HR can reopen
+- a closed route that can produce a new follow-up route
+
+- [ ] **Step 2: Add browser tests**
+
+Manager/browser flow should still stay coherent.
+New HR flows should verify:
+- HR can reopen a closed route and it becomes active again
+- HR can create a vervolgroute and the old route stays closed
+- lineage is visible after reload
+
+- [ ] **Step 3: Validate permission boundaries**
+
+Confirm:
+- manager can read lineage context where appropriate
+- manager cannot trigger reopen/follow-up write actions
+- HR retains closeout/reopen/follow-up authority
+
+---
+
+### Task 7: Final verification and PR prep
+
+**Files:**
+- Update PR notes once implementation exists
+
+- [ ] **Step 1: Run targeted tests**
+
+Required:
+- route reopen truth tests
+- closeout/reopen/follow-up API tests
+- route contract/live tests
+- page shell tests
+
+- [ ] **Step 2: Run static verification**
+
+Required:
+- `npx eslint` on touched Action Center files
+- `npm run build`
+
+- [ ] **Step 3: Run browser verification**
+
+Required:
+- seed script
+- Playwright reopen/follow-up flows
+- confirm reload persistence and route lineage projection
+
+- [ ] **Step 4: Prepare clean PR**
+
+PR summary should call out:
+- reopen is event truth
+- follow-up is relation truth
+- deterministic precedence for reopened routes
+- HR-only write path
+
+---
+
+## Implementation Notes
+
+- Reopen is **not** a relation. Do not model it as `reopened-from`.
+- Follow-up is **not** a reopen. It must create a new route id.
+- Read-path precedence must always use the latest canonical route event ordering.
+- When in doubt operationally, HR defaults to `start vervolgroute`.

--- a/docs/superpowers/specs/2026-05-01-action-center-route-reopen-design.md
+++ b/docs/superpowers/specs/2026-05-01-action-center-route-reopen-design.md
@@ -1,0 +1,213 @@
+# Action Center Route Reopen Design
+
+## 1. Doel
+Deze fase maakt Action Center robuust voor het moment waarop een eerder gesloten route later opnieuw relevant wordt.
+
+Dat gebeurt bijvoorbeeld als:
+- een thema terugkomt in nieuwe resultaten
+- eerdere follow-through toch niet voldoende bleek
+- een afdeling later opnieuw aandacht vraagt na een bestuurlijk gesloten traject
+
+Het doel is:
+- opnieuw opvolgen mogelijk maken
+- zonder dat oude en nieuwe trajecten semantisch door elkaar gaan lopen
+
+## 2. Productgrens
+Wel in scope:
+- expliciet vervolg na een gesloten route
+- heldere relatie tussen oud traject en nieuw traject
+- overzichtelijke projectie in route-overzicht en detail
+- een kleine canonieke relationele laag tussen trajecten
+
+Niet in scope:
+- complexe heropen-workflows
+- routebomen of multi-parent lineage
+- automatische heropening zonder expliciet besluit
+- brede governance- of escalatielagen
+
+## 3. Kernkeuze
+Een gesloten route mag niet stilletjes weer open springen.
+
+Er zijn twee expliciete opties:
+- `heropen bestaand traject`
+- `start vervolgroute`
+
+### Heropen bestaand traject
+Gebruik je als:
+- hetzelfde lokale opvolgpad echt doorloopt
+- het eerdere closeout-besluit feitelijk wordt teruggenomen
+- de bestaande route nog steeds het juiste verhaal draagt
+
+### Start vervolgroute
+Gebruik je als:
+- er opnieuw aandacht nodig is
+- maar op basis van een nieuw moment, nieuwe duiding of nieuwe lokale context
+- het eerdere traject historisch dicht en bestuurlijk intact moet blijven
+
+Mijn ontwerpdefault:
+- `vervolgroute` is de normale optie
+- `heropenen` is de expliciete uitzondering
+
+## 4. Semantiek van Heropenen versus Vervolg
+### Heropenen
+Betekent:
+- dezelfde route opnieuw actief maken
+- de eerdere closeout niet wissen maar historisch contextualiseren
+- historie als één doorlopende lijn blijven lezen
+
+Heropenen past vooral bij:
+- een heel recente closeout
+- nieuwe informatie die direct laat zien dat afsluiting te vroeg was
+- een bestaande interventielijn die gewoon verder moet
+
+### Vervolgroute
+Betekent:
+- oude route blijft gesloten
+- nieuwe route krijgt eigen identiteit
+- nieuwe acties en reviews hangen niet aan de oude route
+- er is wel een expliciete link terug naar het vorige traject
+
+Vervolgroute past vooral bij:
+- een nieuw hoofdstuk
+- nieuwe signalen of nieuwe context
+- bestuurlijke behoefte om oud slot betekenisvol te houden
+
+## 5. Canonieke Relatie- en Truth-Laag
+Gesloten route blijft een echt eindpunt, tenzij er expliciet wordt heropend.
+
+Daarvoor komt een kleine canonieke relationele laag met minimaal:
+- `routeRelationType`
+- `sourceRouteId`
+- `targetRouteId`
+- `recordedAt`
+- `recordedByRole`
+
+### routeRelationType
+Kleine vaste set:
+- `reopened-from`
+- `follow-up-from`
+
+### sourceRouteId
+De eerdere gesloten route.
+
+### targetRouteId
+De route die daarna actief wordt.
+
+Bij heropening mag dit dezelfde route-id zijn, maar dan alleen in combinatie met een expliciet reopen-record.
+
+Bij vervolgroute is dit altijd een nieuwe route-id.
+
+### recordedAt
+Wanneer deze vervolgstap bestuurlijk is vastgelegd.
+
+### recordedByRole
+Minimaal:
+- `hr`
+
+Later eventueel `system`, maar nog niet leidend in deze fase.
+
+## 6. Relatiegedrag
+### Bij heropenen
+- closeout-record wordt niet verwijderd
+- er komt een expliciet reopen-event
+- de read-path weet daardoor dat het slot is teruggedraaid
+
+### Bij vervolgroute
+- nieuwe route krijgt nieuwe identiteit
+- oude route blijft dicht
+- de relatie vertelt dat deze route voortkomt uit een eerder traject
+
+Belangrijke begrenzing:
+- één directe bronrelatie is genoeg
+- geen diepe grafstructuren in deze eerste versie
+
+## 7. Overzicht en Detail
+### Overview
+Overview moet vooral richting geven:
+- loopt dit traject nu?
+- is dit een heropend traject?
+- of is dit een vervolg op een eerder gesloten route?
+
+Compacte labels zijn genoeg, zoals:
+- `Heropend traject`
+- `Vervolg op eerdere route`
+
+Overview moet niet vollopen met relationele details.
+
+### Detail
+Detail moet de relatie explicieter tonen in een klein contextblok:
+- eerder gesloten op datum
+- heropend op datum
+- of: vervolg op route X
+
+Daarnaast moeten oude en nieuwe trajecten klikbaar verbonden zijn:
+- vanuit de nieuwe route naar de vorige gesloten route
+- en vanuit de oude route zichtbaar maken dat er later vervolg ontstond
+
+## 8. Write-Path
+Deze fase begint HR-gedragen.
+
+HR of Verisight krijgt de eerste write-path voor:
+- `heropen bestaand traject`
+- `start vervolgroute`
+
+Managers initiëren dit in deze fase nog niet als primaire actor.
+
+### Heropenen
+Write-path mag niet simpelweg:
+- closeout verwijderen
+- route-status terug open zetten
+
+Maar schrijft:
+- een expliciet reopen-event of relationeel record
+- waarna de read-path de route weer als actief leest
+
+### Vervolgroute
+Write-path schrijft:
+- een nieuwe route
+- plus een relationele link naar de vorige gesloten route
+
+Niet:
+- nieuwe acties aan de oude route hangen
+- of de oude route impliciet hergebruiken
+
+## 9. Read-Path en Prioriteit
+De read-path bepaalt eerst:
+- wat is nu actief
+- wat is historisch gesloten
+- hoe hangen die twee samen
+
+Prioriteitsregel:
+1. actuele route-status bepalen
+2. daarna relationele context tonen
+3. historische closeout niet wissen, maar contextualiseren
+
+### Bij heropening
+- dezelfde route is opnieuw actief
+- de oude closeout blijft historisch zichtbaar
+- het reopen-event verklaart waarom de route weer loopt
+
+### Bij vervolgroute
+- oude route blijft gesloten
+- nieuwe route is actief
+- de relatie legt de verbinding
+
+Geen automatische heropenlogica:
+- nooit stilzwijgend
+- altijd expliciet via een write-besluit
+
+## 10. Succescriteria
+Deze fase is geslaagd als:
+- een gesloten route netjes opnieuw opgepakt kan worden
+- heropening en vervolgroute duidelijk van elkaar verschillen
+- historie bestuurlijk intact blijft
+- overview en detail dezelfde relationele waarheid tonen
+- gebruikers niet hoeven te raden of iets oud, heropend of nieuw vervolg is
+
+## 11. Ontwerpuitspraak
+De juiste default blijft:
+- gesloten blijft echt gesloten
+- vervolg vraagt een expliciete keuze
+- en `vervolgroute` zal meestal gezonder zijn dan pure `heropening`
+
+Dat houdt closeout betekenisvol, vervolg leesbaar en Action Center vrij van verborgen statusmagie.

--- a/docs/superpowers/specs/2026-05-01-action-center-route-reopen-design.md
+++ b/docs/superpowers/specs/2026-05-01-action-center-route-reopen-design.md
@@ -44,16 +44,36 @@ Gebruik je als:
 - maar op basis van een nieuw moment, nieuwe duiding of nieuwe lokale context
 - het eerdere traject historisch dicht en bestuurlijk intact moet blijven
 
-Mijn ontwerpdefault:
+Ontwerpdefault:
 - `vervolgroute` is de normale optie
 - `heropenen` is de expliciete uitzondering
 
-## 4. Semantiek van Heropenen versus Vervolg
+## 4. Operationeel HR-besliskader
+Om drift tussen organisaties te voorkomen krijgt HR een klein, vast besliskader.
+
+Gebruik `heropen bestaand traject` alleen als alle drie waar zijn:
+- de eerdere closeout was recent en blijkt achteraf te vroeg
+- hetzelfde lokale opvolgpad en dezelfde bestuurlijke vraag lopen inhoudelijk door
+- de bestaande routehistorie is nog steeds het juiste kader voor nieuwe opvolging
+
+Gebruik in alle andere gevallen `start vervolgroute`.
+
+Dus als een van deze signalen optreedt, kies je canoniek voor vervolgroute:
+- er is een nieuw resultaatmoment of nieuwe signaalcontext
+- er begint een inhoudelijk nieuw hoofdstuk of nieuwe aanpak
+- je wilt een schoon nieuw traject met eigen acties en reviews
+- het oude closeout moet bestuurlijk volledig intact blijven als afgerond hoofdstuk
+
+Operationele default:
+- bij twijfel `vervolgroute`
+- alleen `heropenen` als HR expliciet vaststelt dat het vorige slot wordt teruggedraaid
+
+## 5. Semantiek van Heropenen versus Vervolg
 ### Heropenen
 Betekent:
 - dezelfde route opnieuw actief maken
 - de eerdere closeout niet wissen maar historisch contextualiseren
-- historie als één doorlopende lijn blijven lezen
+- historie als een doorlopende lijn blijven lezen
 
 Heropenen past vooral bij:
 - een heel recente closeout
@@ -72,8 +92,24 @@ Vervolgroute past vooral bij:
 - nieuwe signalen of nieuwe context
 - bestuurlijke behoefte om oud slot betekenisvol te houden
 
-## 5. Canonieke Relatie- en Truth-Laag
-Gesloten route blijft een echt eindpunt, tenzij er expliciet wordt heropend.
+## 6. Canonieke Truth-Keuze
+Deze fase kiest expliciet voor twee verschillende canonieke modellen.
+
+### A. Reopen truth is een route-event
+Heropening wordt niet als route-relatie gemodelleerd.
+
+Daarvoor komt een kleine canonieke reopen-eventlaag met minimaal:
+- `routeId`
+- `reopenedAt`
+- `reopenedByRole`
+- `reopenReason`
+
+Betekenis:
+- dezelfde route was gesloten
+- hetzelfde traject is daarna expliciet opnieuw actief gemaakt
+
+### B. Follow-up truth is een route-relatie
+Vervolgroute blijft wel een relationeel model.
 
 Daarvoor komt een kleine canonieke relationele laag met minimaal:
 - `routeRelationType`
@@ -83,19 +119,18 @@ Daarvoor komt een kleine canonieke relationele laag met minimaal:
 - `recordedByRole`
 
 ### routeRelationType
-Kleine vaste set:
-- `reopened-from`
+In deze fase is de set bewust enkel:
 - `follow-up-from`
+
+Dus:
+- `reopened-from` bestaat niet meer als relationeel type
+- heropenen en vervolgroute hebben ieder hun eigen expliciete truth-model
 
 ### sourceRouteId
 De eerdere gesloten route.
 
 ### targetRouteId
-De route die daarna actief wordt.
-
-Bij heropening mag dit dezelfde route-id zijn, maar dan alleen in combinatie met een expliciet reopen-record.
-
-Bij vervolgroute is dit altijd een nieuwe route-id.
+De nieuwe vervolgroute.
 
 ### recordedAt
 Wanneer deze vervolgstap bestuurlijk is vastgelegd.
@@ -106,22 +141,23 @@ Minimaal:
 
 Later eventueel `system`, maar nog niet leidend in deze fase.
 
-## 6. Relatiegedrag
+Belangrijke begrenzing:
+- een directe bronrelatie is genoeg
+- geen diepe grafstructuren in deze eerste versie
+
+## 7. Gedrag van Heropenen en Vervolg
 ### Bij heropenen
-- closeout-record wordt niet verwijderd
-- er komt een expliciet reopen-event
-- de read-path weet daardoor dat het slot is teruggedraaid
+- closeout-record blijft historisch bestaan
+- er komt een expliciet reopen-event op dezelfde route
+- route-identiteit blijft gelijk
+- nieuwe acties en reviews hangen dus aan dezelfde route, maar na het reopen-moment
 
 ### Bij vervolgroute
 - nieuwe route krijgt nieuwe identiteit
 - oude route blijft dicht
-- de relatie vertelt dat deze route voortkomt uit een eerder traject
+- de relationele link vertelt dat de nieuwe route voortkomt uit een eerder traject
 
-Belangrijke begrenzing:
-- één directe bronrelatie is genoeg
-- geen diepe grafstructuren in deze eerste versie
-
-## 7. Overzicht en Detail
+## 8. Overzicht en Detail
 ### Overview
 Overview moet vooral richting geven:
 - loopt dit traject nu?
@@ -144,7 +180,7 @@ Daarnaast moeten oude en nieuwe trajecten klikbaar verbonden zijn:
 - vanuit de nieuwe route naar de vorige gesloten route
 - en vanuit de oude route zichtbaar maken dat er later vervolg ontstond
 
-## 8. Write-Path
+## 9. Write-Path
 Deze fase begint HR-gedragen.
 
 HR of Verisight krijgt de eerste write-path voor:
@@ -159,7 +195,7 @@ Write-path mag niet simpelweg:
 - route-status terug open zetten
 
 Maar schrijft:
-- een expliciet reopen-event of relationeel record
+- een expliciet reopen-event
 - waarna de read-path de route weer als actief leest
 
 ### Vervolgroute
@@ -171,32 +207,47 @@ Niet:
 - nieuwe acties aan de oude route hangen
 - of de oude route impliciet hergebruiken
 
-## 9. Read-Path en Prioriteit
-De read-path bepaalt eerst:
-- wat is nu actief
-- wat is historisch gesloten
-- hoe hangen die twee samen
+## 10. Read-Path en Prioriteit
+De read-path krijgt een harde status-derivatie voor routes met closeout- en reopen-historie.
 
-Prioriteitsregel:
-1. actuele route-status bepalen
-2. daarna relationele context tonen
-3. historische closeout niet wissen, maar contextualiseren
+### Canonieke ordering source
+Alle statuslezing voor heropende routes wordt bepaald op basis van tijdsvolgorde:
+- `closedAt` van het laatst geldige closeout-record
+- `reopenedAt` van het laatst geldige reopen-event
 
-### Bij heropening
-- dezelfde route is opnieuw actief
-- de oude closeout blijft historisch zichtbaar
-- het reopen-event verklaart waarom de route weer loopt
+In deze fase gaan we uit van:
+- hoogstens één actuele closeout-record per route
+- nul of meer reopen-events in de historie
+- en later eventueel opnieuw een closeout-record dat de route weer sluit
 
-### Bij vervolgroute
+### Canonieke precedence-regel voor dezelfde route
+1. als er geen closeout-record is, is de route open en leest de status uit de live actie-aggregatie
+2. als er wel een closeout-record is en er is geen later reopen-event, dan is de route gesloten
+3. als er wel een closeout-record is en er is een later reopen-event, dan is de route opnieuw actief
+4. als er daarna opnieuw een later closeout-record wordt geschreven, dan is de route weer gesloten
+
+Kort gezegd:
+- het meest recente bestuurlijke route-event wint
+- open of gesloten wordt dus niet door aanwezigheid alleen bepaald, maar door de laatste canonieke tijdsvolgorde
+
+### Projectieregel voor heropende routes
+Bij een heropende route:
+- actuele status komt uit de live actie-aggregatie
+- de vorige closeout blijft zichtbaar als historische context
+- het reopen-event toont expliciet dat die eerdere sluiting is teruggedraaid
+
+### Projectieregel voor vervolgroute
+Bij een vervolgroute:
 - oude route blijft gesloten
 - nieuwe route is actief
 - de relatie legt de verbinding
+- er is geen ambiguïteit over open of gesloten op dezelfde route-id
 
 Geen automatische heropenlogica:
 - nooit stilzwijgend
 - altijd expliciet via een write-besluit
 
-## 10. Succescriteria
+## 11. Succescriteria
 Deze fase is geslaagd als:
 - een gesloten route netjes opnieuw opgepakt kan worden
 - heropening en vervolgroute duidelijk van elkaar verschillen
@@ -204,7 +255,7 @@ Deze fase is geslaagd als:
 - overview en detail dezelfde relationele waarheid tonen
 - gebruikers niet hoeven te raden of iets oud, heropend of nieuw vervolg is
 
-## 11. Ontwerpuitspraak
+## 12. Ontwerpuitspraak
 De juiste default blijft:
 - gesloten blijft echt gesloten
 - vervolg vraagt een expliciete keuze

--- a/frontend/app/(dashboard)/action-center/page.route-shell.test.ts
+++ b/frontend/app/(dashboard)/action-center/page.route-shell.test.ts
@@ -580,6 +580,75 @@ describe("action center landing shell", () => {
     expect(markup).toContain("Bewust niet voortzetten");
   });
 
+  it("renders compact lineage labels for reopened and follow-up routes", () => {
+    const context = buildLiveContext();
+    const [baseItem] = buildLiveActionCenterItems([context]);
+    const reopenedItem = {
+      ...baseItem,
+      coreSemantics: {
+        ...baseItem.coreSemantics,
+        route: {
+          ...baseItem.coreSemantics.route,
+          isReopened: true,
+          reopenedAt: "2026-05-21T09:00:00.000Z",
+          reopenReason: "te-vroeg-afgesloten" as const,
+          lineageLabel: "Heropend traject" as const,
+        },
+        lineageSemantics: {
+          label: "Heropend traject" as const,
+          summary: "Te vroeg afgesloten na eerdere afsluiting",
+          followUpFromRouteId: null,
+          followUpTargetRouteId: null,
+        },
+      },
+    };
+    const followUpItem = {
+      ...baseItem,
+      coreSemantics: {
+        ...baseItem.coreSemantics,
+        route: {
+          ...baseItem.coreSemantics.route,
+          followUpFromRouteId: "route-older",
+          lineageLabel: "Vervolg op eerdere route" as const,
+        },
+        lineageSemantics: {
+          label: "Vervolg op eerdere route" as const,
+          summary: "Nieuw traject na eerdere routeafsluiting",
+          followUpFromRouteId: "route-older",
+          followUpTargetRouteId: null,
+        },
+      },
+    };
+
+    const reopenedMarkup = renderToStaticMarkup(
+      createElement(ActionCenterPreview, {
+        initialItems: [reopenedItem],
+        initialSelectedItemId: reopenedItem.id,
+        initialView: "actions",
+        fallbackOwnerName: "Admin",
+        ownerOptions: ["Manager Operations"],
+        workbenchHref: "/action-center/dossier",
+        hideSidebar: true,
+        readOnly: true,
+      }),
+    );
+    const followUpMarkup = renderToStaticMarkup(
+      createElement(ActionCenterPreview, {
+        initialItems: [followUpItem],
+        initialSelectedItemId: followUpItem.id,
+        initialView: "actions",
+        fallbackOwnerName: "Admin",
+        ownerOptions: ["Manager Operations"],
+        workbenchHref: "/action-center/dossier",
+        hideSidebar: true,
+        readOnly: true,
+      }),
+    );
+
+    expect(reopenedMarkup).toContain("Heropend traject");
+    expect(followUpMarkup).toContain("Vervolg op eerdere route");
+  });
+
   it("shows a compact ready-for-closeout hint for routes whose actions are finished but not yet explicitly closed", () => {
     const context = buildLiveContext();
     const [baseItem] = buildLiveActionCenterItems([context]);

--- a/frontend/app/(dashboard)/action-center/page.tsx
+++ b/frontend/app/(dashboard)/action-center/page.tsx
@@ -8,6 +8,11 @@ import {
 import { buildActionCenterRouteId } from '@/lib/action-center-route-contract'
 import { projectActionCenterRouteCloseout } from '@/lib/action-center-route-closeout'
 import {
+  projectActionCenterRouteFollowUpRelation,
+  projectActionCenterRouteReopen,
+  type ActionCenterRouteFollowUpRelationRecord,
+} from '@/lib/action-center-route-reopen'
+import {
   projectActionCenterRouteActionCard,
   type ActionCenterRouteActionWriteInput,
 } from '@/lib/action-center-route-actions'
@@ -178,6 +183,8 @@ export default async function ActionCenterPage({
     { data: managerResponsesRaw },
     { data: routeActionsRaw },
     { data: routeCloseoutsRaw },
+    { data: routeReopensRaw },
+    { data: routeFollowUpsRaw },
   ] = await Promise.all([
     deliveryRecords.length > 0
       ? dataClient
@@ -222,6 +229,18 @@ export default async function ActionCenterPage({
           .select('*')
           .in('campaign_id', campaignIds)
       : Promise.resolve({ data: [] }),
+    campaignIds.length > 0
+      ? dataClient
+          .from('action_center_route_reopens')
+          .select('*')
+          .in('campaign_id', campaignIds)
+      : Promise.resolve({ data: [] }),
+    campaignIds.length > 0
+      ? dataClient
+          .from('action_center_route_relations')
+          .select('*')
+          .in('campaign_id', campaignIds)
+      : Promise.resolve({ data: [] }),
   ])
 
   const deliveryCheckpoints = (deliveryCheckpointsRaw ?? []) as CampaignDeliveryCheckpoint[]
@@ -246,6 +265,24 @@ export default async function ActionCenterPage({
       }
     })
     .filter((row): row is ReturnType<typeof projectActionCenterRouteCloseout> => Boolean(row))
+  const routeReopens = (routeReopensRaw ?? [])
+    .map((row) => {
+      try {
+        return projectActionCenterRouteReopen(row as Record<string, unknown>)
+      } catch {
+        return null
+      }
+    })
+    .filter((row): row is ReturnType<typeof projectActionCenterRouteReopen> => Boolean(row))
+  const routeFollowUpRelations = (routeFollowUpsRaw ?? [])
+    .map((row) => {
+      try {
+        return projectActionCenterRouteFollowUpRelation(row as Record<string, unknown>)
+      } catch {
+        return null
+      }
+    })
+    .filter((row): row is ActionCenterRouteFollowUpRelationRecord => Boolean(row))
   const { data: actionReviewsRaw } =
     routeActions.length > 0
       ? await dataClient
@@ -318,6 +355,13 @@ export default async function ActionCenterPage({
     return acc
   }, {})
   const routeCloseoutByRouteId = new Map(routeCloseouts.map((closeout) => [closeout.routeId, closeout]))
+  const routeReopensByRouteId = routeReopens.reduce<Record<string, typeof routeReopens>>((acc, reopen) => {
+    acc[reopen.routeId] ??= []
+    acc[reopen.routeId].push(reopen)
+    return acc
+  }, {})
+  const routeFollowUpBySourceRouteId = new Map(routeFollowUpRelations.map((relation) => [relation.sourceRouteId, relation]))
+  const routeFollowUpByTargetRouteId = new Map(routeFollowUpRelations.map((relation) => [relation.targetRouteId, relation]))
   const actionReviewsByActionId = actionReviews.reduce<Record<string, typeof actionReviews>>((acc, review) => {
     acc[review.actionId] ??= []
     acc[review.actionId].push(review)
@@ -383,6 +427,9 @@ export default async function ActionCenterPage({
             (action) => actionReviewsByActionId[action.actionId] ?? [],
           ),
           routeCloseout: routeCloseoutByRouteId.get(routeId) ?? null,
+          routeReopens: routeReopensByRouteId[routeId] ?? [],
+          followUpFromRelation: routeFollowUpByTargetRouteId.get(routeId) ?? null,
+          followUpTargetRelation: routeFollowUpBySourceRouteId.get(routeId) ?? null,
         }
       })
   })
@@ -474,6 +521,8 @@ export default async function ActionCenterPage({
       actionReviewEndpoint="/api/action-center-action-reviews"
       canCloseRoutes={context.canManageActionCenterAssignments}
       routeCloseoutEndpoint="/api/action-center-route-closeouts"
+      routeReopenEndpoint="/api/action-center-route-reopens"
+      routeFollowUpEndpoint="/api/action-center-route-follow-ups"
       currentUserId={user.id}
       managerOnly={context.managerOnly}
       workbenchHref={context.canViewInsights ? '/dashboard' : '/action-center'}

--- a/frontend/app/api/action-center-route-follow-ups/route.test.ts
+++ b/frontend/app/api/action-center-route-follow-ups/route.test.ts
@@ -118,6 +118,15 @@ describe('action center route follow-ups route', () => {
           error: null,
         })
       }
+      if (table === 'respondents') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockResolvedValue({
+            data: [{ department: 'Operations' }, { department: 'People' }],
+            error: null,
+          }),
+        }
+      }
       if (table === 'action_center_route_relations') {
         return upsertQuery
       }
@@ -152,5 +161,98 @@ describe('action center route follow-ups route', () => {
       sourceRouteId: 'campaign-1::org-1::department::operations',
       targetRouteId: 'campaign-1::org-1::department::people',
     })
+  })
+
+  it('rejects cross-org follow-up lineage even when the caller owns one side', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'hr-owner-1' } } })
+    mockLoadSuiteAccessContext.mockResolvedValue({
+      context: { isVerisightAdmin: false },
+      orgMemberships: [{ org_id: 'org-1', role: 'owner' }],
+      workspaceMemberships: [],
+    })
+
+    let campaignQueryCall = 0
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === 'campaigns') {
+        campaignQueryCall += 1
+        return createCampaignQuery({
+          data:
+            campaignQueryCall === 1
+              ? { id: 'campaign-1', organization_id: 'org-1' }
+              : { id: 'campaign-2', organization_id: 'org-2' },
+          error: null,
+        })
+      }
+      if (table === 'respondents') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockResolvedValue({
+            data: [{ department: 'Operations' }, { department: 'People' }],
+            error: null,
+          }),
+        }
+      }
+      if (table === 'action_center_route_relations') {
+        return createUpsertQuery({ data: null, error: null })
+      }
+
+      throw new Error(`Unexpected table ${table}`)
+    })
+
+    const response = await POST(
+      makeRequest({
+        source_campaign_id: 'campaign-1',
+        source_route_scope_value: 'org-1::department::operations',
+        target_campaign_id: 'campaign-2',
+        target_route_scope_value: 'org-2::department::people',
+      }),
+    )
+
+    expect(response.status).toBe(403)
+  })
+
+  it('rejects mismatched source scope values that do not belong to the source campaign', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'hr-owner-1' } } })
+    mockLoadSuiteAccessContext.mockResolvedValue({
+      context: { isVerisightAdmin: false },
+      orgMemberships: [{ org_id: 'org-1', role: 'owner' }],
+      workspaceMemberships: [],
+    })
+
+    let campaignQueryCall = 0
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === 'campaigns') {
+        campaignQueryCall += 1
+        return createCampaignQuery({
+          data: { id: `campaign-${campaignQueryCall}`, organization_id: 'org-1' },
+          error: null,
+        })
+      }
+      if (table === 'respondents') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockResolvedValue({
+            data: [{ department: 'Operations' }],
+            error: null,
+          }),
+        }
+      }
+      if (table === 'action_center_route_relations') {
+        return createUpsertQuery({ data: null, error: null })
+      }
+
+      throw new Error(`Unexpected table ${table}`)
+    })
+
+    const response = await POST(
+      makeRequest({
+        source_campaign_id: 'campaign-1',
+        source_route_scope_value: 'org-1::department::sales',
+        target_campaign_id: 'campaign-2',
+        target_route_scope_value: 'org-1::department::operations',
+      }),
+    )
+
+    expect(response.status).toBe(400)
   })
 })

--- a/frontend/app/api/action-center-route-follow-ups/route.test.ts
+++ b/frontend/app/api/action-center-route-follow-ups/route.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockGetUser, mockLoadSuiteAccessContext, mockAdminFrom } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockLoadSuiteAccessContext: vi.fn(),
+  mockAdminFrom: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: async () => ({
+    auth: {
+      getUser: mockGetUser,
+    },
+  }),
+}))
+
+vi.mock('@/lib/suite-access-server', () => ({
+  loadSuiteAccessContext: mockLoadSuiteAccessContext,
+}))
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: () => ({
+    from: mockAdminFrom,
+  }),
+}))
+
+import { POST } from './route'
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/action-center-route-follow-ups', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+}
+
+function createCampaignQuery(result: { data: unknown; error: unknown }) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue(result),
+  }
+}
+
+function createUpsertQuery(result: { data: unknown; error: unknown }) {
+  return {
+    upsert: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue(result),
+  }
+}
+
+describe('action center route follow-ups route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('rejects follow-up writes without HR/admin permissions', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'manager-1' } } })
+    mockLoadSuiteAccessContext.mockResolvedValue({
+      context: { isVerisightAdmin: false },
+      orgMemberships: [],
+      workspaceMemberships: [],
+    })
+
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === 'campaigns') {
+        return createCampaignQuery({
+          data: { id: 'campaign-1', organization_id: 'org-1' },
+          error: null,
+        })
+      }
+      if (table === 'action_center_route_relations') {
+        return createUpsertQuery({ data: null, error: null })
+      }
+
+      throw new Error(`Unexpected table ${table}`)
+    })
+
+    const response = await POST(
+      makeRequest({
+        source_campaign_id: 'campaign-1',
+        source_route_scope_value: 'org-1::department::operations',
+        target_campaign_id: 'campaign-1',
+        target_route_scope_value: 'org-1::department::people',
+      }),
+    )
+
+    expect(response.status).toBe(403)
+  })
+
+  it('persists a compact follow-up relation between two route ids', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'hr-owner-1' } } })
+    mockLoadSuiteAccessContext.mockResolvedValue({
+      context: { isVerisightAdmin: false },
+      orgMemberships: [{ org_id: 'org-1', role: 'owner' }],
+      workspaceMemberships: [],
+    })
+
+    const upsertQuery = createUpsertQuery({
+      data: {
+        campaign_id: 'campaign-1',
+        org_id: 'org-1',
+        route_relation_type: 'follow-up-from',
+        source_route_id: 'campaign-1::org-1::department::operations',
+        target_route_id: 'campaign-1::org-1::department::people',
+        recorded_at: '2026-05-21T09:00:00.000Z',
+        recorded_by_role: 'hr',
+      },
+      error: null,
+    })
+
+    let campaignQueryCall = 0
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === 'campaigns') {
+        campaignQueryCall += 1
+        return createCampaignQuery({
+          data: { id: `campaign-${campaignQueryCall}`, organization_id: 'org-1' },
+          error: null,
+        })
+      }
+      if (table === 'action_center_route_relations') {
+        return upsertQuery
+      }
+
+      throw new Error(`Unexpected table ${table}`)
+    })
+
+    const response = await POST(
+      makeRequest({
+        source_campaign_id: 'campaign-1',
+        source_route_scope_value: 'org-1::department::operations',
+        target_campaign_id: 'campaign-1',
+        target_route_scope_value: 'org-1::department::people',
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(upsertQuery.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        route_relation_type: 'follow-up-from',
+        source_route_id: 'campaign-1::org-1::department::operations',
+        target_route_id: 'campaign-1::org-1::department::people',
+        recorded_by_role: 'hr',
+        created_by: 'hr-owner-1',
+      }),
+      { onConflict: 'source_route_id,target_route_id,route_relation_type' },
+    )
+
+    const payload = await response.json()
+    expect(payload.followUp).toMatchObject({
+      routeRelationType: 'follow-up-from',
+      sourceRouteId: 'campaign-1::org-1::department::operations',
+      targetRouteId: 'campaign-1::org-1::department::people',
+    })
+  })
+})

--- a/frontend/app/api/action-center-route-follow-ups/route.ts
+++ b/frontend/app/api/action-center-route-follow-ups/route.ts
@@ -1,0 +1,150 @@
+import { NextResponse } from 'next/server'
+import { buildActionCenterRouteId } from '@/lib/action-center-route-contract'
+import {
+  projectActionCenterRouteFollowUpRelation,
+  type ActionCenterRouteFollowUpRelationRecord,
+} from '@/lib/action-center-route-reopen'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { createClient } from '@/lib/supabase/server'
+import { loadSuiteAccessContext } from '@/lib/suite-access-server'
+
+type FollowUpRequestBody = {
+  source_campaign_id?: string
+  source_route_scope_value?: string
+  target_campaign_id?: string
+  target_route_scope_value?: string
+}
+
+function normalizeText(value: string | null | undefined) {
+  const trimmed = value?.trim() ?? ''
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function parseFollowUpInput(input: FollowUpRequestBody | null) {
+  const sourceCampaignId = normalizeText(input?.source_campaign_id)
+  const sourceRouteScopeValue = normalizeText(input?.source_route_scope_value)
+  const targetCampaignId = normalizeText(input?.target_campaign_id)
+  const targetRouteScopeValue = normalizeText(input?.target_route_scope_value)
+
+  if (!sourceCampaignId || !sourceRouteScopeValue || !targetCampaignId || !targetRouteScopeValue) {
+    throw new Error('Ongeldige follow-up input.')
+  }
+
+  return {
+    source_campaign_id: sourceCampaignId,
+    source_route_scope_value: sourceRouteScopeValue,
+    target_campaign_id: targetCampaignId,
+    target_route_scope_value: targetRouteScopeValue,
+  }
+}
+
+async function loadCampaignOrg(adminClient: ReturnType<typeof createAdminClient>, campaignId: string) {
+  const { data, error } = await adminClient
+    .from('campaigns')
+    .select('id, organization_id')
+    .eq('id', campaignId)
+    .maybeSingle()
+
+  if (error || !data?.id || !data.organization_id) {
+    return null
+  }
+
+  return data
+}
+
+function buildFollowUpRelation(args: {
+  sourceCampaignId: string
+  sourceRouteScopeValue: string
+  targetCampaignId: string
+  targetRouteScopeValue: string
+}): ActionCenterRouteFollowUpRelationRecord {
+  const recordedAt = new Date().toISOString()
+  return projectActionCenterRouteFollowUpRelation({
+    route_relation_type: 'follow-up-from',
+    source_route_id: buildActionCenterRouteId(args.sourceCampaignId, args.sourceRouteScopeValue),
+    target_route_id: buildActionCenterRouteId(args.targetCampaignId, args.targetRouteScopeValue),
+    recorded_at: recordedAt,
+    recorded_by_role: 'hr',
+  })
+}
+
+export async function POST(request: Request) {
+  const body = (await request.json().catch(() => null)) as FollowUpRequestBody | null
+
+  let parsed
+  try {
+    parsed = parseFollowUpInput(body)
+  } catch {
+    return NextResponse.json({ detail: 'Ongeldige follow-up input.' }, { status: 400 })
+  }
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ detail: 'Niet ingelogd.' }, { status: 401 })
+  }
+
+  const { context, orgMemberships } = await loadSuiteAccessContext(supabase, user.id)
+  const adminClient = createAdminClient()
+  const [sourceCampaign, targetCampaign] = await Promise.all([
+    loadCampaignOrg(adminClient, parsed.source_campaign_id),
+    loadCampaignOrg(adminClient, parsed.target_campaign_id),
+  ])
+
+  if (!sourceCampaign?.organization_id || !targetCampaign?.organization_id) {
+    return NextResponse.json({ detail: 'Source of target route bestaat niet.' }, { status: 400 })
+  }
+
+  const hasHrAccess =
+    context.isVerisightAdmin ||
+    orgMemberships.some(
+      (membership) =>
+        (membership.org_id === sourceCampaign.organization_id || membership.org_id === targetCampaign.organization_id) &&
+        membership.role === 'owner',
+    )
+
+  if (!hasHrAccess) {
+    return NextResponse.json({ detail: 'Alleen HR of Verisight kan een vervolgroute koppelen.' }, { status: 403 })
+  }
+
+  const relation = buildFollowUpRelation({
+    sourceCampaignId: parsed.source_campaign_id,
+    sourceRouteScopeValue: parsed.source_route_scope_value,
+    targetCampaignId: parsed.target_campaign_id,
+    targetRouteScopeValue: parsed.target_route_scope_value,
+  })
+
+  const { data, error } = await adminClient
+    .from('action_center_route_relations')
+    .upsert(
+      {
+        campaign_id: targetCampaign.id,
+        org_id: targetCampaign.organization_id,
+        route_relation_type: relation.routeRelationType,
+        source_route_id: relation.sourceRouteId,
+        target_route_id: relation.targetRouteId,
+        recorded_at: relation.recordedAt,
+        recorded_by_role: relation.recordedByRole,
+        created_by: user.id,
+        updated_by: user.id,
+        updated_at: relation.recordedAt,
+      },
+      { onConflict: 'source_route_id,target_route_id,route_relation_type' },
+    )
+    .select('*')
+    .single()
+
+  if (error || !data) {
+    return NextResponse.json({ detail: error?.message ?? 'Vervolgroute opslaan mislukt.' }, { status: 500 })
+  }
+
+  try {
+    const followUp = projectActionCenterRouteFollowUpRelation(data as Record<string, unknown>)
+    return NextResponse.json({ followUp }, { status: 200 })
+  } catch {
+    return NextResponse.json({ detail: 'Vervolgroute opslaan mislukt.' }, { status: 500 })
+  }
+}

--- a/frontend/app/api/action-center-route-follow-ups/route.ts
+++ b/frontend/app/api/action-center-route-follow-ups/route.ts
@@ -1,4 +1,8 @@
 import { NextResponse } from 'next/server'
+import {
+  buildCampaignItemScopeValue,
+  buildDepartmentScopeValue,
+} from '@/lib/action-center-manager-responses'
 import { buildActionCenterRouteId } from '@/lib/action-center-route-contract'
 import {
   projectActionCenterRouteFollowUpRelation,
@@ -15,9 +19,18 @@ type FollowUpRequestBody = {
   target_route_scope_value?: string
 }
 
+type RespondentDepartmentRow = {
+  department: string | null
+}
+
 function normalizeText(value: string | null | undefined) {
   const trimmed = value?.trim() ?? ''
   return trimmed.length > 0 ? trimmed : null
+}
+
+function normalizeDepartmentLabel(value: string | null | undefined) {
+  const normalized = normalizeText(value)
+  return normalized ? normalized.toLocaleLowerCase('nl-NL') : null
 }
 
 function parseFollowUpInput(input: FollowUpRequestBody | null) {
@@ -52,17 +65,64 @@ async function loadCampaignOrg(adminClient: ReturnType<typeof createAdminClient>
   return data
 }
 
+async function loadVisibleDepartmentLabels(adminClient: ReturnType<typeof createAdminClient>, campaignId: string) {
+  const { data: respondentsRaw } = await adminClient
+    .from('respondents')
+    .select('department')
+    .eq('campaign_id', campaignId)
+
+  return [
+    ...new Set(
+      ((respondentsRaw ?? []) as RespondentDepartmentRow[])
+        .map((row) => normalizeDepartmentLabel(row.department))
+        .filter((value): value is string => Boolean(value)),
+    ),
+  ]
+}
+
+function resolveRouteIdentity(args: {
+  campaignId: string
+  campaignOrgId: string
+  routeScopeValue: string
+  visibleDepartmentLabels: string[]
+}) {
+  const normalizedScopeValue = normalizeText(args.routeScopeValue)
+  if (!normalizedScopeValue) {
+    throw new Error('Ongeldige follow-up route-identiteit.')
+  }
+
+  if (normalizedScopeValue === buildCampaignItemScopeValue(args.campaignOrgId, args.campaignId)) {
+    return {
+      route_id: buildActionCenterRouteId(args.campaignId, normalizedScopeValue),
+      route_scope_type: 'item' as const,
+      route_scope_value: normalizedScopeValue,
+    }
+  }
+
+  const matchesDepartment = args.visibleDepartmentLabels.some(
+    (departmentLabel) => buildDepartmentScopeValue(args.campaignOrgId, departmentLabel) === normalizedScopeValue,
+  )
+
+  if (!matchesDepartment) {
+    throw new Error('Follow-up route bestaat niet voor deze campagne.')
+  }
+
+  return {
+    route_id: buildActionCenterRouteId(args.campaignId, normalizedScopeValue),
+    route_scope_type: 'department' as const,
+    route_scope_value: normalizedScopeValue,
+  }
+}
+
 function buildFollowUpRelation(args: {
-  sourceCampaignId: string
-  sourceRouteScopeValue: string
-  targetCampaignId: string
-  targetRouteScopeValue: string
+  sourceRouteId: string
+  targetRouteId: string
 }): ActionCenterRouteFollowUpRelationRecord {
   const recordedAt = new Date().toISOString()
   return projectActionCenterRouteFollowUpRelation({
     route_relation_type: 'follow-up-from',
-    source_route_id: buildActionCenterRouteId(args.sourceCampaignId, args.sourceRouteScopeValue),
-    target_route_id: buildActionCenterRouteId(args.targetCampaignId, args.targetRouteScopeValue),
+    source_route_id: args.sourceRouteId,
+    target_route_id: args.targetRouteId,
     recorded_at: recordedAt,
     recorded_by_role: 'hr',
   })
@@ -98,23 +158,51 @@ export async function POST(request: Request) {
     return NextResponse.json({ detail: 'Source of target route bestaat niet.' }, { status: 400 })
   }
 
+  if (sourceCampaign.organization_id !== targetCampaign.organization_id) {
+    return NextResponse.json({ detail: 'Alleen routes binnen dezelfde organisatie kunnen worden gekoppeld.' }, { status: 403 })
+  }
+
   const hasHrAccess =
     context.isVerisightAdmin ||
     orgMemberships.some(
       (membership) =>
-        (membership.org_id === sourceCampaign.organization_id || membership.org_id === targetCampaign.organization_id) &&
-        membership.role === 'owner',
+        membership.org_id === sourceCampaign.organization_id && membership.role === 'owner',
     )
 
   if (!hasHrAccess) {
     return NextResponse.json({ detail: 'Alleen HR of Verisight kan een vervolgroute koppelen.' }, { status: 403 })
   }
 
+  const [sourceVisibleDepartmentLabels, targetVisibleDepartmentLabels] = await Promise.all([
+    loadVisibleDepartmentLabels(adminClient, parsed.source_campaign_id),
+    loadVisibleDepartmentLabels(adminClient, parsed.target_campaign_id),
+  ])
+
+  let sourceIdentity
+  let targetIdentity
+  try {
+    sourceIdentity = resolveRouteIdentity({
+      campaignId: parsed.source_campaign_id,
+      campaignOrgId: sourceCampaign.organization_id,
+      routeScopeValue: parsed.source_route_scope_value,
+      visibleDepartmentLabels: sourceVisibleDepartmentLabels,
+    })
+    targetIdentity = resolveRouteIdentity({
+      campaignId: parsed.target_campaign_id,
+      campaignOrgId: targetCampaign.organization_id,
+      routeScopeValue: parsed.target_route_scope_value,
+      visibleDepartmentLabels: targetVisibleDepartmentLabels,
+    })
+  } catch (error) {
+    return NextResponse.json(
+      { detail: error instanceof Error ? error.message : 'Ongeldige follow-up route-identiteit.' },
+      { status: 400 },
+    )
+  }
+
   const relation = buildFollowUpRelation({
-    sourceCampaignId: parsed.source_campaign_id,
-    sourceRouteScopeValue: parsed.source_route_scope_value,
-    targetCampaignId: parsed.target_campaign_id,
-    targetRouteScopeValue: parsed.target_route_scope_value,
+    sourceRouteId: sourceIdentity.route_id,
+    targetRouteId: targetIdentity.route_id,
   })
 
   const { data, error } = await adminClient

--- a/frontend/app/api/action-center-route-reopens/route.test.ts
+++ b/frontend/app/api/action-center-route-reopens/route.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockGetUser, mockLoadSuiteAccessContext, mockAdminFrom } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockLoadSuiteAccessContext: vi.fn(),
+  mockAdminFrom: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: async () => ({
+    auth: {
+      getUser: mockGetUser,
+    },
+  }),
+}))
+
+vi.mock('@/lib/suite-access-server', () => ({
+  loadSuiteAccessContext: mockLoadSuiteAccessContext,
+}))
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: () => ({
+    from: mockAdminFrom,
+  }),
+}))
+
+import { POST } from './route'
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/action-center-route-reopens', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+}
+
+function createCampaignQuery(result: { data: unknown; error: unknown }) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue(result),
+  }
+}
+
+function createRespondentsQuery(result: { data: unknown; error?: unknown }) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockResolvedValue(result),
+  }
+}
+
+function createInsertQuery(result: { data: unknown; error: unknown }) {
+  return {
+    insert: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue(result),
+  }
+}
+
+describe('action center route reopens route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('rejects reopen writes without HR/admin permissions', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'manager-1' } } })
+    mockLoadSuiteAccessContext.mockResolvedValue({
+      context: { isVerisightAdmin: false },
+      orgMemberships: [],
+      workspaceMemberships: [],
+    })
+
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === 'campaigns') {
+        return createCampaignQuery({
+          data: { id: 'campaign-1', organization_id: 'org-1' },
+          error: null,
+        })
+      }
+      if (table === 'respondents') {
+        return createRespondentsQuery({ data: [{ department: 'Operations' }] })
+      }
+      if (table === 'action_center_route_reopens') {
+        return createInsertQuery({ data: null, error: null })
+      }
+
+      throw new Error(`Unexpected table ${table}`)
+    })
+
+    const response = await POST(
+      makeRequest({
+        route_id: 'campaign-1::org-1::department::operations',
+        campaign_id: 'campaign-1',
+        route_scope_type: 'department',
+        route_scope_value: 'org-1::department::operations',
+        reopen_reason: 'te-vroeg-afgesloten',
+      }),
+    )
+
+    expect(response.status).toBe(403)
+  })
+
+  it('persists a canonical reopen event', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'hr-owner-1' } } })
+    mockLoadSuiteAccessContext.mockResolvedValue({
+      context: { isVerisightAdmin: false },
+      orgMemberships: [{ org_id: 'org-1', role: 'owner' }],
+      workspaceMemberships: [],
+    })
+
+    const insertQuery = createInsertQuery({
+      data: {
+        route_id: 'campaign-1::org-1::department::operations',
+        campaign_id: 'campaign-1',
+        org_id: 'org-1',
+        route_scope_type: 'department',
+        route_scope_value: 'org-1::department::operations',
+        reopen_reason: 'te-vroeg-afgesloten',
+        reopened_at: '2026-05-21T09:00:00.000Z',
+        reopened_by_role: 'hr',
+      },
+      error: null,
+    })
+
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === 'campaigns') {
+        return createCampaignQuery({
+          data: { id: 'campaign-1', organization_id: 'org-1' },
+          error: null,
+        })
+      }
+      if (table === 'respondents') {
+        return createRespondentsQuery({ data: [{ department: 'Operations' }] })
+      }
+      if (table === 'action_center_route_reopens') {
+        return insertQuery
+      }
+
+      throw new Error(`Unexpected table ${table}`)
+    })
+
+    const response = await POST(
+      makeRequest({
+        route_id: 'campaign-1::org-1::department::operations',
+        campaign_id: 'campaign-1',
+        route_scope_type: 'department',
+        route_scope_value: 'org-1::department::operations',
+        reopen_reason: 'te-vroeg-afgesloten',
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(insertQuery.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        route_id: 'campaign-1::org-1::department::operations',
+        campaign_id: 'campaign-1',
+        org_id: 'org-1',
+        reopen_reason: 'te-vroeg-afgesloten',
+        reopened_by_role: 'hr',
+        created_by: 'hr-owner-1',
+      }),
+    )
+
+    const payload = await response.json()
+    expect(payload.reopen).toMatchObject({
+      routeId: 'campaign-1::org-1::department::operations',
+      reopenReason: 'te-vroeg-afgesloten',
+      reopenedByRole: 'hr',
+    })
+  })
+})

--- a/frontend/app/api/action-center-route-reopens/route.ts
+++ b/frontend/app/api/action-center-route-reopens/route.ts
@@ -1,0 +1,212 @@
+import { NextResponse } from 'next/server'
+import { buildActionCenterRouteId } from '@/lib/action-center-route-contract'
+import {
+  projectActionCenterRouteReopen,
+  type ActionCenterRouteReopenReason,
+} from '@/lib/action-center-route-reopen'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { createClient } from '@/lib/supabase/server'
+import { loadSuiteAccessContext } from '@/lib/suite-access-server'
+
+type RouteReopenRequestBody = {
+  route_id?: string
+  campaign_id?: string
+  route_scope_type?: 'department' | 'item'
+  route_scope_value?: string
+  reopen_reason?: string
+}
+
+type RespondentDepartmentRow = {
+  department: string | null
+}
+
+function normalizeText(value: string | null | undefined) {
+  const trimmed = value?.trim() ?? ''
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function normalizeDepartmentLabel(value: string | null | undefined) {
+  const normalized = normalizeText(value)
+  return normalized ? normalized.toLocaleLowerCase('nl-NL') : null
+}
+
+function buildCampaignFallbackScopeValue(orgId: string, campaignId: string) {
+  return `${orgId}::campaign::${campaignId}`
+}
+
+function parseRouteReopenInput(input: RouteReopenRequestBody | null) {
+  const routeId = normalizeText(input?.route_id)
+  const campaignId = normalizeText(input?.campaign_id)
+  const routeScopeType = input?.route_scope_type
+  const routeScopeValue = normalizeText(input?.route_scope_value)
+  const reopenReason = normalizeText(input?.reopen_reason) as ActionCenterRouteReopenReason | null
+
+  if (
+    !routeId ||
+    !campaignId ||
+    (routeScopeType !== 'department' && routeScopeType !== 'item') ||
+    !routeScopeValue ||
+    !reopenReason
+  ) {
+    throw new Error('Ongeldige route reopen input.')
+  }
+
+  return {
+    route_id: routeId,
+    campaign_id: campaignId,
+    route_scope_type: routeScopeType,
+    route_scope_value: routeScopeValue,
+    reopen_reason: reopenReason,
+  }
+}
+
+async function loadRouteTruth(input: {
+  campaignId: string
+  routeScopeType: 'department' | 'item'
+}) {
+  const adminClient = createAdminClient()
+  const { data: campaign, error: campaignError } = await adminClient
+    .from('campaigns')
+    .select('id, organization_id')
+    .eq('id', input.campaignId)
+    .maybeSingle()
+
+  if (campaignError || !campaign?.id || !campaign.organization_id) {
+    return { campaign: null, visibleDepartmentLabels: [] as string[] }
+  }
+
+  if (input.routeScopeType !== 'department') {
+    return { campaign, visibleDepartmentLabels: [] as string[] }
+  }
+
+  const { data: respondentsRaw } = await adminClient
+    .from('respondents')
+    .select('department')
+    .eq('campaign_id', input.campaignId)
+
+  const visibleDepartmentLabels = [
+    ...new Set(
+      ((respondentsRaw ?? []) as RespondentDepartmentRow[])
+        .map((row) => normalizeDepartmentLabel(row.department))
+        .filter((value): value is string => Boolean(value)),
+    ),
+  ]
+
+  return { campaign, visibleDepartmentLabels }
+}
+
+function resolveRouteReopenIdentity(args: {
+  parsed: ReturnType<typeof parseRouteReopenInput>
+  campaignOrgId: string
+  visibleDepartmentLabels: string[]
+}) {
+  const canonicalRouteId = buildActionCenterRouteId(args.parsed.campaign_id, args.parsed.route_scope_value)
+  if (args.parsed.route_id !== canonicalRouteId) {
+    throw new Error('Route reopen route bestaat niet voor deze campagne.')
+  }
+
+  if (args.parsed.route_scope_type === 'department') {
+    const normalizedScopeValue = args.parsed.route_scope_value.toLocaleLowerCase('nl-NL')
+    if (!args.visibleDepartmentLabels.includes(normalizedScopeValue.split('::').at(-1) ?? '')) {
+      throw new Error('Route reopen route bestaat niet voor deze campagne.')
+    }
+  }
+
+  if (
+    args.parsed.route_scope_type === 'item' &&
+    args.parsed.route_scope_value !== buildCampaignFallbackScopeValue(args.campaignOrgId, args.parsed.campaign_id)
+  ) {
+    throw new Error('Route reopen route bestaat niet voor deze campagne.')
+  }
+
+  return {
+    route_id: canonicalRouteId,
+    campaign_id: args.parsed.campaign_id,
+    org_id: args.campaignOrgId,
+    route_scope_type: args.parsed.route_scope_type,
+    route_scope_value: args.parsed.route_scope_value,
+  }
+}
+
+export async function POST(request: Request) {
+  const body = (await request.json().catch(() => null)) as RouteReopenRequestBody | null
+
+  let parsed
+  try {
+    parsed = parseRouteReopenInput(body)
+  } catch {
+    return NextResponse.json({ detail: 'Ongeldige route reopen input.' }, { status: 400 })
+  }
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ detail: 'Niet ingelogd.' }, { status: 401 })
+  }
+
+  const { context, orgMemberships } = await loadSuiteAccessContext(supabase, user.id)
+  const routeTruth = await loadRouteTruth({
+    campaignId: parsed.campaign_id,
+    routeScopeType: parsed.route_scope_type,
+  })
+
+  if (!routeTruth.campaign?.organization_id) {
+    return NextResponse.json({ detail: 'Route reopen route bestaat niet voor deze campagne.' }, { status: 400 })
+  }
+
+  const canReopenRoute =
+    context.isVerisightAdmin ||
+    orgMemberships.some(
+      (membership) => membership.org_id === routeTruth.campaign.organization_id && membership.role === 'owner',
+    )
+
+  if (!canReopenRoute) {
+    return NextResponse.json({ detail: 'Alleen HR of Verisight kan deze route heropenen.' }, { status: 403 })
+  }
+
+  let identity
+  try {
+    identity = resolveRouteReopenIdentity({
+      parsed,
+      campaignOrgId: routeTruth.campaign.organization_id,
+      visibleDepartmentLabels: routeTruth.visibleDepartmentLabels,
+    })
+  } catch (error) {
+    return NextResponse.json(
+      { detail: error instanceof Error ? error.message : 'Ongeldige route reopen-identiteit.' },
+      { status: 400 },
+    )
+  }
+
+  const reopenedAt = new Date().toISOString()
+  const adminClient = createAdminClient()
+  const persisted = {
+    ...identity,
+    reopen_reason: parsed.reopen_reason,
+    reopened_at: reopenedAt,
+    reopened_by_role: 'hr',
+    created_by: user.id,
+    updated_by: user.id,
+    updated_at: reopenedAt,
+  }
+
+  const { data, error } = await adminClient
+    .from('action_center_route_reopens')
+    .insert(persisted)
+    .select('*')
+    .single()
+
+  if (error || !data) {
+    return NextResponse.json({ detail: error?.message ?? 'Route heropenen mislukt.' }, { status: 500 })
+  }
+
+  try {
+    const reopen = projectActionCenterRouteReopen(data as Record<string, unknown>)
+    return NextResponse.json({ reopen }, { status: 200 })
+  } catch {
+    return NextResponse.json({ detail: 'Route heropenen mislukt.' }, { status: 500 })
+  }
+}

--- a/frontend/components/dashboard/action-center-preview.tsx
+++ b/frontend/components/dashboard/action-center-preview.tsx
@@ -29,6 +29,10 @@ import {
   type ActionCenterRouteCloseoutReason,
   type ActionCenterRouteCloseoutStatus,
 } from '@/lib/action-center-route-closeout'
+import {
+  getActionCenterRouteReopenReasonLabel,
+  projectActionCenterRouteReopen,
+} from '@/lib/action-center-route-reopen'
 import type {
   ActionCenterPreviewItem,
   ActionCenterPreviewManagerOption,
@@ -76,6 +80,8 @@ interface Props {
   actionReviewEndpoint?: string
   canCloseRoutes?: boolean
   routeCloseoutEndpoint?: string
+  routeReopenEndpoint?: string
+  routeFollowUpEndpoint?: string
   currentUserId?: string | null
   managerOnly?: boolean
   workbenchHref: string
@@ -632,6 +638,58 @@ function applyRouteCloseoutToItem(
   )
 }
 
+function applyRouteReopenToItem(
+  item: ActionCenterPreviewItem,
+  reopen: ReturnType<typeof projectActionCenterRouteReopen>,
+) {
+  const routeActionCards = item.coreSemantics.routeActionCards
+  const aggregation =
+    routeActionCards.length > 0
+      ? summarizeActionCenterRouteActions(
+          routeActionCards.map((action) => ({
+            actionId: action.actionId,
+            status: action.status,
+            reviewScheduledFor: action.reviewScheduledFor,
+          })),
+        )
+      : null
+  const nextStatus: ActionCenterPreviewStatus =
+    aggregation?.routeStatus === 'reviewbaar'
+      ? 'reviewbaar'
+      : aggregation?.routeStatus === 'in-uitvoering'
+        ? 'in-uitvoering'
+        : item.coreSemantics.route.followThroughMode === 'open_request'
+          ? 'open-verzoek'
+          : item.coreSemantics.route.followThroughMode === 'none'
+            ? 'te-bespreken'
+            : 'te-bespreken'
+
+  return finalizeActionCenterPreviewItem(
+    {
+      ...item,
+      status: nextStatus,
+      coreSemantics: {
+        ...item.coreSemantics,
+        route: {
+          ...item.coreSemantics.route,
+          routeStatus: getContractRouteStatusFromPreviewStatus(nextStatus),
+          reopenedAt: reopen.reopenedAt,
+          reopenedByRole: reopen.reopenedByRole,
+          reopenReason: reopen.reopenReason,
+          isReopened: true,
+          lineageLabel: 'Heropend traject',
+        },
+        lineageSemantics: {
+          ...item.coreSemantics.lineageSemantics,
+          label: 'Heropend traject',
+          summary: `${getActionCenterRouteReopenReasonLabel(reopen.reopenReason)} na eerdere afsluiting`,
+        },
+      },
+    },
+    { recomputeCoreSemantics: true },
+  )
+}
+
 function getViewCopy(view: ActionCenterPreviewView, selectedTitle: string | null) {
   switch (view) {
     case 'actions':
@@ -741,6 +799,7 @@ export function ActionCenterPreview({
   actionReviewEndpoint,
   canCloseRoutes = false,
   routeCloseoutEndpoint,
+  routeReopenEndpoint,
   currentUserId = null,
   managerOnly = false,
   workbenchHref,
@@ -776,6 +835,8 @@ export function ActionCenterPreview({
   )
   const [routeCloseoutPending, setRouteCloseoutPending] = useState(false)
   const [routeCloseoutError, setRouteCloseoutError] = useState<string | null>(null)
+  const [routeReopenPending, setRouteReopenPending] = useState(false)
+  const [routeReopenError, setRouteReopenError] = useState<string | null>(null)
   const [reviewPendingActionId, setReviewPendingActionId] = useState<string | null>(null)
   const [reviewErrorState, setReviewErrorState] = useState<{ actionId: string; message: string } | null>(null)
   const [expandedReviewActionId, setExpandedReviewActionId] = useState<string | null>(null)
@@ -832,6 +893,7 @@ export function ActionCenterPreview({
       setRouteCloseoutForm(buildRouteCloseoutDefaults(selectedItem))
       setRouteCloseoutError(null)
       setShowRouteCloseoutEditor(false)
+      setRouteReopenError(null)
       setReviewErrorState(null)
     setShowRouteActionEditor(false)
     setExpandedReviewActionId(null)
@@ -901,6 +963,7 @@ export function ActionCenterPreview({
   const canUseActionReviewFlow = Boolean(canUseRouteActionFlow && actionReviewEndpoint)
   const closing = selectedItem?.coreSemantics.closingSemantics ?? null
   const routeCloseout = selectedItem?.coreSemantics.routeCloseout ?? null
+  const lineage = selectedItem?.coreSemantics.lineageSemantics ?? null
   const canUseRouteCloseoutFlow =
     Boolean(
       canCloseRoutes &&
@@ -911,6 +974,13 @@ export function ActionCenterPreview({
     )
   const showReadyForCloseoutHint = Boolean(
     routeCloseout?.readyForCloseout && routeCloseout.closeoutStatus === null,
+  )
+  const canUseRouteReopenFlow = Boolean(
+    canCloseRoutes &&
+      routeReopenEndpoint &&
+      selectedItem?.orgId &&
+      selectedItem.scopeType &&
+      routeCloseout?.closeoutStatus,
   )
 
   function updateItem(
@@ -1277,6 +1347,47 @@ export function ActionCenterPreview({
       setRouteCloseoutError(error instanceof Error ? error.message : 'Route closeout opslaan mislukt.')
     } finally {
       setRouteCloseoutPending(false)
+    }
+  }
+
+  async function handleRouteReopenSave() {
+    if (!selectedItem || !selectedItem.orgId || !selectedItem.scopeType || !routeReopenEndpoint) {
+      return
+    }
+
+    setRouteReopenPending(true)
+    setRouteReopenError(null)
+
+    try {
+      const response = await fetch(routeReopenEndpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          route_id: selectedItem.id,
+          campaign_id: selectedItem.coreSemantics.route.campaignId,
+          route_scope_type: selectedItem.scopeType,
+          route_scope_value: selectedItem.teamId,
+          reopen_reason: 'te-vroeg-afgesloten',
+        }),
+      })
+      const result = (await response.json().catch(() => null)) as
+        | { reopen?: Record<string, unknown>; detail?: string }
+        | null
+
+      if (!response.ok || !result?.reopen) {
+        throw new Error(result?.detail ?? 'Route heropenen mislukt.')
+      }
+
+      const savedReopen = projectActionCenterRouteReopen(result.reopen)
+      setItems((currentItems) =>
+        currentItems.map((item) => (item.id === selectedItem.id ? applyRouteReopenToItem(item, savedReopen) : item)),
+      )
+    } catch (error) {
+      setRouteReopenError(error instanceof Error ? error.message : 'Route heropenen mislukt.')
+    } finally {
+      setRouteReopenPending(false)
     }
   }
 
@@ -2186,6 +2297,17 @@ export function ActionCenterPreview({
                           </div>
                         </div>
 
+                        {lineage?.label ? (
+                          <div className="mt-5 rounded-[18px] border border-white/10 bg-white/[0.04] px-4 py-4">
+                            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/48">
+                              {lineage.label}
+                            </p>
+                            {lineage.summary ? (
+                              <p className="mt-2 text-sm leading-7 text-white/72">{lineage.summary}</p>
+                            ) : null}
+                          </div>
+                        ) : null}
+
                         {routeCloseout?.closeoutStatus ? (
                           <div className="mt-5 rounded-[18px] border border-white/10 bg-white/[0.04] px-4 py-4">
                             <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/48">Route afgesloten</p>
@@ -2201,6 +2323,21 @@ export function ActionCenterPreview({
                             <p className="mt-3 text-xs uppercase tracking-[0.16em] text-white/40">
                               {formatLongDate(routeCloseout.closedAt)} · {routeCloseout.closedByRole}
                             </p>
+                            {canUseRouteReopenFlow ? (
+                              <div className="mt-4 flex flex-wrap gap-3">
+                                <button
+                                  type="button"
+                                  className="inline-flex min-h-11 items-center rounded-full bg-white/10 px-4.5 py-2.5 text-sm font-semibold text-white transition hover:bg-white/15 disabled:cursor-not-allowed disabled:opacity-60"
+                                  disabled={routeReopenPending}
+                                  onClick={() => void handleRouteReopenSave()}
+                                >
+                                  {routeReopenPending ? 'Heropenen...' : 'Heropen traject'}
+                                </button>
+                              </div>
+                            ) : null}
+                            {routeReopenError ? (
+                              <p className="mt-3 text-sm leading-7 text-[#ffcac2]">{routeReopenError}</p>
+                            ) : null}
                           </div>
                         ) : null}
 

--- a/frontend/lib/action-center-core-semantics.ts
+++ b/frontend/lib/action-center-core-semantics.ts
@@ -7,6 +7,7 @@ import {
   projectActionCenterRouteCloseoutState,
   type ActionCenterRouteCloseoutProjection,
 } from './action-center-route-closeout'
+import { getActionCenterRouteReopenReasonLabel } from './action-center-route-reopen'
 import type { LiveActionCenterCampaignContext } from './action-center-live-context'
 import type {
   ActionCenterManagerResponse,
@@ -69,6 +70,12 @@ export interface ActionCenterCoreSemantics {
     } | null
   }>
   routeCloseout: ActionCenterRouteCloseoutProjection
+  lineageSemantics: {
+    label: 'Heropend traject' | 'Vervolg op eerdere route' | null
+    summary: string | null
+    followUpFromRouteId: string | null
+    followUpTargetRouteId: string | null
+  }
   closingSemantics: {
     status: ActionCenterClosingStatus
     summary: string | null
@@ -448,6 +455,25 @@ function getPreviewClosingSummaryValues(route: ActionCenterRouteContract, status
   return []
 }
 
+function getLineageSummary(route: ActionCenterRouteContract, routeCloseout: ActionCenterRouteCloseoutProjection) {
+  if (route.isReopened && route.reopenedAt && route.reopenReason) {
+    const historicalCloseoutLabel =
+      routeCloseout.closeoutStatus === 'afgerond'
+        ? 'na eerdere afronding'
+        : routeCloseout.closeoutStatus === 'gestopt'
+          ? 'na eerdere stop'
+          : 'na eerdere afsluiting'
+
+    return `${getActionCenterRouteReopenReasonLabel(route.reopenReason)} ${historicalCloseoutLabel}`
+  }
+
+  if (route.followUpFromRouteId) {
+    return 'Nieuw traject na eerdere routeafsluiting'
+  }
+
+  return null
+}
+
 function getLiveClosingSummaryValues(
   context: ActionCenterCoreSemanticsProjectionInput,
   route: ActionCenterRouteContract,
@@ -518,6 +544,14 @@ function buildPreviewRoute(input: ActionCenterPreviewCoreSemanticsProjectionInpu
         ? 'bounded_response'
         : input.route?.followThroughMode ?? 'legacy_action',
     blockedBy: routeStatus === 'geblokkeerd' ? (input.route?.blockedBy ?? 'blocked') : null,
+    reopenedAt: input.route?.reopenedAt ?? null,
+    reopenedByRole: input.route?.reopenedByRole ?? null,
+    reopenReason: input.route?.reopenReason ?? null,
+    isReopened: input.route?.isReopened ?? false,
+    followUpFromRouteId: input.route?.followUpFromRouteId ?? null,
+    followUpTargetRouteId: input.route?.followUpTargetRouteId ?? null,
+    hasFollowUpTarget: input.route?.hasFollowUpTarget ?? false,
+    lineageLabel: input.route?.lineageLabel ?? null,
   }
 }
 
@@ -627,6 +661,12 @@ export function projectActionCenterPreviewCoreSemantics(
     decisionHistory,
     routeActionCards: [],
     routeCloseout,
+    lineageSemantics: {
+      label: route.lineageLabel,
+      summary: getLineageSummary(route, routeCloseout),
+      followUpFromRouteId: route.followUpFromRouteId,
+      followUpTargetRouteId: route.followUpTargetRouteId,
+    },
     closingSemantics: {
       status: closingStatus,
       summary: getClosingSummary(closingStatus, getPreviewClosingSummaryValues(route, closingStatus)),
@@ -791,6 +831,12 @@ export function projectActionCenterCoreSemantics(
     decisionHistory,
     routeActionCards,
     routeCloseout,
+    lineageSemantics: {
+      label: route.lineageLabel,
+      summary: getLineageSummary(route, routeCloseout),
+      followUpFromRouteId: route.followUpFromRouteId,
+      followUpTargetRouteId: route.followUpTargetRouteId,
+    },
     closingSemantics: {
       status: closingStatus,
       summary: getClosingSummary(closingStatus, getLiveClosingSummaryValues(context, route, closingStatus)),

--- a/frontend/lib/action-center-live-context.ts
+++ b/frontend/lib/action-center-live-context.ts
@@ -9,6 +9,10 @@ import type {
 import type { ActionCenterRouteActionRecord } from './action-center-route-actions'
 import type { ActionCenterActionReviewRecord } from './action-center-action-reviews'
 import type { ActionCenterRouteCloseoutRecord } from './action-center-route-closeout'
+import type {
+  ActionCenterRouteFollowUpRelationRecord,
+  ActionCenterRouteReopenRecord,
+} from './action-center-route-reopen'
 
 export interface LiveActionCenterCampaignContext {
   campaign: Campaign
@@ -33,4 +37,7 @@ export interface LiveActionCenterCampaignContext {
   routeActions?: ActionCenterRouteActionRecord[]
   actionReviews?: ActionCenterActionReviewRecord[]
   routeCloseout?: ActionCenterRouteCloseoutRecord | null
+  routeReopens?: ActionCenterRouteReopenRecord[]
+  followUpFromRelation?: ActionCenterRouteFollowUpRelationRecord | null
+  followUpTargetRelation?: ActionCenterRouteFollowUpRelationRecord | null
 }

--- a/frontend/lib/action-center-live.test.ts
+++ b/frontend/lib/action-center-live.test.ts
@@ -1029,4 +1029,66 @@ describe('live action center builder', () => {
 
     expect(routeCloseout?.readyForCloseout).toBe(true)
   })
+
+  it('keeps a source route closed while surfacing a follow-up route as the active successor', () => {
+    const sourceContext = {
+      campaign: buildCampaign(),
+      stats: buildStats(),
+      organizationName: 'Acme BV',
+      memberRole: 'owner' as const,
+      scopeType: 'department' as const,
+      scopeValue: 'operations-closed',
+      scopeLabel: 'Operations gesloten',
+      peopleCount: 38,
+      assignedManager: {
+        userId: 'manager-1',
+        displayName: 'Manager Operations',
+        assignedAt: '2026-04-21T08:00:00.000Z',
+      },
+      deliveryRecord: buildDeliveryRecord({
+        first_management_use_confirmed_at: '2026-04-20T09:00:00.000Z',
+      }),
+      deliveryCheckpoints: [],
+      learningDossier: buildDossier({
+        first_action_taken: null,
+        expected_first_value: null,
+        review_moment: null,
+      }),
+      learningCheckpoints: [],
+      routeCloseout: {
+        routeId: 'campaign-exit::operations-closed',
+        closeoutStatus: 'afgerond' as const,
+        closeoutReason: 'voldoende-opgepakt' as const,
+        closeoutNote: 'Afgerond voor nu.',
+        closedAt: '2026-05-10T09:00:00.000Z',
+        closedByRole: 'hr' as const,
+      },
+    }
+    const targetContext = {
+      ...sourceContext,
+      scopeValue: 'operations-follow-up',
+      scopeLabel: 'Operations vervolg',
+      assignedManager: {
+        userId: 'manager-1',
+        displayName: 'Manager Operations',
+        assignedAt: '2026-05-11T08:00:00.000Z',
+      },
+      followUpFromRelation: {
+        routeRelationType: 'follow-up-from' as const,
+        sourceRouteId: 'campaign-exit::operations-closed',
+        targetRouteId: 'campaign-exit::operations-follow-up',
+        recordedAt: '2026-05-11T08:30:00.000Z',
+        recordedByRole: 'hr' as const,
+      },
+      routeCloseout: null,
+    }
+
+    const items = buildLiveActionCenterItems([sourceContext, targetContext])
+    const sourceItem = items.find((item) => item.id === 'campaign-exit::operations-closed')
+    const targetItem = items.find((item) => item.id === 'campaign-exit::operations-follow-up')
+
+    expect(sourceItem?.status).toBe('afgerond')
+    expect(targetItem?.status).toBe('open-verzoek')
+    expect(targetItem?.coreSemantics.lineageSemantics.label).toBe('Vervolg op eerdere route')
+  })
 })

--- a/frontend/lib/action-center-route-contract.test.ts
+++ b/frontend/lib/action-center-route-contract.test.ts
@@ -616,4 +616,69 @@ describe('action center route contract', () => {
 
     expect(route.routeStatus).toBe('afgerond')
   })
+
+  it('treats a later reopen event as stronger than an older closeout on the same route', () => {
+    const route = projectActionCenterRoute({
+      ...buildContext({
+        assignedManager: {
+          userId: 'manager-1',
+          displayName: 'Manager Operations',
+          assignedAt: '2026-04-21T08:00:00.000Z',
+        },
+        dossier: buildDossier({
+          first_action_taken: null,
+          expected_first_value: null,
+          review_moment: null,
+        }),
+      }),
+      routeCloseout: {
+        routeId: 'campaign-exit::operations',
+        closeoutStatus: 'afgerond',
+        closeoutReason: 'voldoende-opgepakt',
+        closeoutNote: 'Voor nu gesloten.',
+        closedAt: '2026-05-10T09:00:00.000Z',
+        closedByRole: 'hr',
+      },
+      routeReopens: [
+        {
+          routeId: 'campaign-exit::operations',
+          reopenedAt: '2026-05-11T09:00:00.000Z',
+          reopenedByRole: 'hr',
+          reopenReason: 'te-vroeg-afgesloten',
+        },
+      ],
+    } as LiveActionCenterCampaignContext)
+
+    expect(route.routeStatus).toBe('open-verzoek')
+    expect(route.isReopened).toBe(true)
+    expect(route.lineageLabel).toBe('Heropend traject')
+  })
+
+  it('projects a follow-up route as a new active route with lineage back to the earlier route', () => {
+    const route = projectActionCenterRoute({
+      ...buildContext({
+        assignedManager: {
+          userId: 'manager-1',
+          displayName: 'Manager Operations',
+          assignedAt: '2026-05-11T08:00:00.000Z',
+        },
+        dossier: buildDossier({
+          first_action_taken: null,
+          expected_first_value: null,
+          review_moment: null,
+        }),
+      }),
+      followUpFromRelation: {
+        routeRelationType: 'follow-up-from',
+        sourceRouteId: 'campaign-exit::operations::previous',
+        targetRouteId: 'campaign-exit::operations',
+        recordedAt: '2026-05-11T08:30:00.000Z',
+        recordedByRole: 'hr',
+      },
+    } as LiveActionCenterCampaignContext)
+
+    expect(route.routeStatus).toBe('open-verzoek')
+    expect(route.followUpFromRouteId).toBe('campaign-exit::operations::previous')
+    expect(route.lineageLabel).toBe('Vervolg op eerdere route')
+  })
 })

--- a/frontend/lib/action-center-route-contract.ts
+++ b/frontend/lib/action-center-route-contract.ts
@@ -4,6 +4,13 @@ import type { PilotLearningCheckpoint } from './pilot-learning'
 import { hasPrimaryManagerAction } from './action-center-manager-responses'
 import type { ActionCenterManagerResponseType, ActionCenterManagerActionThemeKey } from './pilot-learning'
 import type { ActionCenterRouteCloseoutRecord } from './action-center-route-closeout'
+import {
+  projectActionCenterRouteLifecycle,
+  type ActionCenterRouteFollowUpRelationRecord,
+  type ActionCenterRouteReopenReason,
+  type ActionCenterRouteReopenRecord,
+  type ActionCenterRouteReopenRole,
+} from './action-center-route-reopen'
 
 export type ActionCenterEntryStage = 'attention' | 'candidate' | 'active'
 
@@ -71,6 +78,14 @@ export interface ActionCenterRouteContract {
   primaryActionThemeKey: ActionCenterManagerActionThemeKey | null
   followThroughMode: 'open_request' | 'bounded_response' | 'primary_action' | 'legacy_action' | 'none'
   blockedBy: Exclude<DeliveryExceptionStatus, 'none'> | null
+  reopenedAt: string | null
+  reopenedByRole: ActionCenterRouteReopenRole | null
+  reopenReason: ActionCenterRouteReopenReason | null
+  isReopened: boolean
+  followUpFromRouteId: string | null
+  followUpTargetRouteId: string | null
+  hasFollowUpTarget: boolean
+  lineageLabel: 'Heropend traject' | 'Vervolg op eerdere route' | null
 }
 
 interface ActionCenterRouteActionSummaryInput {
@@ -81,6 +96,18 @@ interface ActionCenterRouteActionSummaryInput {
 
 function getRouteCloseout(context: LiveActionCenterCampaignContext): ActionCenterRouteCloseoutRecord | null {
   return context.routeCloseout ?? null
+}
+
+function getRouteReopens(context: LiveActionCenterCampaignContext): ActionCenterRouteReopenRecord[] {
+  return context.routeReopens ?? []
+}
+
+function getFollowUpFromRelation(context: LiveActionCenterCampaignContext): ActionCenterRouteFollowUpRelationRecord | null {
+  return context.followUpFromRelation ?? null
+}
+
+function getFollowUpTargetRelation(context: LiveActionCenterCampaignContext): ActionCenterRouteFollowUpRelationRecord | null {
+  return context.followUpTargetRelation ?? null
 }
 
 const REVIEW_OUTCOMES = new Set<ActionCenterReviewOutcome>([
@@ -254,16 +281,21 @@ export function projectActionCenterRoute(context: LiveActionCenterCampaignContex
     context.deliveryRecord?.exception_status && context.deliveryRecord.exception_status !== 'none'
       ? context.deliveryRecord.exception_status
       : null
-  const routeCloseout = getRouteCloseout(context)
+  const routeLifecycle = projectActionCenterRouteLifecycle({
+    routeCloseout: getRouteCloseout(context),
+    routeReopens: getRouteReopens(context),
+    followUpFromRelation: getFollowUpFromRelation(context),
+    followUpTargetRelation: getFollowUpTargetRelation(context),
+  })
 
   let routeStatus: ActionCenterRouteStatus | null = null
 
   if (entryStage === 'active') {
-    if (routeCloseout?.closeoutStatus) {
-      routeStatus = routeCloseout.closeoutStatus
-    } else if (context.learningDossier?.triage_status === 'uitgevoerd') {
+    if (routeLifecycle.activeCloseout?.closeoutStatus) {
+      routeStatus = routeLifecycle.activeCloseout.closeoutStatus
+    } else if (!routeLifecycle.isCurrentlyReopened && context.learningDossier?.triage_status === 'uitgevoerd') {
       routeStatus = 'afgerond'
-    } else if (context.learningDossier?.triage_status === 'verworpen') {
+    } else if (!routeLifecycle.isCurrentlyReopened && context.learningDossier?.triage_status === 'verworpen') {
       routeStatus = 'gestopt'
     } else if (blockedBy) {
       routeStatus = 'geblokkeerd'
@@ -297,6 +329,14 @@ export function projectActionCenterRoute(context: LiveActionCenterCampaignContex
     primaryActionThemeKey,
     followThroughMode,
     blockedBy,
+    reopenedAt: routeLifecycle.latestReopen?.reopenedAt ?? null,
+    reopenedByRole: routeLifecycle.latestReopen?.reopenedByRole ?? null,
+    reopenReason: routeLifecycle.latestReopen?.reopenReason ?? null,
+    isReopened: routeLifecycle.isCurrentlyReopened,
+    followUpFromRouteId: routeLifecycle.followUpFromRouteId,
+    followUpTargetRouteId: routeLifecycle.followUpTargetRouteId,
+    hasFollowUpTarget: routeLifecycle.hasFollowUpTarget,
+    lineageLabel: routeLifecycle.lineageLabel,
   }
 }
 

--- a/frontend/lib/action-center-route-relations-policy.test.ts
+++ b/frontend/lib/action-center-route-relations-policy.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const schemaPath = path.resolve(process.cwd(), '../supabase/schema.sql')
+
+describe('action center route relations select policy', () => {
+  it('limits manager reads to relations that match either their source or target scope', () => {
+    const schema = readFileSync(schemaPath, 'utf8')
+    const policyStart = schema.indexOf('create policy "route_relations_select_visible_to_route_viewers"')
+    const nextPolicyStart = schema.indexOf('create policy "route_relations_insert_visible_to_hr"', policyStart)
+    const policyBlock = schema.slice(policyStart, nextPolicyStart)
+
+    expect(policyBlock).toContain("m.access_role = 'manager_assignee'")
+    expect(policyBlock).toContain("action_center_route_relations.source_route_id like ('%::' || m.scope_value)")
+    expect(policyBlock).toContain("action_center_route_relations.target_route_id like ('%::' || m.scope_value)")
+  })
+})

--- a/frontend/lib/action-center-route-reopen.test.ts
+++ b/frontend/lib/action-center-route-reopen.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import {
+  projectActionCenterRouteFollowUpRelation,
+  projectActionCenterRouteLifecycle,
+  projectActionCenterRouteReopen,
+} from './action-center-route-reopen'
+
+describe('action center route reopen truth', () => {
+  it('accepts a dedicated reopen event record', () => {
+    const reopen = projectActionCenterRouteReopen({
+      route_id: 'route-1',
+      reopened_at: '2026-05-01T09:00:00.000Z',
+      reopened_by_role: 'hr',
+      reopen_reason: 'te-vroeg-afgesloten',
+    })
+
+    expect(reopen.routeId).toBe('route-1')
+    expect(reopen.reopenReason).toBe('te-vroeg-afgesloten')
+  })
+
+  it('keeps follow-up as a separate relation truth', () => {
+    const relation = projectActionCenterRouteFollowUpRelation({
+      route_relation_type: 'follow-up-from',
+      source_route_id: 'route-1',
+      target_route_id: 'route-2',
+      recorded_at: '2026-05-01T10:00:00.000Z',
+      recorded_by_role: 'hr',
+    })
+
+    expect(relation.routeRelationType).toBe('follow-up-from')
+    expect(relation.sourceRouteId).toBe('route-1')
+    expect(relation.targetRouteId).toBe('route-2')
+  })
+
+  it('does not allow reopen to masquerade as relation truth', () => {
+    expect(() =>
+      projectActionCenterRouteFollowUpRelation({
+        route_relation_type: 'reopened-from',
+        source_route_id: 'route-1',
+        target_route_id: 'route-1',
+        recorded_at: '2026-05-01T10:00:00.000Z',
+        recorded_by_role: 'hr',
+      }),
+    ).toThrow(/route_relation_type/i)
+  })
+
+  it('derives deterministic precedence from latest closeout and reopen ordering', () => {
+    const closed = projectActionCenterRouteLifecycle({
+      routeCloseout: {
+        routeId: 'route-1',
+        closeoutStatus: 'afgerond',
+        closeoutReason: 'voldoende-opgepakt',
+        closeoutNote: null,
+        closedAt: '2026-05-10T09:00:00.000Z',
+        closedByRole: 'hr',
+      },
+      routeReopens: [],
+    })
+    const reopened = projectActionCenterRouteLifecycle({
+      routeCloseout: {
+        routeId: 'route-1',
+        closeoutStatus: 'afgerond',
+        closeoutReason: 'voldoende-opgepakt',
+        closeoutNote: null,
+        closedAt: '2026-05-10T09:00:00.000Z',
+        closedByRole: 'hr',
+      },
+      routeReopens: [
+        {
+          routeId: 'route-1',
+          reopenedAt: '2026-05-11T09:00:00.000Z',
+          reopenedByRole: 'hr',
+          reopenReason: 'te-vroeg-afgesloten',
+        },
+      ],
+    })
+    const closedAgain = projectActionCenterRouteLifecycle({
+      routeCloseout: {
+        routeId: 'route-1',
+        closeoutStatus: 'gestopt',
+        closeoutReason: 'bewust-niet-voortzetten',
+        closeoutNote: null,
+        closedAt: '2026-05-12T09:00:00.000Z',
+        closedByRole: 'hr',
+      },
+      routeReopens: [
+        {
+          routeId: 'route-1',
+          reopenedAt: '2026-05-11T09:00:00.000Z',
+          reopenedByRole: 'hr',
+          reopenReason: 'te-vroeg-afgesloten',
+        },
+      ],
+    })
+
+    expect(closed.activeCloseout?.closeoutStatus).toBe('afgerond')
+    expect(reopened.activeCloseout).toBeNull()
+    expect(reopened.isCurrentlyReopened).toBe(true)
+    expect(closedAgain.activeCloseout?.closeoutStatus).toBe('gestopt')
+    expect(closedAgain.isCurrentlyReopened).toBe(false)
+  })
+})

--- a/frontend/lib/action-center-route-reopen.ts
+++ b/frontend/lib/action-center-route-reopen.ts
@@ -1,0 +1,239 @@
+import type {
+  ActionCenterRouteCloseoutRecord,
+} from './action-center-route-closeout'
+
+export type ActionCenterRouteReopenReason =
+  | 'te-vroeg-afgesloten'
+  | 'zelfde-traject-loopt-door'
+  | 'nieuwe-informatie'
+
+export type ActionCenterRouteReopenRole = 'hr' | 'manager'
+
+export interface ActionCenterRouteReopenRecord {
+  routeId: string
+  reopenedAt: string
+  reopenedByRole: ActionCenterRouteReopenRole
+  reopenReason: ActionCenterRouteReopenReason
+}
+
+export type ActionCenterRouteRelationType = 'follow-up-from'
+
+export interface ActionCenterRouteFollowUpRelationRecord {
+  routeRelationType: ActionCenterRouteRelationType
+  sourceRouteId: string
+  targetRouteId: string
+  recordedAt: string
+  recordedByRole: ActionCenterRouteReopenRole
+}
+
+export interface ActionCenterRouteLifecycleProjection {
+  activeCloseout: ActionCenterRouteCloseoutRecord | null
+  historicalCloseout: ActionCenterRouteCloseoutRecord | null
+  latestReopen: ActionCenterRouteReopenRecord | null
+  isCurrentlyReopened: boolean
+  lineageLabel: 'Heropend traject' | 'Vervolg op eerdere route' | null
+  followUpFromRouteId: string | null
+  followUpTargetRouteId: string | null
+  hasFollowUpTarget: boolean
+}
+
+const REOPEN_REASONS = new Set<ActionCenterRouteReopenReason>([
+  'te-vroeg-afgesloten',
+  'zelfde-traject-loopt-door',
+  'nieuwe-informatie',
+])
+
+const REOPEN_ROLES = new Set<ActionCenterRouteReopenRole>(['hr', 'manager'])
+const ROUTE_RELATION_TYPES = new Set<ActionCenterRouteRelationType>(['follow-up-from'])
+
+function normalizeText(value: string | null | undefined) {
+  const trimmed = value?.trim() ?? ''
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function isIsoTimestamp(value: string | null | undefined) {
+  const normalized = normalizeText(value)
+  if (!normalized) return false
+
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?(?:Z|[+-]\d{2}:\d{2})$/.test(normalized)) {
+    return false
+  }
+
+  return !Number.isNaN(new Date(normalized).getTime())
+}
+
+function compareDescending(left: string, right: string) {
+  return new Date(right).getTime() - new Date(left).getTime()
+}
+
+export function projectActionCenterRouteReopen(
+  input: Record<string, unknown> | null | undefined,
+): ActionCenterRouteReopenRecord {
+  const routeId = normalizeText(
+    typeof input?.route_id === 'string'
+      ? input.route_id
+      : typeof input?.routeId === 'string'
+        ? input.routeId
+        : null,
+  )
+  const reopenedAt = normalizeText(
+    typeof input?.reopened_at === 'string'
+      ? input.reopened_at
+      : typeof input?.reopenedAt === 'string'
+        ? input.reopenedAt
+        : null,
+  )
+  const reopenedByRole = normalizeText(
+    typeof input?.reopened_by_role === 'string'
+      ? input.reopened_by_role
+      : typeof input?.reopenedByRole === 'string'
+        ? input.reopenedByRole
+        : null,
+  ) as ActionCenterRouteReopenRole | null
+  const reopenReason = normalizeText(
+    typeof input?.reopen_reason === 'string'
+      ? input.reopen_reason
+      : typeof input?.reopenReason === 'string'
+        ? input.reopenReason
+        : null,
+  ) as ActionCenterRouteReopenReason | null
+
+  if (
+    !routeId ||
+    !reopenedAt ||
+    !isIsoTimestamp(reopenedAt) ||
+    !reopenedByRole ||
+    !REOPEN_ROLES.has(reopenedByRole) ||
+    !reopenReason ||
+    !REOPEN_REASONS.has(reopenReason)
+  ) {
+    throw new Error('Ongeldige action center route reopen input: route_id, reopened_at, reopened_by_role en reopen_reason zijn verplicht.')
+  }
+
+  return {
+    routeId,
+    reopenedAt,
+    reopenedByRole,
+    reopenReason,
+  }
+}
+
+export function projectActionCenterRouteFollowUpRelation(
+  input: Record<string, unknown> | null | undefined,
+): ActionCenterRouteFollowUpRelationRecord {
+  const routeRelationType = normalizeText(
+    typeof input?.route_relation_type === 'string'
+      ? input.route_relation_type
+      : typeof input?.routeRelationType === 'string'
+        ? input.routeRelationType
+        : null,
+  ) as ActionCenterRouteRelationType | null
+  const sourceRouteId = normalizeText(
+    typeof input?.source_route_id === 'string'
+      ? input.source_route_id
+      : typeof input?.sourceRouteId === 'string'
+        ? input.sourceRouteId
+        : null,
+  )
+  const targetRouteId = normalizeText(
+    typeof input?.target_route_id === 'string'
+      ? input.target_route_id
+      : typeof input?.targetRouteId === 'string'
+        ? input.targetRouteId
+        : null,
+  )
+  const recordedAt = normalizeText(
+    typeof input?.recorded_at === 'string'
+      ? input.recorded_at
+      : typeof input?.recordedAt === 'string'
+        ? input.recordedAt
+        : null,
+  )
+  const recordedByRole = normalizeText(
+    typeof input?.recorded_by_role === 'string'
+      ? input.recorded_by_role
+      : typeof input?.recordedByRole === 'string'
+        ? input.recordedByRole
+        : null,
+  ) as ActionCenterRouteReopenRole | null
+
+  if (
+    !routeRelationType ||
+    !ROUTE_RELATION_TYPES.has(routeRelationType) ||
+    !sourceRouteId ||
+    !targetRouteId ||
+    !recordedAt ||
+    !isIsoTimestamp(recordedAt) ||
+    !recordedByRole ||
+    !REOPEN_ROLES.has(recordedByRole)
+  ) {
+    throw new Error('Ongeldige action center route relation input: route_relation_type, source_route_id, target_route_id, recorded_at en recorded_by_role zijn verplicht.')
+  }
+
+  return {
+    routeRelationType,
+    sourceRouteId,
+    targetRouteId,
+    recordedAt,
+    recordedByRole,
+  }
+}
+
+export function projectActionCenterRouteLifecycle(args: {
+  routeCloseout?: ActionCenterRouteCloseoutRecord | null
+  routeReopens?: ActionCenterRouteReopenRecord[] | null
+  followUpFromRelation?: ActionCenterRouteFollowUpRelationRecord | null
+  followUpTargetRelation?: ActionCenterRouteFollowUpRelationRecord | null
+}): ActionCenterRouteLifecycleProjection {
+  const latestReopen =
+    [...(args.routeReopens ?? [])].sort((left, right) => compareDescending(left.reopenedAt, right.reopenedAt))[0] ??
+    null
+  const closeout = args.routeCloseout ?? null
+  const closeoutIsCurrent =
+    closeout &&
+    (!latestReopen || new Date(closeout.closedAt).getTime() >= new Date(latestReopen.reopenedAt).getTime())
+      ? true
+      : false
+
+  const isCurrentlyReopened = Boolean(closeout && latestReopen && !closeoutIsCurrent)
+  const activeCloseout = closeoutIsCurrent ? closeout : null
+  const historicalCloseout = closeout
+
+  let lineageLabel: ActionCenterRouteLifecycleProjection['lineageLabel'] = null
+  if (isCurrentlyReopened) {
+    lineageLabel = 'Heropend traject'
+  } else if (args.followUpFromRelation) {
+    lineageLabel = 'Vervolg op eerdere route'
+  }
+
+  return {
+    activeCloseout,
+    historicalCloseout,
+    latestReopen,
+    isCurrentlyReopened,
+    lineageLabel,
+    followUpFromRouteId: args.followUpFromRelation?.sourceRouteId ?? null,
+    followUpTargetRouteId: args.followUpTargetRelation?.targetRouteId ?? null,
+    hasFollowUpTarget: Boolean(args.followUpTargetRelation?.targetRouteId),
+  }
+}
+
+export function getActionCenterRouteReopenReasonLabel(reason: ActionCenterRouteReopenReason) {
+  switch (reason) {
+    case 'te-vroeg-afgesloten':
+      return 'Te vroeg afgesloten'
+    case 'zelfde-traject-loopt-door':
+      return 'Zelfde traject loopt door'
+    case 'nieuwe-informatie':
+    default:
+      return 'Nieuwe informatie'
+  }
+}
+
+export function getActionCenterRouteRelationLabel(type: ActionCenterRouteRelationType) {
+  if (type === 'follow-up-from') {
+    return 'Vervolg op eerdere route'
+  }
+
+  return type
+}

--- a/frontend/scripts/seed-action-center-manager-pilot.mjs
+++ b/frontend/scripts/seed-action-center-manager-pilot.mjs
@@ -457,6 +457,20 @@ const { error: cleanupCloseoutRecordError } = await admin
 
 if (cleanupCloseoutRecordError) throw cleanupCloseoutRecordError
 
+const { error: cleanupRouteReopensError } = await admin
+  .from('action_center_route_reopens')
+  .delete()
+  .in('route_id', [primaryRouteId, closeoutRouteId])
+
+if (cleanupRouteReopensError) throw cleanupRouteReopensError
+
+const { error: cleanupRouteRelationsError } = await admin
+  .from('action_center_route_relations')
+  .delete()
+  .or(`source_route_id.eq.${closeoutRouteId},target_route_id.eq.${primaryRouteId}`)
+
+if (cleanupRouteRelationsError) throw cleanupRouteRelationsError
+
 const { data: closeoutResponse, error: closeoutResponseError } = await admin
   .from('action_center_manager_responses')
   .insert({
@@ -549,6 +563,25 @@ const { error: closeoutReviewsError } = await admin
 
 if (closeoutReviewsError) throw closeoutReviewsError
 
+const { error: followUpRelationError } = await admin
+  .from('action_center_route_relations')
+  .upsert(
+    {
+      campaign_id: canonicalCampaign.id,
+      org_id: pilotOrg.orgId,
+      route_relation_type: 'follow-up-from',
+      source_route_id: closeoutRouteId,
+      target_route_id: primaryRouteId,
+      recorded_at: new Date(Date.now() - 6 * 24 * 60 * 60 * 1000).toISOString(),
+      recorded_by_role: 'hr',
+      created_by: hrOwner.id,
+      updated_by: hrOwner.id,
+    },
+    { onConflict: 'source_route_id,target_route_id,route_relation_type' },
+  )
+
+if (followUpRelationError) throw followUpRelationError
+
 mkdirSync(path.dirname(artifactPath), { recursive: true })
 const artifact = {
   seededAt: new Date().toISOString(),
@@ -569,6 +602,11 @@ const artifact = {
   closeoutRouteContext: {
     focusItemId: closeoutRouteId,
     actionCenterFocusUrl: `/action-center?focus=${closeoutRouteId}`,
+  },
+  followUpRouteContext: {
+    sourceFocusItemId: closeoutRouteId,
+    targetFocusItemId: primaryRouteId,
+    targetActionCenterFocusUrl: `/action-center?focus=${primaryRouteId}`,
   },
   managers: managers.map((manager, index) => ({
     email: manager.email,

--- a/frontend/scripts/seed-action-center-manager-pilot.mjs
+++ b/frontend/scripts/seed-action-center-manager-pilot.mjs
@@ -563,6 +563,28 @@ const { error: closeoutReviewsError } = await admin
 
 if (closeoutReviewsError) throw closeoutReviewsError
 
+const { error: closeoutRecordError } = await admin
+  .from('action_center_route_closeouts')
+  .upsert(
+    {
+      route_id: closeoutRouteId,
+      campaign_id: canonicalCampaign.id,
+      org_id: pilotOrg.orgId,
+      route_scope_type: chosenDepartments[1] ? 'department' : 'item',
+      route_scope_value: closeoutRouteScopeValue,
+      closeout_status: 'afgerond',
+      closeout_reason: 'effect-voldoende-zichtbaar',
+      closeout_note: 'Deze route is bestuurlijk gesloten en klaar om later bewust te worden heropend.',
+      closed_at: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+      closed_by_role: 'hr',
+      created_by: hrOwner.id,
+      updated_by: hrOwner.id,
+    },
+    { onConflict: 'route_id' },
+  )
+
+if (closeoutRecordError) throw closeoutRecordError
+
 const { error: followUpRelationError } = await admin
   .from('action_center_route_relations')
   .upsert(

--- a/frontend/tests/e2e/action-center-route-reopen.spec.ts
+++ b/frontend/tests/e2e/action-center-route-reopen.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test } from '@playwright/test'
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+
+type RouteReopenPilotArtifact = {
+  hrOwner: { email: string; password: string }
+  closeoutRouteContext: { focusItemId: string }
+  followUpRouteContext: { targetFocusItemId: string }
+}
+
+const artifactPath = path.join(process.cwd(), 'tests', 'e2e', '.action-center-pilot.json')
+
+function readPilotArtifact() {
+  if (!existsSync(artifactPath)) {
+    throw new Error('Seeded pilot artifact ontbreekt. Draai eerst scripts/seed-action-center-manager-pilot.mjs.')
+  }
+
+  return JSON.parse(readFileSync(artifactPath, 'utf8')) as RouteReopenPilotArtifact
+}
+
+function reseedPilot() {
+  execFileSync('node', ['./scripts/seed-action-center-manager-pilot.mjs'], {
+    cwd: process.cwd(),
+    stdio: 'inherit',
+  })
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+async function login(page: import('@playwright/test').Page, email: string, password: string) {
+  await page.goto('/login')
+  await page.getByLabel('E-mailadres').fill(email)
+  await page.getByLabel('Wachtwoord').fill(password)
+  await Promise.all([
+    page.waitForURL(/\/(dashboard|action-center)(?:\?.*)?$/),
+    page.getByRole('button', { name: 'Inloggen' }).click(),
+  ])
+}
+
+async function openFocusedRoute(page: import('@playwright/test').Page, focusItemId: string) {
+  await page.goto(`/action-center?focus=${encodeURIComponent(focusItemId)}`)
+  await expect(page).toHaveURL(new RegExp(`focus=${escapeRegExp(encodeURIComponent(focusItemId))}$`))
+
+  const openFocusButton = page.getByRole('button', { name: 'Open focusactie' })
+  if (await openFocusButton.isVisible().catch(() => false)) {
+    await openFocusButton.click()
+  }
+}
+
+test.describe('action center route reopen', () => {
+  let pilot: RouteReopenPilotArtifact
+
+  test.beforeAll(() => {
+    reseedPilot()
+    pilot = readPilotArtifact()
+  })
+
+  test('hr can reopen a closed route and see the reopened lineage persist', async ({ page }) => {
+    await login(page, pilot.hrOwner.email, pilot.hrOwner.password)
+    await page.waitForURL(/\/dashboard$/)
+
+    await openFocusedRoute(page, pilot.closeoutRouteContext.focusItemId)
+    await expect(page.getByText('Route afgesloten', { exact: true })).toBeVisible()
+    await page.getByRole('button', { name: 'Heropen traject', exact: true }).click()
+
+    await expect(page.getByText('Heropend traject', { exact: true })).toBeVisible()
+
+    await page.goto(`/action-center?focus=${encodeURIComponent(pilot.closeoutRouteContext.focusItemId)}`)
+    await expect(page).toHaveURL(
+      new RegExp(`focus=${escapeRegExp(encodeURIComponent(pilot.closeoutRouteContext.focusItemId))}$`),
+    )
+    await page.getByRole('button', { name: 'Open focusactie', exact: true }).click()
+    await expect(page.getByText('Heropend traject', { exact: true })).toBeVisible()
+  })
+
+  test('active follow-up route shows compact lineage back to the earlier route', async ({ page }) => {
+    await login(page, pilot.hrOwner.email, pilot.hrOwner.password)
+    await page.waitForURL(/\/dashboard$/)
+
+    await openFocusedRoute(page, pilot.followUpRouteContext.targetFocusItemId)
+    await expect(page.getByText('Vervolg op eerdere route', { exact: true })).toBeVisible()
+  })
+})

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1822,3 +1822,124 @@ from public.campaigns c
 left join public.respondents      r  on r.campaign_id   = c.id
 left join public.survey_responses sr on sr.respondent_id = r.id
 group by c.id, c.name, c.scan_type, c.organization_id, c.is_active, c.created_at;
+
+create table if not exists public.action_center_route_reopens (
+  id uuid primary key default gen_random_uuid(),
+  route_id text not null,
+  campaign_id uuid references public.campaigns(id) on delete cascade not null,
+  org_id uuid references public.organizations(id) on delete cascade not null,
+  route_scope_type text not null check (route_scope_type in ('department', 'item')),
+  route_scope_value text not null,
+  reopen_reason text not null
+    check (reopen_reason in ('te-vroeg-afgesloten', 'zelfde-traject-loopt-door', 'nieuwe-informatie')),
+  reopened_at timestamptz not null,
+  reopened_by_role text not null check (reopened_by_role in ('hr', 'manager')),
+  created_by uuid references auth.users(id) on delete set null,
+  updated_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+create index if not exists idx_action_center_route_reopens_route
+  on public.action_center_route_reopens(route_id, reopened_at desc);
+
+create table if not exists public.action_center_route_relations (
+  id uuid primary key default gen_random_uuid(),
+  campaign_id uuid references public.campaigns(id) on delete cascade not null,
+  org_id uuid references public.organizations(id) on delete cascade not null,
+  route_relation_type text not null check (route_relation_type in ('follow-up-from')),
+  source_route_id text not null,
+  target_route_id text not null,
+  recorded_at timestamptz not null,
+  recorded_by_role text not null check (recorded_by_role in ('hr', 'manager')),
+  created_by uuid references auth.users(id) on delete set null,
+  updated_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now(),
+  unique (source_route_id, target_route_id, route_relation_type)
+);
+
+create index if not exists idx_action_center_route_relations_source
+  on public.action_center_route_relations(source_route_id, recorded_at desc);
+
+create index if not exists idx_action_center_route_relations_target
+  on public.action_center_route_relations(target_route_id, recorded_at desc);
+
+alter table public.action_center_route_reopens enable row level security;
+alter table public.action_center_route_relations enable row level security;
+
+drop policy if exists "route_reopens_select_visible_to_route_viewers"
+  on public.action_center_route_reopens;
+drop policy if exists "route_reopens_insert_visible_to_hr"
+  on public.action_center_route_reopens;
+drop policy if exists "route_relations_select_visible_to_route_viewers"
+  on public.action_center_route_relations;
+drop policy if exists "route_relations_insert_visible_to_hr"
+  on public.action_center_route_relations;
+
+create policy "route_reopens_select_visible_to_route_viewers"
+  on public.action_center_route_reopens for select
+  using (
+    public.is_verisight_admin_user()
+    or exists (
+      select 1
+      from public.action_center_workspace_members m
+      where m.org_id = action_center_route_reopens.org_id
+        and m.user_id = auth.uid()
+        and (
+          (m.access_role = 'hr_owner' and m.scope_type = 'org' and m.can_view)
+          or (
+            m.access_role = 'manager_assignee'
+            and m.scope_type = action_center_route_reopens.route_scope_type
+            and m.scope_value = action_center_route_reopens.route_scope_value
+            and m.can_view
+          )
+        )
+    )
+  );
+
+create policy "route_reopens_insert_visible_to_hr"
+  on public.action_center_route_reopens for insert
+  with check (
+    public.is_verisight_admin_user()
+    or exists (
+      select 1
+      from public.action_center_workspace_members m
+      where m.org_id = action_center_route_reopens.org_id
+        and m.user_id = auth.uid()
+        and m.access_role = 'hr_owner'
+        and m.scope_type = 'org'
+        and m.can_update
+    )
+  );
+
+create policy "route_relations_select_visible_to_route_viewers"
+  on public.action_center_route_relations for select
+  using (
+    public.is_verisight_admin_user()
+    or exists (
+      select 1
+      from public.action_center_workspace_members m
+      where m.org_id = action_center_route_relations.org_id
+        and m.user_id = auth.uid()
+        and (
+          (m.access_role = 'hr_owner' and m.scope_type = 'org' and m.can_view)
+          or (m.access_role = 'manager_assignee' and m.can_view)
+        )
+    )
+  );
+
+create policy "route_relations_insert_visible_to_hr"
+  on public.action_center_route_relations for insert
+  with check (
+    public.is_verisight_admin_user()
+    or exists (
+      select 1
+      from public.action_center_workspace_members m
+      where m.org_id = action_center_route_relations.org_id
+        and m.user_id = auth.uid()
+        and m.access_role = 'hr_owner'
+        and m.scope_type = 'org'
+        and m.can_update
+    )
+  );

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1924,7 +1924,14 @@ create policy "route_relations_select_visible_to_route_viewers"
         and m.user_id = auth.uid()
         and (
           (m.access_role = 'hr_owner' and m.scope_type = 'org' and m.can_view)
-          or (m.access_role = 'manager_assignee' and m.can_view)
+          or (
+            m.access_role = 'manager_assignee'
+            and m.can_view
+            and (
+              action_center_route_relations.source_route_id like ('%::' || m.scope_value)
+              or action_center_route_relations.target_route_id like ('%::' || m.scope_value)
+            )
+          )
         )
     )
   );


### PR DESCRIPTION
## Summary
- add canonical route reopen events and follow-up route relations for Action Center
- project deterministic route lifecycle precedence across closeout, reopen, and follow-up lineage
- expose HR reopen flow in the Action Center UI and seed/browser coverage for reopen + lineage

## What changed
- added `action_center_route_reopens` and `action_center_route_relations` truth layers, APIs, and schema/RLS
- extended route contract/live semantics with reopened state, follow-up lineage, and compact labels
- updated Action Center preview/detail projection to show `Heropend traject` and `Vervolg op eerdere route`
- added seed data and Playwright coverage for HR reopen persistence and follow-up lineage display

## Verification
- `npx vitest run lib/action-center-route-reopen.test.ts lib/action-center-route-contract.test.ts lib/action-center-live.test.ts "app/(dashboard)/action-center/page.route-shell.test.ts" app/api/action-center-route-reopens/route.test.ts app/api/action-center-route-follow-ups/route.test.ts`
- `eslint` on touched reopen/relation files
- `npm run build`
- `node ./scripts/seed-action-center-manager-pilot.mjs`
- `PLAYWRIGHT_PORT=3019 npx playwright test tests/e2e/action-center-manager-access.spec.ts tests/e2e/action-center-route-reopen.spec.ts --project=chromium --workers=1`

## Notes
- reopen is modeled as a dedicated route event on the same route id
- follow-up remains the only relation model via `follow-up-from`
- read-path precedence is explicit for `closed -> reopened -> closed again`
