### PR TITLE
feat: add follow-up route trigger flow

### DIFF
--- a/docs/superpowers/plans/2026-05-01-action-center-follow-up-route-trigger.md
+++ b/docs/superpowers/plans/2026-05-01-action-center-follow-up-route-trigger.md
@@ -1,0 +1,798 @@
+# Action Center Follow-Up Route Trigger V1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a small HR-only `Start vervolgroute` trigger on closed Action Center routes that creates one new follow-up route with the same scope, a newly chosen manager, and a canonical `triggerReason`.
+
+**Architecture:** Build on the existing closeout, reopen, and follow-up relation layers instead of introducing a new workflow system. Extend the existing follow-up relation truth with a required `triggerReason`, enforce a single active direct successor per closed source route in the write-path, and expose a minimal HR UI that only asks for the next manager and reason before creating the new route handoff.
+
+**Tech Stack:** Next.js App Router, TypeScript, Vitest, Playwright, Supabase Postgres schema/RLS, existing Action Center preview/detail projection, existing manager response and workspace membership truth.
+
+---
+
+### Task 1: Lock V1 follow-up-trigger semantics in tests
+
+**Files:**
+- Modify: `frontend/lib/action-center-route-reopen.test.ts`
+- Modify: `frontend/app/api/action-center-route-follow-ups/route.test.ts`
+- Modify: `frontend/app/(dashboard)/action-center/page.route-shell.test.ts`
+- Create: `frontend/lib/action-center-follow-up-route-trigger.test.ts`
+
+- [ ] **Step 1: Write the failing truth test for required trigger reasons**
+
+Add a new failing test in `frontend/lib/action-center-route-reopen.test.ts`:
+
+```ts
+it('requires a triggerReason on follow-up relations', () => {
+  expect(() =>
+    projectActionCenterRouteFollowUpRelation({
+      route_relation_type: 'follow-up-from',
+      source_route_id: 'campaign-1::org-1::department::sales',
+      target_route_id: 'campaign-1::org-1::department::finance',
+      recorded_at: '2026-05-01T10:00:00.000Z',
+      recorded_by_role: 'hr',
+    }),
+  ).toThrow(/trigger_reason/i)
+})
+```
+
+- [ ] **Step 2: Run the truth test to verify it fails**
+
+Run:
+
+```bash
+npx vitest run lib/action-center-route-reopen.test.ts
+```
+
+Expected:
+- FAIL with a missing `trigger_reason` assertion or parser failure.
+
+- [ ] **Step 3: Write the failing API tests for V1 constraints**
+
+Extend `frontend/app/api/action-center-route-follow-ups/route.test.ts` with failing tests for:
+- missing `trigger_reason` returns `400`
+- second active direct follow-up from the same closed source returns `409`
+- non-closed source route returns `409`
+
+Use tests like:
+
+```ts
+it('rejects follow-up creation without a trigger reason', async () => {
+  const response = await POST(
+    makeRequest({
+      source_campaign_id: 'campaign-1',
+      source_route_scope_value: 'org-1::department::sales',
+      target_campaign_id: 'campaign-1',
+      target_route_scope_value: 'org-1::department::sales',
+    }),
+  )
+
+  expect(response.status).toBe(400)
+})
+```
+
+```ts
+it('rejects a second active direct follow-up for the same closed source route', async () => {
+  // mock an existing active follow-up relation row for the same source route
+  expect(response.status).toBe(409)
+})
+```
+
+```ts
+it('rejects follow-up creation when the source route is not closed', async () => {
+  // mock source route with no active closeout
+  expect(response.status).toBe(409)
+})
+```
+
+- [ ] **Step 4: Run the API test file to verify the new tests fail**
+
+Run:
+
+```bash
+npx vitest run app/api/action-center-route-follow-ups/route.test.ts
+```
+
+Expected:
+- FAIL on the new `trigger_reason`, single-successor, and closed-source assertions.
+
+- [ ] **Step 5: Write the failing shell/UI test for the new HR trigger fields**
+
+In `frontend/app/(dashboard)/action-center/page.route-shell.test.ts`, add a failing test that expects:
+- a closed route can render `Start vervolgroute`
+- the HR flow now includes manager choice and a `triggerReason` choice
+
+Example expectation block:
+
+```ts
+expect(markup).toContain('Start vervolgroute')
+expect(markup).toContain('Kies manager')
+expect(markup).toContain('Kies aanleiding')
+```
+
+- [ ] **Step 6: Run the shell test to verify it fails**
+
+Run:
+
+```bash
+npx vitest run "app/(dashboard)/action-center/page.route-shell.test.ts"
+```
+
+Expected:
+- FAIL because the trigger fields are not yet rendered.
+
+---
+
+### Task 2: Extend canonical follow-up truth with `triggerReason`
+
+**Files:**
+- Modify: `frontend/lib/action-center-route-reopen.ts`
+- Modify: `frontend/lib/action-center-route-reopen.test.ts`
+- Create: `frontend/lib/action-center-follow-up-route-trigger.test.ts`
+
+- [ ] **Step 1: Add the canonical trigger reason type and parser**
+
+In `frontend/lib/action-center-route-reopen.ts`, add:
+
+```ts
+export type ActionCenterRouteFollowUpTriggerReason =
+  | 'nieuw-campaign-signaal'
+  | 'nieuw-segment-signaal'
+  | 'hernieuwde-hr-beoordeling'
+```
+
+And extend `ActionCenterRouteFollowUpRelationRecord`:
+
+```ts
+export interface ActionCenterRouteFollowUpRelationRecord {
+  routeRelationType: ActionCenterRouteRelationType
+  sourceRouteId: string
+  targetRouteId: string
+  recordedAt: string
+  recordedByRole: ActionCenterRouteReopenRole
+  triggerReason: ActionCenterRouteFollowUpTriggerReason
+}
+```
+
+- [ ] **Step 2: Update the projector to require `trigger_reason`**
+
+Update `projectActionCenterRouteFollowUpRelation(...)` so it accepts both DB and camelCase input:
+
+```ts
+const triggerReason = normalizeText(
+  typeof input?.trigger_reason === 'string'
+    ? input.trigger_reason
+    : typeof input?.triggerReason === 'string'
+      ? input.triggerReason
+      : null,
+) as ActionCenterRouteFollowUpTriggerReason | null
+
+if (!triggerReason || !FOLLOW_UP_TRIGGER_REASONS.has(triggerReason)) {
+  throw new Error('Ongeldige action center route relation input: trigger_reason is verplicht.')
+}
+```
+
+- [ ] **Step 3: Add a small label helper for trigger reasons**
+
+Still in `frontend/lib/action-center-route-reopen.ts`, add:
+
+```ts
+export function getActionCenterFollowUpTriggerReasonLabel(
+  reason: ActionCenterRouteFollowUpTriggerReason,
+) {
+  switch (reason) {
+    case 'nieuw-campaign-signaal':
+      return 'Nieuw campaign-signaal'
+    case 'nieuw-segment-signaal':
+      return 'Nieuw segmentsignaal'
+    case 'hernieuwde-hr-beoordeling':
+    default:
+      return 'Hernieuwde HR-beoordeling'
+  }
+}
+```
+
+- [ ] **Step 4: Add a dedicated truth helper test for V1 trigger semantics**
+
+Create `frontend/lib/action-center-follow-up-route-trigger.test.ts` with tests like:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import {
+  getActionCenterFollowUpTriggerReasonLabel,
+  projectActionCenterRouteFollowUpRelation,
+} from './action-center-route-reopen'
+
+describe('action center follow-up route trigger truth', () => {
+  it('accepts a canonical trigger reason', () => {
+    const relation = projectActionCenterRouteFollowUpRelation({
+      route_relation_type: 'follow-up-from',
+      source_route_id: 'campaign-1::org-1::department::sales',
+      target_route_id: 'campaign-1::org-1::department::finance',
+      recorded_at: '2026-05-01T10:00:00.000Z',
+      recorded_by_role: 'hr',
+      trigger_reason: 'nieuw-campaign-signaal',
+    })
+
+    expect(relation.triggerReason).toBe('nieuw-campaign-signaal')
+    expect(getActionCenterFollowUpTriggerReasonLabel(relation.triggerReason)).toBe('Nieuw campaign-signaal')
+  })
+})
+```
+
+- [ ] **Step 5: Run the truth tests to verify they pass**
+
+Run:
+
+```bash
+npx vitest run lib/action-center-route-reopen.test.ts lib/action-center-follow-up-route-trigger.test.ts
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/lib/action-center-route-reopen.ts frontend/lib/action-center-route-reopen.test.ts frontend/lib/action-center-follow-up-route-trigger.test.ts
+git commit -m "feat: add canonical follow-up trigger reasons"
+```
+
+---
+
+### Task 3: Add the persistence and write-path guardrails
+
+**Files:**
+- Modify: `supabase/schema.sql`
+- Modify: `frontend/lib/action-center-route-relations-policy.test.ts`
+- Modify: `frontend/app/api/action-center-route-follow-ups/route.ts`
+- Modify: `frontend/app/api/action-center-route-follow-ups/route.test.ts`
+
+- [ ] **Step 1: Add `trigger_reason` to the relation table**
+
+In `supabase/schema.sql`, extend `action_center_route_relations`:
+
+```sql
+trigger_reason text not null
+  check (
+    trigger_reason in (
+      'nieuw-campaign-signaal',
+      'nieuw-segment-signaal',
+      'hernieuwde-hr-beoordeling'
+    )
+  ),
+```
+
+Place it near:
+
+```sql
+route_relation_type text not null check (route_relation_type in ('follow-up-from')),
+source_route_id text not null,
+target_route_id text not null,
+recorded_at timestamptz not null,
+recorded_by_role text not null check (recorded_by_role in ('hr', 'manager')),
+```
+
+- [ ] **Step 2: Update the schema policy test to assert the new column is present**
+
+In `frontend/lib/action-center-route-relations-policy.test.ts`, add:
+
+```ts
+expect(schema).toContain('trigger_reason text not null')
+expect(schema).toContain("'nieuw-campaign-signaal'")
+expect(schema).toContain("'nieuw-segment-signaal'")
+expect(schema).toContain("'hernieuwde-hr-beoordeling'")
+```
+
+- [ ] **Step 3: Introduce a small write input parser for the new trigger**
+
+In `frontend/app/api/action-center-route-follow-ups/route.ts`, extend the request body:
+
+```ts
+type FollowUpRequestBody = {
+  source_campaign_id?: string
+  source_route_scope_value?: string
+  target_campaign_id?: string
+  target_route_scope_value?: string
+  trigger_reason?: string
+  manager_user_id?: string
+}
+```
+
+Update parsing:
+
+```ts
+const triggerReason = normalizeText(input?.trigger_reason)
+const managerUserId = normalizeText(input?.manager_user_id)
+
+if (!sourceCampaignId || !sourceRouteScopeValue || !targetCampaignId || !targetRouteScopeValue || !triggerReason || !managerUserId) {
+  throw new Error('Ongeldige follow-up input.')
+}
+```
+
+- [ ] **Step 4: Add server-side closed-source and single-successor validation**
+
+In the same API file, add helper loaders that:
+- load the source route closeout
+- load the latest follow-up relation for that source route
+- confirm there is no active direct successor already
+
+Use patterns like:
+
+```ts
+const { data: sourceCloseout } = await adminClient
+  .from('action_center_route_closeouts')
+  .select('*')
+  .eq('route_id', sourceIdentity.route_id)
+  .maybeSingle()
+
+if (!sourceCloseout?.route_id) {
+  return NextResponse.json({ detail: 'Alleen gesloten routes kunnen een vervolgroute starten.' }, { status: 409 })
+}
+```
+
+And:
+
+```ts
+const { data: existingFollowUps } = await adminClient
+  .from('action_center_route_relations')
+  .select('*')
+  .eq('route_relation_type', 'follow-up-from')
+  .eq('source_route_id', sourceIdentity.route_id)
+
+if ((existingFollowUps ?? []).length > 0) {
+  return NextResponse.json({ detail: 'Deze route heeft al een actieve directe vervolgroute.' }, { status: 409 })
+}
+```
+
+- [ ] **Step 5: Persist the canonical trigger reason**
+
+Update the `upsert(...)` payload:
+
+```ts
+{
+  campaign_id: targetCampaign.id,
+  org_id: targetCampaign.organization_id,
+  route_relation_type: relation.routeRelationType,
+  source_route_id: relation.sourceRouteId,
+  target_route_id: relation.targetRouteId,
+  recorded_at: relation.recordedAt,
+  recorded_by_role: relation.recordedByRole,
+  trigger_reason: relation.triggerReason,
+  created_by: user.id,
+  updated_by: user.id,
+  updated_at: relation.recordedAt,
+}
+```
+
+- [ ] **Step 6: Run the API and policy tests**
+
+Run:
+
+```bash
+npx vitest run app/api/action-center-route-follow-ups/route.test.ts lib/action-center-route-relations-policy.test.ts
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add supabase/schema.sql frontend/lib/action-center-route-relations-policy.test.ts frontend/app/api/action-center-route-follow-ups/route.ts frontend/app/api/action-center-route-follow-ups/route.test.ts
+git commit -m "feat: enforce follow-up trigger write constraints"
+```
+
+---
+
+### Task 4: Create the new route carrier for the follow-up handoff
+
+**Files:**
+- Modify: `frontend/app/api/action-center-route-follow-ups/route.ts`
+- Modify: `frontend/app/api/action-center-route-follow-ups/route.test.ts`
+- Modify: `frontend/lib/action-center-manager-responses.ts`
+- Modify: `frontend/lib/action-center-live-context.ts`
+
+- [ ] **Step 1: Decide on the minimal carrier created by the trigger**
+
+Use the existing manager-response layer as the lightweight route handoff carrier instead of inventing a new route table in V1.
+
+The follow-up trigger should create:
+- a new `action_center_manager_responses` row
+- for the target campaign + same scope
+- with the chosen manager
+- and with a bounded handoff response type like `schedule`
+
+Document this in the API with a short comment:
+
+```ts
+// V1 follow-up routes are opened through the existing manager-response carrier.
+// HR does not create an action here; it only creates a new manager handoff route.
+```
+
+- [ ] **Step 2: Add a helper to build the handoff response**
+
+In `frontend/app/api/action-center-route-follow-ups/route.ts`, add:
+
+```ts
+function buildFollowUpManagerResponse(args: {
+  campaignId: string
+  orgId: string
+  routeScopeType: 'department' | 'item'
+  routeScopeValue: string
+  managerUserId: string
+}) {
+  return {
+    campaign_id: args.campaignId,
+    org_id: args.orgId,
+    route_scope_type: args.routeScopeType,
+    route_scope_value: args.routeScopeValue,
+    manager_user_id: args.managerUserId,
+    response_type: 'schedule',
+    response_note: 'Vervolgroute geopend door HR.',
+    review_scheduled_for: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10),
+    primary_action_theme_key: null,
+    primary_action_text: null,
+    primary_action_expected_effect: null,
+    primary_action_status: null,
+  }
+}
+```
+
+- [ ] **Step 3: Create or upsert the new route carrier before writing the relation**
+
+Still in the API, insert into `action_center_manager_responses`:
+
+```ts
+const { data: managerResponse, error: managerResponseError } = await adminClient
+  .from('action_center_manager_responses')
+  .upsert(buildFollowUpManagerResponse({...}), {
+    onConflict: 'campaign_id,route_scope_type,route_scope_value',
+  })
+  .select('*')
+  .single()
+
+if (managerResponseError || !managerResponse) {
+  return NextResponse.json({ detail: managerResponseError?.message ?? 'Vervolgroute openen mislukt.' }, { status: 500 })
+}
+```
+
+- [ ] **Step 4: Update the tests so the API now expects carrier creation**
+
+In `frontend/app/api/action-center-route-follow-ups/route.test.ts`, extend the admin mock to handle:
+- `action_center_manager_responses`
+- `action_center_route_relations`
+
+Assert both writes happen:
+
+```ts
+expect(managerResponseUpsert.upsert).toHaveBeenCalled()
+expect(relationUpsert.upsert).toHaveBeenCalledWith(
+  expect.objectContaining({
+    trigger_reason: 'nieuw-campaign-signaal',
+  }),
+  { onConflict: 'source_route_id,target_route_id,route_relation_type' },
+)
+```
+
+- [ ] **Step 5: Run the API tests**
+
+Run:
+
+```bash
+npx vitest run app/api/action-center-route-follow-ups/route.test.ts
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/app/api/action-center-route-follow-ups/route.ts frontend/app/api/action-center-route-follow-ups/route.test.ts frontend/lib/action-center-live-context.ts frontend/lib/action-center-manager-responses.ts
+git commit -m "feat: create follow-up route carrier from hr trigger"
+```
+
+---
+
+### Task 5: Surface the trigger in the Action Center UI
+
+**Files:**
+- Modify: `frontend/components/dashboard/action-center-preview.tsx`
+- Modify: `frontend/app/(dashboard)/action-center/page.tsx`
+- Modify: `frontend/app/(dashboard)/action-center/page.route-shell.test.ts`
+
+- [ ] **Step 1: Add the new follow-up endpoint prop and HR-only trigger state**
+
+In `frontend/app/(dashboard)/action-center/page.tsx`, pass the endpoint:
+
+```tsx
+routeFollowUpEndpoint="/api/action-center-route-follow-ups"
+```
+
+In `frontend/components/dashboard/action-center-preview.tsx`, add local state:
+
+```ts
+const [followUpManagerUserId, setFollowUpManagerUserId] = useState('')
+const [followUpTriggerReason, setFollowUpTriggerReason] = useState<ActionCenterRouteFollowUpTriggerReason>('nieuw-campaign-signaal')
+const [followUpPending, setFollowUpPending] = useState(false)
+```
+
+- [ ] **Step 2: Render the minimal HR trigger only on closed routes**
+
+Still in the preview component, render only when:
+- current user is HR/Verisight
+- selected route is closed
+- no direct active follow-up target exists
+
+Render:
+
+```tsx
+<button type="button">Start vervolgroute</button>
+<label>Kies manager</label>
+<select>{/* manager options */}</select>
+<label>Kies aanleiding</label>
+<select>
+  <option value="nieuw-campaign-signaal">Nieuw campaign-signaal</option>
+  <option value="nieuw-segment-signaal">Nieuw segmentsignaal</option>
+  <option value="hernieuwde-hr-beoordeling">Hernieuwde HR-beoordeling</option>
+</select>
+```
+
+- [ ] **Step 3: Post the minimal payload to the new API**
+
+Add a handler:
+
+```ts
+async function handleFollowUpCreate() {
+  if (!selectedItem || !routeFollowUpEndpoint) return
+
+  setFollowUpPending(true)
+  try {
+    const response = await fetch(routeFollowUpEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        source_campaign_id: selectedItem.campaignId,
+        source_route_scope_value: selectedItem.coreSemantics.route.scopeValue,
+        target_campaign_id: selectedItem.campaignId,
+        target_route_scope_value: selectedItem.coreSemantics.route.scopeValue,
+        manager_user_id: followUpManagerUserId,
+        trigger_reason: followUpTriggerReason,
+      }),
+    })
+
+    if (!response.ok) throw new Error('Vervolgroute openen mislukt.')
+  } finally {
+    setFollowUpPending(false)
+  }
+}
+```
+
+- [ ] **Step 4: Update the shell test to assert manager and reason inputs**
+
+In `frontend/app/(dashboard)/action-center/page.route-shell.test.ts`, verify the markup contains:
+
+```ts
+expect(markup).toContain('Start vervolgroute')
+expect(markup).toContain('Kies manager')
+expect(markup).toContain('Kies aanleiding')
+expect(markup).toContain('Nieuw campaign-signaal')
+```
+
+- [ ] **Step 5: Run the shell and component tests**
+
+Run:
+
+```bash
+npx vitest run "app/(dashboard)/action-center/page.route-shell.test.ts"
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/components/dashboard/action-center-preview.tsx frontend/app/(dashboard)/action-center/page.tsx frontend/app/(dashboard)/action-center/page.route-shell.test.ts
+git commit -m "feat: add hr follow-up route trigger ui"
+```
+
+---
+
+### Task 6: Project the new route and lineage back into overview/detail
+
+**Files:**
+- Modify: `frontend/lib/action-center-core-semantics.ts`
+- Modify: `frontend/lib/action-center-live.ts`
+- Modify: `frontend/lib/action-center-route-contract.ts`
+- Modify: `frontend/lib/action-center-live.test.ts`
+
+- [ ] **Step 1: Keep the old route historical and the new route open**
+
+In `frontend/lib/action-center-live.ts` and `frontend/lib/action-center-route-contract.ts`, preserve:
+- source route stays closed
+- new route reads as a normal open route
+- new route gets lineage label `Vervolg op eerdere route`
+
+Do not introduce a new special live status.
+
+- [ ] **Step 2: Add a small semantics projection for follow-up successor state**
+
+In `frontend/lib/action-center-core-semantics.ts`, add lightweight fields like:
+
+```ts
+followUpSemantics: {
+  triggerReasonLabel: string | null
+  isDirectSuccessor: boolean
+}
+```
+
+Populate them from the relation truth.
+
+- [ ] **Step 3: Extend live tests for the new trigger reason projection**
+
+In `frontend/lib/action-center-live.test.ts`, add expectations like:
+
+```ts
+expect(followUpItem.coreSemantics.lineageSemantics.label).toBe('Vervolg op eerdere route')
+expect(followUpItem.coreSemantics.followUpSemantics.triggerReasonLabel).toBe('Nieuw campaign-signaal')
+```
+
+- [ ] **Step 4: Run the live semantics tests**
+
+Run:
+
+```bash
+npx vitest run lib/action-center-live.test.ts lib/action-center-route-reopen.test.ts
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/lib/action-center-core-semantics.ts frontend/lib/action-center-live.ts frontend/lib/action-center-route-contract.ts frontend/lib/action-center-live.test.ts
+git commit -m "feat: project follow-up trigger lineage semantics"
+```
+
+---
+
+### Task 7: Seed and browser verification
+
+**Files:**
+- Modify: `frontend/scripts/seed-action-center-manager-pilot.mjs`
+- Modify: `frontend/tests/e2e/action-center-route-reopen.spec.ts`
+- Modify: `frontend/tests/e2e/action-center-manager-access.spec.ts`
+
+- [ ] **Step 1: Seed a closed route with no direct successor yet**
+
+Update the seed so there is one stable closed route eligible for:
+- `Start vervolgroute`
+- manager selection
+- trigger reason selection
+
+Keep the artifact shape explicit:
+
+```js
+followUpTriggerContext: {
+  sourceFocusItemId: closeoutRouteId,
+  targetScopeValue: closeoutRouteScopeValue,
+}
+```
+
+- [ ] **Step 2: Add a browser test for HR follow-up creation**
+
+In `frontend/tests/e2e/action-center-route-reopen.spec.ts`, add a new scenario:
+
+```ts
+test('hr can start a vervolgroute from a closed route with manager and trigger reason', async ({ page }) => {
+  await login(page, pilot.hrOwner.email, pilot.hrOwner.password)
+  await openFocusedRoute(page, pilot.closeoutRouteContext.focusItemId)
+  await page.getByRole('button', { name: 'Start vervolgroute' }).click()
+  await page.getByLabel('Kies manager').selectOption({ label: 'Manager Operations' })
+  await page.getByLabel('Kies aanleiding').selectOption('nieuw-campaign-signaal')
+  await page.getByRole('button', { name: 'Bevestig vervolgroute' }).click()
+
+  await expect(page.getByText('Vervolgroute aangemaakt')).toBeVisible()
+  await expect(page.getByText('Vervolg op eerdere route')).toBeVisible()
+})
+```
+
+- [ ] **Step 3: Assert the source route stays closed**
+
+Still in the e2e test, re-open the original closed route and assert:
+
+```ts
+await expect(page.getByText('Route afgesloten', { exact: true })).toBeVisible()
+await expect(page.getByText('Later opgevolgd')).toBeVisible()
+```
+
+- [ ] **Step 4: Run the seed and browser suite**
+
+Run:
+
+```bash
+node ./scripts/seed-action-center-manager-pilot.mjs
+PLAYWRIGHT_PORT=3020 npx playwright test tests/e2e/action-center-route-reopen.spec.ts tests/e2e/action-center-manager-access.spec.ts --project=chromium --workers=1
+```
+
+Expected:
+- seed succeeds
+- Playwright passes
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/scripts/seed-action-center-manager-pilot.mjs frontend/tests/e2e/action-center-route-reopen.spec.ts frontend/tests/e2e/action-center-manager-access.spec.ts
+git commit -m "test: verify hr follow-up route trigger flow"
+```
+
+---
+
+### Task 8: Final verification and PR prep
+
+**Files:**
+- Update PR notes after implementation
+
+- [ ] **Step 1: Run the targeted unit and API suite**
+
+Run:
+
+```bash
+npx vitest run lib/action-center-route-reopen.test.ts lib/action-center-follow-up-route-trigger.test.ts lib/action-center-route-relations-policy.test.ts lib/action-center-live.test.ts "app/(dashboard)/action-center/page.route-shell.test.ts" app/api/action-center-route-follow-ups/route.test.ts
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 2: Run lint on touched files**
+
+Run:
+
+```bash
+.\node_modules\.bin\eslint.cmd "lib/action-center-route-reopen.ts" "lib/action-center-follow-up-route-trigger.test.ts" "lib/action-center-route-relations-policy.test.ts" "lib/action-center-core-semantics.ts" "lib/action-center-live.ts" "lib/action-center-route-contract.ts" "app/api/action-center-route-follow-ups/route.ts" "app/api/action-center-route-follow-ups/route.test.ts" "components/dashboard/action-center-preview.tsx" "app/(dashboard)/action-center/page.tsx" "app/(dashboard)/action-center/page.route-shell.test.ts" "scripts/seed-action-center-manager-pilot.mjs" "tests/e2e/action-center-route-reopen.spec.ts"
+```
+
+Expected:
+- no lint errors
+
+- [ ] **Step 3: Run the production build**
+
+Run:
+
+```bash
+npm run build
+```
+
+Expected:
+- successful Next.js build
+
+- [ ] **Step 4: Prepare the PR summary**
+
+Call out:
+- HR-only `Start vervolgroute` on closed routes
+- required canonical `triggerReason`
+- single active direct successor rule
+- same-scope new route handoff with newly chosen manager
+- source route remains closed and historical
+
+- [ ] **Step 5: Final commit if needed**
+
+```bash
+git status --short
+```
+
+Expected:
+- clean working tree before push / PR
+
+---
+
+## Self-Review
+
+**Spec coverage:** The plan covers the new canonical trigger reason, the same-scope same-campaign follow-up carrier, the small HR UI trigger, the single-successor rule, the route lineage projection, and the browser-backed HR flow. It intentionally does not add free-form context fields, scope changes, or manager-authored action creation at trigger time.
+
+**Placeholder scan:** No `TODO`, `TBD`, or “appropriate handling” placeholders remain. Validation and tests are spelled out concretely.
+
+**Type consistency:** The plan consistently uses `triggerReason`, `follow-up-from`, `manager_user_id`, and the existing route scope value model across truth, API, UI, and tests.

--- a/docs/superpowers/specs/2026-05-01-action-center-follow-up-route-trigger-design.md
+++ b/docs/superpowers/specs/2026-05-01-action-center-follow-up-route-trigger-design.md
@@ -1,0 +1,316 @@
+# Action Center Follow-Up Route Trigger V1 Design
+
+## 1. Doel
+Deze fase maakt het mogelijk om na een gesloten route op een heel lichte manier opnieuw opvolging te starten.
+
+Niet door de oude route stilletjes weer open te zetten, maar door:
+- een nieuwe vervolgroute te maken
+- met dezelfde afdeling of scope
+- en een opnieuw gekozen manager
+
+Het doel is:
+- bestuurlijk eenvoudig vervolg mogelijk maken
+- zonder de betekenis van de gesloten route kapot te maken
+- en zonder HR in een zware workflow te trekken
+
+## 2. Productgrens
+Wel in scope:
+- alleen op gesloten routes
+- kleine HR-trigger: `Start vervolgroute`
+- HR kiest alleen de manager
+- afdeling of scope blijft gelijk aan de gesloten route
+- nieuwe route krijgt een expliciete relatie met de oude route
+- daarna ligt de volgende stap weer bij de manager
+
+Niet in scope:
+- oude route heropenen in deze flow
+- afdeling wijzigen
+- extra contextvelden
+- extra closeout- of herverdeelwizard
+- inhoudelijke actiecreatie door HR
+
+Dus:
+- HR beslist alleen dat er opnieuw opvolging moet komen
+- manager bepaalt daarna weer de inhoudelijke actie
+
+## 3. Lifecycle
+### 3.1 Gesloten route bestaat
+Een route is al:
+- `afgerond`
+- of `gestopt`
+
+Die blijft historisch gesloten.
+
+### 3.2 HR start vervolg
+HR gebruikt op die gesloten route:
+- `Start vervolgroute`
+
+En kiest alleen:
+- welke manager de nieuwe route krijgt
+
+### 3.3 Nieuwe vervolgroute ontstaat
+Het systeem maakt:
+- een nieuwe `routeId`
+- met dezelfde afdeling of scope
+- gekoppeld aan de gekozen manager
+- en canoniek gelinkt aan de oude gesloten route
+
+De oude route blijft dicht.
+
+### 3.4 Manager is weer aan zet
+De nieuwe manager ziet daarna de vervolgroute als een open route.
+
+Daarna begint de bekende flow weer:
+- manager kiest een thema
+- manager maakt een actie
+- review volgt later per actie
+
+## 4. Vorm van de Minimale HR-Trigger
+### 4.1 Alleen op gesloten routes
+`Start vervolgroute` verschijnt alleen wanneer een route al bestuurlijk gesloten is.
+
+Dus alleen bij:
+- `afgerond`
+- `gestopt`
+
+Niet op:
+- open routes
+- routes in uitvoering
+- reviewbare routes
+
+### 4.2 Trigger is klein
+De HR-handeling blijft in deze fase zo klein mogelijk.
+
+Dus:
+1. klik `Start vervolgroute`
+2. kies `manager`
+3. bevestig
+
+Geen extra stappen zoals:
+- thema kiezen
+- actie ontwerpen
+- toelichting invullen
+- afdeling aanpassen
+
+### 4.3 Scope blijft gelijk
+De nieuwe vervolgroute neemt automatisch over:
+- dezelfde afdeling of scope
+- dezelfde lokale context
+
+HR kiest in deze fase dus niet opnieuw de afdeling.
+
+### 4.4 Manager is wel opnieuw kiesbaar
+Het enige expliciete keuzeveld is:
+- `manager`
+
+Dat is belangrijk, want bij vervolg kan het logisch zijn dat:
+- dezelfde manager doorgaat
+- of juist een andere manager het oppakt
+
+Dus:
+- scope blijft vast
+- eigenaarschap mag opnieuw gekozen worden
+
+### 4.5 Geen verplichte contextregel
+In deze eerste versie is geen extra toelichting nodig.
+
+Dus:
+- geen `waarom vervolg?`
+- geen verplichte notitie
+- geen extra redenveld
+
+De betekenis zit in de handeling zelf:
+- gesloten route
+- nieuw vervolg
+- nieuwe manager
+
+## 5. Truth en Write-Path
+### 5.1 Oude route blijft onaangetast
+De gesloten route blijft canoniek precies wat hij al was:
+- gesloten
+- historisch zichtbaar
+- met bestaande acties, reviews en closeout
+
+De vervolgtrigger verandert de oude route dus niet.
+
+### 5.2 Nieuwe vervolgroute krijgt eigen route-truth
+De trigger maakt een nieuwe route.
+
+Die nieuwe route krijgt canoniek:
+- nieuwe `routeId`
+- zelfde `campaign`
+- zelfde `afdeling/scope`
+- nieuw gekozen `manager`
+- nieuwe `routeOpenedAt`
+- open lifecycle als zelfstandig traject
+
+Dus de vervolgroute is een echt nieuw route-object.
+
+### 5.3 Relationele truth legt de afkomst vast
+Naast die nieuwe route-truth komt één kleine relationele waarheid:
+- `routeRelationType = 'follow-up-from'`
+- `sourceRouteId = oude gesloten route`
+- `targetRouteId = nieuwe vervolgroute`
+- `recordedAt`
+- `recordedByRole = hr`
+
+Dat is genoeg om:
+- afkomst te tonen
+- detail en overview te verbinden
+- latere lineage en rapportage te begrijpen
+
+### 5.4 Write-path blijft HR-only
+In deze fase blijft deze handeling expliciet bij HR of Verisight.
+
+Dus:
+- alleen HR of Verisight kan `Start vervolgroute` uitvoeren
+- managers kunnen dit niet zelf doen
+
+### 5.5 Write-path doet twee dingen
+Bij bevestigen moet de write-path atomisch gezien twee waarheden vastleggen:
+
+#### A. Nieuwe route openen
+Nieuwe route met:
+- zelfde scope
+- gekozen manager
+- nieuwe open status
+
+#### B. Follow-up relatie opslaan
+Relationele koppeling van:
+- oude gesloten route
+- naar nieuwe vervolgroute
+
+Dus:
+- nieuw traject
+- plus expliciete afkomst
+
+### 5.6 Geen extra action-truth bij aanmaak
+De HR-trigger maakt nog geen manageractie aan.
+
+Dus na creatie:
+- er is alleen een nieuwe open route
+- manager moet daarna zelf de eerste actie starten
+
+## 6. Overview en Detail
+### 6.1 Oude route blijft historisch
+De gesloten bronroute blijft in overview en detail leesbaar als:
+- gesloten
+- historisch traject
+- met eventueel een compacte verwijzing dat hier later vervolg op is gekomen
+
+Dus niet:
+- half actief
+- half hergebruikt
+- of visueel verward met de nieuwe route
+
+### 6.2 Nieuwe vervolgroute voelt als nieuw open traject
+De nieuwe route moet in overview gewoon lezen als:
+- een nieuwe open route
+- met een toegewezen manager
+- klaar om inhoudelijk te starten
+
+Dus de nadruk ligt op:
+- wat loopt nu
+
+### 6.3 Compact lineage-label op de nieuwe route
+De nieuwe vervolgroute krijgt een kleine, secundaire contextlaag:
+- `Vervolg op eerdere route`
+
+Dat is genoeg om te begrijpen:
+- dit is niet het eerste traject
+- maar wel een nieuw traject
+
+### 6.4 Compact vervolglabel op de oude route
+De oude gesloten route mag een kleine historische indicatie krijgen zoals:
+- `Later opgevolgd`
+
+Niet als primaire status, maar als contextsignaal:
+- dit traject kreeg later een vervolg
+
+### 6.5 Detail toont tweerichtingscontext
+Op detail wil je meer duidelijkheid dan op overview.
+
+Op de nieuwe vervolgroute:
+- label `Vervolg op eerdere route`
+- link of verwijzing naar de vorige gesloten route
+
+Op de oude gesloten route:
+- compacte melding dat hier later een vervolgroute uit ontstond
+- link naar die nieuwe route
+
+Dus:
+- oude en nieuwe route zijn in beide richtingen verbonden
+- zonder zware lineage-UI
+
+## 7. Statusregels en Minimale UX-Flow
+### 7.1 Oude route verandert niet van status
+Wanneer HR `Start vervolgroute` gebruikt, blijft de oude route exact:
+- `afgerond`
+- of `gestopt`
+
+Dus:
+- geen statusmutatie
+- geen impliciete heropening
+- geen hybride toestand
+
+### 7.2 Nieuwe vervolgroute start als gewone open route
+De nieuwe vervolgroute begint canoniek als:
+- open
+- toegewezen aan de gekozen manager
+- nog zonder manageractie
+
+Dus qua live status valt hij direct terug in de bestaande open-route-semantiek.
+
+### 7.3 Geen extra tussenstatus voor vervolg
+In deze fase komen er geen aparte vervolgstatussen zoals:
+- `vervolg-open`
+- `herstart`
+- `opnieuw toegewezen`
+
+De route is gewoon:
+- een open route
+- met extra lineagecontext
+
+### 7.4 Minimale UX-flow
+De flow voor HR is:
+1. open een gesloten route
+2. klik `Start vervolgroute`
+3. kies manager
+4. bevestig
+5. systeem maakt nieuwe vervolgroute
+6. gebruiker komt uit op die nieuwe route of krijgt een directe link ernaartoe
+
+### 7.5 Bevestiging na creatie
+Na succesvolle aanmaak moet de UI helder teruggeven:
+- vervolgroute aangemaakt
+- toegewezen aan manager X
+
+Geen lange succeswizard, alleen een duidelijke bevestiging en door.
+
+### 7.6 Foutgevallen
+Alleen de belangrijkste foutgevallen hoeven in V1 goed afgevangen te worden:
+- route is niet meer gesloten
+- managerkeuze ongeldig
+- route bestaat niet meer
+- aanmaak mislukt
+
+Dan volgt een compacte foutmelding, zonder complexe herstelstappen.
+
+## 8. Succescriteria
+Deze fase is geslaagd als:
+- HR op een gesloten route met één kleine handeling een vervolgroute kan starten
+- HR daarbij alleen de manager hoeft te kiezen
+- de oude route gesloten blijft
+- de nieuwe route als zelfstandig open traject ontstaat
+- de manager daarna weer aan zet is om inhoudelijk te starten
+- overview en detail duidelijk laten zien wat oud traject is en wat nieuwe vervolgroute is
+
+## 9. Ontwerpuitspraak
+Deze V1 is bewust klein:
+- klein genoeg om rustig te blijven
+- sterk genoeg om bestuurlijk netjes vervolg te starten
+- zonder nieuwe statusrommel of workflowzwaarte
+
+De rolverdeling blijft zuiver:
+- HR start bestuurlijk het vervolg
+- manager maakt daarna weer de inhoudelijke actie op basis van een thema

--- a/docs/superpowers/specs/2026-05-01-action-center-follow-up-route-trigger-design.md
+++ b/docs/superpowers/specs/2026-05-01-action-center-follow-up-route-trigger-design.md
@@ -13,11 +13,28 @@ Het doel is:
 - zonder de betekenis van de gesloten route kapot te maken
 - en zonder HR in een zware workflow te trekken
 
+## 1.1 Canonieke aanleiding
+`Start vervolgroute` is niet bedoeld als losse admin-knop, maar als een begrensde vervolgtrigger op een gesloten route.
+
+In V1 mag HR deze trigger alleen gebruiken als er naast de gesloten route ook een canonieke aanleiding is voor hernieuwde opvolging.
+
+Die aanleiding moet in deze fase altijd in een kleine gestructureerde triggerlaag landen:
+- `nieuw-campaign-signaal`
+- `nieuw-segment-signaal`
+- `hernieuwde-hr-beoordeling`
+
+Dus:
+- niet alleen `route is gesloten`
+- maar `route is gesloten` plus `er is een expliciet vastgelegde aanleiding voor vervolg`
+
+De trigger blijft klein, maar niet betekenisloos.
+
 ## 2. Productgrens
 Wel in scope:
 - alleen op gesloten routes
 - kleine HR-trigger: `Start vervolgroute`
 - HR kiest alleen de manager
+- HR kiest ook een kleine canonieke `triggerReason`
 - afdeling of scope blijft gelijk aan de gesloten route
 - nieuwe route krijgt een expliciete relatie met de oude route
 - daarna ligt de volgende stap weer bij de manager
@@ -25,7 +42,7 @@ Wel in scope:
 Niet in scope:
 - oude route heropenen in deze flow
 - afdeling wijzigen
-- extra contextvelden
+- vrije contextvelden
 - extra closeout- of herverdeelwizard
 - inhoudelijke actiecreatie door HR
 
@@ -45,7 +62,30 @@ Die blijft historisch gesloten.
 HR gebruikt op die gesloten route:
 - `Start vervolgroute`
 
-En kiest alleen:
+En kiest:
+- `manager`
+- `triggerReason`
+
+### 3.2.1 TriggerReason in V1
+De triggerReason is verplicht, maar klein en gestructureerd.
+
+De set is:
+- `nieuw-campaign-signaal`
+- `nieuw-segment-signaal`
+- `hernieuwde-hr-beoordeling`
+
+Dus geen vrije notitie, maar wel een canonieke redenlaag die later leesbaarheid en filtering stabiel houdt.
+
+### 3.2.2 Triggercriterium
+De route mag alleen via deze flow worden vervolgd als:
+- de bronroute gesloten is
+- de gebruiker HR/Verisight is
+- er nog geen actieve directe vervolgroute op deze bronroute bestaat
+- en er een gekozen `triggerReason` wordt vastgelegd
+
+Daarmee blijft de handeling bestuurlijk begrensd.
+
+En kiest HR niet meer dan:
 - welke manager de nieuwe route krijgt
 
 ### 3.3 Nieuwe vervolgroute ontstaat
@@ -84,7 +124,8 @@ De HR-handeling blijft in deze fase zo klein mogelijk.
 Dus:
 1. klik `Start vervolgroute`
 2. kies `manager`
-3. bevestig
+3. kies `triggerReason`
+4. bevestig
 
 Geen extra stappen zoals:
 - thema kiezen
@@ -111,18 +152,17 @@ Dus:
 - scope blijft vast
 - eigenaarschap mag opnieuw gekozen worden
 
-### 4.5 Geen verplichte contextregel
-In deze eerste versie is geen extra toelichting nodig.
+### 4.5 Geen vrije contextregel, wel een canonieke triggerReason
+In deze eerste versie is geen vrije toelichting nodig.
 
 Dus:
-- geen `waarom vervolg?`
+- geen open tekstveld `waarom vervolg?`
 - geen verplichte notitie
-- geen extra redenveld
 
-De betekenis zit in de handeling zelf:
-- gesloten route
-- nieuw vervolg
-- nieuwe manager
+Maar wel:
+- een verplichte kleine `triggerReason`
+
+Zo blijft de flow klein, terwijl later nog steeds leesbaar is waarom het vervolgtraject is gestart.
 
 ## 5. Truth en Write-Path
 ### 5.1 Oude route blijft onaangetast
@@ -153,11 +193,24 @@ Naast die nieuwe route-truth komt één kleine relationele waarheid:
 - `targetRouteId = nieuwe vervolgroute`
 - `recordedAt`
 - `recordedByRole = hr`
+- `triggerReason`
 
 Dat is genoeg om:
 - afkomst te tonen
 - detail en overview te verbinden
 - latere lineage en rapportage te begrijpen
+
+### 5.3.1 Single-successor-regel in V1
+In deze fase krijgt een gesloten bronroute maximaal één directe actieve vervolgroute via deze trigger.
+
+Dus:
+- één gesloten route
+- hoogstens één directe `follow-up-from` successor tegelijk
+
+Gevolg:
+- overview en detail hoeven niet te raden welke vervolgroute de actuele opvolger is
+- de relationele truth blijft klein
+- een tweede vervolgtraject start later vanuit de dan meest recente gesloten route, niet opnieuw vanaf dezelfde bronroute
 
 ### 5.4 Write-path blijft HR-only
 In deze fase blijft deze handeling expliciet bij HR of Verisight.
@@ -179,6 +232,7 @@ Nieuwe route met:
 Relationele koppeling van:
 - oude gesloten route
 - naar nieuwe vervolgroute
+- met de gekozen `triggerReason`
 
 Dus:
 - nieuw traject
@@ -190,6 +244,18 @@ De HR-trigger maakt nog geen manageractie aan.
 Dus na creatie:
 - er is alleen een nieuwe open route
 - manager moet daarna zelf de eerste actie starten
+
+### 5.7 Loskoppeling van zwaardere manager-actielogica
+Deze fase moet niet afhankelijk zijn van een rijke of nog veranderlijke actiecard-flow.
+
+Daarom is het canonieke succes van deze trigger alleen:
+- nieuwe route aangemaakt
+- manager toegewezen
+- lineage vastgelegd
+
+De vervolgroute start dus als manager-handoff, niet als al ingevulde interventie.
+
+Of de manager daarna via een lichte eerste reactie, een primaire actie of een latere verfijnde actielogica werkt, is een vervolgstap buiten deze triggerfase.
 
 ## 6. Overview en Detail
 ### 6.1 Oude route blijft historisch
@@ -207,7 +273,7 @@ Dus niet:
 De nieuwe route moet in overview gewoon lezen als:
 - een nieuwe open route
 - met een toegewezen manager
-- klaar om inhoudelijk te starten
+- klaar om door de manager inhoudelijk te worden gestart
 
 Dus de nadruk ligt op:
 - wat loopt nu
@@ -257,7 +323,7 @@ Dus:
 De nieuwe vervolgroute begint canoniek als:
 - open
 - toegewezen aan de gekozen manager
-- nog zonder manageractie
+- nog zonder manageractie of inhoudelijke interventie
 
 Dus qua live status valt hij direct terug in de bestaande open-route-semantiek.
 
@@ -276,9 +342,10 @@ De flow voor HR is:
 1. open een gesloten route
 2. klik `Start vervolgroute`
 3. kies manager
-4. bevestig
-5. systeem maakt nieuwe vervolgroute
-6. gebruiker komt uit op die nieuwe route of krijgt een directe link ernaartoe
+4. kies `triggerReason`
+5. bevestig
+6. systeem maakt nieuwe vervolgroute
+7. gebruiker komt uit op die nieuwe route of krijgt een directe link ernaartoe
 
 ### 7.5 Bevestiging na creatie
 Na succesvolle aanmaak moet de UI helder teruggeven:
@@ -290,7 +357,9 @@ Geen lange succeswizard, alleen een duidelijke bevestiging en door.
 ### 7.6 Foutgevallen
 Alleen de belangrijkste foutgevallen hoeven in V1 goed afgevangen te worden:
 - route is niet meer gesloten
+- bronroute heeft al een actieve directe vervolgroute
 - managerkeuze ongeldig
+- triggerReason ongeldig
 - route bestaat niet meer
 - aanmaak mislukt
 
@@ -299,9 +368,10 @@ Dan volgt een compacte foutmelding, zonder complexe herstelstappen.
 ## 8. Succescriteria
 Deze fase is geslaagd als:
 - HR op een gesloten route met één kleine handeling een vervolgroute kan starten
-- HR daarbij alleen de manager hoeft te kiezen
+- HR daarbij alleen manager en `triggerReason` hoeft te kiezen
 - de oude route gesloten blijft
 - de nieuwe route als zelfstandig open traject ontstaat
+- per gesloten bronroute hoogstens één directe actieve vervolgroute tegelijk ontstaat
 - de manager daarna weer aan zet is om inhoudelijk te starten
 - overview en detail duidelijk laten zien wat oud traject is en wat nieuwe vervolgroute is
 

--- a/frontend/app/(dashboard)/action-center/page.route-shell.test.ts
+++ b/frontend/app/(dashboard)/action-center/page.route-shell.test.ts
@@ -5,6 +5,7 @@ import { projectActionCenterCoreSemantics } from "@/lib/action-center-core-seman
 import { buildLiveActionCenterItems } from "@/lib/action-center-live";
 import type { LiveActionCenterCampaignContext } from "@/lib/action-center-live-context";
 import { projectActionCenterRoute } from "@/lib/action-center-route-contract";
+import { projectActionCenterRouteFollowUpRelation } from "@/lib/action-center-route-reopen";
 import type { Campaign, CampaignStats } from "@/lib/types";
 import type { CampaignDeliveryRecord } from "@/lib/ops-delivery";
 import type { PilotLearningCheckpoint, PilotLearningDossier } from "@/lib/pilot-learning";
@@ -166,10 +167,193 @@ function buildLiveContext(): LiveActionCenterCampaignContext {
   };
 }
 
+function buildFollowUpTargetContext(): LiveActionCenterCampaignContext {
+  return {
+    ...buildLiveContext(),
+    campaign: buildCampaign({
+      id: "campaign-pulse",
+      name: "Pulse voorjaar",
+      scan_type: "pulse",
+    }),
+    stats: buildStats({
+      campaign_id: "campaign-pulse",
+      campaign_name: "Pulse voorjaar",
+      scan_type: "pulse",
+    }),
+    deliveryRecord: buildDeliveryRecord({
+      id: "delivery-pulse",
+      campaign_id: "campaign-pulse",
+    }),
+    learningDossier: buildDossier({
+      id: "dossier-pulse",
+      campaign_id: "campaign-pulse",
+      title: "Pulse follow-through voorjaar",
+      scan_type: "pulse",
+      triage_status: "bevestigd",
+      management_action_outcome: "bijstellen",
+      case_public_summary: "Een nieuwe pulse-route staat klaar als heldere vervolghandoff voor dezelfde afdeling.",
+    }),
+    learningCheckpoints: [
+      buildCheckpoint({
+        id: "checkpoint-pulse-review",
+        dossier_id: "dossier-pulse",
+        checkpoint_key: "follow_up_review",
+        owner_label: "HR lead",
+        status: "bevestigd",
+        confirmed_lesson: "De vervolghandoff voor dezelfde afdeling staat open voor de volgende managerstap.",
+      }),
+    ],
+  };
+}
+
+function buildSecondFollowUpTargetContext(): LiveActionCenterCampaignContext {
+  return {
+    ...buildLiveContext(),
+    campaign: buildCampaign({
+      id: "campaign-pulse-2",
+      name: "Pulse zomer",
+      scan_type: "pulse",
+    }),
+    stats: buildStats({
+      campaign_id: "campaign-pulse-2",
+      campaign_name: "Pulse zomer",
+      scan_type: "pulse",
+    }),
+    deliveryRecord: buildDeliveryRecord({
+      id: "delivery-pulse-2",
+      campaign_id: "campaign-pulse-2",
+    }),
+    learningDossier: buildDossier({
+      id: "dossier-pulse-2",
+      campaign_id: "campaign-pulse-2",
+      title: "Tweede pulse follow-through",
+      scan_type: "pulse",
+      triage_status: "bevestigd",
+      management_action_outcome: "bijstellen",
+      case_public_summary: "Een tweede open pulse-route maakt de vervolghandoff in V1 bewust ambigu.",
+    }),
+  };
+}
+
 function getIsoDateDaysFromNow(daysFromNow: number) {
   const date = new Date();
   date.setDate(date.getDate() + daysFromNow);
+  date.setHours(12, 0, 0, 0);
   return date.toISOString().slice(0, 10);
+}
+
+function renderFollowUpAffordanceMarkup(args: {
+  memberRole: "owner" | "member" | "viewer";
+  triageStatus: "bevestigd" | "uitgevoerd";
+  managementActionOutcome: "bijstellen" | "afronden";
+  canAssignManagers: boolean;
+  canRespondToRequests: boolean;
+  workspaceSubtitle: string;
+  withTargetCandidate?: boolean;
+  withDirectActiveSuccessor?: boolean;
+  withAmbiguousTargetCandidates?: boolean;
+  withOptimisticDirectSuccessor?: boolean;
+}) {
+  const sourceContext = {
+    ...buildLiveContext(),
+    memberRole: args.memberRole,
+    learningDossier: buildDossier({
+      triage_status: args.triageStatus,
+      management_action_outcome: args.managementActionOutcome,
+      case_public_summary:
+        args.triageStatus === "uitgevoerd"
+          ? "De eerste route is bewust afgerond en klaar voor een eventuele vervolgroute."
+          : "De eerste route blijft actief en vraagt nog een gerichte vervolgstap.",
+    }),
+  } satisfies LiveActionCenterCampaignContext;
+  const contexts: LiveActionCenterCampaignContext[] = [sourceContext];
+
+  if (args.withTargetCandidate ?? true) {
+    const targetContext = buildFollowUpTargetContext();
+
+    if (args.withDirectActiveSuccessor) {
+      const sourceRoute = projectActionCenterRoute(sourceContext);
+      const targetRoute = projectActionCenterRoute(targetContext);
+      const relation = projectActionCenterRouteFollowUpRelation({
+        route_relation_type: "follow-up-from",
+        source_campaign_id: sourceContext.campaign.id,
+        target_campaign_id: targetContext.campaign.id,
+        source_route_id: sourceRoute.routeId,
+        target_route_id: targetRoute.routeId,
+        trigger_reason: "nieuw-segment-signaal",
+        recorded_at: "2026-04-30T09:00:00.000Z",
+        recorded_by_role: "hr_owner",
+      });
+
+      contexts[0] = {
+        ...sourceContext,
+        routeFollowUpRelations: [relation],
+      };
+      contexts.push({
+        ...targetContext,
+        routeFollowUpRelations: [relation],
+      });
+    } else {
+      contexts.push(targetContext);
+    }
+  }
+
+  let items = buildLiveActionCenterItems(contexts);
+  const item = items.find((candidate) => candidate.coreSemantics.route.campaignId === sourceContext.campaign.id)!;
+
+  if (args.withAmbiguousTargetCandidates) {
+    items = [
+      ...items,
+      ...buildLiveActionCenterItems([buildSecondFollowUpTargetContext()]),
+    ];
+  }
+
+  if (args.withOptimisticDirectSuccessor) {
+    const targetItem = items.find((candidate) => candidate.id !== item.id && candidate.teamId === item.teamId);
+    if (targetItem) {
+      items = items.map((candidate) =>
+        candidate.id === targetItem.id
+          ? {
+              ...candidate,
+              coreSemantics: {
+                ...candidate.coreSemantics,
+                followUpSemantics: {
+                  isDirectSuccessor: true,
+                  lineageLabel: "Vervolg op eerdere route",
+                  triggerReason: "nieuw-campaign-signaal",
+                  triggerReasonLabel: "Nieuw campaign-signaal",
+                  sourceRouteId: item.coreSemantics.route.routeId,
+                },
+              },
+            }
+          : candidate,
+      );
+    }
+  }
+
+  const markup = renderToStaticMarkup(
+    createElement(ActionCenterPreview, {
+      initialItems: items,
+      initialSelectedItemId: item.id,
+      initialView: "actions",
+      fallbackOwnerName: "Admin",
+      ownerOptions: ["Manager Operations", "Manager Support"],
+      managerOptions: [
+        { value: "manager-1", label: "Manager Operations" },
+        { value: "manager-2", label: "Manager Support" },
+      ],
+      workbenchHref: "/action-center/dossier",
+      hideSidebar: true,
+      readOnly: false,
+      canAssignManagers: args.canAssignManagers,
+      canRespondToRequests: args.canRespondToRequests,
+      routeFollowUpEndpoint: "/api/action-center-route-follow-ups",
+      workspaceName: "Action Center",
+      workspaceSubtitle: args.workspaceSubtitle,
+    }),
+  );
+
+  return { item, items, markup };
 }
 
 describe("action center landing shell", () => {
@@ -178,6 +362,150 @@ describe("action center landing shell", () => {
 
     expect(pageSource).toContain("<ActionCenterPreview");
     expect(pageSource).toContain("searchParams");
+    expect(pageSource).toContain('routeFollowUpEndpoint="/api/action-center-route-follow-ups"');
+  });
+
+  it("renders shell markup that should expose the follow-up route trigger affordances", () => {
+    const { item, markup } = renderFollowUpAffordanceMarkup({
+      memberRole: "owner",
+      triageStatus: "uitgevoerd",
+      managementActionOutcome: "afronden",
+      canAssignManagers: true,
+      canRespondToRequests: true,
+      workspaceSubtitle: "Verisight + HR",
+    });
+
+    expect(item.coreSemantics.route.routeStatus).toBe("afgerond");
+    expect(markup).toContain("Start vervolgroute");
+    expect(markup).toContain("Kies manager");
+    expect(markup).toContain("Kies aanleiding");
+    expect(markup).toContain('name="follow-up-manager"');
+    expect(markup).toContain('name="follow-up-trigger-reason"');
+    expect(markup).toContain("Nieuw campaign-signaal");
+    expect(markup).toContain("Nieuw segmentsignaal");
+    expect(markup).toContain("Hernieuwde HR-beoordeling");
+  });
+
+  it("keeps the trigger disabled when a closed route already has a direct active follow-up successor", () => {
+    const { item, items, markup } = renderFollowUpAffordanceMarkup({
+      memberRole: "owner",
+      triageStatus: "uitgevoerd",
+      managementActionOutcome: "afronden",
+      canAssignManagers: true,
+      canRespondToRequests: true,
+      workspaceSubtitle: "Verisight + HR",
+      withDirectActiveSuccessor: true,
+    });
+
+    const directSuccessor = items.find(
+      (candidate) =>
+        candidate.id !== item.id &&
+        candidate.coreSemantics.followUpSemantics.isDirectSuccessor &&
+        candidate.coreSemantics.followUpSemantics.sourceRouteId === item.coreSemantics.route.routeId,
+    );
+
+    expect(item.coreSemantics.route.routeStatus).toBe("afgerond");
+    expect(directSuccessor ? ["open-verzoek", "te-bespreken", "in-uitvoering"].includes(directSuccessor.status) : false).toBe(true);
+    expect(directSuccessor?.coreSemantics.followUpSemantics.triggerReasonLabel).toBe("Nieuw segmentsignaal");
+    expect(markup).toContain("Voor deze gesloten route loopt al een directe actieve vervolgroute (Nieuw segmentsignaal).");
+    expect(markup).not.toContain("Start vervolgroute");
+    expect(markup).not.toContain("Kies manager");
+    expect(markup).not.toContain("Kies aanleiding");
+  });
+
+  it("keeps the trigger disabled when no single same-scope target route can be derived", () => {
+    const { item, markup } = renderFollowUpAffordanceMarkup({
+      memberRole: "owner",
+      triageStatus: "uitgevoerd",
+      managementActionOutcome: "afronden",
+      canAssignManagers: true,
+      canRespondToRequests: true,
+      workspaceSubtitle: "Verisight + HR",
+      withTargetCandidate: false,
+    });
+
+    expect(item.coreSemantics.route.routeStatus).toBe("afgerond");
+    expect(markup).toContain("Nog geen eenduidige open doelroute beschikbaar binnen deze afdeling.");
+    expect(markup).not.toContain("Start vervolgroute");
+    expect(markup).not.toContain("Kies manager");
+    expect(markup).not.toContain("Kies aanleiding");
+  });
+
+  it("keeps the trigger hidden when multiple same-scope targets are open", () => {
+    const { item, markup } = renderFollowUpAffordanceMarkup({
+      memberRole: "owner",
+      triageStatus: "uitgevoerd",
+      managementActionOutcome: "afronden",
+      canAssignManagers: true,
+      canRespondToRequests: true,
+      workspaceSubtitle: "Verisight + HR",
+      withAmbiguousTargetCandidates: true,
+    });
+
+    expect(item.coreSemantics.route.routeStatus).toBe("afgerond");
+    expect(markup).toContain("Er zijn meerdere open doelroutes binnen deze afdeling. Kies in V1 eerst één eenduidige vervolgrichting.");
+    expect(markup).not.toContain("Start vervolgroute");
+    expect(markup).not.toContain("Kies manager");
+    expect(markup).not.toContain("Kies aanleiding");
+  });
+
+  it("keeps the trigger hidden after the target route is locally marked as the direct successor", () => {
+    const { item, items, markup } = renderFollowUpAffordanceMarkup({
+      memberRole: "owner",
+      triageStatus: "uitgevoerd",
+      managementActionOutcome: "afronden",
+      canAssignManagers: true,
+      canRespondToRequests: true,
+      workspaceSubtitle: "Verisight + HR",
+      withOptimisticDirectSuccessor: true,
+    });
+
+    const optimisticSuccessor = items.find(
+      (candidate) =>
+        candidate.id !== item.id &&
+        candidate.coreSemantics.followUpSemantics.isDirectSuccessor &&
+        candidate.coreSemantics.followUpSemantics.sourceRouteId === item.coreSemantics.route.routeId,
+    );
+
+    expect(optimisticSuccessor?.coreSemantics.followUpSemantics.triggerReasonLabel).toBe("Nieuw campaign-signaal");
+    expect(markup).toContain("Voor deze gesloten route loopt al een directe actieve vervolgroute (Nieuw campaign-signaal).");
+    expect(markup).not.toContain("Start vervolgroute");
+    expect(markup).not.toContain("Kies manager");
+    expect(markup).not.toContain("Kies aanleiding");
+  });
+
+  it("keeps follow-up affordances hidden for a closed route without HR or Verisight capabilities", () => {
+    const { item, markup } = renderFollowUpAffordanceMarkup({
+      memberRole: "viewer",
+      triageStatus: "uitgevoerd",
+      managementActionOutcome: "afronden",
+      canAssignManagers: false,
+      canRespondToRequests: false,
+      workspaceSubtitle: "Manager alleen",
+    });
+
+    expect(item.coreSemantics.route.routeStatus).toBe("afgerond");
+    expect(markup).not.toContain("Start vervolgroute");
+    expect(markup).not.toContain("Kies manager");
+    expect(markup).not.toContain("Kies aanleiding");
+    expect(markup).not.toContain("Nieuw campaign-signaal");
+  });
+
+  it("keeps follow-up affordances hidden for non-closed routes even with HR or Verisight capabilities", () => {
+    const { item, markup } = renderFollowUpAffordanceMarkup({
+      memberRole: "owner",
+      triageStatus: "bevestigd",
+      managementActionOutcome: "bijstellen",
+      canAssignManagers: true,
+      canRespondToRequests: true,
+      workspaceSubtitle: "Verisight + HR",
+    });
+
+    expect(item.coreSemantics.route.routeStatus).toBe("in-uitvoering");
+    expect(markup).not.toContain("Start vervolgroute");
+    expect(markup).not.toContain("Kies manager");
+    expect(markup).not.toContain("Kies aanleiding");
+    expect(markup).not.toContain("Nieuw campaign-signaal");
   });
 
   it("renders detail-first review meaning and action frame from grouped core semantics", () => {

--- a/frontend/app/(dashboard)/action-center/page.tsx
+++ b/frontend/app/(dashboard)/action-center/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from 'next/navigation'
 import { ActionCenterPreview } from '@/components/dashboard/action-center-preview'
 import { buildLiveActionCenterItems, getLiveActionCenterSummary } from '@/lib/action-center-live'
 import { buildActionCenterRouteId } from '@/lib/action-center-route-contract'
+import { projectActionCenterRouteFollowUpRelation } from '@/lib/action-center-route-reopen'
 import { createAdminClient } from '@/lib/supabase/admin'
 import {
   isScopeVisibleToActionCenterContext,
@@ -21,6 +22,19 @@ import type { Campaign, CampaignStats, Organization } from '@/lib/types'
 type RespondentDepartmentRow = {
   campaign_id: string
   department: string | null
+}
+
+type ActionCenterRouteRelationRow = {
+  id: string | null
+  source_campaign_id: string | null
+  target_campaign_id: string | null
+  route_relation_type: string | null
+  source_route_id: string | null
+  target_route_id: string | null
+  trigger_reason: string | null
+  recorded_at: string | null
+  recorded_by_role: string | null
+  ended_at: string | null
 }
 
 function getDisplayName(email: string | null | undefined) {
@@ -102,6 +116,7 @@ export default async function ActionCenterPage({
     { data: deliveryRecordsRaw },
     { data: dossiersRaw },
     { data: managerWorkspaceRowsRaw },
+    { data: routeRelationsRaw },
   ] = await Promise.all([
     orgIds.length > 0
       ? dataClient.from('organizations').select('id, name, slug, contact_email, is_active, created_at').in('id', orgIds)
@@ -126,6 +141,15 @@ export default async function ActionCenterPage({
           )
           .in('org_id', orgIds)
       : Promise.resolve({ data: [] }),
+    orgIds.length > 0
+      ? dataClient
+          .from('action_center_route_relations')
+          .select(
+            'id, source_campaign_id, target_campaign_id, route_relation_type, source_route_id, target_route_id, trigger_reason, recorded_at, recorded_by_role, ended_at',
+          )
+          .in('org_id', orgIds)
+          .eq('route_relation_type', 'follow-up-from')
+      : Promise.resolve({ data: [] }),
   ])
 
   const organizations = (organizationsRaw ?? []) as Organization[]
@@ -141,6 +165,25 @@ export default async function ActionCenterPage({
   const managerWorkspaceRows = (
     context.canManageActionCenterAssignments ? managerWorkspaceRowsRaw ?? [] : currentUserWorkspaceMemberships
   ) as ActionCenterWorkspaceMember[]
+  const routeRelations = ((routeRelationsRaw ?? []) as ActionCenterRouteRelationRow[]).reduce<
+    ReturnType<typeof projectActionCenterRouteFollowUpRelation>[]
+  >((acc, relation) => {
+    const belongsToVisibleCampaign =
+      (relation.source_campaign_id ? campaignIds.includes(relation.source_campaign_id) : false) ||
+      (relation.target_campaign_id ? campaignIds.includes(relation.target_campaign_id) : false)
+
+    if (!belongsToVisibleCampaign) {
+      return acc
+    }
+
+    try {
+      acc.push(projectActionCenterRouteFollowUpRelation(relation))
+    } catch {
+      // Ignore malformed legacy rows so one broken relation does not take down the full Action Center page.
+    }
+
+    return acc
+  }, [])
 
   const { data: respondentsWithDepartmentsRaw } =
     campaignIds.length > 0
@@ -224,6 +267,13 @@ export default async function ActionCenterPage({
       response,
     ]),
   )
+  const routeFollowUpRelationMap = routeRelations.reduce<Record<string, typeof routeRelations>>((acc, relation) => {
+    acc[relation.sourceRouteId] ??= []
+    acc[relation.targetRouteId] ??= []
+    acc[relation.sourceRouteId].push(relation)
+    acc[relation.targetRouteId].push(relation)
+    return acc
+  }, {})
   const respondentDepartmentsByCampaign = respondentsWithDepartments.reduce<Record<string, string[]>>((acc, row) => {
     const departmentLabel = normalizeDepartmentLabel(row.department)
     if (!departmentLabel) return acc
@@ -286,6 +336,7 @@ export default async function ActionCenterPage({
           learningCheckpoints: learningDossier ? (learningCheckpointMap[learningDossier.id] ?? []) : [],
           managerResponse: managerResponseByRouteId.get(routeId) ?? null,
           reviewDecisions: reviewDecisionMap[campaign.id] ?? [],
+          routeFollowUpRelations: routeFollowUpRelationMap[routeId] ?? [],
         }
       })
   })
@@ -368,6 +419,7 @@ export default async function ActionCenterPage({
       managerAssignmentEndpoint="/api/action-center/workspace-members"
       canRespondToRequests={context.canUpdateActionCenter}
       managerResponseEndpoint="/api/action-center-manager-responses"
+      routeFollowUpEndpoint="/api/action-center-route-follow-ups"
       currentUserId={user.id}
       workbenchHref={context.canViewInsights ? '/dashboard' : '/action-center'}
       workbenchLabel={context.canViewInsights ? 'Open broncampagne' : 'Blijf in Action Center'}

--- a/frontend/app/api/action-center-route-follow-ups/route.test.ts
+++ b/frontend/app/api/action-center-route-follow-ups/route.test.ts
@@ -1,0 +1,990 @@
+import { existsSync } from 'node:fs'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const routePath = fileURLToPath(new URL('./route.ts', import.meta.url))
+
+const HR_USER_ID = '11111111-1111-4111-8111-111111111111'
+const MANAGER_USER_ID = '22222222-2222-4222-8222-222222222222'
+const OTHER_MANAGER_USER_ID = '33333333-3333-4333-8333-333333333333'
+const SOURCE_CAMPAIGN_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const TARGET_CAMPAIGN_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const TARGET_NEXT_CAMPAIGN_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+const CROSS_ORG_CAMPAIGN_ID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
+const OPEN_CAMPAIGN_ID = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee'
+const SOURCE_ITEM_SCOPE_VALUE = `org-1::campaign::${SOURCE_CAMPAIGN_ID}`
+const TARGET_ITEM_SCOPE_VALUE = `org-1::campaign::${TARGET_CAMPAIGN_ID}`
+const SOURCE_CAMPAIGN_ID_MIXED_CASE = 'AaAaAaAa-AaAa-4aAa-8aAa-AaAaAaAaAaAa'
+const TARGET_CAMPAIGN_ID_MIXED_CASE = 'BbBbBbBb-BbBb-4bBb-8bBb-BbBbBbBbBbBb'
+const SOURCE_ITEM_SCOPE_VALUE_MIXED_CASE = `org-1::campaign::${SOURCE_CAMPAIGN_ID_MIXED_CASE}`
+const TARGET_ITEM_SCOPE_VALUE_MIXED_CASE = `org-1::campaign::${TARGET_CAMPAIGN_ID_MIXED_CASE}`
+
+type MockCampaign = {
+  id: string
+  organization_id: string
+}
+
+type MockRouteCloseout = {
+  route_id: string
+  closed_at: string | null
+}
+
+type MockWorkspaceMembership = {
+  org_id: string
+  user_id?: string
+  access_role: 'hr_owner' | 'hr_member' | 'manager_assignee'
+  scope_value: string
+  can_update: boolean
+}
+
+type MockManagerMembership = {
+  org_id: string
+  user_id: string
+  access_role: 'manager_assignee'
+  scope_value: string
+  can_view: boolean
+  can_update: boolean
+}
+
+type MockManagerResponse = Record<string, unknown>
+
+const mockState = {
+  user: { id: HR_USER_ID } as { id: string } | null,
+  isVerisightAdmin: false,
+  memberRole: 'viewer' as 'owner' | 'member' | 'viewer' | null,
+  workspaceMemberships: [] as MockWorkspaceMembership[],
+  managerWorkspaceMemberships: [] as MockManagerMembership[],
+  campaigns: {
+    [SOURCE_CAMPAIGN_ID]: {
+      id: SOURCE_CAMPAIGN_ID,
+      organization_id: 'org-1',
+    },
+    [OPEN_CAMPAIGN_ID]: {
+      id: OPEN_CAMPAIGN_ID,
+      organization_id: 'org-1',
+    },
+    [TARGET_CAMPAIGN_ID]: {
+      id: TARGET_CAMPAIGN_ID,
+      organization_id: 'org-1',
+    },
+    [TARGET_NEXT_CAMPAIGN_ID]: {
+      id: TARGET_NEXT_CAMPAIGN_ID,
+      organization_id: 'org-1',
+    },
+    [CROSS_ORG_CAMPAIGN_ID]: {
+      id: CROSS_ORG_CAMPAIGN_ID,
+      organization_id: 'org-2',
+    },
+  } satisfies Record<string, MockCampaign>,
+  routeCloseouts: {
+    [`${SOURCE_CAMPAIGN_ID}::org-1::department::operations`]: {
+      route_id: `${SOURCE_CAMPAIGN_ID}::org-1::department::operations`,
+      closed_at: '2026-04-22T09:00:00.000Z',
+    },
+  } as Record<string, MockRouteCloseout>,
+  existingManagerResponses: [] as MockManagerResponse[],
+  createdManagerResponses: [] as MockManagerResponse[],
+  deletedManagerResponseIds: [] as string[],
+  existingActiveRelations: [] as Array<Record<string, unknown>>,
+  insertedRelations: [] as Array<Record<string, unknown>>,
+  insertConflict: false,
+  managerResponseInsertConflict: false,
+}
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: async () => ({
+    auth: {
+      getUser: async () => ({
+        data: {
+          user: mockState.user,
+        },
+      }),
+    },
+  }),
+}))
+
+vi.mock('@/lib/suite-access-server', () => ({
+  loadSuiteAccessContext: async () => ({
+    context: {
+      isVerisightAdmin: mockState.isVerisightAdmin,
+      memberRole: mockState.memberRole,
+    },
+    workspaceMemberships: mockState.workspaceMemberships,
+    profile: null,
+    orgMemberships: mockState.memberRole
+      ? [
+          {
+            org_id: 'org-1',
+            role: mockState.memberRole,
+          },
+        ]
+      : [],
+  }),
+}))
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: () => ({
+    from: (table: string) => {
+      if (table === 'campaigns') {
+        return {
+          select: () => ({
+            eq: (_column: string, value: string) => ({
+              maybeSingle: async () => ({
+                data: mockState.campaigns[value] ?? null,
+                error: null,
+              }),
+            }),
+          }),
+        }
+      }
+
+      if (table === 'action_center_route_closeouts') {
+        return {
+          select: () => ({
+            eq: (_column: string, value: string) => ({
+              maybeSingle: async () => ({
+                data: mockState.routeCloseouts[value] ?? null,
+                error: null,
+              }),
+            }),
+          }),
+        }
+      }
+
+      if (table === 'action_center_workspace_members') {
+        return {
+          select: () => ({
+            eq: (_column: string, orgId: string) => ({
+              eq: (_column2: string, userId: string) => ({
+                eq: (_column3: string, accessRole: string) => ({
+                  eq: (_column4: string, scopeValue: string) => ({
+                    maybeSingle: async () => ({
+                      data:
+                        mockState.managerWorkspaceMemberships.find(
+                          (membership) =>
+                            membership.org_id === orgId &&
+                            membership.user_id === userId &&
+                            membership.access_role === accessRole &&
+                            membership.scope_value === scopeValue,
+                        ) ?? null,
+                      error: null,
+                    }),
+                  }),
+                }),
+              }),
+            }),
+          }),
+        }
+      }
+
+      if (table === 'action_center_route_relations') {
+        return {
+          select: () => ({
+            eq: (firstColumn: string, firstValue: string) => ({
+              eq: (secondColumn: string, secondValue: string) => ({
+                is: async (thirdColumn: string, thirdValue: unknown) => ({
+                  data: mockState.existingActiveRelations.filter((relation) => {
+                    const relationRecord = relation as Record<string, unknown>
+                    return (
+                      relationRecord[firstColumn] === firstValue &&
+                      relationRecord[secondColumn] === secondValue &&
+                      relationRecord[thirdColumn] === thirdValue
+                    )
+                  }),
+                  error: null,
+                }),
+              }),
+            }),
+          }),
+          insert: (payload: Record<string, unknown>) => ({
+            select: () => ({
+              single: async () => {
+                if (mockState.insertConflict) {
+                  return {
+                    data: null,
+                    error: {
+                      code: '23505',
+                      message:
+                        'duplicate key value violates unique constraint "idx_action_center_route_relations_active_direct_follow_up"',
+                    },
+                  }
+                }
+
+                const inserted = {
+                  id: `relation-${mockState.insertedRelations.length + 1}`,
+                  ...payload,
+                }
+                mockState.insertedRelations.push(inserted)
+                return {
+                  data: inserted,
+                  error: null,
+                }
+              },
+            }),
+          }),
+        }
+      }
+
+      if (table === 'action_center_manager_responses') {
+        return {
+          select: () => ({
+            eq: (_column: string, campaignId: string) => ({
+              eq: (_column2: string, routeScopeType: string) => ({
+                eq: (_column3: string, routeScopeValue: string) => ({
+                  maybeSingle: async () => ({
+                    data:
+                      mockState.existingManagerResponses.find(
+                        (response) =>
+                          response.campaign_id === campaignId &&
+                          response.route_scope_type === routeScopeType &&
+                          response.route_scope_value === routeScopeValue,
+                      ) ?? null,
+                    error: null,
+                  }),
+                }),
+              }),
+            }),
+          }),
+          insert: (payload: Record<string, unknown>) => ({
+            select: () => ({
+              single: async () => {
+                if (mockState.managerResponseInsertConflict) {
+                  return {
+                    data: null,
+                    error: {
+                      code: '23505',
+                      message:
+                        'duplicate key value violates unique constraint "action_center_manager_responses_campaign_id_route_scope_type_route_scope_key"',
+                    },
+                  }
+                }
+
+                const created = {
+                  id: `manager-response-${mockState.createdManagerResponses.length + 1}`,
+                  ...payload,
+                }
+                mockState.createdManagerResponses.push(created)
+                mockState.existingManagerResponses.push(created)
+                return {
+                  data: created,
+                  error: null,
+                }
+              },
+            }),
+          }),
+          delete: () => ({
+            eq: (_column: string, id: string) => ({
+              eq: async (_column2: string, campaignId: string) => {
+                mockState.deletedManagerResponseIds.push(id)
+                mockState.existingManagerResponses = mockState.existingManagerResponses.filter(
+                  (response) => !(response.id === id && response.campaign_id === campaignId),
+                )
+                return {
+                  error: null,
+                }
+              },
+            }),
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected table mocked in follow-up route test: ${table}`)
+    },
+  }),
+}))
+
+beforeEach(() => {
+  mockState.user = { id: HR_USER_ID }
+  mockState.isVerisightAdmin = false
+  mockState.memberRole = 'viewer'
+  mockState.workspaceMemberships = []
+  mockState.managerWorkspaceMemberships = [
+    {
+      org_id: 'org-1',
+      user_id: MANAGER_USER_ID,
+      access_role: 'manager_assignee',
+      scope_value: 'org-1::department::operations',
+      can_view: true,
+      can_update: true,
+    },
+  ]
+  mockState.existingManagerResponses = []
+  mockState.createdManagerResponses = []
+  mockState.deletedManagerResponseIds = []
+  mockState.existingActiveRelations = []
+  mockState.insertedRelations = []
+  mockState.insertConflict = false
+  mockState.managerResponseInsertConflict = false
+  mockState.campaigns[SOURCE_CAMPAIGN_ID] = {
+    id: SOURCE_CAMPAIGN_ID,
+    organization_id: 'org-1',
+  }
+  mockState.campaigns[OPEN_CAMPAIGN_ID] = {
+    id: OPEN_CAMPAIGN_ID,
+    organization_id: 'org-1',
+  }
+  mockState.campaigns[TARGET_CAMPAIGN_ID] = {
+    id: TARGET_CAMPAIGN_ID,
+    organization_id: 'org-1',
+  }
+  mockState.campaigns[TARGET_NEXT_CAMPAIGN_ID] = {
+    id: TARGET_NEXT_CAMPAIGN_ID,
+    organization_id: 'org-1',
+  }
+  mockState.campaigns[CROSS_ORG_CAMPAIGN_ID] = {
+    id: CROSS_ORG_CAMPAIGN_ID,
+    organization_id: 'org-2',
+  }
+  mockState.routeCloseouts = {
+    [`${SOURCE_CAMPAIGN_ID}::org-1::department::operations`]: {
+      route_id: `${SOURCE_CAMPAIGN_ID}::org-1::department::operations`,
+      closed_at: '2026-04-22T09:00:00.000Z',
+    },
+  }
+})
+
+function buildFollowUpRequest(overrides: Record<string, unknown> = {}) {
+  return {
+    source_campaign_id: SOURCE_CAMPAIGN_ID,
+    source_route_scope_value: 'org-1::department::operations',
+    target_campaign_id: TARGET_CAMPAIGN_ID,
+    target_route_scope_value: 'org-1::department::operations',
+    trigger_reason: 'nieuw-campaign-signaal',
+    manager_user_id: MANAGER_USER_ID,
+    ...overrides,
+  }
+}
+
+async function postFollowUp(body: Record<string, unknown>) {
+  if (!existsSync(routePath)) {
+    return new Response(JSON.stringify({ detail: 'Follow-up route API not implemented.' }), {
+      status: 501,
+      headers: {
+        'content-type': 'application/json',
+      },
+    })
+  }
+
+  const routeModule = (await import(pathToFileURL(routePath).href)) as {
+    POST?: (request: Request) => Promise<Response>
+  }
+
+  if (!routeModule.POST) {
+    return new Response(JSON.stringify({ detail: 'Follow-up route POST handler ontbreekt.' }), {
+      status: 501,
+      headers: {
+        'content-type': 'application/json',
+      },
+    })
+  }
+
+  return routeModule.POST(
+    new Request('http://localhost/api/action-center-route-follow-ups', {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: {
+        'content-type': 'application/json',
+      },
+    }),
+  )
+}
+
+describe('action center route follow-up API contract', () => {
+  it('returns 400 when trigger_reason is missing', async () => {
+    const request = buildFollowUpRequest()
+    delete (request as { trigger_reason?: string }).trigger_reason
+
+    const response = await postFollowUp(request)
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({
+      detail: expect.stringMatching(/trigger[_ ]reason/i),
+    })
+  })
+
+  it('returns 400 when manager_user_id is missing', async () => {
+    const request = buildFollowUpRequest()
+    delete (request as { manager_user_id?: string }).manager_user_id
+
+    const response = await postFollowUp(request)
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({
+      detail: expect.stringMatching(/manager_user_id/i),
+    })
+  })
+
+  it('returns 400 when source_campaign_id is malformed', async () => {
+    const response = await postFollowUp(
+      buildFollowUpRequest({
+        source_campaign_id: 'not-a-uuid',
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({
+      detail: expect.stringMatching(/source_campaign_id/i),
+    })
+  })
+
+  it('returns 400 when target_campaign_id is malformed', async () => {
+    const response = await postFollowUp(
+      buildFollowUpRequest({
+        target_campaign_id: 'not-a-uuid',
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({
+      detail: expect.stringMatching(/target_campaign_id/i),
+    })
+  })
+
+  it('returns 400 when manager_user_id is malformed', async () => {
+    const response = await postFollowUp(
+      buildFollowUpRequest({
+        manager_user_id: 'not-a-uuid',
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({
+      detail: expect.stringMatching(/manager_user_id/i),
+    })
+  })
+
+  it('returns 403 when a manager-only actor tries to create a follow-up route relation', async () => {
+    mockState.memberRole = null
+    mockState.workspaceMemberships = [
+      {
+        org_id: 'org-1',
+        access_role: 'manager_assignee',
+        scope_value: 'org-1::department::operations',
+        can_update: true,
+      },
+    ]
+
+    const response = await postFollowUp(buildFollowUpRequest())
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toMatchObject({
+      detail: expect.stringMatching(/HR|Verisight/i),
+    })
+  })
+
+  it('returns 403 when a plain org member without explicit HR workspace access tries to create a follow-up route relation', async () => {
+    mockState.memberRole = 'member'
+    mockState.workspaceMemberships = []
+
+    const response = await postFollowUp(buildFollowUpRequest())
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toMatchObject({
+      detail: expect.stringMatching(/HR|Verisight/i),
+    })
+  })
+
+  it('returns 400 when trigger_reason is invalid', async () => {
+    mockState.workspaceMemberships = [
+      {
+        org_id: 'org-1',
+        user_id: HR_USER_ID,
+        access_role: 'hr_member',
+        scope_value: 'org-1::org::org-1',
+        can_update: true,
+      },
+    ]
+
+    const response = await postFollowUp(
+      buildFollowUpRequest({
+        trigger_reason: 'onbekend-signaal',
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({
+      detail: expect.stringMatching(/trigger_reason/i),
+    })
+  })
+
+  it('returns 400 when manager_user_id is not assigned as a manager for the target route scope', async () => {
+    mockState.workspaceMemberships = [
+      {
+        org_id: 'org-1',
+        user_id: HR_USER_ID,
+        access_role: 'hr_member',
+        scope_value: 'org-1::org::org-1',
+        can_update: true,
+      },
+    ]
+
+    const response = await postFollowUp(
+      buildFollowUpRequest({
+        manager_user_id: OTHER_MANAGER_USER_ID,
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({
+      detail: expect.stringMatching(/manager_user_id|manager assignee/i),
+    })
+  })
+
+  it('returns 409 when an active direct follow-up relation already exists for the same closed source route', async () => {
+    mockState.workspaceMemberships = [
+      {
+        org_id: 'org-1',
+        user_id: HR_USER_ID,
+        access_role: 'hr_member',
+        scope_value: 'org-1::org::org-1',
+        can_update: true,
+      },
+    ]
+    mockState.existingActiveRelations = [
+      {
+        id: 'relation-direct-follow-up-1',
+        route_relation_type: 'follow-up-from',
+        source_route_id: `${SOURCE_CAMPAIGN_ID}::org-1::department::operations`,
+        target_route_id: `${TARGET_CAMPAIGN_ID}::org-1::department::operations`,
+        trigger_reason: 'nieuw-campaign-signaal',
+        ended_at: null,
+      },
+    ]
+
+    const response = await postFollowUp(
+      buildFollowUpRequest({
+        target_campaign_id: TARGET_NEXT_CAMPAIGN_ID,
+      }),
+    )
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toMatchObject({
+      detail: expect.stringMatching(/active direct follow-up/i),
+    })
+  })
+
+  it('returns 409 when the source route has no closeout state yet', async () => {
+    mockState.workspaceMemberships = [
+      {
+        org_id: 'org-1',
+        user_id: HR_USER_ID,
+        access_role: 'hr_member',
+        scope_value: 'org-1::org::org-1',
+        can_update: true,
+      },
+    ]
+    delete mockState.routeCloseouts[`${SOURCE_CAMPAIGN_ID}::org-1::department::operations`]
+
+    const response = await postFollowUp(buildFollowUpRequest())
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toMatchObject({
+      detail: expect.stringMatching(/closed source route/i),
+    })
+  })
+
+  it('returns 400 when source and target campaigns do not belong to the same organization', async () => {
+    const response = await postFollowUp(
+      buildFollowUpRequest({
+        target_campaign_id: CROSS_ORG_CAMPAIGN_ID,
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({
+      detail: expect.stringMatching(/zelfde org|same org/i),
+    })
+  })
+
+  it('returns 400 when the target route scope differs from the closed source route scope', async () => {
+    mockState.workspaceMemberships = [
+      {
+        org_id: 'org-1',
+        user_id: HR_USER_ID,
+        access_role: 'hr_member',
+        scope_value: 'org-1::org::org-1',
+        can_update: true,
+      },
+    ]
+    mockState.managerWorkspaceMemberships = [
+      {
+        org_id: 'org-1',
+        user_id: MANAGER_USER_ID,
+        access_role: 'manager_assignee',
+        scope_value: 'org-1::department::finance',
+        can_view: true,
+        can_update: true,
+      },
+    ]
+
+    const response = await postFollowUp(
+      buildFollowUpRequest({
+        target_route_scope_value: 'org-1::department::finance',
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    expect(mockState.createdManagerResponses).toHaveLength(0)
+    expect(mockState.insertedRelations).toHaveLength(0)
+    await expect(response.json()).resolves.toMatchObject({
+      detail: expect.stringMatching(/zelfde scope|same scope|dezelfde afdeling context/i),
+    })
+  })
+
+  it('returns 400 when a department-scope follow-up uses a foreign-org department scope value', async () => {
+    mockState.workspaceMemberships = [
+      {
+        org_id: 'org-1',
+        user_id: HR_USER_ID,
+        access_role: 'hr_member',
+        scope_value: 'org-1::org::org-1',
+        can_update: true,
+      },
+    ]
+
+    const response = await postFollowUp(
+      buildFollowUpRequest({
+        source_route_scope_value: 'org-2::department::operations',
+        target_route_scope_value: 'org-2::department::operations',
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    expect(mockState.createdManagerResponses).toHaveLength(0)
+    expect(mockState.insertedRelations).toHaveLength(0)
+    await expect(response.json()).resolves.toMatchObject({
+      detail: expect.stringMatching(/ongeldige|campaign|scope|afdeling/i),
+    })
+  })
+
+  it('returns 400 when a department-scope follow-up uses a malformed department scope value', async () => {
+    mockState.workspaceMemberships = [
+      {
+        org_id: 'org-1',
+        user_id: HR_USER_ID,
+        access_role: 'hr_member',
+        scope_value: 'org-1::org::org-1',
+        can_update: true,
+      },
+    ]
+
+    const response = await postFollowUp(
+      buildFollowUpRequest({
+        source_route_scope_value: 'org-1::department::operations::extra',
+        target_route_scope_value: 'org-1::department::operations::extra',
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    expect(mockState.createdManagerResponses).toHaveLength(0)
+    expect(mockState.insertedRelations).toHaveLength(0)
+    await expect(response.json()).resolves.toMatchObject({
+      detail: expect.stringMatching(/ongeldige|campaign|scope|afdeling/i),
+    })
+  })
+
+  it('returns 400 when an item-scope follow-up is requested because V1 only supports department scopes', async () => {
+    mockState.workspaceMemberships = [
+      {
+        org_id: 'org-1',
+        user_id: HR_USER_ID,
+        access_role: 'hr_member',
+        scope_value: 'org-1::org::org-1',
+        can_update: true,
+      },
+    ]
+    mockState.managerWorkspaceMemberships = [
+      {
+        org_id: 'org-1',
+        user_id: MANAGER_USER_ID,
+        access_role: 'manager_assignee',
+        scope_value: TARGET_ITEM_SCOPE_VALUE,
+        can_view: true,
+        can_update: true,
+      },
+    ]
+    mockState.routeCloseouts[`${SOURCE_CAMPAIGN_ID}::${SOURCE_ITEM_SCOPE_VALUE}`] = {
+      route_id: `${SOURCE_CAMPAIGN_ID}::${SOURCE_ITEM_SCOPE_VALUE}`,
+      closed_at: '2026-04-22T09:00:00.000Z',
+    }
+
+    const response = await postFollowUp(
+      buildFollowUpRequest({
+        source_route_scope_value: SOURCE_ITEM_SCOPE_VALUE,
+        target_route_scope_value: TARGET_ITEM_SCOPE_VALUE,
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    expect(mockState.createdManagerResponses).toHaveLength(0)
+    expect(mockState.insertedRelations).toHaveLength(0)
+    await expect(response.json()).resolves.toMatchObject({
+      detail: expect.stringMatching(/V1 follow-up routes|department scopes|alleen.*department/i),
+    })
+  })
+
+  it('returns 400 for mixed-case item-scope follow-up requests because V1 only supports department scopes', async () => {
+    mockState.workspaceMemberships = [
+      {
+        org_id: 'org-1',
+        user_id: HR_USER_ID,
+        access_role: 'hr_member',
+        scope_value: 'org-1::org::org-1',
+        can_update: true,
+      },
+    ]
+    mockState.managerWorkspaceMemberships = [
+      {
+        org_id: 'org-1',
+        user_id: MANAGER_USER_ID,
+        access_role: 'manager_assignee',
+        scope_value: TARGET_ITEM_SCOPE_VALUE,
+        can_view: true,
+        can_update: true,
+      },
+    ]
+    mockState.routeCloseouts[`${SOURCE_CAMPAIGN_ID}::${SOURCE_ITEM_SCOPE_VALUE}`] = {
+      route_id: `${SOURCE_CAMPAIGN_ID}::${SOURCE_ITEM_SCOPE_VALUE}`,
+      closed_at: '2026-04-22T09:00:00.000Z',
+    }
+
+    const response = await postFollowUp(
+      buildFollowUpRequest({
+        source_campaign_id: SOURCE_CAMPAIGN_ID_MIXED_CASE,
+        source_route_scope_value: SOURCE_ITEM_SCOPE_VALUE_MIXED_CASE,
+        target_campaign_id: TARGET_CAMPAIGN_ID_MIXED_CASE,
+        target_route_scope_value: TARGET_ITEM_SCOPE_VALUE_MIXED_CASE,
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    expect(mockState.createdManagerResponses).toHaveLength(0)
+    expect(mockState.insertedRelations).toHaveLength(0)
+    await expect(response.json()).resolves.toMatchObject({
+      detail: expect.stringMatching(/V1 follow-up routes|department scopes|alleen.*department/i),
+    })
+  })
+
+  it('returns 400 when an item-scope target is supplied because V1 only supports department scopes', async () => {
+    mockState.workspaceMemberships = [
+      {
+        org_id: 'org-1',
+        user_id: HR_USER_ID,
+        access_role: 'hr_member',
+        scope_value: 'org-1::org::org-1',
+        can_update: true,
+      },
+    ]
+    mockState.managerWorkspaceMemberships = [
+      {
+        org_id: 'org-1',
+        user_id: MANAGER_USER_ID,
+        access_role: 'manager_assignee',
+        scope_value: SOURCE_ITEM_SCOPE_VALUE,
+        can_view: true,
+        can_update: true,
+      },
+    ]
+    mockState.routeCloseouts[`${SOURCE_CAMPAIGN_ID}::${SOURCE_ITEM_SCOPE_VALUE}`] = {
+      route_id: `${SOURCE_CAMPAIGN_ID}::${SOURCE_ITEM_SCOPE_VALUE}`,
+      closed_at: '2026-04-22T09:00:00.000Z',
+    }
+
+    const response = await postFollowUp(
+      buildFollowUpRequest({
+        source_route_scope_value: SOURCE_ITEM_SCOPE_VALUE,
+        target_route_scope_value: SOURCE_ITEM_SCOPE_VALUE,
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    expect(mockState.createdManagerResponses).toHaveLength(0)
+    expect(mockState.insertedRelations).toHaveLength(0)
+    await expect(response.json()).resolves.toMatchObject({
+      detail: expect.stringMatching(/V1 follow-up routes|department scopes|alleen.*department/i),
+    })
+  })
+
+  it('returns 409 when source and target resolve to the same route instead of a new follow-up handoff', async () => {
+    mockState.workspaceMemberships = [
+      {
+        org_id: 'org-1',
+        user_id: HR_USER_ID,
+        access_role: 'hr_member',
+        scope_value: 'org-1::org::org-1',
+        can_update: true,
+      },
+    ]
+
+    const response = await postFollowUp(
+      buildFollowUpRequest({
+        target_campaign_id: SOURCE_CAMPAIGN_ID,
+      }),
+    )
+
+    expect(response.status).toBe(409)
+    expect(mockState.createdManagerResponses).toHaveLength(0)
+    expect(mockState.insertedRelations).toHaveLength(0)
+    await expect(response.json()).resolves.toMatchObject({
+      detail: expect.stringMatching(/nieuwe route|zelfde route|follow-up handoff/i),
+    })
+  })
+
+  it('returns 409 when a target route manager response already exists so the handoff would overwrite manager-owned data', async () => {
+    mockState.workspaceMemberships = [
+      {
+        org_id: 'org-1',
+        user_id: HR_USER_ID,
+        access_role: 'hr_member',
+        scope_value: 'org-1::org::org-1',
+        can_update: true,
+      },
+    ]
+    mockState.existingManagerResponses = [
+      {
+        id: 'manager-response-existing-1',
+        campaign_id: TARGET_CAMPAIGN_ID,
+        org_id: 'org-1',
+        route_scope_type: 'department',
+        route_scope_value: 'org-1::department::operations',
+        manager_user_id: MANAGER_USER_ID,
+        response_type: 'watch',
+        response_note: 'Bestaande managerreactie.',
+      },
+    ]
+
+    const response = await postFollowUp(buildFollowUpRequest())
+
+    expect(response.status).toBe(409)
+    expect(mockState.createdManagerResponses).toHaveLength(0)
+    expect(mockState.insertedRelations).toHaveLength(0)
+    await expect(response.json()).resolves.toMatchObject({
+      detail: expect.stringMatching(/manager response|managerreactie|bestaat al/i),
+    })
+  })
+
+  it('persists trigger_reason on a new follow-up relation row for a matching manager assignee', async () => {
+    mockState.workspaceMemberships = [
+      {
+        org_id: 'org-1',
+        user_id: HR_USER_ID,
+        access_role: 'hr_member',
+        scope_value: 'org-1::org::org-1',
+        can_update: true,
+      },
+    ]
+    mockState.existingActiveRelations = [
+      {
+        id: 'relation-unrelated-type',
+        route_relation_type: 'depends-on',
+        source_route_id: `${SOURCE_CAMPAIGN_ID}::org-1::department::operations`,
+        target_route_id: `${TARGET_CAMPAIGN_ID}::org-1::department::operations`,
+        trigger_reason: 'nieuw-campaign-signaal',
+        ended_at: null,
+      },
+      {
+        id: 'relation-unrelated-source',
+        route_relation_type: 'follow-up-from',
+        source_route_id: `${TARGET_NEXT_CAMPAIGN_ID}::org-1::department::operations`,
+        target_route_id: `${TARGET_CAMPAIGN_ID}::org-1::department::operations`,
+        trigger_reason: 'nieuw-campaign-signaal',
+        ended_at: null,
+      },
+    ]
+
+    const response = await postFollowUp(
+      buildFollowUpRequest({
+        trigger_reason: 'hernieuwde-hr-beoordeling',
+        manager_user_id: MANAGER_USER_ID,
+      }),
+    )
+
+    expect(response.status).toBe(201)
+    expect(mockState.createdManagerResponses).toHaveLength(1)
+    expect(mockState.createdManagerResponses[0]).toMatchObject({
+      campaign_id: TARGET_CAMPAIGN_ID,
+      org_id: 'org-1',
+      route_scope_type: 'department',
+      route_scope_value: 'org-1::department::operations',
+      manager_user_id: MANAGER_USER_ID,
+      response_type: 'schedule',
+      response_note: 'Vervolgroute geopend door HR.',
+      primary_action_theme_key: null,
+      primary_action_text: null,
+      primary_action_expected_effect: null,
+      primary_action_status: null,
+      created_by: HR_USER_ID,
+      updated_by: HR_USER_ID,
+    })
+    expect(mockState.createdManagerResponses[0].review_scheduled_for).toEqual(expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/))
+    expect(mockState.insertedRelations).toHaveLength(1)
+    expect(mockState.insertedRelations[0]).toMatchObject({
+      org_id: 'org-1',
+      route_relation_type: 'follow-up-from',
+      source_campaign_id: SOURCE_CAMPAIGN_ID,
+      source_route_id: `${SOURCE_CAMPAIGN_ID}::org-1::department::operations`,
+      source_route_scope_value: 'org-1::department::operations',
+      target_campaign_id: TARGET_CAMPAIGN_ID,
+      target_route_id: `${TARGET_CAMPAIGN_ID}::org-1::department::operations`,
+      target_route_scope_value: 'org-1::department::operations',
+      trigger_reason: 'hernieuwde-hr-beoordeling',
+      recorded_by: HR_USER_ID,
+      recorded_by_role: 'hr_member',
+      manager_user_id: MANAGER_USER_ID,
+      ended_at: null,
+    })
+    await expect(response.json()).resolves.toMatchObject({
+      relation: expect.objectContaining({
+        trigger_reason: 'hernieuwde-hr-beoordeling',
+        manager_user_id: MANAGER_USER_ID,
+      }),
+    })
+  })
+
+  it('returns 409 when the insert hits the active direct follow-up unique constraint', async () => {
+    mockState.workspaceMemberships = [
+      {
+        org_id: 'org-1',
+        user_id: HR_USER_ID,
+        access_role: 'hr_member',
+        scope_value: 'org-1::org::org-1',
+        can_update: true,
+      },
+    ]
+    mockState.insertConflict = true
+
+    const response = await postFollowUp(buildFollowUpRequest())
+
+    expect(response.status).toBe(409)
+    expect(mockState.createdManagerResponses).toHaveLength(1)
+    expect(mockState.deletedManagerResponseIds).toEqual(['manager-response-1'])
+    expect(mockState.existingManagerResponses).toHaveLength(0)
+    expect(mockState.insertedRelations).toHaveLength(0)
+    await expect(response.json()).resolves.toMatchObject({
+      detail: expect.stringMatching(/active direct follow-up/i),
+    })
+  })
+
+  it('returns 409 when the manager response carrier insert hits the unique constraint first', async () => {
+    mockState.workspaceMemberships = [
+      {
+        org_id: 'org-1',
+        user_id: HR_USER_ID,
+        access_role: 'hr_member',
+        scope_value: 'org-1::org::org-1',
+        can_update: true,
+      },
+    ]
+    mockState.managerResponseInsertConflict = true
+
+    const response = await postFollowUp(buildFollowUpRequest())
+
+    expect(response.status).toBe(409)
+    expect(mockState.createdManagerResponses).toHaveLength(0)
+    expect(mockState.deletedManagerResponseIds).toHaveLength(0)
+    expect(mockState.insertedRelations).toHaveLength(0)
+    await expect(response.json()).resolves.toMatchObject({
+      detail: expect.stringMatching(/manager response carrier|overschrijven is in V1 niet toegestaan|bestaat al/i),
+    })
+  })
+})

--- a/frontend/app/api/action-center-route-follow-ups/route.ts
+++ b/frontend/app/api/action-center-route-follow-ups/route.ts
@@ -1,0 +1,609 @@
+import { NextResponse } from 'next/server'
+import {
+  buildCampaignItemScopeValue,
+  buildDepartmentScopeValue,
+  inferActionCenterManagerResponseScopeType,
+  normalizeCampaignIdentifier,
+  parseActionCenterManagerResponseScopeValue,
+  type ActionCenterManagerResponseScopeType,
+  type ActionCenterManagerResponseWriteInput,
+} from '@/lib/action-center-manager-responses'
+import { buildActionCenterRouteId } from '@/lib/action-center-route-contract'
+import { projectActionCenterRouteFollowUpRelation } from '@/lib/action-center-route-reopen'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { createClient } from '@/lib/supabase/server'
+import { loadSuiteAccessContext } from '@/lib/suite-access-server'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+type FollowUpRouteBody = {
+  source_campaign_id?: string | null
+  source_route_scope_value?: string | null
+  target_campaign_id?: string | null
+  target_route_scope_value?: string | null
+  trigger_reason?: string | null
+  manager_user_id?: string | null
+}
+
+type CampaignRow = {
+  id: string
+  organization_id: string | null
+}
+
+type RouteCloseoutRow = {
+  route_id: string
+  closed_at: string | null
+}
+
+type ManagerResponseCarrierRow = {
+  id: string
+  campaign_id: string
+  route_scope_type: 'department' | 'item'
+  route_scope_value: string
+}
+
+type FollowUpWriteAccess = {
+  recordedByRole: 'verisight_admin' | 'hr_owner' | 'hr_member'
+}
+
+type ManagerAssignmentRow = {
+  org_id: string
+  user_id: string
+  access_role: 'manager_assignee'
+  scope_value: string
+  can_view: boolean
+  can_update: boolean
+}
+
+function normalizeText(value: string | null | undefined) {
+  const trimmed = value?.trim() ?? ''
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function getCanonicalCampaignRouteScope(args: {
+  campaignId: string
+  campaignOrgId: string
+  routeScopeValue: string
+}) {
+  const parsedScope = parseActionCenterManagerResponseScopeValue(args.routeScopeValue)
+  const routeScopeType = inferActionCenterManagerResponseScopeType(args.routeScopeValue)
+
+  if (routeScopeType === 'item') {
+    const canonicalItemScopeValue = buildCampaignItemScopeValue(args.campaignOrgId, args.campaignId)
+    return {
+      routeScopeType,
+      routeScopeValue: canonicalItemScopeValue,
+      isCanonical:
+        parsedScope.orgId === args.campaignOrgId && parsedScope.canonicalScopeValue === canonicalItemScopeValue,
+    }
+  }
+
+  const canonicalDepartmentScopeValue = buildDepartmentScopeValue(args.campaignOrgId, parsedScope.scopeKey)
+
+  return {
+    routeScopeType,
+    routeScopeValue: canonicalDepartmentScopeValue,
+    isCanonical: parsedScope.orgId === args.campaignOrgId && args.routeScopeValue === canonicalDepartmentScopeValue,
+  }
+}
+
+function validateFollowUpScopeContext(args: {
+  sourceCampaignId: string
+  sourceCampaignOrgId: string
+  sourceRouteScopeValue: string
+  targetCampaignId: string
+  targetCampaignOrgId: string
+  targetRouteScopeValue: string
+}) {
+  const sourceScope = getCanonicalCampaignRouteScope({
+    campaignId: args.sourceCampaignId,
+    campaignOrgId: args.sourceCampaignOrgId,
+    routeScopeValue: args.sourceRouteScopeValue,
+  })
+  const targetScope = getCanonicalCampaignRouteScope({
+    campaignId: args.targetCampaignId,
+    campaignOrgId: args.targetCampaignOrgId,
+    routeScopeValue: args.targetRouteScopeValue,
+  })
+
+  if (sourceScope.routeScopeType === 'item' || targetScope.routeScopeType === 'item') {
+    throw new Error('V1 follow-up routes worden alleen ondersteund voor department scopes.')
+  }
+
+  if (sourceScope.routeScopeType !== targetScope.routeScopeType) {
+    throw new Error('V1 follow-up route-triggers moeten binnen dezelfde scope of afdeling-context blijven.')
+  }
+
+  if (sourceScope.routeScopeType === 'department') {
+    if (!sourceScope.isCanonical || !targetScope.isCanonical) {
+      throw new Error(
+        'V1 department-scope follow-up route-triggers moeten de canonieke afdeling-scope voor bron en doel gebruiken.',
+      )
+    }
+
+    if (sourceScope.routeScopeValue !== targetScope.routeScopeValue) {
+      throw new Error('V1 follow-up route-triggers moeten binnen dezelfde scope of afdeling-context blijven.')
+    }
+  }
+
+  return {
+    routeScopeType: sourceScope.routeScopeType as ActionCenterManagerResponseScopeType,
+    sourceRouteScopeValue: sourceScope.routeScopeValue,
+    targetRouteScopeValue: targetScope.routeScopeValue,
+  }
+}
+
+function isUuidLike(value: string) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)
+}
+
+function buildFollowUpManagerResponse(args: {
+  campaignId: string
+  orgId: string
+  routeScopeType: 'department' | 'item'
+  routeScopeValue: string
+  managerUserId: string
+}): ActionCenterManagerResponseWriteInput {
+  return {
+    campaign_id: args.campaignId,
+    org_id: args.orgId,
+    route_scope_type: args.routeScopeType,
+    route_scope_value: args.routeScopeValue,
+    manager_user_id: args.managerUserId,
+    response_type: 'schedule',
+    response_note: 'Vervolgroute geopend door HR.',
+    review_scheduled_for: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10),
+    primary_action_theme_key: null,
+    primary_action_text: null,
+    primary_action_expected_effect: null,
+    primary_action_status: null,
+  }
+}
+
+function parseFollowUpBody(input: FollowUpRouteBody | null) {
+  const sourceCampaignId = normalizeCampaignIdentifier(input?.source_campaign_id)
+  const sourceRouteScopeValue = normalizeText(input?.source_route_scope_value)
+  const targetCampaignId = normalizeCampaignIdentifier(input?.target_campaign_id)
+  const targetRouteScopeValue = normalizeText(input?.target_route_scope_value)
+  const triggerReason = normalizeText(input?.trigger_reason)
+  const managerUserId = normalizeText(input?.manager_user_id)
+
+  if (!sourceCampaignId || !sourceRouteScopeValue || !targetCampaignId || !targetRouteScopeValue) {
+    throw new Error('source_campaign_id, source_route_scope_value, target_campaign_id en target_route_scope_value zijn verplicht.')
+  }
+
+  if (!triggerReason) {
+    throw new Error('trigger_reason is verplicht.')
+  }
+
+  if (!managerUserId) {
+    throw new Error('manager_user_id is verplicht.')
+  }
+
+  if (!isUuidLike(sourceCampaignId)) {
+    throw new Error('source_campaign_id moet een geldige UUID zijn.')
+  }
+
+  if (!isUuidLike(targetCampaignId)) {
+    throw new Error('target_campaign_id moet een geldige UUID zijn.')
+  }
+
+  if (!isUuidLike(managerUserId)) {
+    throw new Error('manager_user_id moet een geldige UUID zijn.')
+  }
+
+  return {
+    sourceCampaignId,
+    sourceRouteScopeValue,
+    targetCampaignId,
+    targetRouteScopeValue,
+    triggerReason,
+    managerUserId,
+  }
+}
+
+async function loadManagerAssignment(args: {
+  adminClient: ReturnType<typeof createAdminClient>
+  orgId: string
+  managerUserId: string
+  scopeValue: string
+}) {
+  const { data, error } = await args.adminClient
+    .from('action_center_workspace_members')
+    .select('org_id, user_id, access_role, scope_value, can_view, can_update')
+    .eq('org_id', args.orgId)
+    .eq('user_id', args.managerUserId)
+    .eq('access_role', 'manager_assignee')
+    .eq('scope_value', args.scopeValue)
+    .maybeSingle()
+
+  if (error) {
+    return { assignment: null, error }
+  }
+
+  return {
+    assignment: (data ?? null) as ManagerAssignmentRow | null,
+    error: null,
+  }
+}
+
+async function resolveFollowUpWriteAccess(args: { supabase: SupabaseClient; userId: string; orgId: string }) {
+  const { context, orgMemberships, workspaceMemberships } = await loadSuiteAccessContext(args.supabase, args.userId)
+
+  if (context.isVerisightAdmin) {
+    return { access: { recordedByRole: 'verisight_admin' } satisfies FollowUpWriteAccess, error: null }
+  }
+
+  const orgMembership = orgMemberships.find((membership) => membership.org_id === args.orgId) ?? null
+  if (orgMembership?.role === 'owner') {
+    return { access: { recordedByRole: 'hr_owner' } satisfies FollowUpWriteAccess, error: null }
+  }
+
+  const hrWorkspaceMembership =
+    workspaceMemberships.find(
+      (membership) =>
+        membership.org_id === args.orgId &&
+        (membership.access_role === 'hr_owner' || membership.access_role === 'hr_member') &&
+        membership.can_update,
+    ) ?? null
+
+  if (hrWorkspaceMembership) {
+    const recordedByRole: FollowUpWriteAccess['recordedByRole'] =
+      hrWorkspaceMembership.access_role === 'hr_owner' ? 'hr_owner' : 'hr_member'
+
+    return {
+      access: {
+        recordedByRole,
+      } satisfies FollowUpWriteAccess,
+      error: null,
+    }
+  }
+
+  return {
+    access: null,
+    error: NextResponse.json(
+      { detail: 'Alleen HR of Verisight kan een follow-up route-trigger vastleggen.' },
+      { status: 403 },
+    ),
+  }
+}
+
+async function loadCampaign(adminClient: ReturnType<typeof createAdminClient>, campaignId: string) {
+  const { data, error } = await adminClient
+    .from('campaigns')
+    .select('id, organization_id')
+    .eq('id', campaignId)
+    .maybeSingle()
+
+  if (error) {
+    return { campaign: null, error }
+  }
+
+  return {
+    campaign: (data ?? null) as CampaignRow | null,
+    error: null,
+  }
+}
+
+async function loadRouteCloseout(adminClient: ReturnType<typeof createAdminClient>, routeId: string) {
+  const { data, error } = await adminClient
+    .from('action_center_route_closeouts')
+    .select('route_id, closed_at')
+    .eq('route_id', routeId)
+    .maybeSingle()
+
+  if (error) {
+    return { closeout: null, error }
+  }
+
+  return {
+    closeout: (data ?? null) as RouteCloseoutRow | null,
+    error: null,
+  }
+}
+
+async function loadExistingManagerResponseCarrier(args: {
+  adminClient: ReturnType<typeof createAdminClient>
+  campaignId: string
+  routeScopeType: 'department' | 'item'
+  routeScopeValue: string
+}) {
+  const { data, error } = await args.adminClient
+    .from('action_center_manager_responses')
+    .select('id, campaign_id, route_scope_type, route_scope_value')
+    .eq('campaign_id', args.campaignId)
+    .eq('route_scope_type', args.routeScopeType)
+    .eq('route_scope_value', args.routeScopeValue)
+    .maybeSingle()
+
+  if (error) {
+    return { response: null, error }
+  }
+
+  return {
+    response: (data ?? null) as ManagerResponseCarrierRow | null,
+    error: null,
+  }
+}
+
+async function deleteManagerResponseCarrier(args: {
+  adminClient: ReturnType<typeof createAdminClient>
+  id: string
+  campaignId: string
+}) {
+  const { error } = await args.adminClient
+    .from('action_center_manager_responses')
+    .delete()
+    .eq('id', args.id)
+    .eq('campaign_id', args.campaignId)
+
+  return { error: error ?? null }
+}
+
+export async function POST(request: Request) {
+  const body = (await request.json().catch(() => null)) as FollowUpRouteBody | null
+
+  let parsed
+  try {
+    parsed = parseFollowUpBody(body)
+  } catch (error) {
+    return NextResponse.json(
+      { detail: error instanceof Error ? error.message : 'Ongeldige follow-up route request.' },
+      { status: 400 },
+    )
+  }
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ detail: 'Niet ingelogd.' }, { status: 401 })
+  }
+
+  const adminClient = createAdminClient()
+  const [sourceResult, targetResult] = await Promise.all([
+    loadCampaign(adminClient, parsed.sourceCampaignId),
+    loadCampaign(adminClient, parsed.targetCampaignId),
+  ])
+
+  if (sourceResult.error) {
+    return NextResponse.json({ detail: sourceResult.error.message }, { status: 500 })
+  }
+
+  if (targetResult.error) {
+    return NextResponse.json({ detail: targetResult.error.message }, { status: 500 })
+  }
+
+  if (!sourceResult.campaign?.id || !sourceResult.campaign.organization_id) {
+    return NextResponse.json({ detail: 'Broncampagne niet gevonden.' }, { status: 404 })
+  }
+
+  if (!targetResult.campaign?.id || !targetResult.campaign.organization_id) {
+    return NextResponse.json({ detail: 'Doelcampagne niet gevonden.' }, { status: 404 })
+  }
+
+  if (sourceResult.campaign.organization_id !== targetResult.campaign.organization_id) {
+    return NextResponse.json({ detail: 'Source en target moeten binnen dezelfde org vallen.' }, { status: 400 })
+  }
+
+  let scopeContext
+  try {
+    scopeContext = validateFollowUpScopeContext({
+      sourceCampaignId: parsed.sourceCampaignId,
+      sourceCampaignOrgId: sourceResult.campaign.organization_id,
+      sourceRouteScopeValue: parsed.sourceRouteScopeValue,
+      targetCampaignId: parsed.targetCampaignId,
+      targetCampaignOrgId: targetResult.campaign.organization_id,
+      targetRouteScopeValue: parsed.targetRouteScopeValue,
+    })
+  } catch (error) {
+    return NextResponse.json(
+      { detail: error instanceof Error ? error.message : 'Ongeldige follow-up route-identiteit.' },
+      { status: 400 },
+    )
+  }
+
+  const access = await resolveFollowUpWriteAccess({
+    supabase,
+    userId: user.id,
+    orgId: sourceResult.campaign.organization_id,
+  })
+  if (access.error || !access.access) {
+    return access.error
+  }
+
+  const sourceRouteId = buildActionCenterRouteId(parsed.sourceCampaignId, scopeContext.sourceRouteScopeValue)
+  const targetRouteId = buildActionCenterRouteId(parsed.targetCampaignId, scopeContext.targetRouteScopeValue)
+
+  if (sourceRouteId === targetRouteId) {
+    return NextResponse.json(
+      { detail: 'Een follow-up route-trigger moet een nieuwe route of manager handoff openen, niet dezelfde route hergebruiken.' },
+      { status: 409 },
+    )
+  }
+
+  const sourceCloseoutResult = await loadRouteCloseout(adminClient, sourceRouteId)
+  if (sourceCloseoutResult.error) {
+    return NextResponse.json({ detail: sourceCloseoutResult.error.message }, { status: 500 })
+  }
+
+  if (!sourceCloseoutResult.closeout?.closed_at) {
+    return NextResponse.json(
+      { detail: 'Een follow-up route-trigger vereist eerst een closed source route.' },
+      { status: 409 },
+    )
+  }
+
+  const managerAssignmentResult = await loadManagerAssignment({
+    adminClient,
+    orgId: sourceResult.campaign.organization_id,
+    managerUserId: parsed.managerUserId,
+    scopeValue: scopeContext.targetRouteScopeValue,
+  })
+
+  if (managerAssignmentResult.error) {
+    return NextResponse.json({ detail: managerAssignmentResult.error.message }, { status: 500 })
+  }
+
+  if (
+    !managerAssignmentResult.assignment ||
+    !managerAssignmentResult.assignment.can_view ||
+    !managerAssignmentResult.assignment.can_update
+  ) {
+    return NextResponse.json(
+      { detail: 'manager_user_id moet een toegewezen manager assignee zijn voor deze follow-up route scope.' },
+      { status: 400 },
+    )
+  }
+
+  const nowIso = new Date().toISOString()
+
+  let relationTruth
+  try {
+    relationTruth = projectActionCenterRouteFollowUpRelation({
+      route_relation_type: 'follow-up-from',
+      source_route_id: sourceRouteId,
+      target_route_id: targetRouteId,
+      trigger_reason: parsed.triggerReason,
+      recorded_at: nowIso,
+      recorded_by_role: access.access.recordedByRole,
+    })
+  } catch (error) {
+    return NextResponse.json(
+      { detail: error instanceof Error ? error.message : 'Ongeldige follow-up route-relatie.' },
+      { status: 400 },
+    )
+  }
+
+  const { data: existingRelations, error: existingRelationsError } = await adminClient
+    .from('action_center_route_relations')
+    .select('id, route_relation_type, source_route_id, target_route_id, trigger_reason, ended_at')
+    .eq('route_relation_type', 'follow-up-from')
+    .eq('source_route_id', relationTruth.sourceRouteId)
+    .is('ended_at', null)
+
+  if (existingRelationsError) {
+    return NextResponse.json(
+      { detail: existingRelationsError.message ?? 'Bestaande follow-up route-relaties ophalen mislukt.' },
+      { status: 500 },
+    )
+  }
+
+  if ((existingRelations ?? []).length > 0) {
+    return NextResponse.json(
+      { detail: 'Er bestaat al een active direct follow-up voor deze gesloten bronroute.' },
+      { status: 409 },
+    )
+  }
+
+  const existingManagerResponseResult = await loadExistingManagerResponseCarrier({
+    adminClient,
+    campaignId: parsed.targetCampaignId,
+    routeScopeType: scopeContext.routeScopeType,
+    routeScopeValue: scopeContext.targetRouteScopeValue,
+  })
+
+  if (existingManagerResponseResult.error) {
+    return NextResponse.json(
+      { detail: existingManagerResponseResult.error.message ?? 'Bestaande manager handoff ophalen mislukt.' },
+      { status: 500 },
+    )
+  }
+
+  if (existingManagerResponseResult.response) {
+    return NextResponse.json(
+      { detail: 'Voor deze doelroute bestaat al een manager response carrier; overschrijven is in V1 niet toegestaan.' },
+      { status: 409 },
+    )
+  }
+
+  // V1 follow-up routes are opened through the existing manager-response carrier.
+  // HR does not create an action here; it only creates a new manager handoff route.
+  const { data: managerResponse, error: managerResponseError } = await adminClient
+    .from('action_center_manager_responses')
+    .insert({
+      ...buildFollowUpManagerResponse({
+        campaignId: parsed.targetCampaignId,
+        orgId: sourceResult.campaign.organization_id,
+        routeScopeType: scopeContext.routeScopeType,
+        routeScopeValue: scopeContext.targetRouteScopeValue,
+        managerUserId: parsed.managerUserId,
+      }),
+      created_by: user.id,
+      updated_by: user.id,
+      updated_at: nowIso,
+    })
+    .select('*')
+    .single()
+
+  if (managerResponseError?.code === '23505') {
+    return NextResponse.json(
+      { detail: 'Voor deze doelroute bestaat al een manager response carrier; overschrijven is in V1 niet toegestaan.' },
+      { status: 409 },
+    )
+  }
+
+  if (managerResponseError || !managerResponse) {
+    return NextResponse.json(
+      { detail: managerResponseError?.message ?? 'Vervolgroute openen mislukt.' },
+      { status: 500 },
+    )
+  }
+
+  const { data: insertedRelation, error: insertError } = await adminClient
+    .from('action_center_route_relations')
+    .insert({
+      org_id: sourceResult.campaign.organization_id,
+      source_campaign_id: parsed.sourceCampaignId,
+      source_route_id: relationTruth.sourceRouteId,
+      source_route_scope_value: scopeContext.sourceRouteScopeValue,
+      target_campaign_id: parsed.targetCampaignId,
+      target_route_id: relationTruth.targetRouteId,
+      target_route_scope_value: scopeContext.targetRouteScopeValue,
+      route_relation_type: relationTruth.routeRelationType,
+      trigger_reason: relationTruth.triggerReason,
+      manager_user_id: parsed.managerUserId,
+      recorded_by: user.id,
+      recorded_by_role: relationTruth.recordedByRole,
+      recorded_at: relationTruth.recordedAt,
+      ended_at: relationTruth.endedAt ?? null,
+    })
+    .select('*')
+    .single()
+
+  if (insertError || !insertedRelation) {
+    const rollbackResult = await deleteManagerResponseCarrier({
+      adminClient,
+      id: managerResponse.id,
+      campaignId: parsed.targetCampaignId,
+    })
+
+    if (rollbackResult.error) {
+      return NextResponse.json(
+        {
+          detail:
+            rollbackResult.error.message ??
+            'Follow-up route-relatie opslaan mislukte en de nieuwe manager handoff kon niet worden teruggedraaid.',
+        },
+        { status: 500 },
+      )
+    }
+  }
+
+  if (insertError?.code === '23505') {
+    return NextResponse.json(
+      { detail: 'Er bestaat al een active direct follow-up voor deze gesloten bronroute.' },
+      { status: 409 },
+    )
+  }
+
+  if (insertError || !insertedRelation) {
+    return NextResponse.json(
+      { detail: insertError?.message ?? 'Follow-up route-relatie opslaan mislukt.' },
+      { status: 500 },
+    )
+  }
+
+  return NextResponse.json({ relation: insertedRelation }, { status: 201 })
+}

--- a/frontend/components/dashboard/action-center-preview.tsx
+++ b/frontend/components/dashboard/action-center-preview.tsx
@@ -12,6 +12,10 @@ import {
   getActionCenterManagerResponseLabel,
   hasPrimaryManagerAction,
 } from '@/lib/action-center-manager-responses'
+import {
+  getActionCenterFollowUpTriggerReasonLabel,
+  type ActionCenterRouteFollowUpTriggerReason,
+} from '@/lib/action-center-route-reopen'
 import { finalizeActionCenterPreviewItem } from '@/lib/action-center-live'
 import type {
   ActionCenterPreviewItem,
@@ -47,6 +51,7 @@ interface Props {
   managerAssignmentEndpoint?: string
   canRespondToRequests?: boolean
   managerResponseEndpoint?: string
+  routeFollowUpEndpoint?: string
   currentUserId?: string | null
   workbenchHref: string
   workbenchLabel?: string
@@ -78,6 +83,16 @@ interface ManagerResponseFormState {
   primaryActionExpectedEffect: string
 }
 
+interface FollowUpRouteFormState {
+  managerUserId: string
+  triggerReason: ActionCenterRouteFollowUpTriggerReason
+}
+
+type FollowUpRouteBlockReason =
+  | 'already-has-direct-active-successor'
+  | 'no-same-scope-target'
+  | 'ambiguous-same-scope-target'
+
 const SIDEBAR_ITEMS: Array<{ key: ActionCenterPreviewView; label: string }> = [
   { key: 'overview', label: 'Overzicht' },
   { key: 'actions', label: 'Acties' },
@@ -87,6 +102,11 @@ const SIDEBAR_ITEMS: Array<{ key: ActionCenterPreviewView; label: string }> = [
 ]
 
 const REVIEW_RHYTHM_OPTIONS = ['Wekelijks', 'Tweewekelijks', 'Maandelijks', 'Per kwartaal']
+const FOLLOW_UP_TRIGGER_REASON_OPTIONS: ActionCenterRouteFollowUpTriggerReason[] = [
+  'nieuw-campaign-signaal',
+  'nieuw-segment-signaal',
+  'hernieuwde-hr-beoordeling',
+]
 
 const DUTCH_SHORT_DATE = new Intl.DateTimeFormat('nl-NL', {
   day: 'numeric',
@@ -315,6 +335,10 @@ function supportsManagerResponseFlow(item: ActionCenterPreviewItem | null) {
   return item?.scopeType === 'department' || item?.scopeType === 'item'
 }
 
+function isClosedRouteStatus(status: ActionCenterPreviewStatus) {
+  return status === 'afgerond' || status === 'gestopt'
+}
+
 function isOpenAttentionStatus(status: ActionCenterPreviewStatus) {
   return status === 'open-verzoek' || status === 'te-bespreken' || status === 'geblokkeerd'
 }
@@ -455,6 +479,120 @@ function buildTeamRows(items: ActionCenterPreviewItem[]) {
   })
 }
 
+function getInitialFollowUpFormState(args: {
+  item: ActionCenterPreviewItem | null
+  assignmentOptions: ActionCenterPreviewManagerOption[]
+}): FollowUpRouteFormState {
+  const selectedOwnerId = args.item?.ownerId ?? null
+  const defaultManagerUserId =
+    (selectedOwnerId &&
+    args.assignmentOptions.some((option) => option.value === selectedOwnerId)
+      ? selectedOwnerId
+      : args.assignmentOptions[0]?.value) ?? ''
+
+  return {
+    managerUserId: defaultManagerUserId,
+    triggerReason: 'nieuw-campaign-signaal',
+  }
+}
+
+function findDirectActiveFollowUpSuccessor(args: {
+  items: ActionCenterPreviewItem[]
+  sourceRouteId: string
+}) {
+  return (
+    args.items.find(
+      (item) =>
+        item.coreSemantics.followUpSemantics?.isDirectSuccessor === true &&
+        item.coreSemantics.followUpSemantics?.sourceRouteId === args.sourceRouteId &&
+        !isClosedRouteStatus(item.status),
+    ) ?? null
+  )
+}
+
+function resolveSameScopeFollowUpTarget(args: {
+  items: ActionCenterPreviewItem[]
+  sourceItem: ActionCenterPreviewItem | null
+}): {
+  targetItem: ActionCenterPreviewItem | null
+  reason: Exclude<FollowUpRouteBlockReason, 'already-has-direct-active-successor'> | null
+} {
+  const sourceItem = args.sourceItem
+  if (!sourceItem) {
+    return { targetItem: null, reason: 'no-same-scope-target' }
+  }
+
+  // V1 only supports department-scoped follow-up handoffs to one clear open route in the same department.
+  const candidates = args.items.filter(
+    (item) =>
+      item.id !== sourceItem.id &&
+      item.orgId === sourceItem.orgId &&
+      item.scopeType === 'department' &&
+      item.scopeType === sourceItem.scopeType &&
+      item.teamId === sourceItem.teamId &&
+      item.coreSemantics.route.campaignId !== sourceItem.coreSemantics.route.campaignId &&
+      !isClosedRouteStatus(item.status) &&
+      item.coreSemantics.followUpSemantics?.isDirectSuccessor !== true,
+  )
+
+  if (candidates.length === 1) {
+    return { targetItem: candidates[0], reason: null }
+  }
+
+  return {
+    targetItem: null,
+    reason: candidates.length === 0 ? 'no-same-scope-target' : 'ambiguous-same-scope-target',
+  }
+}
+
+function getFollowUpRouteBlockMessage(args: {
+  reason: FollowUpRouteBlockReason
+  directSuccessor: ActionCenterPreviewItem | null
+}) {
+  if (args.reason === 'already-has-direct-active-successor') {
+    const triggerReasonLabel = args.directSuccessor?.coreSemantics.followUpSemantics?.triggerReasonLabel
+    return triggerReasonLabel
+      ? `Voor deze gesloten route loopt al een directe actieve vervolgroute (${triggerReasonLabel}).`
+      : 'Voor deze gesloten route loopt al een directe actieve vervolgroute binnen dezelfde afdeling.'
+  }
+
+  if (args.reason === 'ambiguous-same-scope-target') {
+    return 'Er zijn meerdere open doelroutes binnen deze afdeling. Kies in V1 eerst één eenduidige vervolgrichting.'
+  }
+
+  return 'Nog geen eenduidige open doelroute beschikbaar binnen deze afdeling.'
+}
+
+function applyOptimisticFollowUpSuccessor(args: {
+  items: ActionCenterPreviewItem[]
+  sourceRouteId: string
+  targetItemId: string
+  triggerReason: ActionCenterRouteFollowUpTriggerReason
+}) {
+  return args.items.map((item) => {
+    if (item.id !== args.targetItemId) {
+      return item
+    }
+
+    return finalizeActionCenterPreviewItem(
+      {
+        ...item,
+        coreSemantics: {
+          ...item.coreSemantics,
+          followUpSemantics: {
+            isDirectSuccessor: true,
+            lineageLabel: 'Vervolg op eerdere route',
+            triggerReason: args.triggerReason,
+            triggerReasonLabel: getActionCenterFollowUpTriggerReasonLabel(args.triggerReason),
+            sourceRouteId: args.sourceRouteId,
+          },
+        },
+      },
+      { recomputeCoreSemantics: true },
+    )
+  })
+}
+
 export function ActionCenterPreview({
   initialItems,
   initialSelectedItemId = null,
@@ -466,6 +604,7 @@ export function ActionCenterPreview({
   managerAssignmentEndpoint,
   canRespondToRequests = false,
   managerResponseEndpoint,
+  routeFollowUpEndpoint,
   currentUserId = null,
   workbenchHref,
   workbenchLabel = 'Open dossierbron',
@@ -551,10 +690,19 @@ export function ActionCenterPreview({
           })),
     [managerOptions, ownerOptions],
   )
+  const [followUpForm, setFollowUpForm] = useState<FollowUpRouteFormState>(() =>
+    getInitialFollowUpFormState({ item: initialSelectedItem, assignmentOptions }),
+  )
+  const [followUpPending, setFollowUpPending] = useState(false)
+  const [followUpError, setFollowUpError] = useState<string | null>(null)
   const managerLabelByValue = useMemo(
     () => new Map(assignmentOptions.map((option) => [option.value, option.label])),
     [assignmentOptions],
   )
+  useEffect(() => {
+    setFollowUpForm(getInitialFollowUpFormState({ item: selectedItem, assignmentOptions }))
+    setFollowUpError(null)
+  }, [assignmentOptions, selectedItem])
   const teamRows = buildTeamRows(items)
   const selectedTeam = teamRows.find((team) => team.id === selectedTeamId) ?? teamRows[0] ?? null
   const allSources = [...new Set(items.map((item) => item.sourceLabel))]
@@ -593,6 +741,44 @@ export function ActionCenterPreview({
         currentUserId &&
         selectedItem.ownerId === currentUserId,
     )
+  const canRenderFollowUpRoute = Boolean(
+    routeFollowUpEndpoint &&
+      canAssignManagers &&
+      selectedItem?.orgId &&
+      selectedItem.scopeType === 'department' &&
+      isClosedRouteStatus(selectedItem.status),
+  )
+  const directActiveFollowUpSuccessor = useMemo(
+    () =>
+      selectedItem
+        ? findDirectActiveFollowUpSuccessor({
+            items,
+            sourceRouteId: selectedItem.coreSemantics.route.routeId,
+          })
+        : null,
+    [items, selectedItem],
+  )
+  const followUpTargetResolution = useMemo(
+    () =>
+      resolveSameScopeFollowUpTarget({
+        items,
+        sourceItem: selectedItem,
+      }),
+    [items, selectedItem],
+  )
+  const followUpTargetItem = followUpTargetResolution.targetItem
+  const followUpRouteBlockReason = !canRenderFollowUpRoute
+    ? null
+    : directActiveFollowUpSuccessor
+      ? 'already-has-direct-active-successor'
+      : followUpTargetResolution.reason
+  const followUpRouteBlockMessage = followUpRouteBlockReason
+    ? getFollowUpRouteBlockMessage({
+        reason: followUpRouteBlockReason,
+        directSuccessor: directActiveFollowUpSuccessor,
+      })
+    : null
+  const canShowFollowUpRouteAffordance = Boolean(canRenderFollowUpRoute && !followUpRouteBlockReason)
 
   function updateItem(itemId: string, updater: (item: ActionCenterPreviewItem) => ActionCenterPreviewItem) {
     setItems((currentItems) =>
@@ -776,6 +962,61 @@ export function ActionCenterPreview({
       )
     } finally {
       setManagerResponsePending(false)
+    }
+  }
+
+  async function handleFollowUpRouteStart() {
+    if (!selectedItem || !routeFollowUpEndpoint) return
+
+    const managerUserId = followUpForm.managerUserId.trim()
+    if (!managerUserId) {
+      setFollowUpError('Kies eerst een manager voor deze vervolgroute.')
+      return
+    }
+
+    if (!followUpTargetItem) {
+      setFollowUpError('Nog geen doelroute beschikbaar voor deze afdeling.')
+      return
+    }
+
+    setFollowUpPending(true)
+    setFollowUpError(null)
+
+    try {
+      const response = await fetch(routeFollowUpEndpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          source_campaign_id: selectedItem.coreSemantics.route.campaignId,
+          source_route_scope_value: selectedItem.teamId,
+          target_campaign_id: followUpTargetItem.coreSemantics.route.campaignId,
+          target_route_scope_value: followUpTargetItem.teamId,
+          trigger_reason: followUpForm.triggerReason,
+          manager_user_id: managerUserId,
+        }),
+      })
+      const result = (await response.json().catch(() => null)) as { detail?: string } | null
+
+      if (!response.ok) {
+        throw new Error(result?.detail ?? 'Vervolgroute kon niet worden gestart.')
+      }
+
+      setItems((currentItems) =>
+        applyOptimisticFollowUpSuccessor({
+          items: currentItems,
+          sourceRouteId: selectedItem.coreSemantics.route.routeId,
+          targetItemId: followUpTargetItem.id,
+          triggerReason: followUpForm.triggerReason,
+        }),
+      )
+      setSelectedItemId(followUpTargetItem.id)
+      setActiveView('actions')
+    } catch (error) {
+      setFollowUpError(error instanceof Error ? error.message : 'Vervolgroute kon niet worden gestart.')
+    } finally {
+      setFollowUpPending(false)
     }
   }
 
@@ -1591,6 +1832,93 @@ export function ActionCenterPreview({
                           <LabelValue label="Review-eigenaar" value={getReviewOwnerDisplayName(selectedItem.reviewOwnerName)} />
                         </dl>
                       </div>
+
+                      {canShowFollowUpRouteAffordance ? (
+                        <div className="rounded-[24px] border border-[#e4d9cb] bg-white px-6 py-6 shadow-[0_12px_36px_rgba(19,32,51,0.06)]">
+                          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">
+                            Vervolgroute
+                          </p>
+                          <h3 className="mt-3 text-[1.35rem] font-semibold tracking-[-0.03em] text-[#132033]">
+                            Start vervolgroute
+                          </h3>
+                          <p className="mt-3 text-sm leading-7 text-[#4f6175]">
+                            Open vanuit deze gesloten route een nieuwe HR-handoff binnen dezelfde afdeling.
+                          </p>
+
+                          <div className="mt-5 space-y-5">
+                            <FormField label="Kies manager">
+                              <select
+                                name="follow-up-manager"
+                                value={followUpForm.managerUserId}
+                                onChange={(event) =>
+                                  setFollowUpForm((current) => ({
+                                    ...current,
+                                    managerUserId: event.target.value,
+                                  }))
+                                }
+                                disabled={followUpPending}
+                                className="w-full rounded-2xl border border-[#ddd3c7] bg-[#fbf8f4] px-4 py-3 text-sm text-[#132033] outline-none transition focus:border-[#ff9b4a]"
+                              >
+                                <option value="">Kies manager</option>
+                                {assignmentOptions.map((option) => (
+                                  <option key={`follow-up-${option.value}`} value={option.value}>
+                                    {option.label}
+                                  </option>
+                                ))}
+                              </select>
+                            </FormField>
+
+                            <FormField label="Kies aanleiding">
+                              <div className="space-y-3">
+                                {FOLLOW_UP_TRIGGER_REASON_OPTIONS.map((option) => (
+                                  <label
+                                    key={option}
+                                    className="flex items-start gap-3 rounded-2xl border border-[#e4d9cb] bg-[#fcfaf7] px-4 py-3 text-sm text-[#132033]"
+                                  >
+                                    <input
+                                      type="radio"
+                                      name="follow-up-trigger-reason"
+                                      value={option}
+                                      checked={followUpForm.triggerReason === option}
+                                      onChange={() =>
+                                        setFollowUpForm((current) => ({
+                                          ...current,
+                                          triggerReason: option,
+                                        }))
+                                      }
+                                      disabled={followUpPending}
+                                      className="mt-1 h-4 w-4 border-[#c9bcad] text-[#ff9b4a] focus:ring-[#ff9b4a]"
+                                    />
+                                    <span>{getActionCenterFollowUpTriggerReasonLabel(option)}</span>
+                                  </label>
+                                ))}
+                              </div>
+                            </FormField>
+
+                            {followUpError ? (
+                              <p className="rounded-2xl border border-[#f0d9d4] bg-[#fff1ef] px-4 py-3 text-sm text-[#b24a43]">
+                                {followUpError}
+                              </p>
+                            ) : null}
+
+                            <button
+                              type="button"
+                              className="inline-flex min-h-11 items-center rounded-full bg-[#ff9b4a] px-4.5 py-2.5 text-sm font-semibold text-[#132033] transition hover:brightness-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
+                              disabled={followUpPending}
+                              onClick={() => void handleFollowUpRouteStart()}
+                            >
+                              {followUpPending ? 'Vervolgroute starten...' : 'Start vervolgroute'}
+                            </button>
+                          </div>
+                        </div>
+                      ) : canRenderFollowUpRoute && followUpRouteBlockMessage ? (
+                        <div className="rounded-[24px] border border-[#e4d9cb] bg-[#fcfaf7] px-6 py-6 shadow-[0_12px_36px_rgba(19,32,51,0.06)]">
+                          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">
+                            Vervolgroute
+                          </p>
+                          <p className="mt-3 text-sm leading-7 text-[#4f6175]">{followUpRouteBlockMessage}</p>
+                        </div>
+                      ) : null}
 
                       {supportsManagerResponseFlow(selectedItem) ? (
                         <div className="rounded-[24px] border border-[#e4d9cb] bg-white px-6 py-6 shadow-[0_12px_36px_rgba(19,32,51,0.06)]">

--- a/frontend/lib/action-center-core-semantics.ts
+++ b/frontend/lib/action-center-core-semantics.ts
@@ -4,6 +4,11 @@ import type {
   ActionCenterRouteContract,
 } from './action-center-route-contract'
 import type { LiveActionCenterCampaignContext } from './action-center-live-context'
+import {
+  getActionCenterFollowUpTriggerReasonLabel,
+  type ActionCenterRouteFollowUpRelationRecord,
+  type ActionCenterRouteFollowUpTriggerReason,
+} from './action-center-route-reopen'
 import type {
   ActionCenterManagerResponse,
   ActionCenterReviewDecision,
@@ -48,11 +53,20 @@ export interface ActionCenterCoreSemantics {
   }
   resultProgression: ActionCenterResultProgressEntry[]
   decisionHistory: ActionCenterDecisionRecord[]
+  followUpSemantics?: ActionCenterProjectedFollowUpSemantics
   closingSemantics: {
     status: ActionCenterClosingStatus
     summary: string | null
     historicalSummary: string | null
   }
+}
+
+export interface ActionCenterProjectedFollowUpSemantics {
+  isDirectSuccessor: boolean
+  lineageLabel: string | null
+  triggerReason: ActionCenterRouteFollowUpTriggerReason | null
+  triggerReasonLabel: string | null
+  sourceRouteId: string | null
 }
 
 export type ActionCenterCoreSemanticsProjectionInput = Pick<
@@ -64,6 +78,7 @@ export type ActionCenterCoreSemanticsProjectionInput = Pick<
   | 'learningCheckpoints'
   | 'reviewDecisions'
   | 'managerResponse'
+  | 'routeFollowUpRelations'
 > & {
   route: ActionCenterRouteContract
   latestVisibleUpdateNote?: string | null
@@ -86,6 +101,7 @@ export interface ActionCenterPreviewCoreSemanticsProjectionInput {
   latestVisibleUpdateNote?: string | null
   route?: ActionCenterRouteContract | null
   managerResponse?: ActionCenterManagerResponse | null
+  followUpSemantics?: ActionCenterProjectedFollowUpSemantics | null
 }
 
 const UNASSIGNED_OWNER_LABEL = 'Nog niet toegewezen'
@@ -126,6 +142,7 @@ const ACTION_STEP_PREFIXES = new Set([
   'koppel',
   'vervolg',
 ])
+const FOLLOW_UP_SUCCESSOR_LINEAGE_LABEL = 'Vervolg op eerdere route'
 const HISTORICAL_CLOSEOUT_SIGNAL_PATTERNS = [
   /\bvorige stap\s+(?:is|was|werd)\s+(?:al\s+|reeds\s+)?(?:definitief\s+)?afgerond\b/i,
   /\bvorige stap\s+(?:is|was|werd)\s+(?:al\s+|reeds\s+)?(?:definitief\s+)?afgesloten\b/i,
@@ -149,8 +166,46 @@ function pickFirst(values: Array<string | null | undefined>) {
   return null
 }
 
+function getEmptyFollowUpSemantics(): ActionCenterProjectedFollowUpSemantics {
+  return {
+    isDirectSuccessor: false,
+    lineageLabel: null,
+    triggerReason: null,
+    triggerReasonLabel: null,
+    sourceRouteId: null,
+  }
+}
+
 function getCheckpoint(context: ActionCenterCoreSemanticsProjectionInput, key: PilotLearningCheckpoint['checkpoint_key']) {
   return context.learningCheckpoints.find((checkpoint) => checkpoint.checkpoint_key === key) ?? null
+}
+
+function getDirectSuccessorRelation(
+  routeId: string,
+  relations: ActionCenterRouteFollowUpRelationRecord[] | undefined,
+) {
+  return [...(relations ?? [])]
+    .filter((relation) => relation.targetRouteId === routeId && !normalizeText(relation.endedAt))
+    .sort((left, right) => new Date(right.recordedAt).getTime() - new Date(left.recordedAt).getTime())[0] ?? null
+}
+
+function projectFollowUpSemanticsFromRelation(
+  routeId: string,
+  relations: ActionCenterRouteFollowUpRelationRecord[] | undefined,
+): ActionCenterProjectedFollowUpSemantics {
+  const relation = getDirectSuccessorRelation(routeId, relations)
+
+  if (!relation) {
+    return getEmptyFollowUpSemantics()
+  }
+
+  return {
+    isDirectSuccessor: true,
+    lineageLabel: FOLLOW_UP_SUCCESSOR_LINEAGE_LABEL,
+    triggerReason: relation.triggerReason,
+    triggerReasonLabel: getActionCenterFollowUpTriggerReasonLabel(relation.triggerReason),
+    sourceRouteId: relation.sourceRouteId,
+  }
 }
 
 function getVisibleReviewOutcome(outcome: ActionCenterReviewOutcome): ActionCenterVisibleReviewOutcome {
@@ -530,6 +585,7 @@ export function projectActionCenterPreviewCoreSemantics(
     latestVisibleUpdateNote,
   })
   const closingStatus = getPreviewClosingStatus(route.routeStatus)
+  const followUpSemantics = input.followUpSemantics ?? getEmptyFollowUpSemantics()
 
   return {
     route,
@@ -563,6 +619,7 @@ export function projectActionCenterPreviewCoreSemantics(
     },
     resultProgression,
     decisionHistory,
+    followUpSemantics,
     closingSemantics: {
       status: closingStatus,
       summary: getClosingSummary(closingStatus, getPreviewClosingSummaryValues(route, closingStatus)),
@@ -651,6 +708,7 @@ export function projectActionCenterCoreSemantics(
   const latestObservation = getLatestObservation(context, route)
   const latestActionUpdate = getLatestActionUpdate(context)
   const closingStatus = getClosingStatus(context, route)
+  const followUpSemantics = projectFollowUpSemanticsFromRelation(route.routeId, context.routeFollowUpRelations)
   const decisionHistory = buildDecisionHistory({
     route,
     reviewQuestion,
@@ -718,6 +776,7 @@ export function projectActionCenterCoreSemantics(
     },
     resultProgression,
     decisionHistory,
+    followUpSemantics,
     closingSemantics: {
       status: closingStatus,
       summary: getClosingSummary(closingStatus, getLiveClosingSummaryValues(context, route, closingStatus)),

--- a/frontend/lib/action-center-follow-up-route-trigger.test.ts
+++ b/frontend/lib/action-center-follow-up-route-trigger.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { projectActionCenterRouteFollowUpRelation } from './action-center-route-reopen'
+
+describe('action center follow-up route trigger projector', () => {
+  it('accepts canonical camelCase triggerReason input and returns canonical truth', () => {
+    const relation = projectActionCenterRouteFollowUpRelation({
+      id: ' relation-direct-follow-up-1 ',
+      routeRelationType: ' follow-up-from ',
+      sourceRouteId: ' campaign-exit-closed::org-1::department::operations ',
+      targetRouteId: ' campaign-pulse-open::org-1::department::operations ',
+      triggerReason: ' nieuw-campaign-signaal ',
+      recordedAt: ' 2026-04-24T10:00:00.000Z ',
+      recordedByRole: ' hr ',
+      endedAt: ' 2026-05-01T10:00:00.000Z ',
+    })
+
+    expect(relation).toEqual({
+      id: 'relation-direct-follow-up-1',
+      routeRelationType: 'follow-up-from',
+      sourceRouteId: 'campaign-exit-closed::org-1::department::operations',
+      targetRouteId: 'campaign-pulse-open::org-1::department::operations',
+      triggerReason: 'nieuw-campaign-signaal',
+      recordedAt: '2026-04-24T10:00:00.000Z',
+      recordedByRole: 'hr',
+      endedAt: '2026-05-01T10:00:00.000Z',
+    })
+  })
+})

--- a/frontend/lib/action-center-live-context.ts
+++ b/frontend/lib/action-center-live-context.ts
@@ -6,6 +6,7 @@ import type {
   PilotLearningCheckpoint,
   PilotLearningDossier,
 } from './pilot-learning'
+import type { ActionCenterRouteFollowUpRelationRecord } from './action-center-route-reopen'
 
 export interface LiveActionCenterCampaignContext {
   campaign: Campaign
@@ -27,4 +28,5 @@ export interface LiveActionCenterCampaignContext {
   learningCheckpoints: PilotLearningCheckpoint[]
   managerResponse?: ActionCenterManagerResponse | null
   reviewDecisions?: ActionCenterReviewDecision[]
+  routeFollowUpRelations?: ActionCenterRouteFollowUpRelationRecord[]
 }

--- a/frontend/lib/action-center-live.test.ts
+++ b/frontend/lib/action-center-live.test.ts
@@ -5,7 +5,7 @@ import {
   finalizeActionCenterPreviewItem,
   isLiveActionCenterScanType,
 } from './action-center-live'
-import { projectActionCenterRoute } from './action-center-route-contract'
+import { buildActionCenterRouteId, projectActionCenterRoute } from './action-center-route-contract'
 import type { Campaign, CampaignStats } from '@/lib/types'
 import type { CampaignDeliveryRecord } from '@/lib/ops-delivery'
 import type {
@@ -554,6 +554,120 @@ describe('live action center builder', () => {
     )
   })
 
+  it('preserves projected follow-up lineage semantics when preview core semantics recomputes', () => {
+    const seeded = finalizeActionCenterPreviewItem({
+      id: 'local-follow-up',
+      code: 'ACT-2010',
+      title: 'Bestaande vervolgroute',
+      summary: 'Lijstsamenvatting voor de vervolgroute.',
+      reason: 'Afgeleide reviewcopy uit de vorige render.',
+      sourceLabel: 'ExitScan',
+      teamId: 'operations',
+      teamLabel: 'Operations',
+      ownerId: 'manager-1',
+      ownerName: 'Manager Operations',
+      ownerRole: 'Manager - Operations',
+      ownerSubtitle: 'Operations',
+      reviewOwnerName: 'Manager Operations',
+      priority: 'hoog',
+      status: 'te-bespreken',
+      reviewDate: '2026-05-12',
+      expectedEffect: 'Afgeleid verwacht effect.',
+      reviewReason: 'Afgeleide reviewreden.',
+      reviewOutcome: 'geen-uitkomst',
+      reviewDateLabel: '12 mei',
+      reviewRhythm: 'Tweewekelijks',
+      signalLabel: 'ExitScan - Operations',
+      signalBody: 'Zichtbaar signaal voor de kaart.',
+      nextStep: 'Afgeleide eerste stap uit de vorige render.',
+      peopleCount: 38,
+      updates: [],
+      coreSemantics: {
+        route: {
+          routeId: 'local-follow-up',
+          campaignId: 'local-follow-up',
+          entryStage: 'active',
+          routeOpenedAt: '2026-05-01T09:00:00.000Z',
+          ownerAssignedAt: '2026-05-01T09:00:00.000Z',
+          routeStatus: 'te-bespreken',
+          reviewOutcome: 'geen-uitkomst',
+          reviewCompletedAt: null,
+          outcomeRecordedAt: null,
+          outcomeSummary: null,
+          intervention: null,
+          owner: 'Manager Operations',
+          expectedEffect: null,
+          reviewScheduledFor: '2026-05-12',
+          reviewReason: 'Canonieke previewreviewreden.',
+          managerResponseType: 'schedule',
+          managerResponseNote: 'Nieuwe vervolgroute geopend door HR.',
+          primaryActionThemeKey: null,
+          followThroughMode: 'bounded_response',
+          blockedBy: null,
+        },
+        reviewSemantics: {
+          reviewReason: 'Canonieke previewreviewreden.',
+          reviewQuestion: 'Welke vervolgstap vraagt deze route nu als eerste review?',
+          reviewOutcomeRaw: 'geen-uitkomst',
+          reviewOutcomeVisible: 'geen-uitkomst',
+        },
+        actionProgress: {
+          currentStep: null,
+          nextStep: null,
+          expectedEffect: null,
+        },
+        actionFrame: {
+          whyNow: 'Canonieke previewreviewreden.',
+          firstStep: 'Nog te bepalen in review',
+          owner: 'Manager Operations',
+          expectedEffect: 'Nog te bepalen in review',
+        },
+        resultLoop: {
+          whatWasTried: null,
+          whatWeObserved: 'Zichtbaar signaal voor de kaart.',
+          whatWasDecided: null,
+        },
+        resultProgression: [],
+        decisionHistory: [],
+        followUpSemantics: {
+          isDirectSuccessor: true,
+          lineageLabel: 'Vervolg op eerdere route',
+          triggerReason: 'nieuw-segment-signaal',
+          triggerReasonLabel: 'Nieuw segmentsignaal',
+          sourceRouteId: 'campaign-source::operations',
+        },
+        closingSemantics: {
+          status: 'lopend',
+          summary: null,
+          historicalSummary: null,
+        },
+      },
+    })
+
+    const recomputed = finalizeActionCenterPreviewItem(
+      {
+        ...seeded,
+        updates: [
+          {
+            id: 'update-follow-up-1',
+            author: 'Admin',
+            dateLabel: '1 mei',
+            note: 'Update: vervolgroute is opnieuw ingepland.',
+          },
+        ],
+      },
+      { recomputeCoreSemantics: true },
+    )
+
+    expect(recomputed.coreSemantics.followUpSemantics).toMatchObject({
+      isDirectSuccessor: true,
+      lineageLabel: 'Vervolg op eerdere route',
+      triggerReason: 'nieuw-segment-signaal',
+      triggerReasonLabel: 'Nieuw segmentsignaal',
+      sourceRouteId: 'campaign-source::operations',
+    })
+  })
+
   it('does not promote management_action_outcome into the latest visible update fallback for live items', () => {
     const items = buildLiveActionCenterItems([
       {
@@ -917,5 +1031,162 @@ describe('live action center builder', () => {
     )
     expect(item?.coreSemantics.decisionHistory).toHaveLength(1)
     expect(item?.coreSemantics.decisionHistory[0]?.decisionEntryId).toBe('authored-decision-1')
+  })
+
+  it('projects follow-up lineage and trigger reason labels onto direct successor routes without changing normal open status', () => {
+    const scopeValue = 'org-1::department::operations'
+    const sourceCampaign = buildCampaign({
+      id: 'campaign-source',
+      name: 'Exit maart',
+    })
+    const targetCampaign = buildCampaign({
+      id: 'campaign-target',
+      name: 'Exit april',
+      created_at: '2026-04-18T10:00:00.000Z',
+    })
+    const sourceRouteId = buildActionCenterRouteId(sourceCampaign.id, scopeValue)
+    const targetRouteId = buildActionCenterRouteId(targetCampaign.id, scopeValue)
+
+    const items = buildLiveActionCenterItems([
+      {
+        campaign: sourceCampaign,
+        stats: buildStats({ campaign_id: sourceCampaign.id, campaign_name: sourceCampaign.name }),
+        organizationName: 'Acme BV',
+        memberRole: 'owner',
+        scopeType: 'department',
+        scopeValue,
+        scopeLabel: 'Operations',
+        peopleCount: 38,
+        assignedManager: {
+          userId: 'manager-source',
+          displayName: 'Manager Operations',
+          assignedAt: '2026-04-10T08:00:00.000Z',
+        },
+        deliveryRecord: buildDeliveryRecord({
+          campaign_id: sourceCampaign.id,
+          lifecycle_stage: 'follow_up_decided',
+          first_management_use_confirmed_at: '2026-04-10T08:00:00.000Z',
+        }),
+        deliveryCheckpoints: [],
+        learningDossier: buildDossier({
+          campaign_id: sourceCampaign.id,
+          triage_status: 'uitgevoerd',
+          management_action_outcome: 'afronden',
+          adoption_outcome: 'De vorige route is bewust afgesloten na de review.',
+          case_public_summary: 'De eerdere route is afgesloten en wordt nu historisch bewaard.',
+        }),
+        learningCheckpoints: [],
+        reviewDecisions: [],
+        routeFollowUpRelations: [
+          {
+            id: 'relation-1',
+            routeRelationType: 'follow-up-from',
+            sourceRouteId,
+            targetRouteId,
+            triggerReason: 'nieuw-segment-signaal',
+            recordedAt: '2026-04-30T09:00:00.000Z',
+            recordedByRole: 'hr_owner',
+            endedAt: null,
+          },
+        ],
+      },
+      {
+        campaign: targetCampaign,
+        stats: buildStats({ campaign_id: targetCampaign.id, campaign_name: targetCampaign.name }),
+        organizationName: 'Acme BV',
+        memberRole: 'owner',
+        scopeType: 'department',
+        scopeValue,
+        scopeLabel: 'Operations',
+        peopleCount: 38,
+        assignedManager: {
+          userId: 'manager-target',
+          displayName: 'Manager Operations',
+          assignedAt: '2026-04-30T09:00:00.000Z',
+        },
+        deliveryRecord: buildDeliveryRecord({
+          campaign_id: targetCampaign.id,
+          lifecycle_stage: 'first_value_reached',
+          first_management_use_confirmed_at: null,
+        }),
+        deliveryCheckpoints: [],
+        learningDossier: buildDossier({
+          campaign_id: targetCampaign.id,
+          title: 'Nieuwe vervolgroute',
+          triage_status: 'bevestigd',
+          expected_first_value: null,
+          first_management_value: null,
+          first_action_taken: null,
+          review_moment: null,
+          management_action_outcome: null,
+        }),
+        learningCheckpoints: [],
+        managerResponse: {
+          id: 'manager-response-1',
+          campaign_id: targetCampaign.id,
+          org_id: 'org-1',
+          route_scope_type: 'department',
+          route_scope_value: scopeValue,
+          manager_user_id: 'manager-target',
+          response_type: 'schedule',
+          response_note: 'Vervolgroute geopend door HR.',
+          review_scheduled_for: '2026-05-14',
+          primary_action_theme_key: null,
+          primary_action_text: null,
+          primary_action_expected_effect: null,
+          primary_action_status: null,
+          created_by: null,
+          updated_by: null,
+          created_at: '2026-04-30T09:00:00.000Z',
+          updated_at: '2026-04-30T09:00:00.000Z',
+        },
+        reviewDecisions: [],
+        routeFollowUpRelations: [
+          {
+            id: 'relation-1',
+            routeRelationType: 'follow-up-from',
+            sourceRouteId,
+            targetRouteId,
+            triggerReason: 'nieuw-segment-signaal',
+            recordedAt: '2026-04-30T09:00:00.000Z',
+            recordedByRole: 'hr_owner',
+            endedAt: null,
+          },
+        ],
+      },
+    ])
+
+    const sourceItem = items.find((item) => item.id === sourceRouteId)
+    const successorItem = items.find((item) => item.id === targetRouteId)
+
+    expect(sourceItem).toMatchObject({
+      status: 'afgerond',
+      coreSemantics: {
+        closingSemantics: {
+          status: 'afgerond',
+        },
+        followUpSemantics: {
+          isDirectSuccessor: false,
+          lineageLabel: null,
+          triggerReason: null,
+          triggerReasonLabel: null,
+        },
+      },
+    })
+    expect(successorItem).toMatchObject({
+      status: 'te-bespreken',
+      coreSemantics: {
+        route: {
+          routeStatus: 'te-bespreken',
+        },
+        followUpSemantics: {
+          isDirectSuccessor: true,
+          lineageLabel: 'Vervolg op eerdere route',
+          triggerReason: 'nieuw-segment-signaal',
+          triggerReasonLabel: 'Nieuw segmentsignaal',
+          sourceRouteId,
+        },
+      },
+    })
   })
 })

--- a/frontend/lib/action-center-live.ts
+++ b/frontend/lib/action-center-live.ts
@@ -290,6 +290,7 @@ export function finalizeActionCenterPreviewItem(
       latestVisibleUpdateNote,
       route: existingRoute,
       managerResponse: item.managerResponse ?? null,
+      followUpSemantics: item.coreSemantics?.followUpSemantics ?? null,
     })
 
   const reviewReason = coreSemantics.reviewSemantics.reviewReason

--- a/frontend/lib/action-center-manager-responses.ts
+++ b/frontend/lib/action-center-manager-responses.ts
@@ -11,6 +11,8 @@ import type {
   ActionCenterManagerResponseType,
 } from './pilot-learning'
 
+export type { ActionCenterManagerResponseScopeType } from './pilot-learning'
+
 const RESPONSE_TYPES = new Set<ActionCenterManagerResponseType>(['confirm', 'sharpen', 'schedule', 'watch'])
 const RESPONSE_SCOPE_TYPES = new Set<ActionCenterManagerResponseScopeType>(['department', 'item'])
 const ACTION_STATUSES = new Set<ActionCenterManagerActionStatus>(['active', 'completed', 'abandoned'])
@@ -68,6 +70,19 @@ function normalizeText(value: string | null | undefined) {
   return trimmed.length > 0 ? trimmed : null
 }
 
+function isUuidLike(value: string) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)
+}
+
+export function normalizeCampaignIdentifier(value: string | null | undefined) {
+  const normalized = normalizeText(value)
+  if (!normalized) {
+    return null
+  }
+
+  return isUuidLike(normalized) ? normalized.toLowerCase() : normalized
+}
+
 function normalizeDepartmentLabel(value: string | null | undefined) {
   const normalized = normalizeText(value)
   return normalized ? normalized.toLocaleLowerCase('nl-NL') : null
@@ -84,7 +99,60 @@ export function buildDepartmentScopeValue(orgId: string, departmentLabel: string
 }
 
 export function buildCampaignItemScopeValue(orgId: string, campaignId: string) {
-  return `${orgId}::campaign::${campaignId}`
+  return `${orgId}::campaign::${normalizeCampaignIdentifier(campaignId) ?? ''}`
+}
+
+export function parseActionCenterManagerResponseScopeValue(routeScopeValue: string) {
+  const normalizedRouteScopeValue = normalizeText(routeScopeValue)
+  if (!normalizedRouteScopeValue) {
+    throw new Error('Ongeldige manager response route-identiteit.')
+  }
+
+  const segments = normalizedRouteScopeValue.split('::')
+  if (segments.length !== 3) {
+    throw new Error('Ongeldige manager response route-identiteit.')
+  }
+
+  const [orgId, rawScopeType, scopeKey] = segments
+  if (!orgId || !scopeKey) {
+    throw new Error('Ongeldige manager response route-identiteit.')
+  }
+
+  if (rawScopeType === 'department') {
+    const normalizedDepartmentLabel = normalizeDepartmentLabel(scopeKey)
+    if (!normalizedDepartmentLabel) {
+      throw new Error('Ongeldige manager response route-identiteit.')
+    }
+
+    return {
+      orgId,
+      scopeType: 'department' as const,
+      scopeKey: normalizedDepartmentLabel,
+      canonicalScopeValue: buildDepartmentScopeValue(orgId, normalizedDepartmentLabel),
+    }
+  }
+
+  if (rawScopeType === 'campaign') {
+    const normalizedCampaignId = normalizeCampaignIdentifier(scopeKey)
+    if (!normalizedCampaignId) {
+      throw new Error('Ongeldige manager response route-identiteit.')
+    }
+
+    return {
+      orgId,
+      scopeType: 'item' as const,
+      scopeKey: normalizedCampaignId,
+      canonicalScopeValue: buildCampaignItemScopeValue(orgId, normalizedCampaignId),
+    }
+  }
+
+  throw new Error('Ongeldige manager response route-identiteit.')
+}
+
+export function inferActionCenterManagerResponseScopeType(
+  routeScopeValue: string,
+): ActionCenterManagerResponseScopeType {
+  return parseActionCenterManagerResponseScopeValue(routeScopeValue).scopeType
 }
 
 function isCanonicalRouteScopeForCampaign(args: {
@@ -94,8 +162,14 @@ function isCanonicalRouteScopeForCampaign(args: {
   routeScopeValue: string
   visibleDepartmentLabels: string[]
 }) {
+  const parsedScopeValue = parseActionCenterManagerResponseScopeValue(args.routeScopeValue)
+
   if (args.routeScopeType === 'item') {
-    return args.routeScopeValue === buildCampaignItemScopeValue(args.campaignOrgId, args.campaignId)
+    return (
+      parsedScopeValue.orgId === args.campaignOrgId &&
+      parsedScopeValue.scopeType === 'item' &&
+      parsedScopeValue.canonicalScopeValue === buildCampaignItemScopeValue(args.campaignOrgId, args.campaignId)
+    )
   }
 
   return args.visibleDepartmentLabels.some(
@@ -111,7 +185,7 @@ export function resolveManagerResponseWriteIdentity(args: {
   membership: ManagerAssignmentTruth | null
   isVerisightAdmin: boolean
 }) {
-  const submittedCampaignId = normalizeText(args.submitted.campaign_id)
+  const submittedCampaignId = normalizeCampaignIdentifier(args.submitted.campaign_id)
   const submittedOrgId = normalizeText(args.submitted.org_id)
   const submittedScopeValue = normalizeText(args.submitted.route_scope_value)
   const submittedManagerUserId = normalizeText(args.submitted.manager_user_id)
@@ -218,7 +292,7 @@ export function hasPrimaryManagerAction(
 export function validateActionCenterManagerResponseWriteInput(
   input: Partial<ActionCenterManagerResponseWriteInput> | null | undefined,
 ): ActionCenterManagerResponseWriteInput {
-  const campaignId = normalizeText(input?.campaign_id)
+  const campaignId = normalizeCampaignIdentifier(input?.campaign_id)
   const orgId = normalizeText(input?.org_id)
   const routeScopeType = input?.route_scope_type
   const routeScopeValue = normalizeText(input?.route_scope_value)

--- a/frontend/lib/action-center-route-relations-policy.test.ts
+++ b/frontend/lib/action-center-route-relations-policy.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const schemaPath = fileURLToPath(new URL('../../supabase/schema.sql', import.meta.url))
+const schemaSql = readFileSync(schemaPath, 'utf8')
+
+describe('action center route relations schema policy contract', () => {
+  it('defines trigger_reason on action_center_route_relations with the canonical three-value check', () => {
+    expect(schemaSql).toMatch(/create table if not exists public\.action_center_route_relations/i)
+    expect(schemaSql).toMatch(/trigger_reason text not null/i)
+    expect(schemaSql).toMatch(
+      /check\s*\(\s*trigger_reason in \('nieuw-campaign-signaal', 'nieuw-segment-signaal', 'hernieuwde-hr-beoordeling'\)\s*\)/i,
+    )
+  })
+
+  it('keeps the route relation select policy scope-limited for managers', () => {
+    expect(schemaSql).toMatch(/create policy "managers_can_select_action_center_route_relations"/i)
+    expect(schemaSql).toMatch(/from public\.action_center_workspace_members m/i)
+    expect(schemaSql).toMatch(/m\.access_role = 'manager_assignee'/i)
+    expect(schemaSql).toMatch(/m\.org_id = action_center_route_relations\.org_id/i)
+    expect(schemaSql).toMatch(/m\.scope_value = action_center_route_relations\.source_route_scope_value/i)
+    expect(schemaSql).toMatch(/m\.can_view/i)
+  })
+})

--- a/frontend/lib/action-center-route-reopen.test.ts
+++ b/frontend/lib/action-center-route-reopen.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getActionCenterFollowUpTriggerReasonLabel,
+  projectActionCenterRouteFollowUpRelation,
+} from './action-center-route-reopen'
+
+describe('action center route reopen follow-up relation contract', () => {
+  it('throws when trigger_reason is missing on a follow-up relation', () => {
+    expect(() => {
+      projectActionCenterRouteFollowUpRelation({
+        route_relation_type: 'follow-up-from',
+        source_route_id: 'campaign-exit-closed::org-1::department::operations',
+        target_route_id: 'campaign-pulse-open::org-1::department::operations',
+        recorded_at: '2026-04-24T10:00:00.000Z',
+        recorded_by_role: 'hr',
+      })
+    }).toThrow(/trigger_reason/i)
+  })
+
+  it('accepts a canonical trigger_reason on a follow-up relation', () => {
+    const relation = projectActionCenterRouteFollowUpRelation({
+      route_relation_type: 'follow-up-from',
+      source_route_id: 'campaign-exit-closed::org-1::department::operations',
+      target_route_id: 'campaign-pulse-open::org-1::department::operations',
+      trigger_reason: 'nieuw-campaign-signaal',
+      recorded_at: '2026-04-24T10:00:00.000Z',
+      recorded_by_role: 'hr',
+    })
+
+    expect(relation.triggerReason).toBe('nieuw-campaign-signaal')
+  })
+
+  it('accepts another canonical trigger_reason on a follow-up relation', () => {
+    const relation = projectActionCenterRouteFollowUpRelation({
+      route_relation_type: 'follow-up-from',
+      source_route_id: 'campaign-exit-closed::org-1::department::operations',
+      target_route_id: 'campaign-pulse-open::org-1::department::operations',
+      trigger_reason: 'nieuw-segment-signaal',
+      recorded_at: '2026-04-24T10:00:00.000Z',
+      recorded_by_role: 'hr',
+    })
+
+    expect(relation.triggerReason).toBe('nieuw-segment-signaal')
+  })
+
+  it('rejects an invalid trigger_reason on a follow-up relation', () => {
+    expect(() =>
+      projectActionCenterRouteFollowUpRelation({
+        route_relation_type: 'follow-up-from',
+        source_route_id: 'campaign-exit-closed::org-1::department::operations',
+        target_route_id: 'campaign-pulse-open::org-1::department::operations',
+        trigger_reason: 'onbekend-signaal',
+        recorded_at: '2026-04-24T10:00:00.000Z',
+        recorded_by_role: 'hr',
+      }),
+    ).toThrow(/trigger_reason/i)
+  })
+
+  it('rejects an invalid recorded_at timestamp on a follow-up relation', () => {
+    expect(() =>
+      projectActionCenterRouteFollowUpRelation({
+        route_relation_type: 'follow-up-from',
+        source_route_id: 'campaign-exit-closed::org-1::department::operations',
+        target_route_id: 'campaign-pulse-open::org-1::department::operations',
+        trigger_reason: 'nieuw-campaign-signaal',
+        recorded_at: 'geen-datum',
+        recorded_by_role: 'hr',
+      }),
+    ).toThrow(/recorded_at is invalid/i)
+  })
+
+  it('normalizes trimmed whitespace across mixed snake_case and camelCase input', () => {
+    const relation = projectActionCenterRouteFollowUpRelation({
+      route_relation_type: ' follow-up-from ',
+      sourceRouteId: ' campaign-exit-closed::org-1::department::operations ',
+      target_route_id: ' campaign-pulse-open::org-1::department::operations ',
+      triggerReason: ' nieuw-campaign-signaal ',
+      recorded_at: ' 2026-04-24T10:00:00.000Z ',
+      recordedByRole: ' hr ',
+    })
+
+    expect(relation).toEqual({
+      id: null,
+      routeRelationType: 'follow-up-from',
+      sourceRouteId: 'campaign-exit-closed::org-1::department::operations',
+      targetRouteId: 'campaign-pulse-open::org-1::department::operations',
+      triggerReason: 'nieuw-campaign-signaal',
+      recordedAt: '2026-04-24T10:00:00.000Z',
+      recordedByRole: 'hr',
+      endedAt: null,
+    })
+  })
+
+  it('returns the expected trigger reason labels', () => {
+    expect(getActionCenterFollowUpTriggerReasonLabel('nieuw-campaign-signaal')).toBe('Nieuw campaign-signaal')
+    expect(getActionCenterFollowUpTriggerReasonLabel('nieuw-segment-signaal')).toBe('Nieuw segmentsignaal')
+    expect(getActionCenterFollowUpTriggerReasonLabel('hernieuwde-hr-beoordeling')).toBe(
+      'Hernieuwde HR-beoordeling',
+    )
+  })
+})

--- a/frontend/lib/action-center-route-reopen.ts
+++ b/frontend/lib/action-center-route-reopen.ts
@@ -1,0 +1,120 @@
+export type ActionCenterRouteFollowUpTriggerReason =
+  | 'nieuw-campaign-signaal'
+  | 'nieuw-segment-signaal'
+  | 'hernieuwde-hr-beoordeling'
+
+export interface ActionCenterRouteFollowUpRelationRecord {
+  id?: string | null
+  routeRelationType: 'follow-up-from'
+  sourceRouteId: string
+  targetRouteId: string
+  triggerReason: ActionCenterRouteFollowUpTriggerReason
+  recordedAt: string
+  recordedByRole: string
+  endedAt?: string | null
+}
+
+export interface ActionCenterRouteFollowUpRelationInput {
+  id?: string | null
+  route_relation_type?: string | null
+  routeRelationType?: string | null
+  source_route_id?: string | null
+  sourceRouteId?: string | null
+  target_route_id?: string | null
+  targetRouteId?: string | null
+  trigger_reason?: string | null
+  triggerReason?: string | null
+  recorded_at?: string | null
+  recordedAt?: string | null
+  recorded_by_role?: string | null
+  recordedByRole?: string | null
+  ended_at?: string | null
+  endedAt?: string | null
+}
+
+const FOLLOW_UP_TRIGGER_REASONS = new Set<ActionCenterRouteFollowUpTriggerReason>([
+  'nieuw-campaign-signaal',
+  'nieuw-segment-signaal',
+  'hernieuwde-hr-beoordeling',
+])
+
+function normalizeText(value: string | null | undefined) {
+  const trimmed = value?.trim() ?? ''
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function isValidIsoTimestamp(value: string) {
+  return !Number.isNaN(Date.parse(value))
+}
+
+function readCanonicalText(input: ActionCenterRouteFollowUpRelationInput, snakeKey: keyof ActionCenterRouteFollowUpRelationInput, camelKey: keyof ActionCenterRouteFollowUpRelationInput) {
+  return normalizeText((input[snakeKey] as string | null | undefined) ?? (input[camelKey] as string | null | undefined))
+}
+
+export function projectActionCenterRouteFollowUpRelation(
+  input: ActionCenterRouteFollowUpRelationInput,
+): ActionCenterRouteFollowUpRelationRecord {
+  const routeRelationType = readCanonicalText(input, 'route_relation_type', 'routeRelationType')
+  const sourceRouteId = readCanonicalText(input, 'source_route_id', 'sourceRouteId')
+  const targetRouteId = readCanonicalText(input, 'target_route_id', 'targetRouteId')
+  const triggerReason = readCanonicalText(input, 'trigger_reason', 'triggerReason')
+  const recordedAt = readCanonicalText(input, 'recorded_at', 'recordedAt')
+  const recordedByRole = readCanonicalText(input, 'recorded_by_role', 'recordedByRole')
+
+  if (routeRelationType !== 'follow-up-from') {
+    throw new Error('route_relation_type is required and must be follow-up-from.')
+  }
+
+  if (!sourceRouteId) {
+    throw new Error('source_route_id is required.')
+  }
+
+  if (!targetRouteId) {
+    throw new Error('target_route_id is required.')
+  }
+
+  if (!triggerReason) {
+    throw new Error('trigger_reason is required.')
+  }
+
+  if (!FOLLOW_UP_TRIGGER_REASONS.has(triggerReason as ActionCenterRouteFollowUpTriggerReason)) {
+    throw new Error('trigger_reason is invalid.')
+  }
+
+  if (!recordedAt) {
+    throw new Error('recorded_at is required.')
+  }
+
+  if (!isValidIsoTimestamp(recordedAt)) {
+    throw new Error('recorded_at is invalid.')
+  }
+
+  if (!recordedByRole) {
+    throw new Error('recorded_by_role is required.')
+  }
+
+  return {
+    id: normalizeText(input.id),
+    routeRelationType: 'follow-up-from',
+    sourceRouteId,
+    targetRouteId,
+    triggerReason: triggerReason as ActionCenterRouteFollowUpTriggerReason,
+    recordedAt,
+    recordedByRole,
+    endedAt: readCanonicalText(input, 'ended_at', 'endedAt'),
+  }
+}
+
+export function getActionCenterFollowUpTriggerReasonLabel(value: ActionCenterRouteFollowUpTriggerReason) {
+  switch (value) {
+    case 'nieuw-campaign-signaal':
+      return 'Nieuw campaign-signaal'
+    case 'nieuw-segment-signaal':
+      return 'Nieuw segmentsignaal'
+    case 'hernieuwde-hr-beoordeling':
+      return 'Hernieuwde HR-beoordeling'
+  }
+
+  const exhaustiveCheck: never = value
+  throw new Error(`Onbekende follow-up trigger reason: ${exhaustiveCheck}`)
+}

--- a/frontend/scripts/seed-action-center-manager-pilot.mjs
+++ b/frontend/scripts/seed-action-center-manager-pilot.mjs
@@ -5,7 +5,8 @@ import { createClient } from '@supabase/supabase-js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const frontendRoot = path.resolve(__dirname, '..')
-const envPath = path.join(frontendRoot, '.env.local')
+const primaryEnvPath = path.join(frontendRoot, '.env.local')
+const fallbackEnvPath = path.resolve(frontendRoot, '..', '..', '..', 'frontend', '.env.local')
 const artifactPath = path.join(frontendRoot, 'tests', 'e2e', '.action-center-pilot.json')
 
 const SUPPORTED_SCAN_TYPES = ['exit', 'retention', 'onboarding', 'pulse', 'leadership']
@@ -15,6 +16,8 @@ const MANAGER_EMAILS = [
   'manager.noord@demo.verisight.local',
   'manager.people@demo.verisight.local',
 ]
+const FOLLOW_UP_TRIGGER_REASON = 'hernieuwde-hr-beoordeling'
+const FOLLOW_UP_TRIGGER_REASON_LABEL = 'Hernieuwde HR-beoordeling'
 
 function loadEnv(filePath) {
   const values = {}
@@ -26,6 +29,11 @@ function loadEnv(filePath) {
     values[key] = rest.join('=').trim().replace(/^['"]|['"]$/g, '')
   }
   return values
+}
+
+function normalizeDepartmentLabel(value) {
+  const trimmed = value?.trim() ?? ''
+  return trimmed.length > 0 ? trimmed : null
 }
 
 function toDisplayName(email) {
@@ -40,42 +48,8 @@ function buildDepartmentScopeValue(orgId, departmentLabel) {
   return `${orgId}::department::${departmentLabel.toLowerCase()}`
 }
 
-async function findUserByEmail(admin, email) {
-  let page = 1
-  const perPage = 200
-  while (true) {
-    const { data, error } = await admin.auth.admin.listUsers({ page, perPage })
-    if (error) throw error
-    const match = data.users.find((user) => user.email?.toLowerCase() === email.toLowerCase())
-    if (match) return match
-    if (data.users.length < perPage) return null
-    page += 1
-  }
-}
-
-async function ensureUser(admin, email, password) {
-  const existing = await findUserByEmail(admin, email)
-  if (existing) {
-    await admin.auth.admin.updateUserById(existing.id, {
-      password,
-      email_confirm: true,
-      user_metadata: {
-        full_name: toDisplayName(email),
-      },
-    })
-    return existing
-  }
-
-  const { data, error } = await admin.auth.admin.createUser({
-    email,
-    password,
-    email_confirm: true,
-    user_metadata: {
-      full_name: toDisplayName(email),
-    },
-  })
-  if (error || !data.user) throw error ?? new Error(`Kon gebruiker ${email} niet aanmaken.`)
-  return data.user
+function buildRouteId(campaignId, scopeValue) {
+  return `${campaignId}::${scopeValue}`
 }
 
 function getScanPriority(scanType) {
@@ -95,44 +69,222 @@ function getScanPriority(scanType) {
   }
 }
 
-function choosePilotOrg(campaigns, respondents, statsByCampaignId) {
-  const departmentsByCampaign = respondents.reduce((acc, respondent) => {
-    const label = respondent.department?.trim()
-    if (!label) return acc
-    acc[respondent.campaign_id] ??= new Set()
-    acc[respondent.campaign_id].add(label)
-    return acc
-  }, {})
+function sortCampaignsForTarget(campaigns, statsByCampaignId) {
+  return [...campaigns].sort((left, right) => {
+    const leftStats = statsByCampaignId.get(left.id)
+    const rightStats = statsByCampaignId.get(right.id)
+    const priorityDelta = getScanPriority(right.scan_type) - getScanPriority(left.scan_type)
+    if (priorityDelta !== 0) return priorityDelta
+    const completionDelta = (rightStats?.total_completed ?? 0) - (leftStats?.total_completed ?? 0)
+    if (completionDelta !== 0) return completionDelta
+    return new Date(right.created_at).getTime() - new Date(left.created_at).getTime()
+  })
+}
 
-  const byOrg = new Map()
-  for (const campaign of campaigns) {
-    const orgEntry = byOrg.get(campaign.organization_id) ?? {
-      orgId: campaign.organization_id,
-      campaigns: [],
-      departments: new Set(),
-      reportReadyCampaignCount: 0,
-    }
-    orgEntry.campaigns.push(campaign)
-    const stats = statsByCampaignId.get(campaign.id)
-    if (stats?.is_active && stats.total_completed >= 10) {
-      orgEntry.reportReadyCampaignCount += 1
-    }
-    for (const department of departmentsByCampaign[campaign.id] ?? []) {
-      orgEntry.departments.add(department)
-    }
-    byOrg.set(campaign.organization_id, orgEntry)
+function sortCampaignsForSource(campaigns, statsByCampaignId) {
+  return [...campaigns].sort((left, right) => {
+    const leftStats = statsByCampaignId.get(left.id)
+    const rightStats = statsByCampaignId.get(right.id)
+    const completionDelta = (rightStats?.total_completed ?? 0) - (leftStats?.total_completed ?? 0)
+    if (completionDelta !== 0) return completionDelta
+    return new Date(left.created_at).getTime() - new Date(right.created_at).getTime()
+  })
+}
+
+function chooseFollowUpScenario(campaigns, respondents, statsByCampaignId) {
+  const campaignById = new Map(campaigns.map((campaign) => [campaign.id, campaign]))
+  const departmentCampaigns = new Map()
+
+  for (const respondent of respondents) {
+    const departmentLabel = normalizeDepartmentLabel(respondent.department)
+    if (!departmentLabel) continue
+    const campaign = campaignById.get(respondent.campaign_id)
+    if (!campaign) continue
+    const key = `${campaign.organization_id}::${departmentLabel.toLowerCase()}`
+    const entry =
+      departmentCampaigns.get(key) ?? {
+        orgId: campaign.organization_id,
+        departmentLabel,
+        campaigns: new Map(),
+      }
+    entry.campaigns.set(campaign.id, campaign)
+    departmentCampaigns.set(key, entry)
   }
 
-  return [...byOrg.values()]
-    .sort((left, right) => {
-      if (right.reportReadyCampaignCount !== left.reportReadyCampaignCount) {
-        return right.reportReadyCampaignCount - left.reportReadyCampaignCount
-      }
-      if (right.departments.size !== left.departments.size) {
-        return right.departments.size - left.departments.size
-      }
-      return right.campaigns.length - left.campaigns.length
-    })[0]
+  const candidates = []
+  for (const entry of departmentCampaigns.values()) {
+    const scopedCampaigns = [...entry.campaigns.values()]
+    if (scopedCampaigns.length !== 2) continue
+
+    const targetCandidates = sortCampaignsForTarget(
+      scopedCampaigns.filter((campaign) => {
+        const stats = statsByCampaignId.get(campaign.id)
+        return stats?.is_active === true && (stats.total_completed ?? 0) >= 10
+      }),
+      statsByCampaignId,
+    )
+
+    if (targetCandidates.length === 0) continue
+
+    const targetCampaign = targetCandidates[0]
+    const sourceCampaign =
+      sortCampaignsForSource(
+        scopedCampaigns.filter((campaign) => campaign.id !== targetCampaign.id),
+        statsByCampaignId,
+      )[0] ?? null
+
+    if (!sourceCampaign) continue
+
+    const targetStats = statsByCampaignId.get(targetCampaign.id)
+    const sourceStats = statsByCampaignId.get(sourceCampaign.id)
+    candidates.push({
+      orgId: entry.orgId,
+      departmentLabel: entry.departmentLabel,
+      sourceCampaign,
+      targetCampaign,
+      score:
+        ((targetStats?.total_completed ?? 0) * 1000) +
+        (sourceStats?.total_completed ?? 0) +
+        getScanPriority(targetCampaign.scan_type) * 100000,
+    })
+  }
+
+  return candidates.sort((left, right) => right.score - left.score)[0] ?? null
+}
+
+async function findUserByEmail(admin, email) {
+  let page = 1
+  const perPage = 200
+  while (true) {
+    const { data, error } = await admin.auth.admin.listUsers({ page, perPage })
+    if (error) throw error
+    const match = data.users.find((user) => user.email?.toLowerCase() === email.toLowerCase())
+    if (match) return match
+    if (data.users.length < perPage) return null
+    page += 1
+  }
+}
+
+async function ensureUser(admin, email, password) {
+  const existing = await findUserByEmail(admin, email)
+  if (existing) {
+    const { data, error } = await admin.auth.admin.updateUserById(existing.id, {
+      password,
+      email_confirm: true,
+      user_metadata: {
+        full_name: toDisplayName(email),
+      },
+    })
+    if (error) throw error
+    return data.user ?? existing
+  }
+
+  const { data, error } = await admin.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true,
+    user_metadata: {
+      full_name: toDisplayName(email),
+    },
+  })
+  if (error || !data.user) throw error ?? new Error(`Kon gebruiker ${email} niet aanmaken.`)
+  return data.user
+}
+
+async function upsertDeliveryRecord(admin, payload) {
+  const { data, error } = await admin
+    .from('campaign_delivery_records')
+    .upsert(payload, { onConflict: 'campaign_id' })
+    .select('id')
+    .single()
+
+  if (error || !data) {
+    throw error ?? new Error('Kon campaign delivery record niet opslaan.')
+  }
+
+  return data
+}
+
+async function upsertLearningDossier(admin, campaignId, payload) {
+  const { data: existingDossier, error: existingDossierError } = await admin
+    .from('pilot_learning_dossiers')
+    .select('id')
+    .eq('campaign_id', campaignId)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (existingDossierError) throw existingDossierError
+
+  const result = existingDossier
+    ? await admin
+        .from('pilot_learning_dossiers')
+        .update({
+          ...payload,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', existingDossier.id)
+        .select('id')
+        .single()
+    : await admin.from('pilot_learning_dossiers').insert(payload).select('id').single()
+
+  if (result.error || !result.data) {
+    throw result.error ?? new Error('Kon learning dossier niet opslaan.')
+  }
+
+  return result.data
+}
+
+async function deleteRouteRelations(admin, routeId) {
+  const bySource = await admin.from('action_center_route_relations').delete().eq('source_route_id', routeId)
+  if (bySource.error) throw bySource.error
+  const byTarget = await admin.from('action_center_route_relations').delete().eq('target_route_id', routeId)
+  if (byTarget.error) throw byTarget.error
+}
+
+async function deleteManagerResponseCarrier(admin, campaignId, scopeValue) {
+  const { error } = await admin
+    .from('action_center_manager_responses')
+    .delete()
+    .eq('campaign_id', campaignId)
+    .eq('route_scope_type', 'department')
+    .eq('route_scope_value', scopeValue)
+
+  if (error) throw error
+}
+
+async function upsertRouteCloseout(admin, args) {
+  const { error } = await admin
+    .from('action_center_route_closeouts')
+    .upsert(
+      {
+        route_id: args.routeId,
+        campaign_id: args.campaignId,
+        org_id: args.orgId,
+        route_scope_type: 'department',
+        route_scope_value: args.scopeValue,
+        closeout_status: 'afgerond',
+        closeout_reason: 'effect-voldoende-zichtbaar',
+        closeout_note: 'Deze route is bestuurlijk gesloten en blijft alleen als historische broncontext zichtbaar.',
+        closed_at: args.closedAt,
+        closed_by_role: 'hr',
+        created_by: args.userId,
+        updated_by: args.userId,
+      },
+      { onConflict: 'route_id' },
+    )
+
+  if (error) throw error
+}
+
+async function deleteRouteCloseout(admin, routeId) {
+  const { error } = await admin.from('action_center_route_closeouts').delete().eq('route_id', routeId)
+  if (error) throw error
+}
+
+const envPath = existsSync(primaryEnvPath) ? primaryEnvPath : fallbackEnvPath
+if (!existsSync(envPath)) {
+  throw new Error(`Geen .env.local gevonden op ${primaryEnvPath} of ${fallbackEnvPath}.`)
 }
 
 const env = loadEnv(envPath)
@@ -179,136 +331,148 @@ const { data: respondents, error: respondentError } = await admin
 if (respondentError) throw respondentError
 
 const statsByCampaignId = new Map((campaignStats ?? []).map((campaign) => [campaign.campaign_id, campaign]))
-const pilotOrg = choosePilotOrg(campaigns, respondents ?? [], statsByCampaignId)
-if (!pilotOrg) throw new Error('Kon geen pilotorganisatie kiezen.')
-
-const chosenDepartments = [...pilotOrg.departments].slice(0, 2)
-const canonicalCampaign =
-  [...pilotOrg.campaigns]
-    .filter((campaign) => {
-      const stats = statsByCampaignId.get(campaign.id)
-      return stats?.is_active === true && (stats.total_completed ?? 0) >= 10
-    })
-    .sort((left, right) => {
-      const leftStats = statsByCampaignId.get(left.id)
-      const rightStats = statsByCampaignId.get(right.id)
-      const priorityDelta = getScanPriority(right.scan_type) - getScanPriority(left.scan_type)
-      if (priorityDelta !== 0) return priorityDelta
-      const completionDelta = (rightStats?.total_completed ?? 0) - (leftStats?.total_completed ?? 0)
-      if (completionDelta !== 0) return completionDelta
-      return new Date(right.created_at).getTime() - new Date(left.created_at).getTime()
-    })[0] ?? null
-
-if (!canonicalCampaign) {
-  throw new Error('Kon geen canonieke report-ready demo campaign vinden voor de HR pilotseed.')
-}
-
-const firstManagementUseAt = new Date(Date.now() - 21 * 24 * 60 * 60 * 1000).toISOString()
-const reviewMoment = new Date(Date.now() + 10 * 24 * 60 * 60 * 1000).toISOString()
-
-const { data: deliveryRecord, error: deliveryRecordError } = await admin
-  .from('campaign_delivery_records')
-  .upsert(
-    {
-      organization_id: pilotOrg.orgId,
-      campaign_id: canonicalCampaign.id,
-      lifecycle_stage: 'first_management_use',
-      exception_status: 'none',
-      operator_owner: 'Verisight',
-      next_step: 'Volg de werkafspraken en toets ze opnieuw in de eerstvolgende review.',
-      operator_notes: 'HR demo route voor Action Center.',
-      customer_handoff_note: 'HR gebruikt deze campagne als vaste demo-route voor opvolging en review.',
-      first_management_use_confirmed_at: firstManagementUseAt,
-    },
-    { onConflict: 'campaign_id' },
+const scenario = chooseFollowUpScenario(campaigns, respondents ?? [], statsByCampaignId)
+if (!scenario) {
+  throw new Error(
+    'Kon geen afdeling vinden met precies twee campaigns en exact een bruikbare open doelroute voor de follow-up demo.',
   )
-  .select('id')
-  .single()
-
-if (deliveryRecordError || !deliveryRecord) {
-  throw deliveryRecordError ?? new Error('Kon delivery record niet opslaan.')
 }
 
-const dossierPayload = {
-  organization_id: pilotOrg.orgId,
-  campaign_id: canonicalCampaign.id,
-  title: `HR demo route - ${canonicalCampaign.name}`,
+const sourceCampaign = scenario.sourceCampaign
+const targetCampaign = scenario.targetCampaign
+const scopeLabel = scenario.departmentLabel
+const scopeValue = buildDepartmentScopeValue(scenario.orgId, scopeLabel)
+const sourceRouteId = buildRouteId(sourceCampaign.id, scopeValue)
+const targetRouteId = buildRouteId(targetCampaign.id, scopeValue)
+
+const hrOwner = await ensureUser(admin, HR_EMAIL, PILOT_PASSWORD)
+const managers = await Promise.all(MANAGER_EMAILS.map((email) => ensureUser(admin, email, PILOT_PASSWORD)))
+const followUpManager = managers[0]
+const secondaryManager = managers[1]
+
+const sourceClosedAt = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()
+const sourceReviewMoment = new Date(Date.now() - 4 * 24 * 60 * 60 * 1000).toISOString()
+const targetReviewMoment = new Date(Date.now() + 12 * 24 * 60 * 60 * 1000).toISOString()
+const firstManagementUseAt = new Date(Date.now() - 21 * 24 * 60 * 60 * 1000).toISOString()
+
+await deleteRouteRelations(admin, sourceRouteId)
+await deleteRouteRelations(admin, targetRouteId)
+await deleteManagerResponseCarrier(admin, sourceCampaign.id, scopeValue)
+await deleteManagerResponseCarrier(admin, targetCampaign.id, scopeValue)
+await upsertRouteCloseout(admin, {
+  routeId: sourceRouteId,
+  campaignId: sourceCampaign.id,
+  orgId: scenario.orgId,
+  scopeValue,
+  closedAt: sourceClosedAt,
+  userId: hrOwner.id,
+})
+await deleteRouteCloseout(admin, targetRouteId)
+
+await upsertDeliveryRecord(admin, {
+  organization_id: scenario.orgId,
+  campaign_id: sourceCampaign.id,
+  lifecycle_stage: 'first_management_use',
+  exception_status: 'none',
+  operator_owner: 'Verisight',
+  next_step: 'Bewaar deze eerdere route alleen historisch en open pas opnieuw bij een nieuw signaal.',
+  operator_notes: 'Historische bronroute voor HR follow-up trigger demo.',
+  customer_handoff_note: 'Deze route is afgesloten; HR opent alleen een nieuwe handoff als het signaal terugkomt.',
+  first_management_use_confirmed_at: firstManagementUseAt,
+})
+
+await upsertDeliveryRecord(admin, {
+  organization_id: scenario.orgId,
+  campaign_id: targetCampaign.id,
+  lifecycle_stage: 'first_management_use',
+  exception_status: 'none',
+  operator_owner: 'Verisight',
+  next_step: 'Gebruik deze open route als enige vervolgrichting voor dezelfde afdeling.',
+  operator_notes: 'Open doelroute voor HR follow-up trigger demo.',
+  customer_handoff_note: 'Deze route wacht op HR-handoff naar een manager binnen dezelfde afdeling.',
+  first_management_use_confirmed_at: firstManagementUseAt,
+})
+
+const sourceDossier = await upsertLearningDossier(admin, sourceCampaign.id, {
+  organization_id: scenario.orgId,
+  campaign_id: sourceCampaign.id,
+  title: `Gesloten HR bronroute - ${sourceCampaign.name}`,
   route_interest:
-    canonicalCampaign.scan_type === 'exit'
+    sourceCampaign.scan_type === 'exit'
       ? 'exitscan'
-      : canonicalCampaign.scan_type === 'retention'
+      : sourceCampaign.scan_type === 'retention'
         ? 'retentiescan'
         : 'nog-onzeker',
-  scan_type: canonicalCampaign.scan_type,
+  scan_type: sourceCampaign.scan_type,
+  triage_status: 'uitgevoerd',
+  expected_first_value: 'De eerdere interventie moest de teamafspraken tijdelijk verduidelijken.',
+  first_management_value: 'De eerste managementreactie is afgerond en historisch vastgelegd.',
+  first_action_taken: 'De vorige manageractie is uitgevoerd en geëvalueerd.',
+  review_moment: sourceReviewMoment,
+  adoption_outcome: 'De eerdere route is afgerond; alleen een nieuw HR-signaal mag nog een vervolg openen.',
+  management_action_outcome: 'afronden',
+  next_route: 'Bewaar deze route historisch en open een nieuwe route alleen bij een hernieuwd signaal.',
+  case_public_summary: 'De eerdere route is afgesloten en wordt nu historisch bewaard voor eventuele vervolgacties.',
+})
+
+const targetDossier = await upsertLearningDossier(admin, targetCampaign.id, {
+  organization_id: scenario.orgId,
+  campaign_id: targetCampaign.id,
+  title: `Open HR doelroute - ${targetCampaign.name}`,
+  route_interest:
+    targetCampaign.scan_type === 'exit'
+      ? 'exitscan'
+      : targetCampaign.scan_type === 'retention'
+        ? 'retentiescan'
+        : 'nog-onzeker',
+  scan_type: targetCampaign.scan_type,
   triage_status: 'bevestigd',
-  expected_first_value: 'Binnen twee weken moet de rolduidelijkheid merkbaar toenemen in het teamoverleg.',
-  first_management_value:
-    'We reviewen omdat HR wil toetsen of het eerste teamgesprek echt tot heldere werkafspraken leidde.',
-  first_action_taken: 'Plan een teamsessie van 30 minuten en leg drie concrete werkafspraken vast.',
-  review_moment: reviewMoment,
-  adoption_outcome: 'De eerste reactie is positiever, maar borging in het teamritme is nog nodig.',
-  management_action_outcome: 'bijstellen',
-  next_route: 'Borg de afspraken in het volgende teamoverleg en bevestig opnieuw wie eigenaar blijft.',
-  case_public_summary: 'De vorige stap is afgerond; deze actieve route bewaakt nu alleen de borging en bijsturing.',
-}
-
-const { data: existingDossier, error: existingDossierError } = await admin
-  .from('pilot_learning_dossiers')
-  .select('id')
-  .eq('campaign_id', canonicalCampaign.id)
-  .order('created_at', { ascending: false })
-  .limit(1)
-  .maybeSingle()
-
-if (existingDossierError) {
-  throw existingDossierError
-}
-
-const { data: dossier, error: dossierError } = existingDossier
-  ? await admin
-      .from('pilot_learning_dossiers')
-      .update({
-        ...dossierPayload,
-        updated_at: new Date().toISOString(),
-      })
-      .eq('id', existingDossier.id)
-      .select('id')
-      .single()
-  : await admin
-      .from('pilot_learning_dossiers')
-      .insert(dossierPayload)
-      .select('id')
-      .single()
-
-if (dossierError || !dossier) {
-  throw dossierError ?? new Error('Kon learning dossier niet opslaan.')
-}
+  expected_first_value: 'Binnen twee weken moet zichtbaar zijn of dit hernieuwde signaal opnieuw lokale opvolging vraagt.',
+  first_management_value: 'HR gebruikt deze doelroute als expliciete vervolghandoff binnen dezelfde afdeling.',
+  first_action_taken: 'Nog niet gestart; HR kiest eerst de manager en aanleiding voor deze follow-up route.',
+  review_moment: targetReviewMoment,
+  adoption_outcome: 'Deze route staat open en wacht op de nieuwe managerreactie.',
+  management_action_outcome: null,
+  next_route: 'Laat de toegewezen manager de eerste bounded reactie vastleggen in Action Center.',
+  case_public_summary: 'Deze open route is de enige expliciete vervolgrichting binnen dezelfde afdeling.',
+})
 
 const checkpointRows = [
   {
-    dossier_id: dossier.id,
+    dossier_id: sourceDossier.id,
     checkpoint_key: 'first_management_use',
     owner_label: 'HR',
     status: 'bevestigd',
-    objective_signal_notes: 'Drie werkafspraken zijn expliciet gemaakt.',
-    qualitative_notes: 'Het eerste gesprek gaf rust, maar opvolging moet nog worden geborgd.',
-    interpreted_observation: 'Het teamoverleg werd concreter en minder diffuus.',
-    confirmed_lesson: 'De eerste cyclus kon worden afgerond; de huidige route bewaakt of de afspraken blijven staan.',
+    objective_signal_notes: 'De vorige manageractie is afgerond.',
+    qualitative_notes: 'HR bewaart de uitkomst alleen nog als historische context.',
+    interpreted_observation: 'Deze route is gesloten en moet niet opnieuw worden gebruikt.',
+    confirmed_lesson: 'Nieuwe opvolging moet via een aparte route met nieuwe managerhandoff lopen.',
     lesson_strength: 'direct_uitvoerbare_verbetering',
     destination_areas: ['report', 'operations'],
   },
   {
-    dossier_id: dossier.id,
+    dossier_id: sourceDossier.id,
     checkpoint_key: 'follow_up_review',
     owner_label: 'HR',
     status: 'bevestigd',
-    objective_signal_notes: 'Managers melden rustiger weekstarts en minder rolverwarring.',
-    qualitative_notes: 'De eerste interventie lijkt te werken, maar borging in het vaste ritme is nodig.',
-    interpreted_observation: 'De vorige stap is afgerond; nu toetsen we vooral of het effect standhoudt.',
-    confirmed_lesson:
-      'De vorige stap is afgerond; deze actieve route kijkt nu alleen nog naar borging en eventuele bijsturing.',
+    objective_signal_notes: 'Alleen een hernieuwd signaal rechtvaardigt nog een vervolg.',
+    qualitative_notes: 'De oude route blijft gesloten en historisch.',
+    interpreted_observation: 'De vervolghandoff moet losstaan van deze afgesloten cyclus.',
+    confirmed_lesson: 'Gesloten routes blijven broncontext, geen actieve carrier.',
     lesson_strength: 'terugkerend_patroon',
     destination_areas: ['report', 'product'],
+  },
+  {
+    dossier_id: targetDossier.id,
+    checkpoint_key: 'first_management_use',
+    owner_label: 'HR',
+    status: 'bevestigd',
+    objective_signal_notes: 'Er is precies een open doelroute voor deze afdeling.',
+    qualitative_notes: 'HR kan hier nu een manager aan koppelen met expliciete triggerreden.',
+    interpreted_observation: 'Deze route is klaar voor een nieuwe handoff.',
+    confirmed_lesson: 'De afdeling heeft een eenduidige vervolgrichting zonder extra ambiguiteit.',
+    lesson_strength: 'direct_uitvoerbare_verbetering',
+    destination_areas: ['report', 'operations'],
   },
 ]
 
@@ -316,45 +480,41 @@ const { error: checkpointError } = await admin
   .from('pilot_learning_checkpoints')
   .upsert(checkpointRows, { onConflict: 'dossier_id,checkpoint_key' })
 
-if (checkpointError) {
-  throw checkpointError
-}
-
-const hrOwner = await ensureUser(admin, HR_EMAIL, PILOT_PASSWORD)
-const managers = await Promise.all(MANAGER_EMAILS.map((email) => ensureUser(admin, email, PILOT_PASSWORD)))
-
-const ownerMembershipRow = {
-  org_id: pilotOrg.orgId,
-  user_id: hrOwner.id,
-  role: 'owner',
-}
+if (checkpointError) throw checkpointError
 
 const { error: ownerMembershipError } = await admin
   .from('org_members')
-  .upsert(ownerMembershipRow, { onConflict: 'org_id,user_id' })
+  .upsert(
+    {
+      org_id: scenario.orgId,
+      user_id: hrOwner.id,
+      role: 'owner',
+    },
+    { onConflict: 'org_id,user_id' },
+  )
 
 if (ownerMembershipError) throw ownerMembershipError
 
 const workspaceRows = [
   {
-    org_id: pilotOrg.orgId,
+    org_id: scenario.orgId,
     user_id: hrOwner.id,
     display_name: toDisplayName(HR_EMAIL),
     login_email: HR_EMAIL,
     access_role: 'hr_owner',
     scope_type: 'org',
-    scope_value: `org:${pilotOrg.orgId}`,
+    scope_value: `org:${scenario.orgId}`,
     can_view: true,
     can_update: true,
     can_assign: true,
     can_schedule_review: true,
     created_by: hrOwner.id,
   },
-  ...managers.map((manager) => ({
-    org_id: pilotOrg.orgId,
-    user_id: manager.id,
-    display_name: manager.user_metadata?.full_name ?? toDisplayName(manager.email ?? 'manager'),
-    login_email: manager.email ?? null,
+  {
+    org_id: scenario.orgId,
+    user_id: followUpManager.id,
+    display_name: followUpManager.user_metadata?.full_name ?? toDisplayName(followUpManager.email ?? 'manager'),
+    login_email: followUpManager.email ?? null,
     access_role: 'manager_assignee',
     scope_type: 'org',
     scope_value: 'manager-pool',
@@ -363,23 +523,35 @@ const workspaceRows = [
     can_assign: false,
     can_schedule_review: true,
     created_by: hrOwner.id,
-  })),
-  ...managers.map((manager, index) => ({
-    org_id: pilotOrg.orgId,
-    user_id: manager.id,
-    display_name: manager.user_metadata?.full_name ?? toDisplayName(manager.email ?? 'manager'),
-    login_email: manager.email ?? null,
+  },
+  {
+    org_id: scenario.orgId,
+    user_id: followUpManager.id,
+    display_name: followUpManager.user_metadata?.full_name ?? toDisplayName(followUpManager.email ?? 'manager'),
+    login_email: followUpManager.email ?? null,
     access_role: 'manager_assignee',
-    scope_type: chosenDepartments[index] ? 'department' : 'item',
-    scope_value: chosenDepartments[index]
-      ? buildDepartmentScopeValue(pilotOrg.orgId, chosenDepartments[index])
-      : `${pilotOrg.orgId}::campaign::${canonicalCampaign.id}`,
+    scope_type: 'department',
+    scope_value: scopeValue,
     can_view: true,
     can_update: true,
     can_assign: false,
     can_schedule_review: true,
     created_by: hrOwner.id,
-  })),
+  },
+  {
+    org_id: scenario.orgId,
+    user_id: secondaryManager.id,
+    display_name: secondaryManager.user_metadata?.full_name ?? toDisplayName(secondaryManager.email ?? 'manager'),
+    login_email: secondaryManager.email ?? null,
+    access_role: 'manager_assignee',
+    scope_type: 'org',
+    scope_value: 'manager-pool',
+    can_view: true,
+    can_update: true,
+    can_assign: false,
+    can_schedule_review: true,
+    created_by: hrOwner.id,
+  },
 ]
 
 const { error: workspaceError } = await admin
@@ -391,30 +563,65 @@ if (workspaceError) throw workspaceError
 mkdirSync(path.dirname(artifactPath), { recursive: true })
 const artifact = {
   seededAt: new Date().toISOString(),
-  orgId: pilotOrg.orgId,
-  campaignId: canonicalCampaign.id,
+  envPathUsed: envPath,
+  orgId: scenario.orgId,
+  campaignId: targetCampaign.id,
   hrOwner: {
     email: HR_EMAIL,
     password: PILOT_PASSWORD,
   },
   routeContext: {
-    focusItemId: canonicalCampaign.id,
+    focusItemId: targetRouteId,
     overviewUrl: '/dashboard',
     reportsUrl: '/reports',
-    campaignDetailUrl: `/campaigns/${canonicalCampaign.id}`,
+    campaignDetailUrl: `/campaigns/${targetCampaign.id}`,
     actionCenterUrl: '/action-center',
-    actionCenterFocusUrl: `/action-center?focus=${canonicalCampaign.id}`,
+    actionCenterFocusUrl: `/action-center?focus=${targetRouteId}`,
   },
-  managers: managers.map((manager, index) => ({
-    email: manager.email,
-    password: PILOT_PASSWORD,
-    scopeType: chosenDepartments[index] ? 'department' : 'item',
-    scopeLabel: chosenDepartments[index] ?? canonicalCampaign.name,
-    scopeValue: chosenDepartments[index]
-      ? buildDepartmentScopeValue(pilotOrg.orgId, chosenDepartments[index])
-      : `${pilotOrg.orgId}::campaign::${canonicalCampaign.id}`,
-  })),
-  departmentLabels: chosenDepartments,
+  followUp: {
+    sourceCampaignId: sourceCampaign.id,
+    targetCampaignId: targetCampaign.id,
+    sourceRouteTitle: `Gesloten HR bronroute - ${sourceCampaign.name}`,
+    scopeLabel,
+    scopeValue,
+    sourceRouteId,
+    targetRouteId,
+    sourceCampaignDetailUrl: `/campaigns/${sourceCampaign.id}`,
+    targetCampaignDetailUrl: `/campaigns/${targetCampaign.id}`,
+    sourceActionCenterFocusUrl: `/action-center?focus=${sourceRouteId}`,
+    targetActionCenterFocusUrl: `/action-center?focus=${targetRouteId}`,
+    triggerReason: FOLLOW_UP_TRIGGER_REASON,
+    triggerReasonLabel: FOLLOW_UP_TRIGGER_REASON_LABEL,
+    manager: {
+      email: followUpManager.email,
+      password: PILOT_PASSWORD,
+      userId: followUpManager.id,
+      displayName: followUpManager.user_metadata?.full_name ?? toDisplayName(followUpManager.email ?? 'manager'),
+      scopeLabel,
+      scopeValue,
+    },
+  },
+  managers: [
+    {
+      email: followUpManager.email,
+      password: PILOT_PASSWORD,
+      userId: followUpManager.id,
+      displayName: followUpManager.user_metadata?.full_name ?? toDisplayName(followUpManager.email ?? 'manager'),
+      scopeType: 'department',
+      scopeLabel,
+      scopeValue,
+    },
+    {
+      email: secondaryManager.email,
+      password: PILOT_PASSWORD,
+      userId: secondaryManager.id,
+      displayName: secondaryManager.user_metadata?.full_name ?? toDisplayName(secondaryManager.email ?? 'manager'),
+      scopeType: 'org',
+      scopeLabel: 'Manager pool',
+      scopeValue: 'manager-pool',
+    },
+  ],
+  departmentLabels: [scopeLabel],
 }
 
 writeFileSync(artifactPath, JSON.stringify(artifact, null, 2), 'utf8')

--- a/frontend/tests/e2e/action-center-manager-access.spec.ts
+++ b/frontend/tests/e2e/action-center-manager-access.spec.ts
@@ -7,7 +7,24 @@ const artifact = existsSync(artifactPath)
   ? (JSON.parse(readFileSync(artifactPath, 'utf8')) as {
       campaignId: string
       hrOwner: { email: string; password: string }
-      managers: Array<{ email: string; password: string; scopeLabel: string }>
+      managers: Array<{
+        email: string
+        password: string
+        scopeLabel: string
+        displayName?: string
+        userId?: string
+      }>
+      followUp?: {
+        targetCampaignId: string
+        targetActionCenterFocusUrl: string
+        manager: {
+          email: string
+          password: string
+          scopeLabel: string
+          displayName: string
+          userId: string
+        }
+      }
     })
   : null
 
@@ -18,11 +35,30 @@ function escapeRegExp(value: string) {
 test.describe('action center manager access', () => {
   test.skip(!artifact, 'Seeded pilot artifact ontbreekt. Draai eerst scripts/seed-action-center-manager-pilot.mjs.')
 
-  const pilot = artifact as {
-    campaignId: string
-    hrOwner: { email: string; password: string }
-    managers: Array<{ email: string; password: string; scopeLabel: string }>
-  }
+  const pilot = artifact as
+    | {
+        campaignId: string
+        hrOwner: { email: string; password: string }
+        managers: Array<{
+          email: string
+          password: string
+          scopeLabel: string
+          displayName?: string
+          userId?: string
+        }>
+        followUp?: {
+          targetCampaignId: string
+          targetActionCenterFocusUrl: string
+          manager: {
+            email: string
+            password: string
+            scopeLabel: string
+            displayName: string
+            userId: string
+          }
+        }
+      }
+    | null
 
 async function login(page: import('@playwright/test').Page, email: string, password: string) {
   await page.goto('/login')
@@ -35,13 +71,17 @@ async function login(page: import('@playwright/test').Page, email: string, passw
 }
 
   test('hr owner keeps both modules inside one shared shell', async ({ page }) => {
+    if (!pilot) {
+      throw new Error('Seed artifact ontbreekt voor manager access test.')
+    }
+
     await login(page, pilot.hrOwner.email, pilot.hrOwner.password)
     await page.waitForURL(/\/dashboard$/)
 
     await expect(page.getByRole('navigation').getByRole('link', { name: 'Action Center' })).toBeVisible()
     await expect(page.getByRole('banner').getByRole('link', { name: 'Rapporten' })).toBeVisible()
 
-    await page.goto('/action-center')
+    await page.goto('/action-center', { waitUntil: 'domcontentloaded' })
     await expect(page.getByRole('heading', { name: 'Action Center', exact: true })).toBeVisible()
     await expect(page.getByRole('navigation').getByRole('link', { name: 'Managers', exact: true })).toBeVisible()
     await expect(page.getByRole('heading', { name: 'Managers en toewijzing' })).toBeVisible()
@@ -49,7 +89,13 @@ async function login(page: import('@playwright/test').Page, email: string, passw
   })
 
   test('manager assignee lands on action center only and gets denied on insights routes', async ({ page }) => {
-    const manager = pilot.managers[0]
+    if (!pilot) {
+      throw new Error('Seed artifact ontbreekt voor manager access test.')
+    }
+
+    const followUpManager = pilot.followUp?.manager ?? pilot.managers[0]
+    const targetCampaignId = pilot.followUp?.targetCampaignId ?? pilot.campaignId
+    const manager = followUpManager
     await login(page, manager.email, manager.password)
     await page.waitForURL(/\/action-center$/)
 
@@ -69,18 +115,25 @@ async function login(page: import('@playwright/test').Page, email: string, passw
     await page.goto('/reports')
     await expect(page.getByRole('heading', { name: 'Je ziet hier geen rapporten' })).toBeVisible()
 
-    await page.goto(`/campaigns/${pilot.campaignId}`)
+    await page.goto(`/campaigns/${targetCampaignId}`, { waitUntil: 'domcontentloaded' })
     await expect(page.getByRole('heading', { name: 'Je ziet hier geen campagnedetail' })).toBeVisible()
   })
 
   test('manager can save a bounded first response and see the route transition persist', async ({ page }) => {
-    const manager = pilot.managers[0]
-    const focusUrl = `/action-center?focus=${pilot.campaignId}`
+    if (!pilot) {
+      throw new Error('Seed artifact ontbreekt voor manager access test.')
+    }
+
+    const followUpManager = pilot.followUp?.manager ?? pilot.managers[0]
+    const targetCampaignId = pilot.followUp?.targetCampaignId ?? pilot.campaignId
+    const targetFocusUrl = pilot.followUp?.targetActionCenterFocusUrl ?? `/action-center?focus=${targetCampaignId}`
+    const manager = followUpManager
+    const focusUrl = targetFocusUrl
     await login(page, manager.email, manager.password)
     await page.waitForURL(/\/action-center$/)
 
     await page.goto(focusUrl)
-    await expect(page).toHaveURL(new RegExp(`focus=${pilot.campaignId}$`))
+    await expect(page).toHaveURL(new RegExp(`${escapeRegExp(focusUrl)}$`))
     await page.getByRole('button', { name: 'Open focusactie' }).click()
     await expect(page.getByRole('heading', { name: /route staat klaar voor eerste reactie|eerste lokale follow-through/i })).toBeVisible()
 
@@ -107,7 +160,7 @@ async function login(page: import('@playwright/test').Page, email: string, passw
     const savedRouteTitle = (await page.getByRole('heading', { level: 2 }).textContent())?.trim() ?? ''
 
     await page.goto(focusUrl)
-    await expect(page).toHaveURL(new RegExp(`focus=${pilot.campaignId}$`))
+    await expect(page).toHaveURL(new RegExp(`${escapeRegExp(focusUrl)}$`))
     await page
       .getByRole('button', { name: new RegExp(escapeRegExp(savedRouteTitle), 'i') })
       .first()

--- a/frontend/tests/e2e/action-center-route-reopen.spec.ts
+++ b/frontend/tests/e2e/action-center-route-reopen.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from '@playwright/test'
+import { existsSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+
+type ActionCenterPilotArtifact = {
+  hrOwner: { email: string; password: string }
+  followUp?: {
+    sourceCampaignId: string
+    targetCampaignId: string
+    sourceRouteTitle: string
+    scopeLabel: string
+    sourceActionCenterFocusUrl: string
+    targetActionCenterFocusUrl: string
+    triggerReason: string
+    triggerReasonLabel: string
+    manager: {
+      email: string
+      password: string
+      userId: string
+      displayName: string
+      scopeLabel: string
+      scopeValue: string
+    }
+  }
+}
+
+const artifactPath = path.join(process.cwd(), 'tests', 'e2e', '.action-center-pilot.json')
+const artifact = existsSync(artifactPath)
+  ? (JSON.parse(readFileSync(artifactPath, 'utf8')) as ActionCenterPilotArtifact)
+  : null
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+async function login(page: import('@playwright/test').Page, email: string, password: string) {
+  await page.goto('/login')
+  await page.getByLabel('E-mailadres').fill(email)
+  await page.getByLabel('Wachtwoord').fill(password)
+  await Promise.all([
+    page.waitForURL(/\/(dashboard|action-center)(?:\?.*)?$/),
+    page.getByRole('button', { name: 'Inloggen' }).click(),
+  ])
+}
+
+test.describe('action center route reopen flow', () => {
+  test.skip(!artifact, 'Seeded pilot artifact ontbreekt. Draai eerst scripts/seed-action-center-manager-pilot.mjs.')
+
+  const pilot = artifact as ActionCenterPilotArtifact
+
+  test('hr starts a same-scope follow-up route and the source route stays historical', async ({ page }) => {
+    if (!pilot.followUp) {
+      throw new Error('Seed artifact mist followUp-context voor Task 7.')
+    }
+
+    await login(page, pilot.hrOwner.email, pilot.hrOwner.password)
+    await page.goto(pilot.followUp.sourceActionCenterFocusUrl)
+    await expect(page).toHaveURL(new RegExp(`${escapeRegExp(pilot.followUp.sourceActionCenterFocusUrl)}$`))
+    await page.getByRole('button', { name: /^Acties/ }).click()
+
+    await expect(page.getByText('Action Center / Acties')).toBeVisible()
+    await expect(page.getByText('Afgerond voor nu', { exact: true })).toBeVisible()
+    await expect(page.getByRole('heading', { name: pilot.followUp.sourceRouteTitle })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Start vervolgroute' })).toBeVisible()
+    await expect(page.getByText('Open vanuit deze gesloten route een nieuwe HR-handoff binnen dezelfde afdeling.')).toBeVisible()
+
+    await page.getByLabel('Kies manager').selectOption({ label: pilot.followUp.manager.displayName })
+    await page.getByRole('radio', { name: pilot.followUp.triggerReasonLabel, exact: true }).check()
+    await page.getByRole('button', { name: 'Start vervolgroute' }).click()
+
+    await expect(page.getByRole('heading', { name: 'Eerste lokale follow-through' })).toBeVisible()
+    await expect(page.getByText(pilot.followUp.scopeLabel, { exact: true }).first()).toBeVisible()
+
+    await expect(
+      page.getByText('Voor deze doelroute bestaat al een manager response carrier; overschrijven is in V1 niet toegestaan.'),
+    ).toHaveCount(0)
+    await expect(page.getByRole('heading', { name: 'Eerste lokale follow-through' })).toBeVisible()
+  })
+})

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -674,6 +674,27 @@ create table if not exists public.action_center_manager_responses (
   unique (campaign_id, route_scope_type, route_scope_value)
 );
 
+create table if not exists public.action_center_route_relations (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid references public.organizations(id) on delete cascade not null,
+  source_campaign_id uuid references public.campaigns(id) on delete cascade not null,
+  source_route_id text not null,
+  source_route_scope_value text not null,
+  target_campaign_id uuid references public.campaigns(id) on delete cascade not null,
+  target_route_id text not null,
+  target_route_scope_value text not null,
+  route_relation_type text not null
+    check (route_relation_type in ('follow-up-from')),
+  trigger_reason text not null
+    check (trigger_reason in ('nieuw-campaign-signaal', 'nieuw-segment-signaal', 'hernieuwde-hr-beoordeling')),
+  manager_user_id uuid references auth.users(id) on delete set null,
+  recorded_by uuid references auth.users(id) on delete set null,
+  recorded_by_role text not null
+    check (recorded_by_role in ('verisight_admin', 'hr_owner', 'hr_member')),
+  recorded_at timestamptz not null default now(),
+  ended_at timestamptz
+);
+
 -- ============================================================
 -- INDEXES
 -- ============================================================
@@ -697,6 +718,11 @@ create index if not exists idx_action_center_review_decisions_checkpoint on publ
 create index if not exists idx_action_center_review_decisions_recorded_at on public.action_center_review_decisions(decision_recorded_at desc);
 create index if not exists idx_action_center_manager_responses_route on public.action_center_manager_responses(campaign_id, route_scope_type, route_scope_value);
 create index if not exists idx_action_center_manager_responses_manager on public.action_center_manager_responses(manager_user_id);
+create index if not exists idx_action_center_route_relations_source on public.action_center_route_relations(source_route_id);
+create index if not exists idx_action_center_route_relations_target on public.action_center_route_relations(target_route_id);
+create unique index if not exists idx_action_center_route_relations_active_direct_follow_up
+  on public.action_center_route_relations(source_route_id)
+  where route_relation_type = 'follow-up-from' and ended_at is null;
 create index if not exists idx_delivery_records_org on public.campaign_delivery_records(organization_id);
 create index if not exists idx_delivery_records_contact_request on public.campaign_delivery_records(contact_request_id);
 create index if not exists idx_delivery_records_lifecycle on public.campaign_delivery_records(lifecycle_stage);
@@ -720,6 +746,7 @@ alter table public.pilot_learning_dossiers enable row level security;
 alter table public.pilot_learning_checkpoints enable row level security;
 alter table public.action_center_review_decisions enable row level security;
 alter table public.action_center_manager_responses enable row level security;
+alter table public.action_center_route_relations enable row level security;
 
 -- ── Hulpfuncties ─────────────────────────────────────────────────────────────
 
@@ -1170,6 +1197,83 @@ create policy "managers_can_update_action_center_manager_responses"
         and m.access_role = 'manager_assignee'
         and m.scope_type = action_center_manager_responses.route_scope_type
         and m.scope_value = action_center_manager_responses.route_scope_value
+        and m.can_update
+    )
+  );
+
+drop policy if exists "hr_and_admins_can_select_action_center_route_relations" on public.action_center_route_relations;
+drop policy if exists "managers_can_select_action_center_route_relations" on public.action_center_route_relations;
+drop policy if exists "hr_and_admins_can_insert_action_center_route_relations" on public.action_center_route_relations;
+drop policy if exists "hr_and_admins_can_update_action_center_route_relations" on public.action_center_route_relations;
+
+create policy "hr_and_admins_can_select_action_center_route_relations"
+  on public.action_center_route_relations for select
+  using (
+    public.is_verisight_admin_user()
+    or public.is_org_member(org_id)
+    or exists (
+      select 1
+      from public.action_center_workspace_members m
+      where m.user_id = auth.uid()
+        and m.org_id = action_center_route_relations.org_id
+        and m.access_role in ('hr_owner', 'hr_member')
+        and m.can_view
+    )
+  );
+
+create policy "managers_can_select_action_center_route_relations"
+  on public.action_center_route_relations for select
+  using (
+    public.is_verisight_admin_user()
+    or exists (
+      select 1
+      from public.action_center_workspace_members m
+      where m.user_id = auth.uid()
+        and m.org_id = action_center_route_relations.org_id
+        and m.access_role = 'manager_assignee'
+        and m.scope_value = action_center_route_relations.source_route_scope_value
+        and m.can_view
+    )
+  );
+
+create policy "hr_and_admins_can_insert_action_center_route_relations"
+  on public.action_center_route_relations for insert
+  with check (
+    public.is_verisight_admin_user()
+    or public.is_org_owner(org_id)
+    or exists (
+      select 1
+      from public.action_center_workspace_members m
+      where m.user_id = auth.uid()
+        and m.org_id = action_center_route_relations.org_id
+        and m.access_role in ('hr_owner', 'hr_member')
+        and m.can_update
+    )
+  );
+
+create policy "hr_and_admins_can_update_action_center_route_relations"
+  on public.action_center_route_relations for update
+  using (
+    public.is_verisight_admin_user()
+    or public.is_org_owner(org_id)
+    or exists (
+      select 1
+      from public.action_center_workspace_members m
+      where m.user_id = auth.uid()
+        and m.org_id = action_center_route_relations.org_id
+        and m.access_role in ('hr_owner', 'hr_member')
+        and m.can_update
+    )
+  )
+  with check (
+    public.is_verisight_admin_user()
+    or public.is_org_owner(org_id)
+    or exists (
+      select 1
+      from public.action_center_workspace_members m
+      where m.user_id = auth.uid()
+        and m.org_id = action_center_route_relations.org_id
+        and m.access_role in ('hr_owner', 'hr_member')
         and m.can_update
     )
   );


### PR DESCRIPTION
## Summary
- add the HR `Start vervolgroute` write-path for closed routes with manager selection and canonical trigger reasons
- add the follow-up route API, route relation truth projection, live semantics wiring, seed updates, and browser coverage
- align the live Supabase relation schema with the new follow-up trigger columns and compatibility requirements

## Verification
- `node ./scripts/seed-action-center-manager-pilot.mjs`
- `npx vitest run lib/action-center-route-reopen.test.ts lib/action-center-follow-up-route-trigger.test.ts lib/action-center-route-relations-policy.test.ts lib/action-center-live.test.ts "app/(dashboard)/action-center/page.route-shell.test.ts" app/api/action-center-route-follow-ups/route.test.ts`
- `npx eslint "tests/e2e/action-center-route-reopen.spec.ts" "tests/e2e/action-center-manager-access.spec.ts" "components/dashboard/action-center-preview.tsx" "app/api/action-center-route-follow-ups/route.ts" "app/api/action-center-route-follow-ups/route.test.ts" "lib/action-center-route-reopen.ts" "lib/action-center-route-reopen.test.ts" "lib/action-center-follow-up-route-trigger.test.ts" "lib/action-center-route-relations-policy.test.ts" "lib/action-center-live.ts" "lib/action-center-live.test.ts" "app/(dashboard)/action-center/page.tsx" "app/(dashboard)/action-center/page.route-shell.test.ts"`
- `npx playwright test tests/e2e/action-center-route-reopen.spec.ts tests/e2e/action-center-manager-access.spec.ts --project=chromium --workers=1`

## Note
- `npm run build` currently hits a local Next.js/Node OOM (`Zone Allocation failed`) in this worktree, rather than a feature compile error.