### PR TITLE
Add lineage read summaries for follow-up routes

### DIFF
--- a/docs/superpowers/plans/2026-05-01-action-center-lineage-read-summaries.md
+++ b/docs/superpowers/plans/2026-05-01-action-center-lineage-read-summaries.md
@@ -1,0 +1,507 @@
+# Action Center Lineage Read Summaries Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a small shared lineage/read summary layer so HR and managers can see one-step-back and one-step-forward route context in overview and detail without adding new workflow or truth.
+
+**Architecture:** Extend the existing Action Center route projector so it derives a compact lineage summary from existing reopen event truth and `follow-up-from` route relations. Surface those derived labels in the existing route summary/header UI, keeping overview compact and detail slightly richer, while preserving a single deterministic read contract for middle routes and inconsistent data fallback.
+
+**Tech Stack:** Next.js App Router, TypeScript, React, Vitest, Playwright, Supabase-backed Action Center truth
+
+---
+
+### Task 1: Add lineage summary projector coverage first
+
+**Files:**
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\action-center-follow-up-route-trigger\frontend\lib\action-center-core-semantics.test.ts`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\action-center-follow-up-route-trigger\frontend\lib\action-center-live.test.ts`
+- Test: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\action-center-follow-up-route-trigger\frontend\lib\action-center-core-semantics.test.ts`
+
+- [ ] **Step 1: Write the failing lineage projector tests**
+
+Add tests that pin the intended read contract:
+
+```ts
+it("projects a follow-up route as vervolg op eerdere route", () => {
+  const projected = projectActionCenterRoute({
+    ...buildBaseRoute(),
+    routeRelations: [
+      buildFollowUpRelation({
+        sourceRouteId: "campaign-a::department::finance",
+        targetRouteId: "campaign-b::department::finance",
+        recordedAt: "2026-05-01T10:00:00.000Z",
+      }),
+    ],
+    routeId: "campaign-b::department::finance",
+  })
+
+  expect(projected.lineageSummary?.backwardLabel).toBe("Vervolg op eerdere route")
+  expect(projected.lineageSummary?.forwardLabel).toBeNull()
+})
+
+it("projects a middle route with overview-backward and detail-both lineage", () => {
+  const projected = projectActionCenterRoute({
+    ...buildBaseRoute(),
+    routeId: "campaign-b::department::finance",
+    routeRelations: [
+      buildFollowUpRelation({
+        sourceRouteId: "campaign-a::department::finance",
+        targetRouteId: "campaign-b::department::finance",
+        recordedAt: "2026-05-01T09:00:00.000Z",
+      }),
+      buildFollowUpRelation({
+        sourceRouteId: "campaign-b::department::finance",
+        targetRouteId: "campaign-c::department::finance",
+        recordedAt: "2026-05-02T09:00:00.000Z",
+      }),
+    ],
+  })
+
+  expect(projected.lineageSummary?.overviewLabel).toBe("Vervolg op eerdere route")
+  expect(projected.lineageSummary?.detailLabels).toEqual([
+    "Vervolg op eerdere route",
+    "Later opgevolgd",
+  ])
+})
+
+it("prefers reopen over follow-up for backward lineage", () => {
+  const projected = projectActionCenterRoute({
+    ...buildBaseRoute(),
+    routeReopens: [
+      buildRouteReopen({
+        routeId: "campaign-a::department::finance",
+        reopenedAt: "2026-05-03T12:00:00.000Z",
+      }),
+    ],
+    routeRelations: [
+      buildFollowUpRelation({
+        sourceRouteId: "campaign-z::department::finance",
+        targetRouteId: "campaign-a::department::finance",
+        recordedAt: "2026-05-01T10:00:00.000Z",
+      }),
+    ],
+    routeId: "campaign-a::department::finance",
+  })
+
+  expect(projected.lineageSummary?.backwardLabel).toBe("Heropend traject")
+})
+
+it("falls back to the most recent follow-up neighbor when data is inconsistent", () => {
+  const projected = projectActionCenterRoute({
+    ...buildBaseRoute(),
+    routeId: "campaign-b::department::finance",
+    routeRelations: [
+      buildFollowUpRelation({
+        sourceRouteId: "campaign-a::department::finance",
+        targetRouteId: "campaign-b::department::finance",
+        recordedAt: "2026-05-01T08:00:00.000Z",
+      }),
+      buildFollowUpRelation({
+        sourceRouteId: "campaign-a2::department::finance",
+        targetRouteId: "campaign-b::department::finance",
+        recordedAt: "2026-05-01T11:00:00.000Z",
+      }),
+    ],
+  })
+
+  expect(projected.lineageSummary?.backwardRouteId).toBe("campaign-a2::department::finance")
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+npx vitest run lib/action-center-core-semantics.test.ts lib/action-center-live.test.ts
+```
+
+Expected: FAIL with missing `lineageSummary` fields or incorrect projection behavior.
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+git add frontend/lib/action-center-core-semantics.test.ts frontend/lib/action-center-live.test.ts
+git commit -m "test: define action center lineage summary contract"
+```
+
+### Task 2: Implement deterministic lineage projector logic
+
+**Files:**
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\action-center-follow-up-route-trigger\frontend\lib\action-center-core-semantics.ts`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\action-center-follow-up-route-trigger\frontend\lib\action-center-route-reopen.ts`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\action-center-follow-up-route-trigger\frontend\lib\action-center-live.ts`
+- Test: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\action-center-follow-up-route-trigger\frontend\lib\action-center-core-semantics.test.ts`
+
+- [ ] **Step 1: Add minimal lineage summary types**
+
+Add a focused type near the existing projected route types:
+
+```ts
+export type ActionCenterLineageLabel =
+  | "Heropend traject"
+  | "Vervolg op eerdere route"
+  | "Later opgevolgd"
+
+export type ActionCenterLineageSummary = {
+  overviewLabel: ActionCenterLineageLabel | null
+  backwardLabel: ActionCenterLineageLabel | null
+  backwardRouteId: string | null
+  forwardLabel: ActionCenterLineageLabel | null
+  forwardRouteId: string | null
+  detailLabels: ActionCenterLineageLabel[]
+}
+```
+
+- [ ] **Step 2: Implement reusable neighbor resolution helpers**
+
+Add small pure helpers that keep the rules local and testable:
+
+```ts
+function pickMostRecentRelation<T extends { recordedAt: string }>(rows: T[]): T | null {
+  return rows
+    .slice()
+    .sort((a, b) => Date.parse(b.recordedAt) - Date.parse(a.recordedAt))[0] ?? null
+}
+
+function pickMostRecentReopen<T extends { reopenedAt: string }>(rows: T[]): T | null {
+  return rows
+    .slice()
+    .sort((a, b) => Date.parse(b.reopenedAt) - Date.parse(a.reopenedAt))[0] ?? null
+}
+```
+
+- [ ] **Step 3: Implement the lineage summary projector**
+
+Add a projector that only reads existing truth:
+
+```ts
+export function projectActionCenterLineageSummary(input: {
+  routeId: string
+  routeReopens: ActionCenterRouteReopen[]
+  routeRelations: ActionCenterRouteRelation[]
+}): ActionCenterLineageSummary {
+  const reopen = pickMostRecentReopen(
+    input.routeReopens.filter((row) => row.routeId === input.routeId),
+  )
+
+  const backwardRelation = pickMostRecentRelation(
+    input.routeRelations.filter((row) => row.targetRouteId === input.routeId),
+  )
+
+  const forwardRelation = pickMostRecentRelation(
+    input.routeRelations.filter((row) => row.sourceRouteId === input.routeId),
+  )
+
+  const backwardLabel = reopen
+    ? "Heropend traject"
+    : backwardRelation
+      ? "Vervolg op eerdere route"
+      : null
+
+  const forwardLabel = forwardRelation ? "Later opgevolgd" : null
+
+  return {
+    overviewLabel: backwardLabel ?? forwardLabel,
+    backwardLabel,
+    backwardRouteId: backwardRelation?.sourceRouteId ?? null,
+    forwardLabel,
+    forwardRouteId: forwardRelation?.targetRouteId ?? null,
+    detailLabels: [backwardLabel, forwardLabel].filter(Boolean) as ActionCenterLineageLabel[],
+  }
+}
+```
+
+- [ ] **Step 4: Thread the summary into the existing projected route shape**
+
+When projecting route cards/items, add:
+
+```ts
+lineageSummary: projectActionCenterLineageSummary({
+  routeId,
+  routeReopens,
+  routeRelations,
+}),
+```
+
+Do not add new persistence or mutation logic in this step.
+
+- [ ] **Step 5: Run targeted tests to verify the projector passes**
+
+Run:
+
+```bash
+npx vitest run lib/action-center-core-semantics.test.ts lib/action-center-live.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Commit the projector implementation**
+
+```bash
+git add frontend/lib/action-center-core-semantics.ts frontend/lib/action-center-route-reopen.ts frontend/lib/action-center-live.ts frontend/lib/action-center-core-semantics.test.ts frontend/lib/action-center-live.test.ts
+git commit -m "feat: project action center lineage summaries"
+```
+
+### Task 3: Surface overview lineage labels in the route list
+
+**Files:**
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\action-center-follow-up-route-trigger\frontend\components\dashboard\action-center-preview.tsx`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\action-center-follow-up-route-trigger\frontend\app\(dashboard)\action-center\page.tsx`
+- Test: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\action-center-follow-up-route-trigger\frontend\app\(dashboard)\action-center\page.route-shell.test.ts`
+
+- [ ] **Step 1: Add failing overview rendering tests**
+
+Add assertions that route cards render only the compact overview label:
+
+```ts
+it("shows a compact lineage label for a follow-up route in the route list", async () => {
+  renderRouteShell({
+    items: [
+      buildRouteItem({
+        lineageSummary: {
+          overviewLabel: "Vervolg op eerdere route",
+          backwardLabel: "Vervolg op eerdere route",
+          backwardRouteId: "campaign-a::department::finance",
+          forwardLabel: null,
+          forwardRouteId: null,
+          detailLabels: ["Vervolg op eerdere route"],
+        },
+      }),
+    ],
+  })
+
+  expect(screen.getByText("Vervolg op eerdere route")).toBeInTheDocument()
+})
+
+it("prefers the backward lineage label over forward lineage in overview", async () => {
+  renderRouteShell({
+    items: [
+      buildRouteItem({
+        lineageSummary: {
+          overviewLabel: "Vervolg op eerdere route",
+          backwardLabel: "Vervolg op eerdere route",
+          backwardRouteId: "campaign-a::department::finance",
+          forwardLabel: "Later opgevolgd",
+          forwardRouteId: "campaign-c::department::finance",
+          detailLabels: ["Vervolg op eerdere route", "Later opgevolgd"],
+        },
+      }),
+    ],
+  })
+
+  expect(screen.getAllByText("Vervolg op eerdere route")).not.toHaveLength(0)
+  expect(screen.queryByText("Later opgevolgd")).not.toBeInTheDocument()
+})
+```
+
+- [ ] **Step 2: Run the overview tests to verify they fail**
+
+Run:
+
+```bash
+npx vitest run "app/(dashboard)/action-center/page.route-shell.test.ts"
+```
+
+Expected: FAIL because the overview surface does not yet render the lineage label.
+
+- [ ] **Step 3: Render the compact overview label**
+
+In the existing route card/preview summary area, add a small secondary line:
+
+```tsx
+{item.lineageSummary?.overviewLabel ? (
+  <p className="text-xs text-muted-foreground">
+    {item.lineageSummary.overviewLabel}
+  </p>
+) : null}
+```
+
+Keep this close to the route title/summary, not as a separate panel.
+
+- [ ] **Step 4: Re-run the overview tests**
+
+Run:
+
+```bash
+npx vitest run "app/(dashboard)/action-center/page.route-shell.test.ts"
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit the overview UI**
+
+```bash
+git add "frontend/components/dashboard/action-center-preview.tsx" "frontend/app/(dashboard)/action-center/page.tsx" "frontend/app/(dashboard)/action-center/page.route-shell.test.ts"
+git commit -m "feat: show action center lineage labels in overview"
+```
+
+### Task 4: Surface richer detail lineage context with direct links
+
+**Files:**
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\action-center-follow-up-route-trigger\frontend\components\dashboard\action-center-preview.tsx`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\action-center-follow-up-route-trigger\frontend\lib\action-center-live.test.ts`
+- Test: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\action-center-follow-up-route-trigger\frontend\tests\e2e\action-center-route-reopen.spec.ts`
+
+- [ ] **Step 1: Add failing detail tests for dual lineage**
+
+Add a render test for the selected route detail state:
+
+```ts
+it("shows both backward and forward lineage in detail for a middle route", () => {
+  renderPreview({
+    selectedItem: buildRouteItem({
+      lineageSummary: {
+        overviewLabel: "Vervolg op eerdere route",
+        backwardLabel: "Vervolg op eerdere route",
+        backwardRouteId: "campaign-a::department::finance",
+        forwardLabel: "Later opgevolgd",
+        forwardRouteId: "campaign-c::department::finance",
+        detailLabels: ["Vervolg op eerdere route", "Later opgevolgd"],
+      },
+    }),
+  })
+
+  expect(screen.getByText("Vervolg op eerdere route")).toBeInTheDocument()
+  expect(screen.getByText("Later opgevolgd")).toBeInTheDocument()
+})
+```
+
+- [ ] **Step 2: Run the detail tests to verify they fail**
+
+Run:
+
+```bash
+npx vitest run lib/action-center-live.test.ts
+```
+
+Expected: FAIL because the detail surface does not yet show both lineage readings.
+
+- [ ] **Step 3: Render compact lineage links in the detail header**
+
+Add a small inline block near the route heading:
+
+```tsx
+<div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+  {selected.lineageSummary?.backwardLabel && selected.lineageSummary.backwardRouteId ? (
+    <button onClick={() => focusRoute(selected.lineageSummary!.backwardRouteId!)}>
+      {selected.lineageSummary.backwardLabel}
+    </button>
+  ) : null}
+  {selected.lineageSummary?.forwardLabel && selected.lineageSummary.forwardRouteId ? (
+    <button onClick={() => focusRoute(selected.lineageSummary!.forwardRouteId!)}>
+      {selected.lineageSummary.forwardLabel}
+    </button>
+  ) : null}
+</div>
+```
+
+Use the existing focus/open route mechanism rather than introducing a new router path helper.
+
+- [ ] **Step 4: Add browser coverage for the detail links**
+
+Extend the existing route reopen/follow-up Playwright flow:
+
+```ts
+test("detail lineage lets HR navigate to previous and next route context", async ({ page }) => {
+  await page.goto("/action-center", { waitUntil: "domcontentloaded" })
+  await expect(page.getByText("Vervolg op eerdere route")).toBeVisible()
+  await page.getByRole("button", { name: "Vervolg op eerdere route" }).click()
+  await expect(page.getByText("Later opgevolgd")).toBeVisible()
+})
+```
+
+- [ ] **Step 5: Run the detail unit test and browser spec**
+
+Run:
+
+```bash
+npx vitest run lib/action-center-live.test.ts
+npx playwright test tests/e2e/action-center-route-reopen.spec.ts --project=chromium --workers=1
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Commit the detail lineage UI**
+
+```bash
+git add frontend/components/dashboard/action-center-preview.tsx frontend/lib/action-center-live.test.ts frontend/tests/e2e/action-center-route-reopen.spec.ts
+git commit -m "feat: add action center detail lineage context"
+```
+
+### Task 5: Verify the full lineage summary slice end-to-end
+
+**Files:**
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\action-center-follow-up-route-trigger\frontend\tests\e2e\action-center-manager-access.spec.ts`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\action-center-follow-up-route-trigger\frontend\scripts\seed-action-center-manager-pilot.mjs`
+- Test: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\action-center-follow-up-route-trigger\frontend\tests\e2e\action-center-manager-access.spec.ts`
+
+- [ ] **Step 1: Ensure the seed still exposes previous/current/next route data**
+
+If the current seed only creates one direction of lineage, extend it minimally:
+
+```js
+await upsertRouteRelation({
+  source_route_id: sourceRouteId,
+  target_route_id: currentRouteId,
+  route_relation_type: "follow-up-from",
+  trigger_reason: "hernieuwde-hr-beoordeling",
+  recorded_at: now,
+})
+
+await upsertRouteRelation({
+  source_route_id: currentRouteId,
+  target_route_id: nextRouteId,
+  route_relation_type: "follow-up-from",
+  trigger_reason: "nieuw-campaign-signaal",
+  recorded_at: later,
+})
+```
+
+- [ ] **Step 2: Add a manager-facing browser assertion**
+
+Extend the manager spec to verify the compact label also makes sense outside HR:
+
+```ts
+test("manager sees compact lineage context on a follow-up route", async ({ page }) => {
+  await page.goto("/action-center", { waitUntil: "domcontentloaded" })
+  await expect(page.getByText("Vervolg op eerdere route")).toBeVisible()
+})
+```
+
+- [ ] **Step 3: Run the seed, unit tests, browser tests, lint, and build**
+
+Run:
+
+```bash
+node ./scripts/seed-action-center-manager-pilot.mjs
+npx vitest run lib/action-center-core-semantics.test.ts lib/action-center-live.test.ts "app/(dashboard)/action-center/page.route-shell.test.ts"
+npx eslint "components/dashboard/action-center-preview.tsx" "lib/action-center-core-semantics.ts" "lib/action-center-live.ts" "lib/action-center-core-semantics.test.ts" "lib/action-center-live.test.ts" "app/(dashboard)/action-center/page.route-shell.test.ts" "tests/e2e/action-center-route-reopen.spec.ts" "tests/e2e/action-center-manager-access.spec.ts"
+npx playwright test tests/e2e/action-center-route-reopen.spec.ts tests/e2e/action-center-manager-access.spec.ts --project=chromium --workers=1
+npm run build
+```
+
+Expected:
+- seed succeeds
+- targeted Vitest passes
+- ESLint is clean
+- Playwright passes
+- build succeeds
+
+- [ ] **Step 4: Commit the verification slice**
+
+```bash
+git add frontend/tests/e2e/action-center-manager-access.spec.ts frontend/tests/e2e/action-center-route-reopen.spec.ts frontend/scripts/seed-action-center-manager-pilot.mjs
+git commit -m "test: verify action center lineage summaries"
+```
+
+## Spec Coverage Check
+- Shared small lineage summary for HR and manager: Tasks 2-4
+- One step back and one step forward only: Tasks 1-2
+- Canonical labels `Heropend traject`, `Vervolg op eerdere route`, `Later opgevolgd`: Tasks 1-4
+- Overview compact / detail slightly richer: Tasks 3-4
+- Reopen precedence over follow-up: Task 1 and Task 2
+- Middle-route projection rule: Task 1 and Task 4
+- Deterministic fallback for inconsistent neighbor data: Task 1 and Task 2
+- No new truth or workflow additions: enforced by Task 2 scope and Task 4 reuse of existing focus behavior
+

--- a/docs/superpowers/specs/2026-05-01-action-center-lineage-read-summaries-design.md
+++ b/docs/superpowers/specs/2026-05-01-action-center-lineage-read-summaries-design.md
@@ -86,6 +86,28 @@ Bijvoorbeeld:
 - `Vervolg op eerdere route` met link naar de vorige route
 - `Later opgevolgd` met link naar de opvolger
 
+### 4.3.1 Route met zowel terug- als vooruitcontext
+Een route kan tegelijk:
+- `Vervolg op eerdere route` zijn
+- en later `Later opgevolgd` krijgen
+
+In dat geval geldt een vaste projectieregel:
+- overview toont alleen de teruglezing
+- detail toont beide lezingen
+
+Dus:
+- overview kiest de lezing die helpt begrijpen wat deze route nu is
+- detail mag daarnaast ook laten zien dat deze route later weer een directe opvolger kreeg
+
+De volgorde op detail is:
+1. directe voorganger of `Heropend traject`
+2. directe opvolger of `Later opgevolgd`
+
+Daarmee blijven overview en detail consistent:
+- overview is compacter
+- detail is rijker
+- maar beide gebruiken dezelfde canonieke prioriteit
+
 ### 4.4 Geen losse lineage-sectie
 In deze fase komt er geen apart `Lineage` blok onderaan de pagina.
 
@@ -102,6 +124,16 @@ Dus:
 - geen nieuwe tabellen
 - geen nieuwe lineage-state
 - geen aparte read cache in V1
+
+### 5.1.1 Reopen-bron is al vastgelegd
+Deze fase leunt bewust op de eerdere reopen-richting waarin `reopen` canoniek als dedicated route-event is gekozen.
+
+Dus voor deze leeslaag geldt expliciet:
+- `reopen` wordt niet gelezen uit een relationeel record
+- `reopen` wordt niet afgeleid uit statusmutatie
+- `reopen` komt alleen uit de bestaande reopen event truth
+
+Als die reopen event truth op een route niet aanwezig of niet betrouwbaar uitleesbaar is, projecteert deze fase ook geen `Heropend traject` label.
 
 ### 5.2 Een stap terug
 Voor een gegeven route leest de summary maximaal een directe voorganger.
@@ -131,6 +163,23 @@ Deze fase rust op de al gekozen begrenzing:
 - geen multigeneratie-projectie
 
 Daardoor hoeft de UI niet te kiezen uit meerdere buren.
+
+### 5.4.1 Defensieve fallback bij inconsistente data
+Als upstream data de single-neighbor-invariant toch schendt, blijft de projector deterministisch.
+
+De fallback is:
+- kies de meest recente directe buurroute op basis van canonieke event- of relationele tijd
+- onderdruk overige concurrerende buurlezingen
+- toon geen extra inconsistentiemelding in V1
+
+Concreet:
+- bij meerdere reopen events wint de meest recente `reopenedAt`
+- bij meerdere `follow-up-from` voorgangers of opvolgers wint de meest recente `recordedAt`
+
+Dus:
+- de UI blijft stabiel leesbaar
+- detail en overview blijven dezelfde buurroute kiezen
+- en we introduceren in deze fase geen extra error-surface voor datakwaliteit
 
 ### 5.5 Geen statusverrijking
 De projector leest alleen:

--- a/docs/superpowers/specs/2026-05-01-action-center-lineage-read-summaries-design.md
+++ b/docs/superpowers/specs/2026-05-01-action-center-lineage-read-summaries-design.md
@@ -1,0 +1,187 @@
+# Action Center Lineage Read Summaries Design
+
+## 1. Doel
+Deze fase maakt routegeschiedenis sneller leesbaar voor zowel HR als manager, zonder extra workflow toe te voegen.
+
+De kern is:
+- een route kan een directe voorganger hebben
+- een route kan een directe opvolger hebben
+- gebruikers moeten dat snel kunnen zien
+- zonder dat ze zelf route-IDs, relationele records of oude detailcontext hoeven te reconstrueren
+
+Dus:
+`lineage/read summaries` gaat niet over nieuwe truth, maar over een betere lezing van truth die al bestaat.
+
+## 2. Productgrens
+Wel in scope:
+- gedeelde lineage-samenvatting voor HR en manager
+- maximaal een stap terug
+- maximaal een stap vooruit
+- compacte relationele context in overview en detail
+- onderscheid tussen:
+  - `Heropend traject`
+  - `Vervolg op eerdere route`
+  - `Later opgevolgd`
+
+Niet in scope:
+- volledige trajectketens
+- meergeneratie-lineage
+- extra statussamenvattingen van buurtroutes
+- nieuwe workflowknoppen
+- dossierachtige tijdlijnen
+
+Dus:
+kleine leeslaag, geen nieuwe proceslaag.
+
+## 3. Canonieke Lineage-Lezingen
+Deze fase projecteert precies drie relationele lezingen.
+
+### 3.1 Heropend traject
+Gebruik je wanneer:
+- dit dezelfde route is
+- die na eerdere afsluiting opnieuw actief werd
+
+De lezing is dan:
+- dit is niet een nieuw traject
+- maar een hervatting van een eerdere lijn
+
+### 3.2 Vervolg op eerdere route
+Gebruik je wanneer:
+- dit een nieuwe route is
+- die voortkomt uit een eerder gesloten traject
+
+De lezing is dan:
+- dit is een nieuw traject
+- maar niet zonder voorgeschiedenis
+
+### 3.3 Later opgevolgd
+Gebruik je wanneer:
+- dit een historisch gesloten traject is
+- dat later een directe opvolger kreeg
+
+De lezing is dan:
+- dit traject is historisch gesloten
+- en kreeg later een directe opvolger
+
+## 4. Placement in Overview en Detail
+### 4.1 Overview blijft klein
+In overview verschijnt lineage alleen als compacte contextlaag:
+- niet als extra paneel
+- niet als tweede beschrijvingsblok
+- niet als uitgebreide historie
+
+Maar als een kleine secundaire regel of label bij de route.
+
+### 4.2 Zelfde kern voor HR en manager
+De kernlezing is voor beide rollen hetzelfde:
+- HR en manager krijgen dezelfde relationele basis
+- niet twee verschillende interpretaties van dezelfde route
+
+### 4.3 Detail mag net iets explicieter zijn
+Op detail toon je:
+- het lineage-label
+- plus een korte verwijzing naar de directe buurroute wanneer die er is
+
+Bijvoorbeeld:
+- `Vervolg op eerdere route` met link naar de vorige route
+- `Later opgevolgd` met link naar de opvolger
+
+### 4.4 Geen losse lineage-sectie
+In deze fase komt er geen apart `Lineage` blok onderaan de pagina.
+
+Lineage hoort dicht bij de routekop of summarylaag, omdat het een orientatiesignaal is en geen apart dossieronderdeel.
+
+## 5. Truth en Projectieregels
+### 5.1 Geen nieuwe truth
+De lineage-samenvatting leest volledig uit bestaande canonieke waarheid:
+- route-closeout truth
+- route-reopen event truth
+- route-relation truth (`follow-up-from`)
+
+Dus:
+- geen nieuwe tabellen
+- geen nieuwe lineage-state
+- geen aparte read cache in V1
+
+### 5.2 Een stap terug
+Voor een gegeven route leest de summary maximaal een directe voorganger.
+
+De prioriteit is:
+1. `reopen event` op dezelfde route
+2. `follow-up-from` waarbij deze route de `targetRouteId` is
+
+Projectie:
+- bij `reopen event`: `Heropend traject`
+- bij `follow-up-from`: `Vervolg op eerdere route`
+
+Reopen wint dus van relationele voorgeschiedenis op dezelfde huidige routelezing.
+
+### 5.3 Een stap vooruit
+Voor een gegeven route leest de summary maximaal een directe opvolger.
+
+Alleen:
+- `follow-up-from` waarbij deze route de `sourceRouteId` is
+
+Projectie:
+- `Later opgevolgd`
+
+### 5.4 Single-neighbor-regel
+Deze fase rust op de al gekozen begrenzing:
+- geen meerdere directe actieve opvolgers tegelijk
+- geen multigeneratie-projectie
+
+Daardoor hoeft de UI niet te kiezen uit meerdere buren.
+
+### 5.5 Geen statusverrijking
+De projector leest alleen:
+- is er een directe vorige relatie
+- is er een directe volgende relatie
+- is dit `reopen` of `follow-up`
+
+Niet:
+- wat is de status van die buurroute
+- wat was de closeoutreden
+- hoeveel rondes zijn er totaal geweest
+
+## 6. Tekst en Links
+### 6.1 Tekst blijft kort
+De canonieke labels zijn:
+- `Heropend traject`
+- `Vervolg op eerdere route`
+- `Later opgevolgd`
+
+Geen langere zinnen als standaardlabel.
+
+### 6.2 Detail mag een directe link tonen
+Op detail mag bij het label een directe link of routeverwijzing staan naar de buurroute.
+
+Dus:
+- bij `Vervolg op eerdere route` een link naar de vorige route
+- bij `Later opgevolgd` een link naar de opvolger
+- bij `Heropend traject` alleen contextuele reopen-lezing, geen aparte buurroute nodig als het om dezelfde route gaat
+
+### 6.3 Geen extra bestuurlijke uitleg
+Deze fase voegt geen extra bestuurlijke uitleg toe zoals:
+- waarom HR dit vervolg startte
+- waarom de eerdere route sloot
+- wat de bredere governance was
+
+De lineage-samenvatting helpt alleen orienteren.
+
+## 7. Succescriteria
+Deze fase is geslaagd als:
+- een gebruiker op een route direct kan zien of dit een heropend traject is
+- een gebruiker op een nieuwe vervolgroute direct ziet dat er een eerdere route aan voorafging
+- een gebruiker op een oude gesloten route direct ziet dat er later een opvolger kwam
+- overview en detail dezelfde lineage-lezing tonen
+- er geen extra statuslagen of workflowruis bijkomen
+
+## 8. Ontwerpuitspraak
+Deze fase is bewust klein:
+- klein genoeg om rustig te blijven
+- sterk genoeg om oud versus nieuw traject sneller leesbaar te maken
+- zonder nieuwe statusrommel of workflowzwaarte
+
+De samenvatting moet alleen helpen begrijpen:
+- waar deze route direct vandaan komt
+- en of hier direct iets op volgde

--- a/frontend/app/(dashboard)/action-center/page.route-shell.test.ts
+++ b/frontend/app/(dashboard)/action-center/page.route-shell.test.ts
@@ -365,6 +365,14 @@ describe("action center landing shell", () => {
     expect(pageSource).toContain('routeFollowUpEndpoint="/api/action-center-route-follow-ups"');
   });
 
+  it("loads route reopen rows into the live action-center contexts", () => {
+    const pageSource = readFileSync(new URL("./page.tsx", import.meta.url), "utf8");
+
+    expect(pageSource).toContain("action_center_route_reopens");
+    expect(pageSource).toContain("projectActionCenterRouteReopen");
+    expect(pageSource).toContain("routeReopens:");
+  });
+
   it("renders shell markup that should expose the follow-up route trigger affordances", () => {
     const { item, markup } = renderFollowUpAffordanceMarkup({
       memberRole: "owner",
@@ -842,6 +850,43 @@ describe("action center landing shell", () => {
     expect(markup).not.toContain("Beslisgeschiedenis");
     expect((markup.match(/>Stap</g) ?? []).length).toBe(1);
     expect((markup.match(/>Besluit</g) ?? []).length).toBe(1);
+  });
+
+  it("shows only the compact overview lineage label for a follow-up route in overview", () => {
+    const context = buildLiveContext();
+    const [baseItem] = buildLiveActionCenterItems([context]);
+    const item = {
+      ...baseItem,
+      coreSemantics: {
+        ...baseItem.coreSemantics,
+        lineageSummary: {
+          overviewLabel: "Vervolg op eerdere route" as const,
+          backwardLabel: "Vervolg op eerdere route" as const,
+          backwardRouteId: "route-earlier",
+          forwardLabel: "Later opgevolgd" as const,
+          forwardRouteId: "route-later",
+          detailLabels: ["Vervolg op eerdere route", "Later opgevolgd"] as const,
+        },
+      },
+    };
+
+    const markup = renderToStaticMarkup(
+      createElement(ActionCenterPreview, {
+        initialItems: [item],
+        initialSelectedItemId: item.id,
+        initialView: "overview",
+        fallbackOwnerName: "Admin",
+        ownerOptions: ["Manager Operations"],
+        workbenchHref: "/action-center/dossier",
+        hideSidebar: true,
+        readOnly: true,
+      }),
+    );
+
+    expect(markup).toContain("Vervolg op eerdere route");
+    expect(markup).not.toContain("Later opgevolgd");
+    expect(markup).not.toContain("Heropend traject");
+    expect((markup.match(/Vervolg op eerdere route/g) ?? []).length).toBe(1);
   });
 
   it("shows team Review < 7 dagen for upcoming reviews within the next week", () => {

--- a/frontend/app/(dashboard)/action-center/page.tsx
+++ b/frontend/app/(dashboard)/action-center/page.tsx
@@ -2,7 +2,10 @@ import { redirect } from 'next/navigation'
 import { ActionCenterPreview } from '@/components/dashboard/action-center-preview'
 import { buildLiveActionCenterItems, getLiveActionCenterSummary } from '@/lib/action-center-live'
 import { buildActionCenterRouteId } from '@/lib/action-center-route-contract'
-import { projectActionCenterRouteFollowUpRelation } from '@/lib/action-center-route-reopen'
+import {
+  projectActionCenterRouteFollowUpRelation,
+  projectActionCenterRouteReopen,
+} from '@/lib/action-center-route-reopen'
 import { createAdminClient } from '@/lib/supabase/admin'
 import {
   isScopeVisibleToActionCenterContext,
@@ -37,6 +40,20 @@ type ActionCenterRouteRelationRow = {
   ended_at: string | null
 }
 
+type ActionCenterRouteReopenRow = {
+  id: string | null
+  route_id: string | null
+  reopened_at: string | null
+  reopened_by_role: string | null
+}
+
+type ActionCenterScopeRow = {
+  scopeType: 'department' | 'item'
+  scopeValue: string
+  scopeLabel: string
+  peopleCount: number
+}
+
 function getDisplayName(email: string | null | undefined) {
   if (!email) return 'Verisight gebruiker'
   const localPart = email.split('@')[0] ?? 'verisight-gebruiker'
@@ -57,6 +74,36 @@ function buildDepartmentScopeValue(orgId: string, departmentLabel: string) {
 
 function buildCampaignFallbackScopeValue(orgId: string, campaignId: string) {
   return `${orgId}::campaign::${campaignId}`
+}
+
+function buildActionCenterScopes(args: {
+  campaign: Campaign
+  departmentLabels: string[]
+  fallbackPeopleCount: number
+}) {
+  const departmentCounts = args.departmentLabels.reduce<Record<string, number>>((acc, label) => {
+    acc[label] = (acc[label] ?? 0) + 1
+    return acc
+  }, {})
+  const departmentEntries = Object.entries(departmentCounts)
+
+  if (departmentEntries.length > 0) {
+    return departmentEntries.map<ActionCenterScopeRow>(([departmentLabel, peopleCount]) => ({
+      scopeType: 'department',
+      scopeValue: buildDepartmentScopeValue(args.campaign.organization_id, departmentLabel),
+      scopeLabel: departmentLabel,
+      peopleCount,
+    }))
+  }
+
+  return [
+    {
+      scopeType: 'item' as const,
+      scopeValue: buildCampaignFallbackScopeValue(args.campaign.organization_id, args.campaign.id),
+      scopeLabel: args.campaign.name,
+      peopleCount: args.fallbackPeopleCount,
+    },
+  ]
 }
 
 function getManagerAssignment(
@@ -165,6 +212,7 @@ export default async function ActionCenterPage({
   const managerWorkspaceRows = (
     context.canManageActionCenterAssignments ? managerWorkspaceRowsRaw ?? [] : currentUserWorkspaceMemberships
   ) as ActionCenterWorkspaceMember[]
+  const statsByCampaignId = new Map(stats.map((entry) => [entry.campaign_id, entry]))
   const routeRelations = ((routeRelationsRaw ?? []) as ActionCenterRouteRelationRow[]).reduce<
     ReturnType<typeof projectActionCenterRouteFollowUpRelation>[]
   >((acc, relation) => {
@@ -191,12 +239,38 @@ export default async function ActionCenterPage({
       : { data: [] }
 
   const respondentsWithDepartments = (respondentsWithDepartmentsRaw ?? []) as RespondentDepartmentRow[]
+  const respondentDepartmentsByCampaign = respondentsWithDepartments.reduce<Record<string, string[]>>((acc, row) => {
+    const departmentLabel = normalizeDepartmentLabel(row.department)
+    if (!departmentLabel) return acc
+    acc[row.campaign_id] ??= []
+    acc[row.campaign_id].push(departmentLabel)
+    return acc
+  }, {})
+  const visibleScopesByCampaignId = campaigns.reduce<Record<string, ActionCenterScopeRow[]>>((acc, campaign) => {
+    const scopes = buildActionCenterScopes({
+      campaign,
+      departmentLabels: respondentDepartmentsByCampaign[campaign.id] ?? [],
+      fallbackPeopleCount:
+        statsByCampaignId.get(campaign.id)?.total_completed ?? statsByCampaignId.get(campaign.id)?.total_invited ?? 0,
+    }).filter((scope) => isScopeVisibleToActionCenterContext(context, scope.scopeValue))
+
+    if (scopes.length > 0) {
+      acc[campaign.id] = scopes
+    }
+
+    return acc
+  }, {})
+  const visibleRouteIds = campaigns.flatMap((campaign) =>
+    (visibleScopesByCampaignId[campaign.id] ?? []).map((scope) => buildActionCenterRouteId(campaign.id, scope.scopeValue)),
+  )
+  const visibleRouteIdSet = new Set(visibleRouteIds)
 
   const [
     { data: deliveryCheckpointsRaw },
     { data: learningCheckpointsRaw },
     { data: reviewDecisionsRaw },
     { data: managerResponsesRaw },
+    { data: routeReopensRaw },
   ] = await Promise.all([
     deliveryRecords.length > 0
       ? dataClient
@@ -229,12 +303,32 @@ export default async function ActionCenterPage({
           .select('*')
           .in('campaign_id', campaignIds)
       : Promise.resolve({ data: [] }),
+    visibleRouteIds.length > 0
+      ? dataClient
+          .from('action_center_route_reopens')
+          .select('id, route_id, reopened_at, reopened_by_role')
+          .in('route_id', visibleRouteIds)
+      : Promise.resolve({ data: [] }),
   ])
 
   const deliveryCheckpoints = (deliveryCheckpointsRaw ?? []) as CampaignDeliveryCheckpoint[]
   const learningCheckpoints = (learningCheckpointsRaw ?? []) as PilotLearningCheckpoint[]
   const reviewDecisions = (reviewDecisionsRaw ?? []) as ActionCenterReviewDecision[]
   const managerResponses = (managerResponsesRaw ?? []) as ActionCenterManagerResponse[]
+  const routeReopens = ((routeReopensRaw ?? []) as ActionCenterRouteReopenRow[]).reduce<
+    ReturnType<typeof projectActionCenterRouteReopen>[]
+  >((acc, routeReopen) => {
+    try {
+      const parsedRouteReopen = projectActionCenterRouteReopen(routeReopen)
+      if (visibleRouteIdSet.has(parsedRouteReopen.routeId)) {
+        acc.push(parsedRouteReopen)
+      }
+    } catch {
+      // Ignore malformed legacy rows so one broken reopen does not take down the full Action Center page.
+    }
+
+    return acc
+  }, [])
 
   const organizationById = new Map(organizations.map((organization) => [organization.id, organization]))
   const roleByOrgId = orgMemberships.reduce<Record<string, 'owner' | 'member' | 'viewer'>>((acc, membership) => {
@@ -243,7 +337,6 @@ export default async function ActionCenterPage({
     }
     return acc
   }, {})
-  const statsByCampaignId = new Map(stats.map((entry) => [entry.campaign_id, entry]))
   const deliveryRecordByCampaignId = new Map(deliveryRecords.map((record) => [record.campaign_id, record]))
   const deliveryCheckpointMap = deliveryCheckpoints.reduce<Record<string, CampaignDeliveryCheckpoint[]>>((acc, checkpoint) => {
     acc[checkpoint.delivery_record_id] ??= []
@@ -274,41 +367,14 @@ export default async function ActionCenterPage({
     acc[relation.targetRouteId].push(relation)
     return acc
   }, {})
-  const respondentDepartmentsByCampaign = respondentsWithDepartments.reduce<Record<string, string[]>>((acc, row) => {
-    const departmentLabel = normalizeDepartmentLabel(row.department)
-    if (!departmentLabel) return acc
-    acc[row.campaign_id] ??= []
-    acc[row.campaign_id].push(departmentLabel)
+  const routeReopenMap = routeReopens.reduce<Record<string, typeof routeReopens>>((acc, routeReopen) => {
+    acc[routeReopen.routeId] ??= []
+    acc[routeReopen.routeId].push(routeReopen)
     return acc
   }, {})
 
   const liveContexts = campaigns.flatMap((campaign) => {
-    const departmentLabels = respondentDepartmentsByCampaign[campaign.id] ?? []
-    const departmentCounts = departmentLabels.reduce<Record<string, number>>((acc, label) => {
-      acc[label] = (acc[label] ?? 0) + 1
-      return acc
-    }, {})
-    const departmentEntries = Object.entries(departmentCounts)
-    const scopes =
-      departmentEntries.length > 0
-        ? departmentEntries.map(([departmentLabel, peopleCount]) => ({
-            scopeType: 'department' as const,
-            scopeValue: buildDepartmentScopeValue(campaign.organization_id, departmentLabel),
-            scopeLabel: departmentLabel,
-            peopleCount,
-          }))
-        : [
-            {
-              scopeType: 'item' as const,
-              scopeValue: buildCampaignFallbackScopeValue(campaign.organization_id, campaign.id),
-              scopeLabel: campaign.name,
-              peopleCount: statsByCampaignId.get(campaign.id)?.total_completed ?? statsByCampaignId.get(campaign.id)?.total_invited ?? 0,
-            },
-          ]
-
-    return scopes
-      .filter((scope) => isScopeVisibleToActionCenterContext(context, scope.scopeValue))
-      .map((scope) => {
+    return (visibleScopesByCampaignId[campaign.id] ?? []).map((scope) => {
         const deliveryRecord = deliveryRecordByCampaignId.get(campaign.id) ?? null
         const learningDossier = learningDossierByCampaignId.get(campaign.id) ?? null
         const assignment = getManagerAssignment(managerWorkspaceRows, campaign.organization_id, scope.scopeValue)
@@ -337,6 +403,7 @@ export default async function ActionCenterPage({
           managerResponse: managerResponseByRouteId.get(routeId) ?? null,
           reviewDecisions: reviewDecisionMap[campaign.id] ?? [],
           routeFollowUpRelations: routeFollowUpRelationMap[routeId] ?? [],
+          routeReopens: routeReopenMap[routeId] ?? [],
         }
       })
   })

--- a/frontend/app/api/action-center-route-follow-ups/route.test.ts
+++ b/frontend/app/api/action-center-route-follow-ups/route.test.ts
@@ -929,7 +929,7 @@ describe('action center route follow-up API contract', () => {
       target_route_scope_value: 'org-1::department::operations',
       trigger_reason: 'hernieuwde-hr-beoordeling',
       recorded_by: HR_USER_ID,
-      recorded_by_role: 'hr_member',
+      recorded_by_role: 'hr',
       manager_user_id: MANAGER_USER_ID,
       ended_at: null,
     })

--- a/frontend/app/api/action-center-route-follow-ups/route.ts
+++ b/frontend/app/api/action-center-route-follow-ups/route.ts
@@ -42,7 +42,7 @@ type ManagerResponseCarrierRow = {
 }
 
 type FollowUpWriteAccess = {
-  recordedByRole: 'verisight_admin' | 'hr_owner' | 'hr_member'
+  recordedByRole: 'verisight_admin' | 'hr'
 }
 
 type ManagerAssignmentRow = {
@@ -235,7 +235,7 @@ async function resolveFollowUpWriteAccess(args: { supabase: SupabaseClient; user
 
   const orgMembership = orgMemberships.find((membership) => membership.org_id === args.orgId) ?? null
   if (orgMembership?.role === 'owner') {
-    return { access: { recordedByRole: 'hr_owner' } satisfies FollowUpWriteAccess, error: null }
+    return { access: { recordedByRole: 'hr' } satisfies FollowUpWriteAccess, error: null }
   }
 
   const hrWorkspaceMembership =
@@ -247,12 +247,9 @@ async function resolveFollowUpWriteAccess(args: { supabase: SupabaseClient; user
     ) ?? null
 
   if (hrWorkspaceMembership) {
-    const recordedByRole: FollowUpWriteAccess['recordedByRole'] =
-      hrWorkspaceMembership.access_role === 'hr_owner' ? 'hr_owner' : 'hr_member'
-
     return {
       access: {
-        recordedByRole,
+        recordedByRole: 'hr',
       } satisfies FollowUpWriteAccess,
       error: null,
     }

--- a/frontend/components/dashboard/action-center-preview.tsx
+++ b/frontend/components/dashboard/action-center-preview.tsx
@@ -570,26 +570,64 @@ function applyOptimisticFollowUpSuccessor(args: {
   triggerReason: ActionCenterRouteFollowUpTriggerReason
 }) {
   return args.items.map((item) => {
-    if (item.id !== args.targetItemId) {
-      return item
-    }
-
-    return finalizeActionCenterPreviewItem(
-      {
-        ...item,
-        coreSemantics: {
-          ...item.coreSemantics,
-          followUpSemantics: {
-            isDirectSuccessor: true,
-            lineageLabel: 'Vervolg op eerdere route',
-            triggerReason: args.triggerReason,
-            triggerReasonLabel: getActionCenterFollowUpTriggerReasonLabel(args.triggerReason),
-            sourceRouteId: args.sourceRouteId,
+    if (item.id === args.targetItemId) {
+      return finalizeActionCenterPreviewItem(
+        {
+          ...item,
+          coreSemantics: {
+            ...item.coreSemantics,
+            lineageSummary: {
+              overviewLabel: 'Vervolg op eerdere route',
+              backwardLabel: 'Vervolg op eerdere route',
+              backwardRouteId: args.sourceRouteId,
+              forwardLabel: item.coreSemantics.lineageSummary.forwardLabel,
+              forwardRouteId: item.coreSemantics.lineageSummary.forwardRouteId,
+              detailLabels: [
+                'Vervolg op eerdere route',
+                ...item.coreSemantics.lineageSummary.detailLabels.filter(
+                  (label) => label !== 'Vervolg op eerdere route',
+                ),
+              ],
+            },
+            followUpSemantics: {
+              isDirectSuccessor: true,
+              lineageLabel: 'Vervolg op eerdere route',
+              triggerReason: args.triggerReason,
+              triggerReasonLabel: getActionCenterFollowUpTriggerReasonLabel(args.triggerReason),
+              sourceRouteId: args.sourceRouteId,
+            },
           },
         },
-      },
-      { recomputeCoreSemantics: true },
-    )
+        { recomputeCoreSemantics: true },
+      )
+    }
+
+    if (item.coreSemantics.route.routeId === args.sourceRouteId) {
+      return finalizeActionCenterPreviewItem(
+        {
+          ...item,
+          coreSemantics: {
+            ...item.coreSemantics,
+            lineageSummary: {
+              overviewLabel: item.coreSemantics.lineageSummary.backwardLabel ?? 'Later opgevolgd',
+              backwardLabel: item.coreSemantics.lineageSummary.backwardLabel,
+              backwardRouteId: item.coreSemantics.lineageSummary.backwardRouteId,
+              forwardLabel: 'Later opgevolgd',
+              forwardRouteId: args.targetItemId,
+              detailLabels: [
+                ...(item.coreSemantics.lineageSummary.backwardLabel
+                  ? [item.coreSemantics.lineageSummary.backwardLabel]
+                  : []),
+                'Later opgevolgd',
+              ],
+            },
+          },
+        },
+        { recomputeCoreSemantics: true },
+      )
+    }
+
+    return item
   })
 }
 
@@ -699,6 +737,8 @@ export function ActionCenterPreview({
     () => new Map(assignmentOptions.map((option) => [option.value, option.label])),
     [assignmentOptions],
   )
+  const previewRouteIds = useMemo(() => new Set(items.map((item) => item.id)), [items])
+  const previewRouteTitles = useMemo(() => new Map(items.map((item) => [item.id, item.title] as const)), [items])
   useEffect(() => {
     setFollowUpForm(getInitialFollowUpFormState({ item: selectedItem, assignmentOptions }))
     setFollowUpError(null)
@@ -706,6 +746,7 @@ export function ActionCenterPreview({
   const teamRows = buildTeamRows(items)
   const selectedTeam = teamRows.find((team) => team.id === selectedTeamId) ?? teamRows[0] ?? null
   const allSources = [...new Set(items.map((item) => item.sourceLabel))]
+  const selectedItemLineage = selectedItem ? buildDetailLineageEntries(selectedItem, previewRouteTitles) : []
   const today = new Date()
   const dueItems = items.filter((item) => isOpenAttentionStatus(item.status))
   const openItems = items.filter((item) => item.status !== 'afgerond' && item.status !== 'gestopt')
@@ -1011,12 +1052,21 @@ export function ActionCenterPreview({
           triggerReason: followUpForm.triggerReason,
         }),
       )
-      setSelectedItemId(followUpTargetItem.id)
-      setActiveView('actions')
+      focusActionRoute(followUpTargetItem.id)
     } catch (error) {
       setFollowUpError(error instanceof Error ? error.message : 'Vervolgroute kon niet worden gestart.')
     } finally {
       setFollowUpPending(false)
+    }
+  }
+
+  function focusActionRoute(routeId: string) {
+    setSelectedItemId(routeId)
+    setActiveView('actions')
+    if (typeof window !== 'undefined') {
+      const url = new URL(window.location.href)
+      url.searchParams.set('focus', routeId)
+      window.history.replaceState(window.history.state, '', `${url.pathname}${url.search}${url.hash}`)
     }
   }
 
@@ -1601,6 +1651,55 @@ export function ActionCenterPreview({
                         </div>
                         <h2 className="mt-5 text-[2rem] font-semibold tracking-[-0.05em] text-[#132033]">{selectedItem.title}</h2>
                         <p className="mt-4 max-w-3xl text-[1rem] leading-8 text-[#4f6175]">{selectedItem.summary}</p>
+                        {selectedItemLineage.length > 0 ? (
+                          <div className="mt-5 flex flex-wrap items-center gap-2.5">
+                            {selectedItemLineage.map((entry) => {
+                              const routeId = entry.routeId
+                              const href = routeId ? (itemHrefs[routeId] ?? null) : null
+                              const isFocusableInPreview = routeId ? previewRouteIds.has(routeId) : false
+                              const className =
+                                'inline-flex min-h-10 items-center rounded-full border border-[#ded3c6] bg-white px-4 py-2 text-sm font-semibold text-[#4a5f74] transition hover:border-[#1a2533] hover:text-[#132033]'
+
+                              if (routeId && isFocusableInPreview) {
+                                return (
+                                  <button
+                                    key={`${selectedItem.id}-${entry.key}`}
+                                    type="button"
+                                    className={className}
+                                    aria-label={entry.label}
+                                    onClick={() => focusActionRoute(routeId)}
+                                  >
+                                    <span>{entry.label}</span>
+                                    {entry.routeTitle ? (
+                                      <span className="ml-2 text-xs font-medium text-[#7d7368]">{entry.routeTitle}</span>
+                                    ) : null}
+                                  </button>
+                                )
+                              }
+
+                              if (href) {
+                                return (
+                                  <Link key={`${selectedItem.id}-${entry.key}`} href={href} className={className} aria-label={entry.label}>
+                                    <span>{entry.label}</span>
+                                    {entry.routeTitle ? (
+                                      <span className="ml-2 text-xs font-medium text-[#7d7368]">{entry.routeTitle}</span>
+                                    ) : null}
+                                  </Link>
+                                )
+                              }
+
+                              return (
+                                <span
+                                  key={`${selectedItem.id}-${entry.key}`}
+                                  className="inline-flex min-h-10 items-center rounded-full border border-[#e6ddd2] bg-[#f7f2ea] px-4 py-2 text-sm font-semibold text-[#7d7368]"
+                                >
+                                  <span>{entry.label}</span>
+                                  {entry.routeTitle ? <span className="ml-2 text-xs font-medium">{entry.routeTitle}</span> : null}
+                                </span>
+                              )
+                            })}
+                          </div>
+                        ) : null}
 
                         <div className="mt-7 grid gap-4 lg:grid-cols-[minmax(0,1fr),minmax(0,0.92fr)]">
                           <div className="rounded-[24px] border border-[#eadfce] bg-white px-5 py-5">
@@ -2933,24 +3032,64 @@ export function buildCompactLandingSummaryLines(item: ActionCenterPreviewItem) {
 
 function CompactLandingSummary({ item }: { item: ActionCenterPreviewItem }) {
   const summaryLines = buildCompactLandingSummaryLines(item)
+  const overviewLineageLabel = item.coreSemantics.lineageSummary.overviewLabel
 
-  if (summaryLines.length === 0) {
+  if (summaryLines.length === 0 && !overviewLineageLabel) {
     return null
   }
 
   return (
     <div className="mt-4 rounded-[18px] border border-[#eadfce] bg-white px-4 py-4">
       <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Laatste route-read</p>
-      <div className="mt-3 space-y-2.5">
-        {summaryLines.map((line) => (
-          <div key={`${line.label}-${line.value}`} className="flex items-start justify-between gap-3 text-sm">
-            <span className="shrink-0 font-semibold text-[#7d7368]">{line.label}</span>
-            <span className="text-right leading-6 text-[#42556b]">{line.value}</span>
-          </div>
-        ))}
-      </div>
+      {overviewLineageLabel ? (
+        <p className="mt-3 text-sm leading-6 text-[#7d7368]">{overviewLineageLabel}</p>
+      ) : null}
+      {summaryLines.length > 0 ? (
+        <div className="mt-3 space-y-2.5">
+          {summaryLines.map((line) => (
+            <div key={`${line.label}-${line.value}`} className="flex items-start justify-between gap-3 text-sm">
+              <span className="shrink-0 font-semibold text-[#7d7368]">{line.label}</span>
+              <span className="text-right leading-6 text-[#42556b]">{line.value}</span>
+            </div>
+          ))}
+        </div>
+      ) : null}
     </div>
   )
+}
+
+type ActionCenterDetailLineageEntry = {
+  key: 'backward' | 'forward'
+  label: string
+  routeId: string | null
+  routeTitle: string | null
+}
+
+function buildDetailLineageEntries(
+  item: ActionCenterPreviewItem,
+  routeTitlesById: ReadonlyMap<string, string>,
+): ActionCenterDetailLineageEntry[] {
+  const { backwardLabel, backwardRouteId, forwardLabel, forwardRouteId } = item.coreSemantics.lineageSummary
+  const entries: Array<ActionCenterDetailLineageEntry | null> = [
+    backwardLabel
+      ? {
+          key: 'backward',
+          label: backwardLabel,
+          routeId: backwardRouteId,
+          routeTitle: backwardRouteId ? (routeTitlesById.get(backwardRouteId) ?? null) : null,
+        }
+      : null,
+    forwardLabel
+      ? {
+          key: 'forward',
+          label: forwardLabel,
+          routeId: forwardRouteId,
+          routeTitle: forwardRouteId ? (routeTitlesById.get(forwardRouteId) ?? null) : null,
+        }
+      : null,
+  ]
+
+  return entries.filter((entry): entry is ActionCenterDetailLineageEntry => entry !== null)
 }
 
 function RouteFieldCard({ label, value }: { label: string; value: string }) {

--- a/frontend/lib/action-center-core-semantics.test.ts
+++ b/frontend/lib/action-center-core-semantics.test.ts
@@ -140,6 +140,23 @@ function buildCheckpoint(overrides: Partial<PilotLearningCheckpoint> = {}): Pilo
   } as PilotLearningCheckpoint
 }
 
+function buildRouteReopen(
+  overrides: Partial<{
+    id: string | null
+    routeId: string
+    reopenedAt: string
+    reopenedByRole: string
+  }> = {},
+) {
+  return {
+    id: 'reopen-1',
+    routeId: 'campaign-exit::operations',
+    reopenedAt: '2026-05-03T12:00:00.000Z',
+    reopenedByRole: 'hr_owner',
+    ...overrides,
+  }
+}
+
 function buildContext(args: {
   dossier?: PilotLearningDossier | null
   deliveryRecord?: CampaignDeliveryRecord | null
@@ -147,6 +164,22 @@ function buildContext(args: {
   learningCheckpoints?: PilotLearningCheckpoint[]
   reviewDecisions?: ActionCenterReviewDecision[]
   managerResponse?: ActionCenterManagerResponse | null
+  routeFollowUpRelations?: Array<{
+    id?: string | null
+    routeRelationType: 'follow-up-from'
+    sourceRouteId: string
+    targetRouteId: string
+    triggerReason: 'nieuw-campaign-signaal' | 'nieuw-segment-signaal' | 'hernieuwde-hr-beoordeling'
+    recordedAt: string
+    recordedByRole: string
+    endedAt?: string | null
+  }>
+  routeReopens?: Array<{
+    id?: string | null
+    routeId: string
+    reopenedAt: string
+    reopenedByRole: string
+  }>
 } = {}): ActionCenterCoreSemanticsProjectionInput {
   const liveContext: LiveActionCenterCampaignContext = {
     campaign: buildCampaign(),
@@ -164,6 +197,7 @@ function buildContext(args: {
     learningCheckpoints: args.learningCheckpoints ?? [],
     reviewDecisions: args.reviewDecisions ?? [],
     managerResponse: args.managerResponse ?? null,
+    routeFollowUpRelations: args.routeFollowUpRelations,
   }
 
   return {
@@ -174,8 +208,10 @@ function buildContext(args: {
     learningCheckpoints: liveContext.learningCheckpoints,
     reviewDecisions: liveContext.reviewDecisions,
     managerResponse: liveContext.managerResponse,
+    routeFollowUpRelations: liveContext.routeFollowUpRelations,
+    routeReopens: args.routeReopens,
     route: projectActionCenterRoute(liveContext),
-  }
+  } as ActionCenterCoreSemanticsProjectionInput
 }
 
 describe('action center core semantics', () => {
@@ -396,6 +432,183 @@ describe('action center core semantics', () => {
 
       expect(semantics.latestDecision).toBeNull()
       expect(semantics.decisionHistory).toEqual([])
+    })
+  })
+
+  describe('lineage summaries', () => {
+    it('projects a follow-up route with a backward lineage label', () => {
+      const semantics = projectActionCenterCoreSemantics(buildContext({
+        routeFollowUpRelations: [
+          {
+            id: 'relation-backward',
+            routeRelationType: 'follow-up-from',
+            sourceRouteId: 'campaign-source::operations',
+            targetRouteId: 'campaign-exit::operations',
+            triggerReason: 'nieuw-segment-signaal',
+            recordedAt: '2026-05-01T10:00:00.000Z',
+            recordedByRole: 'hr_owner',
+            endedAt: null,
+          },
+        ],
+      }))
+
+      expect(semantics.lineageSummary).toMatchObject({
+        overviewLabel: 'Vervolg op eerdere route',
+        backwardLabel: 'Vervolg op eerdere route',
+        backwardRouteId: 'campaign-source::operations',
+        forwardLabel: null,
+        forwardRouteId: null,
+        detailLabels: ['Vervolg op eerdere route'],
+      })
+      expect(semantics.followUpSemantics).toMatchObject({
+        isDirectSuccessor: true,
+        lineageLabel: 'Vervolg op eerdere route',
+        triggerReason: 'nieuw-segment-signaal',
+        triggerReasonLabel: 'Nieuw segmentsignaal',
+        sourceRouteId: 'campaign-source::operations',
+      })
+    })
+
+    it('prefers reopen over follow-up for backward lineage', () => {
+      const semantics = projectActionCenterCoreSemantics(buildContext({
+        routeFollowUpRelations: [
+          {
+            id: 'relation-backward',
+            routeRelationType: 'follow-up-from',
+            sourceRouteId: 'campaign-older::operations',
+            targetRouteId: 'campaign-exit::operations',
+            triggerReason: 'nieuw-campaign-signaal',
+            recordedAt: '2026-05-01T10:00:00.000Z',
+            recordedByRole: 'hr_owner',
+            endedAt: null,
+          },
+        ],
+        routeReopens: [
+          buildRouteReopen({
+            routeId: 'campaign-exit::operations',
+            reopenedAt: '2026-05-03T12:00:00.000Z',
+          }),
+        ],
+      }) as ActionCenterCoreSemanticsProjectionInput)
+
+      expect(semantics.lineageSummary).toMatchObject({
+        overviewLabel: 'Heropend traject',
+        backwardLabel: 'Heropend traject',
+        detailLabels: ['Heropend traject'],
+        backwardRouteId: null,
+        forwardLabel: null,
+        forwardRouteId: null,
+      })
+      expect(semantics.followUpSemantics).toMatchObject({
+        isDirectSuccessor: false,
+        lineageLabel: 'Heropend traject',
+        triggerReason: null,
+        triggerReasonLabel: null,
+        sourceRouteId: null,
+      })
+    })
+
+    it('chooses the most recent reopen event when multiple reopen rows exist', () => {
+      const semantics = projectActionCenterCoreSemantics(buildContext({
+        routeReopens: [
+          buildRouteReopen({
+            id: 'reopen-older',
+            routeId: 'campaign-exit::operations',
+            reopenedAt: '2026-05-01T09:00:00.000Z',
+          }),
+          buildRouteReopen({
+            id: 'reopen-newer',
+            routeId: 'campaign-exit::operations',
+            reopenedAt: '2026-05-03T12:00:00.000Z',
+          }),
+        ],
+      }))
+
+      expect(semantics.lineageSummary).toMatchObject({
+        overviewLabel: 'Heropend traject',
+        backwardLabel: 'Heropend traject',
+        backwardRouteId: null,
+        forwardLabel: null,
+        forwardRouteId: null,
+        detailLabels: ['Heropend traject'],
+      })
+      expect(semantics.followUpSemantics).toMatchObject({
+        isDirectSuccessor: false,
+        lineageLabel: 'Heropend traject',
+        triggerReason: null,
+        triggerReasonLabel: null,
+        sourceRouteId: null,
+      })
+    })
+
+    it('chooses the most recent inconsistent backward neighbor deterministically', () => {
+      const semantics = projectActionCenterCoreSemantics(buildContext({
+        routeFollowUpRelations: [
+          {
+            id: 'relation-older',
+            routeRelationType: 'follow-up-from',
+            sourceRouteId: 'campaign-a::operations',
+            targetRouteId: 'campaign-exit::operations',
+            triggerReason: 'nieuw-campaign-signaal',
+            recordedAt: '2026-05-01T08:00:00.000Z',
+            recordedByRole: 'hr_owner',
+            endedAt: null,
+          },
+          {
+            id: 'relation-newer',
+            routeRelationType: 'follow-up-from',
+            sourceRouteId: 'campaign-a2::operations',
+            targetRouteId: 'campaign-exit::operations',
+            triggerReason: 'hernieuwde-hr-beoordeling',
+            recordedAt: '2026-05-01T11:00:00.000Z',
+            recordedByRole: 'hr_owner',
+            endedAt: null,
+          },
+        ],
+      }))
+
+      expect(semantics.lineageSummary).toMatchObject({
+        backwardLabel: 'Vervolg op eerdere route',
+        backwardRouteId: 'campaign-a2::operations',
+      })
+      expect(semantics.followUpSemantics).toMatchObject({
+        sourceRouteId: 'campaign-a2::operations',
+        triggerReason: 'hernieuwde-hr-beoordeling',
+        triggerReasonLabel: 'Hernieuwde HR-beoordeling',
+      })
+    })
+
+    it('ignores ended backward relations for current lineage and successor truth', () => {
+      const semantics = projectActionCenterCoreSemantics(buildContext({
+        routeFollowUpRelations: [
+          {
+            id: 'relation-ended-backward',
+            routeRelationType: 'follow-up-from',
+            sourceRouteId: 'campaign-ended::operations',
+            targetRouteId: 'campaign-exit::operations',
+            triggerReason: 'nieuw-campaign-signaal',
+            recordedAt: '2026-05-04T11:00:00.000Z',
+            recordedByRole: 'hr_owner',
+            endedAt: '2026-05-05T10:00:00.000Z',
+          },
+        ],
+      }))
+
+      expect(semantics.lineageSummary).toEqual({
+        overviewLabel: null,
+        backwardLabel: null,
+        backwardRouteId: null,
+        forwardLabel: null,
+        forwardRouteId: null,
+        detailLabels: [],
+      })
+      expect(semantics.followUpSemantics).toMatchObject({
+        isDirectSuccessor: false,
+        lineageLabel: null,
+        triggerReason: null,
+        triggerReasonLabel: null,
+        sourceRouteId: null,
+      })
     })
   })
 

--- a/frontend/lib/action-center-core-semantics.ts
+++ b/frontend/lib/action-center-core-semantics.ts
@@ -7,6 +7,7 @@ import type { LiveActionCenterCampaignContext } from './action-center-live-conte
 import {
   getActionCenterFollowUpTriggerReasonLabel,
   type ActionCenterRouteFollowUpRelationRecord,
+  type ActionCenterRouteReopenRecord,
   type ActionCenterRouteFollowUpTriggerReason,
 } from './action-center-route-reopen'
 import type {
@@ -53,12 +54,22 @@ export interface ActionCenterCoreSemantics {
   }
   resultProgression: ActionCenterResultProgressEntry[]
   decisionHistory: ActionCenterDecisionRecord[]
+  lineageSummary: ActionCenterLineageSummary
   followUpSemantics?: ActionCenterProjectedFollowUpSemantics
   closingSemantics: {
     status: ActionCenterClosingStatus
     summary: string | null
     historicalSummary: string | null
   }
+}
+
+export interface ActionCenterLineageSummary {
+  overviewLabel: ActionCenterLineageLabel | null
+  backwardLabel: ActionCenterLineageLabel | null
+  backwardRouteId: string | null
+  forwardLabel: ActionCenterLineageLabel | null
+  forwardRouteId: string | null
+  detailLabels: ActionCenterLineageLabel[]
 }
 
 export interface ActionCenterProjectedFollowUpSemantics {
@@ -68,6 +79,11 @@ export interface ActionCenterProjectedFollowUpSemantics {
   triggerReasonLabel: string | null
   sourceRouteId: string | null
 }
+
+export type ActionCenterLineageLabel =
+  | 'Heropend traject'
+  | 'Vervolg op eerdere route'
+  | 'Later opgevolgd'
 
 export type ActionCenterCoreSemanticsProjectionInput = Pick<
   LiveActionCenterCampaignContext,
@@ -79,6 +95,7 @@ export type ActionCenterCoreSemanticsProjectionInput = Pick<
   | 'reviewDecisions'
   | 'managerResponse'
   | 'routeFollowUpRelations'
+  | 'routeReopens'
 > & {
   route: ActionCenterRouteContract
   latestVisibleUpdateNote?: string | null
@@ -101,6 +118,7 @@ export interface ActionCenterPreviewCoreSemanticsProjectionInput {
   latestVisibleUpdateNote?: string | null
   route?: ActionCenterRouteContract | null
   managerResponse?: ActionCenterManagerResponse | null
+  lineageSummary?: ActionCenterLineageSummary | null
   followUpSemantics?: ActionCenterProjectedFollowUpSemantics | null
 }
 
@@ -143,6 +161,8 @@ const ACTION_STEP_PREFIXES = new Set([
   'vervolg',
 ])
 const FOLLOW_UP_SUCCESSOR_LINEAGE_LABEL = 'Vervolg op eerdere route'
+const REOPENED_ROUTE_LINEAGE_LABEL = 'Heropend traject'
+const FOLLOWED_UP_LATER_LINEAGE_LABEL = 'Later opgevolgd'
 const HISTORICAL_CLOSEOUT_SIGNAL_PATTERNS = [
   /\bvorige stap\s+(?:is|was|werd)\s+(?:al\s+|reeds\s+)?(?:definitief\s+)?afgerond\b/i,
   /\bvorige stap\s+(?:is|was|werd)\s+(?:al\s+|reeds\s+)?(?:definitief\s+)?afgesloten\b/i,
@@ -176,35 +196,109 @@ function getEmptyFollowUpSemantics(): ActionCenterProjectedFollowUpSemantics {
   }
 }
 
+function getEmptyLineageSummary(): ActionCenterLineageSummary {
+  return {
+    overviewLabel: null,
+    backwardLabel: null,
+    backwardRouteId: null,
+    forwardLabel: null,
+    forwardRouteId: null,
+    detailLabels: [],
+  }
+}
+
 function getCheckpoint(context: ActionCenterCoreSemanticsProjectionInput, key: PilotLearningCheckpoint['checkpoint_key']) {
   return context.learningCheckpoints.find((checkpoint) => checkpoint.checkpoint_key === key) ?? null
 }
 
-function getDirectSuccessorRelation(
-  routeId: string,
-  relations: ActionCenterRouteFollowUpRelationRecord[] | undefined,
-) {
-  return [...(relations ?? [])]
-    .filter((relation) => relation.targetRouteId === routeId && !normalizeText(relation.endedAt))
+function pickMostRecentRelation<T extends { recordedAt: string }>(rows: T[]) {
+  return rows
+    .slice()
     .sort((left, right) => new Date(right.recordedAt).getTime() - new Date(left.recordedAt).getTime())[0] ?? null
 }
 
-function projectFollowUpSemanticsFromRelation(
-  routeId: string,
-  relations: ActionCenterRouteFollowUpRelationRecord[] | undefined,
-): ActionCenterProjectedFollowUpSemantics {
-  const relation = getDirectSuccessorRelation(routeId, relations)
+function pickMostRecentReopen<T extends { reopenedAt: string }>(rows: T[]) {
+  return rows
+    .slice()
+    .sort((left, right) => new Date(right.reopenedAt).getTime() - new Date(left.reopenedAt).getTime())[0] ?? null
+}
 
-  if (!relation) {
+function resolveLineageRead(args: {
+  routeId: string
+  relations: ActionCenterRouteFollowUpRelationRecord[] | undefined
+  routeReopens: ActionCenterRouteReopenRecord[] | undefined
+}) {
+  const activeRelations = (args.relations ?? []).filter((relation) => !normalizeText(relation.endedAt))
+  const backwardRelation = pickMostRecentRelation(
+    activeRelations.filter((relation) => relation.targetRouteId === args.routeId),
+  )
+  const forwardRelation = pickMostRecentRelation(
+    activeRelations.filter((relation) => relation.sourceRouteId === args.routeId),
+  )
+  const reopen = pickMostRecentReopen(
+    (args.routeReopens ?? []).filter((routeReopen) => routeReopen.routeId === args.routeId),
+  )
+  const predecessorRelation = reopen ? null : backwardRelation
+  const backwardLabel: ActionCenterLineageLabel | null = reopen
+    ? REOPENED_ROUTE_LINEAGE_LABEL
+    : backwardRelation
+      ? FOLLOW_UP_SUCCESSOR_LINEAGE_LABEL
+      : null
+  const forwardLabel: ActionCenterLineageLabel | null = forwardRelation
+    ? FOLLOWED_UP_LATER_LINEAGE_LABEL
+    : null
+
+  return {
+    backwardRelation,
+    forwardRelation,
+    reopen,
+    predecessorRelation,
+    backwardLabel,
+    forwardLabel,
+  }
+}
+
+export function projectActionCenterLineageSummary(args: {
+  routeId: string
+  relations: ActionCenterRouteFollowUpRelationRecord[] | undefined
+  routeReopens: ActionCenterRouteReopenRecord[] | undefined
+}): ActionCenterLineageSummary {
+  const { backwardRelation, forwardRelation, reopen, backwardLabel, forwardLabel, predecessorRelation } =
+    resolveLineageRead(args)
+
+  if (!backwardRelation && !forwardRelation && !reopen) {
+    return getEmptyLineageSummary()
+  }
+
+  return {
+    overviewLabel: backwardLabel ?? forwardLabel,
+    backwardLabel,
+    backwardRouteId: predecessorRelation?.sourceRouteId ?? null,
+    forwardLabel,
+    forwardRouteId: forwardRelation?.targetRouteId ?? null,
+    detailLabels: [backwardLabel, forwardLabel].filter((label): label is ActionCenterLineageLabel => Boolean(label)),
+  }
+}
+
+function projectFollowUpSemantics(args: {
+  routeId: string
+  relations: ActionCenterRouteFollowUpRelationRecord[] | undefined
+  routeReopens: ActionCenterRouteReopenRecord[] | undefined
+}): ActionCenterProjectedFollowUpSemantics {
+  const { backwardRelation, forwardRelation, reopen, predecessorRelation, backwardLabel } = resolveLineageRead(args)
+
+  if (!backwardRelation && !forwardRelation && !reopen) {
     return getEmptyFollowUpSemantics()
   }
 
   return {
-    isDirectSuccessor: true,
-    lineageLabel: FOLLOW_UP_SUCCESSOR_LINEAGE_LABEL,
-    triggerReason: relation.triggerReason,
-    triggerReasonLabel: getActionCenterFollowUpTriggerReasonLabel(relation.triggerReason),
-    sourceRouteId: relation.sourceRouteId,
+    isDirectSuccessor: Boolean(predecessorRelation),
+    lineageLabel: backwardLabel,
+    triggerReason: predecessorRelation?.triggerReason ?? null,
+    triggerReasonLabel: predecessorRelation
+      ? getActionCenterFollowUpTriggerReasonLabel(predecessorRelation.triggerReason)
+      : null,
+    sourceRouteId: predecessorRelation?.sourceRouteId ?? null,
   }
 }
 
@@ -585,6 +679,7 @@ export function projectActionCenterPreviewCoreSemantics(
     latestVisibleUpdateNote,
   })
   const closingStatus = getPreviewClosingStatus(route.routeStatus)
+  const lineageSummary = input.lineageSummary ?? getEmptyLineageSummary()
   const followUpSemantics = input.followUpSemantics ?? getEmptyFollowUpSemantics()
 
   return {
@@ -619,6 +714,7 @@ export function projectActionCenterPreviewCoreSemantics(
     },
     resultProgression,
     decisionHistory,
+    lineageSummary,
     followUpSemantics,
     closingSemantics: {
       status: closingStatus,
@@ -708,7 +804,16 @@ export function projectActionCenterCoreSemantics(
   const latestObservation = getLatestObservation(context, route)
   const latestActionUpdate = getLatestActionUpdate(context)
   const closingStatus = getClosingStatus(context, route)
-  const followUpSemantics = projectFollowUpSemanticsFromRelation(route.routeId, context.routeFollowUpRelations)
+  const lineageSummary = projectActionCenterLineageSummary({
+    routeId: route.routeId,
+    relations: context.routeFollowUpRelations,
+    routeReopens: context.routeReopens,
+  })
+  const followUpSemantics = projectFollowUpSemantics({
+    routeId: route.routeId,
+    relations: context.routeFollowUpRelations,
+    routeReopens: context.routeReopens,
+  })
   const decisionHistory = buildDecisionHistory({
     route,
     reviewQuestion,
@@ -776,6 +881,7 @@ export function projectActionCenterCoreSemantics(
     },
     resultProgression,
     decisionHistory,
+    lineageSummary,
     followUpSemantics,
     closingSemantics: {
       status: closingStatus,

--- a/frontend/lib/action-center-live-context.ts
+++ b/frontend/lib/action-center-live-context.ts
@@ -6,7 +6,10 @@ import type {
   PilotLearningCheckpoint,
   PilotLearningDossier,
 } from './pilot-learning'
-import type { ActionCenterRouteFollowUpRelationRecord } from './action-center-route-reopen'
+import type {
+  ActionCenterRouteFollowUpRelationRecord,
+  ActionCenterRouteReopenRecord,
+} from './action-center-route-reopen'
 
 export interface LiveActionCenterCampaignContext {
   campaign: Campaign
@@ -29,4 +32,5 @@ export interface LiveActionCenterCampaignContext {
   managerResponse?: ActionCenterManagerResponse | null
   reviewDecisions?: ActionCenterReviewDecision[]
   routeFollowUpRelations?: ActionCenterRouteFollowUpRelationRecord[]
+  routeReopens?: ActionCenterRouteReopenRecord[]
 }

--- a/frontend/lib/action-center-live.test.ts
+++ b/frontend/lib/action-center-live.test.ts
@@ -1,4 +1,7 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
+import { ActionCenterPreview } from '@/components/dashboard/action-center-preview'
 import {
   buildActionCenterTelemetryEvents,
   buildLiveActionCenterItems,
@@ -117,6 +120,23 @@ function buildDossier(overrides: Partial<PilotLearningDossier> = {}): PilotLearn
     updated_at: '2026-04-24T10:00:00.000Z',
     ...overrides,
   } as PilotLearningDossier
+}
+
+function buildRouteReopen(
+  overrides: Partial<{
+    id: string | null
+    routeId: string
+    reopenedAt: string
+    reopenedByRole: string
+  }> = {},
+) {
+  return {
+    id: 'reopen-1',
+    routeId: 'campaign-exit::operations',
+    reopenedAt: '2026-05-03T12:00:00.000Z',
+    reopenedByRole: 'hr_owner',
+    ...overrides,
+  }
 }
 
 describe('live action center builder', () => {
@@ -514,6 +534,14 @@ describe('live action center builder', () => {
           whatWeObserved: 'Zichtbaar signaal voor de kaart.',
           whatWasDecided: null,
         },
+        lineageSummary: {
+          overviewLabel: null,
+          backwardLabel: null,
+          backwardRouteId: null,
+          forwardLabel: null,
+          forwardRouteId: null,
+          detailLabels: [],
+        },
         closingSemantics: {
           status: 'lopend',
           summary: null,
@@ -629,6 +657,14 @@ describe('live action center builder', () => {
         },
         resultProgression: [],
         decisionHistory: [],
+        lineageSummary: {
+          overviewLabel: 'Vervolg op eerdere route',
+          backwardLabel: 'Vervolg op eerdere route',
+          backwardRouteId: 'campaign-source::operations',
+          forwardLabel: null,
+          forwardRouteId: null,
+          detailLabels: ['Vervolg op eerdere route'],
+        },
         followUpSemantics: {
           isDirectSuccessor: true,
           lineageLabel: 'Vervolg op eerdere route',
@@ -659,6 +695,14 @@ describe('live action center builder', () => {
       { recomputeCoreSemantics: true },
     )
 
+    expect(recomputed.coreSemantics.lineageSummary).toMatchObject({
+      overviewLabel: 'Vervolg op eerdere route',
+      backwardLabel: 'Vervolg op eerdere route',
+      backwardRouteId: 'campaign-source::operations',
+      forwardLabel: null,
+      forwardRouteId: null,
+      detailLabels: ['Vervolg op eerdere route'],
+    })
     expect(recomputed.coreSemantics.followUpSemantics).toMatchObject({
       isDirectSuccessor: true,
       lineageLabel: 'Vervolg op eerdere route',
@@ -1165,11 +1209,13 @@ describe('live action center builder', () => {
         closingSemantics: {
           status: 'afgerond',
         },
-        followUpSemantics: {
-          isDirectSuccessor: false,
-          lineageLabel: null,
-          triggerReason: null,
-          triggerReasonLabel: null,
+        lineageSummary: {
+          overviewLabel: 'Later opgevolgd',
+          backwardLabel: null,
+          backwardRouteId: null,
+          forwardLabel: 'Later opgevolgd',
+          forwardRouteId: targetRouteId,
+          detailLabels: ['Later opgevolgd'],
         },
       },
     })
@@ -1179,14 +1225,828 @@ describe('live action center builder', () => {
         route: {
           routeStatus: 'te-bespreken',
         },
-        followUpSemantics: {
-          isDirectSuccessor: true,
-          lineageLabel: 'Vervolg op eerdere route',
-          triggerReason: 'nieuw-segment-signaal',
-          triggerReasonLabel: 'Nieuw segmentsignaal',
-          sourceRouteId,
+        lineageSummary: {
+          overviewLabel: 'Vervolg op eerdere route',
+          backwardLabel: 'Vervolg op eerdere route',
+          backwardRouteId: sourceRouteId,
+          forwardLabel: null,
+          forwardRouteId: null,
+          detailLabels: ['Vervolg op eerdere route'],
         },
       },
+    })
+  })
+
+  it('uses backward lineage in overview and both lineage labels in detail for a middle route', () => {
+    const scopeValue = 'org-1::department::operations'
+    const previousCampaign = buildCampaign({
+      id: 'campaign-previous',
+      name: 'Exit maart',
+      created_at: '2026-03-10T10:00:00.000Z',
+    })
+    const currentCampaign = buildCampaign({
+      id: 'campaign-current',
+      name: 'Exit april',
+      created_at: '2026-04-10T10:00:00.000Z',
+    })
+    const nextCampaign = buildCampaign({
+      id: 'campaign-next',
+      name: 'Exit mei',
+      created_at: '2026-05-10T10:00:00.000Z',
+    })
+    const previousRouteId = buildActionCenterRouteId(previousCampaign.id, scopeValue)
+    const currentRouteId = buildActionCenterRouteId(currentCampaign.id, scopeValue)
+    const nextRouteId = buildActionCenterRouteId(nextCampaign.id, scopeValue)
+    const sharedRelations = [
+      {
+        id: 'relation-backward',
+        routeRelationType: 'follow-up-from' as const,
+        sourceRouteId: previousRouteId,
+        targetRouteId: currentRouteId,
+        triggerReason: 'nieuw-campaign-signaal' as const,
+        recordedAt: '2026-05-01T09:00:00.000Z',
+        recordedByRole: 'hr_owner',
+        endedAt: null,
+      },
+      {
+        id: 'relation-forward',
+        routeRelationType: 'follow-up-from' as const,
+        sourceRouteId: currentRouteId,
+        targetRouteId: nextRouteId,
+        triggerReason: 'hernieuwde-hr-beoordeling' as const,
+        recordedAt: '2026-05-02T09:00:00.000Z',
+        recordedByRole: 'hr_owner',
+        endedAt: null,
+      },
+    ]
+
+    const items = buildLiveActionCenterItems([
+      {
+        campaign: previousCampaign,
+        stats: buildStats({ campaign_id: previousCampaign.id, campaign_name: previousCampaign.name }),
+        organizationName: 'Acme BV',
+        memberRole: 'owner',
+        scopeType: 'department',
+        scopeValue,
+        scopeLabel: 'Operations',
+        peopleCount: 38,
+        assignedManager: {
+          userId: 'manager-previous',
+          displayName: 'Manager Operations',
+          assignedAt: '2026-03-10T08:00:00.000Z',
+        },
+        deliveryRecord: buildDeliveryRecord({
+          campaign_id: previousCampaign.id,
+          lifecycle_stage: 'follow_up_decided',
+          first_management_use_confirmed_at: '2026-03-10T08:00:00.000Z',
+        }),
+        deliveryCheckpoints: [],
+        learningDossier: buildDossier({
+          campaign_id: previousCampaign.id,
+          triage_status: 'uitgevoerd',
+          management_action_outcome: 'afronden',
+          case_public_summary: 'De vorige route is afgerond.',
+        }),
+        learningCheckpoints: [],
+        reviewDecisions: [],
+        routeFollowUpRelations: sharedRelations,
+      },
+      {
+        campaign: currentCampaign,
+        stats: buildStats({ campaign_id: currentCampaign.id, campaign_name: currentCampaign.name }),
+        organizationName: 'Acme BV',
+        memberRole: 'owner',
+        scopeType: 'department',
+        scopeValue,
+        scopeLabel: 'Operations',
+        peopleCount: 38,
+        assignedManager: {
+          userId: 'manager-current',
+          displayName: 'Manager Operations',
+          assignedAt: '2026-04-10T08:00:00.000Z',
+        },
+        deliveryRecord: buildDeliveryRecord({
+          campaign_id: currentCampaign.id,
+          lifecycle_stage: 'first_management_use',
+          first_management_use_confirmed_at: '2026-04-10T08:00:00.000Z',
+        }),
+        deliveryCheckpoints: [],
+        learningDossier: buildDossier({
+          campaign_id: currentCampaign.id,
+          title: 'Middenroute',
+          triage_status: 'bevestigd',
+          management_action_outcome: 'bijstellen',
+        }),
+        learningCheckpoints: [],
+        reviewDecisions: [],
+        routeFollowUpRelations: sharedRelations,
+      },
+      {
+        campaign: nextCampaign,
+        stats: buildStats({ campaign_id: nextCampaign.id, campaign_name: nextCampaign.name }),
+        organizationName: 'Acme BV',
+        memberRole: 'owner',
+        scopeType: 'department',
+        scopeValue,
+        scopeLabel: 'Operations',
+        peopleCount: 38,
+        assignedManager: {
+          userId: 'manager-next',
+          displayName: 'Manager Operations',
+          assignedAt: '2026-05-10T08:00:00.000Z',
+        },
+        deliveryRecord: buildDeliveryRecord({
+          campaign_id: nextCampaign.id,
+          lifecycle_stage: 'first_value_reached',
+        }),
+        deliveryCheckpoints: [],
+        learningDossier: buildDossier({
+          campaign_id: nextCampaign.id,
+          title: 'Nieuwe vervolgroute',
+          triage_status: 'bevestigd',
+        }),
+        learningCheckpoints: [],
+        reviewDecisions: [],
+        routeFollowUpRelations: sharedRelations,
+      },
+    ] as Parameters<typeof buildLiveActionCenterItems>[0])
+
+    const currentItem = items.find((item) => item.id === currentRouteId)
+
+    expect(currentItem?.coreSemantics.lineageSummary).toMatchObject({
+      overviewLabel: 'Vervolg op eerdere route',
+      backwardLabel: 'Vervolg op eerdere route',
+      backwardRouteId: previousRouteId,
+      forwardLabel: 'Later opgevolgd',
+      forwardRouteId: nextRouteId,
+      detailLabels: ['Vervolg op eerdere route', 'Later opgevolgd'],
+    })
+  })
+
+  it('renders both backward and forward lineage controls in detail for a middle route', () => {
+    const scopeValue = 'org-1::department::operations'
+    const previousCampaign = buildCampaign({
+      id: 'campaign-previous-detail',
+      name: 'Exit maart',
+      created_at: '2026-03-10T10:00:00.000Z',
+    })
+    const currentCampaign = buildCampaign({
+      id: 'campaign-current-detail',
+      name: 'Exit april',
+      created_at: '2026-04-10T10:00:00.000Z',
+    })
+    const nextCampaign = buildCampaign({
+      id: 'campaign-next-detail',
+      name: 'Exit mei',
+      created_at: '2026-05-10T10:00:00.000Z',
+    })
+    const previousRouteId = buildActionCenterRouteId(previousCampaign.id, scopeValue)
+    const currentRouteId = buildActionCenterRouteId(currentCampaign.id, scopeValue)
+    const nextRouteId = buildActionCenterRouteId(nextCampaign.id, scopeValue)
+    const sharedRelations = [
+      {
+        id: 'relation-backward-detail',
+        routeRelationType: 'follow-up-from' as const,
+        sourceRouteId: previousRouteId,
+        targetRouteId: currentRouteId,
+        triggerReason: 'nieuw-campaign-signaal' as const,
+        recordedAt: '2026-05-01T09:00:00.000Z',
+        recordedByRole: 'hr_owner',
+        endedAt: null,
+      },
+      {
+        id: 'relation-forward-detail',
+        routeRelationType: 'follow-up-from' as const,
+        sourceRouteId: currentRouteId,
+        targetRouteId: nextRouteId,
+        triggerReason: 'hernieuwde-hr-beoordeling' as const,
+        recordedAt: '2026-05-02T09:00:00.000Z',
+        recordedByRole: 'hr_owner',
+        endedAt: null,
+      },
+    ]
+
+    const items = buildLiveActionCenterItems([
+      {
+        campaign: previousCampaign,
+        stats: buildStats({ campaign_id: previousCampaign.id, campaign_name: previousCampaign.name }),
+        organizationName: 'Acme BV',
+        memberRole: 'owner',
+        scopeType: 'department',
+        scopeValue,
+        scopeLabel: 'Operations',
+        peopleCount: 38,
+        assignedManager: {
+          userId: 'manager-previous-detail',
+          displayName: 'Manager Operations',
+          assignedAt: '2026-03-10T08:00:00.000Z',
+        },
+        deliveryRecord: buildDeliveryRecord({
+          campaign_id: previousCampaign.id,
+          lifecycle_stage: 'follow_up_decided',
+          first_management_use_confirmed_at: '2026-03-10T08:00:00.000Z',
+        }),
+        deliveryCheckpoints: [],
+        learningDossier: buildDossier({
+          campaign_id: previousCampaign.id,
+          triage_status: 'uitgevoerd',
+          management_action_outcome: 'afronden',
+          case_public_summary: 'De vorige route is afgerond.',
+        }),
+        learningCheckpoints: [],
+        reviewDecisions: [],
+        routeFollowUpRelations: sharedRelations,
+      },
+      {
+        campaign: currentCampaign,
+        stats: buildStats({ campaign_id: currentCampaign.id, campaign_name: currentCampaign.name }),
+        organizationName: 'Acme BV',
+        memberRole: 'owner',
+        scopeType: 'department',
+        scopeValue,
+        scopeLabel: 'Operations',
+        peopleCount: 38,
+        assignedManager: {
+          userId: 'manager-current-detail',
+          displayName: 'Manager Operations',
+          assignedAt: '2026-04-10T08:00:00.000Z',
+        },
+        deliveryRecord: buildDeliveryRecord({
+          campaign_id: currentCampaign.id,
+          lifecycle_stage: 'first_management_use',
+          first_management_use_confirmed_at: '2026-04-10T08:00:00.000Z',
+        }),
+        deliveryCheckpoints: [],
+        learningDossier: buildDossier({
+          campaign_id: currentCampaign.id,
+          title: 'Middenroute detail',
+          triage_status: 'bevestigd',
+          management_action_outcome: 'bijstellen',
+        }),
+        learningCheckpoints: [],
+        reviewDecisions: [],
+        routeFollowUpRelations: sharedRelations,
+      },
+      {
+        campaign: nextCampaign,
+        stats: buildStats({ campaign_id: nextCampaign.id, campaign_name: nextCampaign.name }),
+        organizationName: 'Acme BV',
+        memberRole: 'owner',
+        scopeType: 'department',
+        scopeValue,
+        scopeLabel: 'Operations',
+        peopleCount: 38,
+        assignedManager: {
+          userId: 'manager-next-detail',
+          displayName: 'Manager Operations',
+          assignedAt: '2026-05-10T08:00:00.000Z',
+        },
+        deliveryRecord: buildDeliveryRecord({
+          campaign_id: nextCampaign.id,
+          lifecycle_stage: 'first_value_reached',
+        }),
+        deliveryCheckpoints: [],
+        learningDossier: buildDossier({
+          campaign_id: nextCampaign.id,
+          title: 'Nieuwe vervolgroute detail',
+          triage_status: 'bevestigd',
+        }),
+        learningCheckpoints: [],
+        reviewDecisions: [],
+        routeFollowUpRelations: sharedRelations,
+      },
+    ] as Parameters<typeof buildLiveActionCenterItems>[0])
+
+    const html = renderToStaticMarkup(
+      React.createElement(ActionCenterPreview, {
+        initialItems: items,
+        initialSelectedItemId: currentRouteId,
+        initialView: 'actions',
+        fallbackOwnerName: 'Verisight gebruiker',
+        ownerOptions: ['Manager Operations'],
+        workbenchHref: '/dashboard',
+        itemHrefs: {
+          [previousRouteId]: `/dashboard/action-center?focus=${previousRouteId}`,
+          [currentRouteId]: `/dashboard/action-center?focus=${currentRouteId}`,
+          [nextRouteId]: `/dashboard/action-center?focus=${nextRouteId}`,
+        },
+        readOnly: true,
+      }),
+    )
+
+    expect(html).toMatch(
+      /<button[^>]*aria-label="Vervolg op eerdere route"[\s\S]*?<span>Vervolg op eerdere route<\/span>[\s\S]*?Exit follow-through voorjaar/,
+    )
+    expect(html).toMatch(
+      /<button[^>]*aria-label="Later opgevolgd"[\s\S]*?<span>Later opgevolgd<\/span>[\s\S]*?Nieuwe vervolgroute detail/,
+    )
+    expect(html.indexOf('aria-label="Vervolg op eerdere route"')).toBeLessThan(html.indexOf('aria-label="Later opgevolgd"'))
+  })
+
+  it('chooses the most recent forward successor when multiple successor rows exist', () => {
+    const scopeValue = 'org-1::department::operations'
+    const currentCampaign = buildCampaign({
+      id: 'campaign-current-forward',
+      name: 'Exit april',
+      created_at: '2026-04-10T10:00:00.000Z',
+    })
+    const nextOlderCampaign = buildCampaign({
+      id: 'campaign-next-older',
+      name: 'Exit mei oud',
+      created_at: '2026-05-01T10:00:00.000Z',
+    })
+    const nextNewerCampaign = buildCampaign({
+      id: 'campaign-next-newer',
+      name: 'Exit mei nieuw',
+      created_at: '2026-05-10T10:00:00.000Z',
+    })
+    const currentRouteId = buildActionCenterRouteId(currentCampaign.id, scopeValue)
+    const olderForwardRouteId = buildActionCenterRouteId(nextOlderCampaign.id, scopeValue)
+    const newerForwardRouteId = buildActionCenterRouteId(nextNewerCampaign.id, scopeValue)
+    const sharedRelations = [
+      {
+        id: 'relation-forward-older',
+        routeRelationType: 'follow-up-from' as const,
+        sourceRouteId: currentRouteId,
+        targetRouteId: olderForwardRouteId,
+        triggerReason: 'nieuw-campaign-signaal' as const,
+        recordedAt: '2026-05-01T09:00:00.000Z',
+        recordedByRole: 'hr_owner',
+        endedAt: null,
+      },
+      {
+        id: 'relation-forward-newer',
+        routeRelationType: 'follow-up-from' as const,
+        sourceRouteId: currentRouteId,
+        targetRouteId: newerForwardRouteId,
+        triggerReason: 'hernieuwde-hr-beoordeling' as const,
+        recordedAt: '2026-05-03T09:00:00.000Z',
+        recordedByRole: 'hr_owner',
+        endedAt: null,
+      },
+    ]
+
+    const items = buildLiveActionCenterItems([
+      {
+        campaign: currentCampaign,
+        stats: buildStats({ campaign_id: currentCampaign.id, campaign_name: currentCampaign.name }),
+        organizationName: 'Acme BV',
+        memberRole: 'owner',
+        scopeType: 'department',
+        scopeValue,
+        scopeLabel: 'Operations',
+        peopleCount: 38,
+        assignedManager: {
+          userId: 'manager-current',
+          displayName: 'Manager Operations',
+          assignedAt: '2026-04-10T08:00:00.000Z',
+        },
+        deliveryRecord: buildDeliveryRecord({
+          campaign_id: currentCampaign.id,
+          lifecycle_stage: 'follow_up_decided',
+          first_management_use_confirmed_at: '2026-04-10T08:00:00.000Z',
+        }),
+        deliveryCheckpoints: [],
+        learningDossier: buildDossier({
+          campaign_id: currentCampaign.id,
+          triage_status: 'uitgevoerd',
+          management_action_outcome: 'afronden',
+          case_public_summary: 'De route is afgerond en later opgevolgd.',
+        }),
+        learningCheckpoints: [],
+        reviewDecisions: [],
+        routeFollowUpRelations: sharedRelations,
+      },
+      {
+        campaign: nextOlderCampaign,
+        stats: buildStats({ campaign_id: nextOlderCampaign.id, campaign_name: nextOlderCampaign.name }),
+        organizationName: 'Acme BV',
+        memberRole: 'owner',
+        scopeType: 'department',
+        scopeValue,
+        scopeLabel: 'Operations',
+        peopleCount: 38,
+        assignedManager: {
+          userId: 'manager-next-older',
+          displayName: 'Manager Operations',
+          assignedAt: '2026-05-01T08:00:00.000Z',
+        },
+        deliveryRecord: buildDeliveryRecord({
+          campaign_id: nextOlderCampaign.id,
+          lifecycle_stage: 'first_value_reached',
+        }),
+        deliveryCheckpoints: [],
+        learningDossier: buildDossier({
+          campaign_id: nextOlderCampaign.id,
+          title: 'Oudere vervolgroute',
+        }),
+        learningCheckpoints: [],
+        reviewDecisions: [],
+        routeFollowUpRelations: sharedRelations,
+      },
+      {
+        campaign: nextNewerCampaign,
+        stats: buildStats({ campaign_id: nextNewerCampaign.id, campaign_name: nextNewerCampaign.name }),
+        organizationName: 'Acme BV',
+        memberRole: 'owner',
+        scopeType: 'department',
+        scopeValue,
+        scopeLabel: 'Operations',
+        peopleCount: 38,
+        assignedManager: {
+          userId: 'manager-next-newer',
+          displayName: 'Manager Operations',
+          assignedAt: '2026-05-03T08:00:00.000Z',
+        },
+        deliveryRecord: buildDeliveryRecord({
+          campaign_id: nextNewerCampaign.id,
+          lifecycle_stage: 'first_value_reached',
+        }),
+        deliveryCheckpoints: [],
+        learningDossier: buildDossier({
+          campaign_id: nextNewerCampaign.id,
+          title: 'Nieuwere vervolgroute',
+        }),
+        learningCheckpoints: [],
+        reviewDecisions: [],
+        routeFollowUpRelations: sharedRelations,
+      },
+    ] as Parameters<typeof buildLiveActionCenterItems>[0])
+
+    const currentItem = items.find((item) => item.id === currentRouteId)
+
+    expect(currentItem?.coreSemantics.lineageSummary).toMatchObject({
+      overviewLabel: 'Later opgevolgd',
+      backwardLabel: null,
+      backwardRouteId: null,
+      forwardLabel: 'Later opgevolgd',
+      forwardRouteId: newerForwardRouteId,
+      detailLabels: ['Later opgevolgd'],
+    })
+  })
+
+  it('chooses the most recent backward predecessor when multiple predecessor rows exist', () => {
+    const scopeValue = 'org-1::department::operations'
+    const olderCampaign = buildCampaign({
+      id: 'campaign-prev-older',
+      name: 'Exit februari',
+      created_at: '2026-02-10T10:00:00.000Z',
+    })
+    const newerCampaign = buildCampaign({
+      id: 'campaign-prev-newer',
+      name: 'Exit maart',
+      created_at: '2026-03-10T10:00:00.000Z',
+    })
+    const currentCampaign = buildCampaign({
+      id: 'campaign-current-backward',
+      name: 'Exit april',
+      created_at: '2026-04-10T10:00:00.000Z',
+    })
+    const currentRouteId = buildActionCenterRouteId(currentCampaign.id, scopeValue)
+    const olderRouteId = buildActionCenterRouteId(olderCampaign.id, scopeValue)
+    const newerRouteId = buildActionCenterRouteId(newerCampaign.id, scopeValue)
+    const sharedRelations = [
+      {
+        id: 'relation-backward-older-live',
+        routeRelationType: 'follow-up-from' as const,
+        sourceRouteId: olderRouteId,
+        targetRouteId: currentRouteId,
+        triggerReason: 'nieuw-campaign-signaal' as const,
+        recordedAt: '2026-05-01T09:00:00.000Z',
+        recordedByRole: 'hr_owner',
+        endedAt: null,
+      },
+      {
+        id: 'relation-backward-newer-live',
+        routeRelationType: 'follow-up-from' as const,
+        sourceRouteId: newerRouteId,
+        targetRouteId: currentRouteId,
+        triggerReason: 'hernieuwde-hr-beoordeling' as const,
+        recordedAt: '2026-05-02T09:00:00.000Z',
+        recordedByRole: 'hr_owner',
+        endedAt: null,
+      },
+    ]
+
+    const items = buildLiveActionCenterItems([
+      {
+        campaign: olderCampaign,
+        stats: buildStats({ campaign_id: olderCampaign.id, campaign_name: olderCampaign.name }),
+        organizationName: 'Acme BV',
+        memberRole: 'owner',
+        scopeType: 'department',
+        scopeValue,
+        scopeLabel: 'Operations',
+        peopleCount: 38,
+        assignedManager: {
+          userId: 'manager-prev-older',
+          displayName: 'Manager Operations',
+          assignedAt: '2026-02-10T08:00:00.000Z',
+        },
+        deliveryRecord: buildDeliveryRecord({
+          campaign_id: olderCampaign.id,
+          lifecycle_stage: 'follow_up_decided',
+          first_management_use_confirmed_at: '2026-02-10T08:00:00.000Z',
+        }),
+        deliveryCheckpoints: [],
+        learningDossier: buildDossier({
+          campaign_id: olderCampaign.id,
+          triage_status: 'uitgevoerd',
+          management_action_outcome: 'afronden',
+        }),
+        learningCheckpoints: [],
+        reviewDecisions: [],
+        routeFollowUpRelations: sharedRelations,
+      },
+      {
+        campaign: newerCampaign,
+        stats: buildStats({ campaign_id: newerCampaign.id, campaign_name: newerCampaign.name }),
+        organizationName: 'Acme BV',
+        memberRole: 'owner',
+        scopeType: 'department',
+        scopeValue,
+        scopeLabel: 'Operations',
+        peopleCount: 38,
+        assignedManager: {
+          userId: 'manager-prev-newer',
+          displayName: 'Manager Operations',
+          assignedAt: '2026-03-10T08:00:00.000Z',
+        },
+        deliveryRecord: buildDeliveryRecord({
+          campaign_id: newerCampaign.id,
+          lifecycle_stage: 'follow_up_decided',
+          first_management_use_confirmed_at: '2026-03-10T08:00:00.000Z',
+        }),
+        deliveryCheckpoints: [],
+        learningDossier: buildDossier({
+          campaign_id: newerCampaign.id,
+          triage_status: 'uitgevoerd',
+          management_action_outcome: 'afronden',
+        }),
+        learningCheckpoints: [],
+        reviewDecisions: [],
+        routeFollowUpRelations: sharedRelations,
+      },
+      {
+        campaign: currentCampaign,
+        stats: buildStats({ campaign_id: currentCampaign.id, campaign_name: currentCampaign.name }),
+        organizationName: 'Acme BV',
+        memberRole: 'owner',
+        scopeType: 'department',
+        scopeValue,
+        scopeLabel: 'Operations',
+        peopleCount: 38,
+        assignedManager: {
+          userId: 'manager-current-backward',
+          displayName: 'Manager Operations',
+          assignedAt: '2026-04-10T08:00:00.000Z',
+        },
+        deliveryRecord: buildDeliveryRecord({
+          campaign_id: currentCampaign.id,
+          lifecycle_stage: 'first_management_use',
+          first_management_use_confirmed_at: '2026-04-10T08:00:00.000Z',
+        }),
+        deliveryCheckpoints: [],
+        learningDossier: buildDossier({
+          campaign_id: currentCampaign.id,
+          triage_status: 'bevestigd',
+        }),
+        learningCheckpoints: [],
+        reviewDecisions: [],
+        routeFollowUpRelations: sharedRelations,
+      },
+    ] as Parameters<typeof buildLiveActionCenterItems>[0])
+
+    const currentItem = items.find((item) => item.id === currentRouteId)
+
+    expect(currentItem?.coreSemantics.lineageSummary).toMatchObject({
+      overviewLabel: 'Vervolg op eerdere route',
+      backwardLabel: 'Vervolg op eerdere route',
+      backwardRouteId: newerRouteId,
+      forwardLabel: null,
+      forwardRouteId: null,
+      detailLabels: ['Vervolg op eerdere route'],
+    })
+  })
+
+  it('chooses the most recent reopen event in live lineage summaries', () => {
+    const scopeValue = 'org-1::department::operations'
+    const currentCampaign = buildCampaign({
+      id: 'campaign-current-reopen-live',
+      name: 'Exit april',
+      created_at: '2026-04-10T10:00:00.000Z',
+    })
+    const currentRouteId = buildActionCenterRouteId(currentCampaign.id, scopeValue)
+
+    const items = buildLiveActionCenterItems([
+      {
+        campaign: currentCampaign,
+        stats: buildStats({ campaign_id: currentCampaign.id, campaign_name: currentCampaign.name }),
+        organizationName: 'Acme BV',
+        memberRole: 'owner',
+        scopeType: 'department',
+        scopeValue,
+        scopeLabel: 'Operations',
+        peopleCount: 38,
+        assignedManager: {
+          userId: 'manager-current-reopen',
+          displayName: 'Manager Operations',
+          assignedAt: '2026-04-10T08:00:00.000Z',
+        },
+        deliveryRecord: buildDeliveryRecord({
+          campaign_id: currentCampaign.id,
+          lifecycle_stage: 'first_management_use',
+          first_management_use_confirmed_at: '2026-04-10T08:00:00.000Z',
+        }),
+        deliveryCheckpoints: [],
+        learningDossier: buildDossier({
+          campaign_id: currentCampaign.id,
+          triage_status: 'bevestigd',
+        }),
+        learningCheckpoints: [],
+        reviewDecisions: [],
+        routeFollowUpRelations: [],
+        routeReopens: [
+          buildRouteReopen({
+            id: 'reopen-older-live',
+            routeId: currentRouteId,
+            reopenedAt: '2026-05-01T09:00:00.000Z',
+          }),
+          buildRouteReopen({
+            id: 'reopen-newer-live',
+            routeId: currentRouteId,
+            reopenedAt: '2026-05-03T12:00:00.000Z',
+          }),
+        ],
+      },
+    ] as Parameters<typeof buildLiveActionCenterItems>[0])
+
+    const currentItem = items.find((item) => item.id === currentRouteId)
+
+    expect(currentItem?.coreSemantics.lineageSummary).toMatchObject({
+      overviewLabel: 'Heropend traject',
+      backwardLabel: 'Heropend traject',
+      backwardRouteId: null,
+      forwardLabel: null,
+      forwardRouteId: null,
+      detailLabels: ['Heropend traject'],
+    })
+  })
+
+  it('ignores ended forward successor relations in live lineage summaries', () => {
+    const scopeValue = 'org-1::department::operations'
+    const currentCampaign = buildCampaign({
+      id: 'campaign-current-ended-forward',
+      name: 'Exit april',
+      created_at: '2026-04-10T10:00:00.000Z',
+    })
+    const nextCampaign = buildCampaign({
+      id: 'campaign-next-ended-forward',
+      name: 'Exit mei',
+      created_at: '2026-05-10T10:00:00.000Z',
+    })
+    const currentRouteId = buildActionCenterRouteId(currentCampaign.id, scopeValue)
+    const nextRouteId = buildActionCenterRouteId(nextCampaign.id, scopeValue)
+    const endedRelations = [
+      {
+        id: 'relation-forward-ended',
+        routeRelationType: 'follow-up-from' as const,
+        sourceRouteId: currentRouteId,
+        targetRouteId: nextRouteId,
+        triggerReason: 'nieuw-campaign-signaal' as const,
+        recordedAt: '2026-05-03T09:00:00.000Z',
+        recordedByRole: 'hr_owner',
+        endedAt: '2026-05-04T09:00:00.000Z',
+      },
+    ]
+
+    const items = buildLiveActionCenterItems([
+      {
+        campaign: currentCampaign,
+        stats: buildStats({ campaign_id: currentCampaign.id, campaign_name: currentCampaign.name }),
+        organizationName: 'Acme BV',
+        memberRole: 'owner',
+        scopeType: 'department',
+        scopeValue,
+        scopeLabel: 'Operations',
+        peopleCount: 38,
+        assignedManager: {
+          userId: 'manager-current',
+          displayName: 'Manager Operations',
+          assignedAt: '2026-04-10T08:00:00.000Z',
+        },
+        deliveryRecord: buildDeliveryRecord({
+          campaign_id: currentCampaign.id,
+          lifecycle_stage: 'follow_up_decided',
+          first_management_use_confirmed_at: '2026-04-10T08:00:00.000Z',
+        }),
+        deliveryCheckpoints: [],
+        learningDossier: buildDossier({
+          campaign_id: currentCampaign.id,
+          triage_status: 'uitgevoerd',
+          management_action_outcome: 'afronden',
+          case_public_summary: 'De route is afgerond zonder actieve opvolger.',
+        }),
+        learningCheckpoints: [],
+        reviewDecisions: [],
+        routeFollowUpRelations: endedRelations,
+      },
+      {
+        campaign: nextCampaign,
+        stats: buildStats({ campaign_id: nextCampaign.id, campaign_name: nextCampaign.name }),
+        organizationName: 'Acme BV',
+        memberRole: 'owner',
+        scopeType: 'department',
+        scopeValue,
+        scopeLabel: 'Operations',
+        peopleCount: 38,
+        assignedManager: {
+          userId: 'manager-next',
+          displayName: 'Manager Operations',
+          assignedAt: '2026-05-03T08:00:00.000Z',
+        },
+        deliveryRecord: buildDeliveryRecord({
+          campaign_id: nextCampaign.id,
+          lifecycle_stage: 'first_value_reached',
+        }),
+        deliveryCheckpoints: [],
+        learningDossier: buildDossier({
+          campaign_id: nextCampaign.id,
+          title: 'Beeindigde vervolgroute',
+        }),
+        learningCheckpoints: [],
+        reviewDecisions: [],
+        routeFollowUpRelations: endedRelations,
+      },
+    ] as Parameters<typeof buildLiveActionCenterItems>[0])
+
+    const currentItem = items.find((item) => item.id === currentRouteId)
+
+    expect(currentItem?.coreSemantics.lineageSummary).toEqual({
+      overviewLabel: null,
+      backwardLabel: null,
+      backwardRouteId: null,
+      forwardLabel: null,
+      forwardRouteId: null,
+      detailLabels: [],
+    })
+  })
+
+  it('clears predecessor linkage fields when a reopen reading wins over follow-up history', () => {
+    const scopeValue = 'org-1::department::operations'
+    const routeId = buildActionCenterRouteId('campaign-exit', scopeValue)
+
+    const [item] = buildLiveActionCenterItems([
+      {
+        campaign: buildCampaign(),
+        stats: buildStats(),
+        organizationName: 'Acme BV',
+        memberRole: 'owner',
+        scopeType: 'department',
+        scopeValue,
+        scopeLabel: 'Operations',
+        peopleCount: 38,
+        assignedManager: {
+          userId: 'manager-1',
+          displayName: 'Manager Operations',
+          assignedAt: '2026-04-21T08:00:00.000Z',
+        },
+        deliveryRecord: buildDeliveryRecord({
+          lifecycle_stage: 'first_management_use',
+          first_management_use_confirmed_at: '2026-04-20T09:00:00.000Z',
+        }),
+        deliveryCheckpoints: [],
+        learningDossier: buildDossier({
+          management_action_outcome: 'bijstellen',
+        }),
+        learningCheckpoints: [],
+        reviewDecisions: [],
+        routeFollowUpRelations: [
+          {
+            id: 'relation-backward',
+            routeRelationType: 'follow-up-from',
+            sourceRouteId: 'campaign-older::org-1::department::operations',
+            targetRouteId: routeId,
+            triggerReason: 'nieuw-campaign-signaal',
+            recordedAt: '2026-05-01T10:00:00.000Z',
+            recordedByRole: 'hr_owner',
+            endedAt: null,
+          },
+        ],
+        routeReopens: [
+          buildRouteReopen({
+            routeId,
+            reopenedAt: '2026-05-03T12:00:00.000Z',
+          }),
+        ],
+      },
+    ] as Parameters<typeof buildLiveActionCenterItems>[0])
+
+    expect(item?.coreSemantics.lineageSummary).toMatchObject({
+      overviewLabel: 'Heropend traject',
+      backwardLabel: 'Heropend traject',
+      backwardRouteId: null,
+      detailLabels: ['Heropend traject'],
     })
   })
 })

--- a/frontend/lib/action-center-live.ts
+++ b/frontend/lib/action-center-live.ts
@@ -290,6 +290,7 @@ export function finalizeActionCenterPreviewItem(
       latestVisibleUpdateNote,
       route: existingRoute,
       managerResponse: item.managerResponse ?? null,
+      lineageSummary: item.coreSemantics?.lineageSummary ?? null,
       followUpSemantics: item.coreSemantics?.followUpSemantics ?? null,
     })
 
@@ -350,6 +351,7 @@ export function buildLiveActionCenterItems(contexts: LiveActionCenterCampaignCon
         latestVisibleUpdateNote: latestUpdate,
         reviewDecisions: context.reviewDecisions ?? ([] as ActionCenterReviewDecision[]),
         decisionRecords: [],
+        routeReopens: context.routeReopens,
       })
       const priority = getPriorityFromSignals({
         exceptionStatus: context.deliveryRecord?.exception_status,

--- a/frontend/lib/action-center-preview-display.test.ts
+++ b/frontend/lib/action-center-preview-display.test.ts
@@ -113,6 +113,14 @@ describe('action center preview display helpers', () => {
             reviewCompletedAt: '2026-04-22T09:00:00.000Z',
           },
         ],
+        lineageSummary: {
+          overviewLabel: null,
+          backwardLabel: null,
+          backwardRouteId: null,
+          forwardLabel: null,
+          forwardRouteId: null,
+          detailLabels: [],
+        },
         closingSemantics: {
           status: 'lopend',
           summary: null,

--- a/frontend/lib/action-center-preview-route-fields-render.test.ts
+++ b/frontend/lib/action-center-preview-route-fields-render.test.ts
@@ -120,6 +120,14 @@ describe('action center preview route fields render', () => {
             reviewCompletedAt: '2026-04-24T09:00:00.000Z',
           },
         ],
+        lineageSummary: {
+          overviewLabel: null,
+          backwardLabel: null,
+          backwardRouteId: null,
+          forwardLabel: null,
+          forwardRouteId: null,
+          detailLabels: [],
+        },
         closingSemantics: {
           status: 'lopend',
           summary: null,
@@ -214,6 +222,14 @@ describe('action center preview route fields render', () => {
         },
         resultProgression: [],
         decisionHistory: [],
+        lineageSummary: {
+          overviewLabel: null,
+          backwardLabel: null,
+          backwardRouteId: null,
+          forwardLabel: null,
+          forwardRouteId: null,
+          detailLabels: [],
+        },
         closingSemantics: {
           status: 'lopend',
           summary: null,
@@ -328,6 +344,14 @@ describe('action center preview route fields render', () => {
             reviewCompletedAt: '2026-04-28T09:00:00.000Z',
           },
         ],
+        lineageSummary: {
+          overviewLabel: null,
+          backwardLabel: null,
+          backwardRouteId: null,
+          forwardLabel: null,
+          forwardRouteId: null,
+          detailLabels: [],
+        },
         closingSemantics: {
           status: 'afgerond',
           summary: 'De lokale correctie hield zichtbaar stand.',

--- a/frontend/lib/action-center-route-reopen.ts
+++ b/frontend/lib/action-center-route-reopen.ts
@@ -3,6 +3,23 @@ export type ActionCenterRouteFollowUpTriggerReason =
   | 'nieuw-segment-signaal'
   | 'hernieuwde-hr-beoordeling'
 
+export interface ActionCenterRouteReopenRecord {
+  id?: string | null
+  routeId: string
+  reopenedAt: string
+  reopenedByRole: string
+}
+
+export interface ActionCenterRouteReopenInput {
+  id?: string | null
+  route_id?: string | null
+  routeId?: string | null
+  reopened_at?: string | null
+  reopenedAt?: string | null
+  reopened_by_role?: string | null
+  reopenedByRole?: string | null
+}
+
 export interface ActionCenterRouteFollowUpRelationRecord {
   id?: string | null
   routeRelationType: 'follow-up-from'
@@ -49,6 +66,43 @@ function isValidIsoTimestamp(value: string) {
 
 function readCanonicalText(input: ActionCenterRouteFollowUpRelationInput, snakeKey: keyof ActionCenterRouteFollowUpRelationInput, camelKey: keyof ActionCenterRouteFollowUpRelationInput) {
   return normalizeText((input[snakeKey] as string | null | undefined) ?? (input[camelKey] as string | null | undefined))
+}
+
+function readCanonicalReopenText(
+  input: ActionCenterRouteReopenInput,
+  snakeKey: keyof ActionCenterRouteReopenInput,
+  camelKey: keyof ActionCenterRouteReopenInput,
+) {
+  return normalizeText((input[snakeKey] as string | null | undefined) ?? (input[camelKey] as string | null | undefined))
+}
+
+export function projectActionCenterRouteReopen(input: ActionCenterRouteReopenInput): ActionCenterRouteReopenRecord {
+  const routeId = readCanonicalReopenText(input, 'route_id', 'routeId')
+  const reopenedAt = readCanonicalReopenText(input, 'reopened_at', 'reopenedAt')
+  const reopenedByRole = readCanonicalReopenText(input, 'reopened_by_role', 'reopenedByRole')
+
+  if (!routeId) {
+    throw new Error('route_id is required.')
+  }
+
+  if (!reopenedAt) {
+    throw new Error('reopened_at is required.')
+  }
+
+  if (!isValidIsoTimestamp(reopenedAt)) {
+    throw new Error('reopened_at is invalid.')
+  }
+
+  if (!reopenedByRole) {
+    throw new Error('reopened_by_role is required.')
+  }
+
+  return {
+    id: normalizeText(input.id),
+    routeId,
+    reopenedAt,
+    reopenedByRole,
+  }
 }
 
 export function projectActionCenterRouteFollowUpRelation(

--- a/frontend/scripts/seed-action-center-manager-pilot.mjs
+++ b/frontend/scripts/seed-action-center-manager-pilot.mjs
@@ -114,7 +114,7 @@ function chooseFollowUpScenario(campaigns, respondents, statsByCampaignId) {
   const candidates = []
   for (const entry of departmentCampaigns.values()) {
     const scopedCampaigns = [...entry.campaigns.values()]
-    if (scopedCampaigns.length !== 2) continue
+    if (scopedCampaigns.length < 2) continue
 
     const targetCandidates = sortCampaignsForTarget(
       scopedCampaigns.filter((campaign) => {
@@ -124,7 +124,7 @@ function chooseFollowUpScenario(campaigns, respondents, statsByCampaignId) {
       statsByCampaignId,
     )
 
-    if (targetCandidates.length === 0) continue
+    if (targetCandidates.length !== 1) continue
 
     const targetCampaign = targetCandidates[0]
     const sourceCampaign =
@@ -282,6 +282,11 @@ async function deleteRouteCloseout(admin, routeId) {
   if (error) throw error
 }
 
+async function deleteRouteReopens(admin, routeId) {
+  const { error } = await admin.from('action_center_route_reopens').delete().eq('route_id', routeId)
+  if (error) throw error
+}
+
 const envPath = existsSync(primaryEnvPath) ? primaryEnvPath : fallbackEnvPath
 if (!existsSync(envPath)) {
   throw new Error(`Geen .env.local gevonden op ${primaryEnvPath} of ${fallbackEnvPath}.`)
@@ -334,7 +339,7 @@ const statsByCampaignId = new Map((campaignStats ?? []).map((campaign) => [campa
 const scenario = chooseFollowUpScenario(campaigns, respondents ?? [], statsByCampaignId)
 if (!scenario) {
   throw new Error(
-    'Kon geen afdeling vinden met precies twee campaigns en exact een bruikbare open doelroute voor de follow-up demo.',
+    'Kon geen afdeling vinden met minstens twee campaigns en precies één bruikbare open doelroute voor de follow-up demo.',
   )
 }
 
@@ -359,6 +364,8 @@ await deleteRouteRelations(admin, sourceRouteId)
 await deleteRouteRelations(admin, targetRouteId)
 await deleteManagerResponseCarrier(admin, sourceCampaign.id, scopeValue)
 await deleteManagerResponseCarrier(admin, targetCampaign.id, scopeValue)
+await deleteRouteReopens(admin, sourceRouteId)
+await deleteRouteReopens(admin, targetRouteId)
 await upsertRouteCloseout(admin, {
   routeId: sourceRouteId,
   campaignId: sourceCampaign.id,
@@ -582,6 +589,7 @@ const artifact = {
     sourceCampaignId: sourceCampaign.id,
     targetCampaignId: targetCampaign.id,
     sourceRouteTitle: `Gesloten HR bronroute - ${sourceCampaign.name}`,
+    targetRouteTitle: `Open HR doelroute - ${targetCampaign.name}`,
     scopeLabel,
     scopeValue,
     sourceRouteId,

--- a/frontend/tests/e2e/action-center-route-reopen.spec.ts
+++ b/frontend/tests/e2e/action-center-route-reopen.spec.ts
@@ -8,6 +8,7 @@ type ActionCenterPilotArtifact = {
     sourceCampaignId: string
     targetCampaignId: string
     sourceRouteTitle: string
+    targetRouteTitle: string
     scopeLabel: string
     sourceActionCenterFocusUrl: string
     targetActionCenterFocusUrl: string
@@ -29,8 +30,20 @@ const artifact = existsSync(artifactPath)
   ? (JSON.parse(readFileSync(artifactPath, 'utf8')) as ActionCenterPilotArtifact)
   : null
 
-function escapeRegExp(value: string) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+async function expectFocusUrl(page: import('@playwright/test').Page, relativeUrl: string) {
+  const expected = new URL(relativeUrl, 'http://127.0.0.1')
+  await expect
+    .poll(() => {
+      const current = new URL(page.url())
+      return {
+        pathname: current.pathname,
+        focus: current.searchParams.get('focus'),
+      }
+    })
+    .toEqual({
+      pathname: expected.pathname,
+      focus: expected.searchParams.get('focus'),
+    })
 }
 
 async function login(page: import('@playwright/test').Page, email: string, password: string) {
@@ -48,32 +61,55 @@ test.describe('action center route reopen flow', () => {
 
   const pilot = artifact as ActionCenterPilotArtifact
 
-  test('hr starts a same-scope follow-up route and the source route stays historical', async ({ page }) => {
+  test('hr can start a follow-up route and manager sees the same direct lineage context', async ({ page }) => {
     if (!pilot.followUp) {
       throw new Error('Seed artifact mist followUp-context voor Task 7.')
     }
 
     await login(page, pilot.hrOwner.email, pilot.hrOwner.password)
     await page.goto(pilot.followUp.sourceActionCenterFocusUrl)
-    await expect(page).toHaveURL(new RegExp(`${escapeRegExp(pilot.followUp.sourceActionCenterFocusUrl)}$`))
+    await expectFocusUrl(page, pilot.followUp.sourceActionCenterFocusUrl)
     await page.getByRole('button', { name: /^Acties/ }).click()
 
     await expect(page.getByText('Action Center / Acties')).toBeVisible()
-    await expect(page.getByText('Afgerond voor nu', { exact: true })).toBeVisible()
     await expect(page.getByRole('heading', { name: pilot.followUp.sourceRouteTitle })).toBeVisible()
     await expect(page.getByRole('heading', { name: 'Start vervolgroute' })).toBeVisible()
-    await expect(page.getByText('Open vanuit deze gesloten route een nieuwe HR-handoff binnen dezelfde afdeling.')).toBeVisible()
-
-    await page.getByLabel('Kies manager').selectOption({ label: pilot.followUp.manager.displayName })
+    await page.getByLabel('Kies manager').selectOption({ value: pilot.followUp.manager.userId })
     await page.getByRole('radio', { name: pilot.followUp.triggerReasonLabel, exact: true }).check()
-    await page.getByRole('button', { name: 'Start vervolgroute' }).click()
+    const followUpResponsePromise = page.waitForResponse((response) =>
+      response.url().includes('/api/action-center-route-follow-ups') && response.request().method() === 'POST',
+    )
+    await page.getByRole('button', { name: 'Start vervolgroute', exact: true }).click()
+    const followUpResponse = await followUpResponsePromise
+    expect(followUpResponse.status()).toBe(201)
 
-    await expect(page.getByRole('heading', { name: 'Eerste lokale follow-through' })).toBeVisible()
-    await expect(page.getByText(pilot.followUp.scopeLabel, { exact: true }).first()).toBeVisible()
+    await expectFocusUrl(page, pilot.followUp.targetActionCenterFocusUrl)
+    await expect(page.getByRole('heading', { name: pilot.followUp.targetRouteTitle })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Vervolg op eerdere route', exact: true })).toBeVisible()
 
-    await expect(
-      page.getByText('Voor deze doelroute bestaat al een manager response carrier; overschrijven is in V1 niet toegestaan.'),
-    ).toHaveCount(0)
-    await expect(page.getByRole('heading', { name: 'Eerste lokale follow-through' })).toBeVisible()
+    await page.getByRole('button', { name: 'Vervolg op eerdere route', exact: true }).click()
+    await expectFocusUrl(page, pilot.followUp.sourceActionCenterFocusUrl)
+    await expect(page.getByRole('heading', { name: pilot.followUp.sourceRouteTitle })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Later opgevolgd', exact: true })).toBeVisible()
+
+    await page.getByRole('button', { name: 'Later opgevolgd', exact: true }).click()
+    await expectFocusUrl(page, pilot.followUp.targetActionCenterFocusUrl)
+    await expect(page.getByRole('heading', { name: pilot.followUp.targetRouteTitle })).toBeVisible()
+
+    await page.getByRole('button', { name: 'Uitloggen' }).click()
+    await expect(page).toHaveURL(/\/login$/)
+
+    await login(page, pilot.followUp.manager.email, pilot.followUp.manager.password)
+    await page.goto(pilot.followUp.targetActionCenterFocusUrl)
+    await expectFocusUrl(page, pilot.followUp.targetActionCenterFocusUrl)
+    await page.getByRole('button', { name: /^Acties/ }).click()
+
+    await expect(page.getByRole('heading', { name: pilot.followUp.targetRouteTitle })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Vervolg op eerdere route', exact: true })).toBeVisible()
+
+    await page.getByRole('button', { name: 'Vervolg op eerdere route', exact: true }).click()
+    await expectFocusUrl(page, pilot.followUp.sourceActionCenterFocusUrl)
+    await expect(page.getByRole('heading', { name: pilot.followUp.sourceRouteTitle })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Later opgevolgd', exact: true })).toBeVisible()
   })
 })

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -690,7 +690,7 @@ create table if not exists public.action_center_route_relations (
   manager_user_id uuid references auth.users(id) on delete set null,
   recorded_by uuid references auth.users(id) on delete set null,
   recorded_by_role text not null
-    check (recorded_by_role in ('verisight_admin', 'hr_owner', 'hr_member')),
+    check (recorded_by_role in ('verisight_admin', 'hr', 'hr_owner', 'hr_member')),
   recorded_at timestamptz not null default now(),
   ended_at timestamptz
 );


### PR DESCRIPTION
## Summary
- add one-step-back/one-step-forward lineage summaries for follow-up and reopened routes
- harden the HR follow-up trigger flow so optimistic navigation and `?focus=` stay canonical
- tighten seed/test coverage for follow-up creation, lineage rendering, and manager parity

## Verification
- `npm test -- app/api/action-center-route-follow-ups/route.test.ts lib/action-center-core-semantics.test.ts lib/action-center-live.test.ts "app/(dashboard)/action-center/page.route-shell.test.ts" lib/action-center-preview-display.test.ts lib/action-center-preview-route-fields-render.test.ts`
- `npx eslint app/api/action-center-route-follow-ups/route.ts app/api/action-center-route-follow-ups/route.test.ts components/dashboard/action-center-preview.tsx lib/action-center-core-semantics.ts lib/action-center-core-semantics.test.ts lib/action-center-live.ts lib/action-center-live.test.ts lib/action-center-preview-display.test.ts lib/action-center-preview-route-fields-render.test.ts scripts/seed-action-center-manager-pilot.mjs tests/e2e/action-center-route-reopen.spec.ts`
- `npm run build`
- `node ./scripts/seed-action-center-manager-pilot.mjs`
- `npx playwright test tests/e2e/action-center-route-reopen.spec.ts --project=chromium --workers=1`

## Notes
- local worktree still has an untracked `node_modules/` directory only
- build still emits the existing unused `goTo` warning in `components/marketing/home-insight-action-demo.tsx`