### PR TITLE
Add Action Center route summary wave

### DIFF
--- a/docs/superpowers/plans/2026-05-02-action-center-route-summary.md
+++ b/docs/superpowers/plans/2026-05-02-action-center-route-summary.md
@@ -1,0 +1,229 @@
+# Implementation Plan: Action Center Route-Brede Voortgang en Samenvatting
+
+## Status
+Proposed
+
+## Objective
+Implement Wave 1 of the Action Center commercial roadmap by adding a compact, stable route summary layer that makes route meaning readable above action, review, closeout, and lineage detail.
+
+This plan assumes:
+
+- route/open/closeout/follow-up truth already exists
+- route summary is a read-model improvement, not a new workflow
+- manager action semantics are still hardening and must not be overfit
+
+---
+
+## 1. Scope
+
+### In scope
+
+- add route-summary projection to the core semantics layer
+- surface route summary consistently in overview and detail
+- keep lineage and closeout reading aligned with the new route summary
+- extend focused rendering and projector tests
+
+### Out of scope
+
+- redesigning manager action creation
+- changing route aggregation semantics
+- redesigning closeout or follow-up write flows
+- broad reporting additions
+
+---
+
+## 2. Deliverables
+
+### 2.1 Core semantics projection
+
+Add a compact route summary projection that expresses:
+
+- route state
+- route ask
+- route progress summary
+- immediate historical context label
+
+Likely home:
+
+- `frontend/lib/action-center-core-semantics.ts`
+
+### 2.2 Preview model integration
+
+Ensure the live preview model carries enough route-summary fields for overview and detail without recomputing UI-only meaning in multiple places.
+
+Likely touchpoints:
+
+- `frontend/lib/action-center-live.ts`
+- `frontend/lib/action-center-preview-model.ts`
+
+### 2.3 UI rendering
+
+Render the new route summary near the route header/detail entrypoint and keep overview compact.
+
+Likely touchpoint:
+
+- `frontend/components/dashboard/action-center-preview.tsx`
+
+### 2.4 Focused verification
+
+Extend route projector and shell tests to cover:
+
+- open request summary
+- active route summary
+- reviewable route summary
+- closed route summary
+- backward and forward lineage summary precedence
+
+Likely tests:
+
+- `frontend/lib/action-center-live.test.ts`
+- `frontend/app/(dashboard)/action-center/page.route-shell.test.ts`
+- route-summary rendering/unit tests if a small helper is extracted
+
+---
+
+## 3. Execution Sequence
+
+### Step 1: Map current route-reading fields
+
+Inspect the current projector and preview rendering to identify:
+
+- where route state is already derived
+- which existing blocks currently carry route meaning indirectly
+- where summary duplication would appear if we do not centralize it
+
+Output:
+
+- a small field map for route summary inputs and outputs
+
+### Step 2: Add route summary projection
+
+Extend core semantics with a stable route summary structure, likely including:
+
+- `headlineState`
+- `routeAsk`
+- `progressSummary`
+- `lineageOverviewLabel`
+
+Keep naming aligned with current semantics style rather than introducing a parallel model.
+
+### Step 3: Thread summary through live preview shaping
+
+Ensure the finalized preview item carries the route summary fields so overview/detail can render them from one source of truth.
+
+### Step 4: Render the summary in overview and detail
+
+Implement the UI so that:
+
+- overview gets one compact summary line and at most one lineage label
+- detail gets the same high-level reading plus slightly richer context
+- closeout and lineage blocks still remain available as supporting detail
+
+### Step 5: Harden with tests
+
+Add targeted tests for:
+
+- summary selection rules
+- lineage precedence in overview vs detail
+- closed-route summary behavior
+- routes that have both backward and forward context
+
+### Step 6: Verify and prepare PR
+
+Run focused verification, commit intentionally, push the branch, and open a draft PR.
+
+---
+
+## 4. Design Constraints
+
+### 4.1 Do not overstate action maturity
+
+The summary copy must not assume:
+
+- multiple action cards are already a perfectly quiet pilot model
+- action-bound review is already the final practical manager loop
+
+Prefer route-level language over task-style language when uncertain.
+
+### 4.2 Do not create new workflow meaning
+
+This wave may clarify:
+
+- what the route asks now
+
+but may not introduce:
+
+- new statuses
+- new authorities
+- new action lifecycle expectations
+
+### 4.3 Keep overview calmer than detail
+
+If there is any ambiguity about how much to show:
+
+- overview should get less
+- detail may get slightly more
+
+### 4.4 Respect existing foundation
+
+Do not redesign:
+
+- closeout truth
+- reopen truth
+- follow-up truth
+- lineage truth
+
+This is a reading layer on top of those foundations.
+
+---
+
+## 5. Verification Strategy
+
+Minimum verification before completion:
+
+1. focused route semantics and preview tests
+2. route shell rendering tests for overview/detail summary presence
+3. `npm run build`
+
+If UI behavior changes materially, also run the relevant seeded browser flow if the route-summary branch stays aligned with the current Action Center shell.
+
+---
+
+## 6. Risks and Guardrails
+
+### Risk: duplicating meaning across UI blocks
+
+Guardrail:
+
+- centralize route summary projection in semantics/live layers first
+
+### Risk: summary overfits current action model
+
+Guardrail:
+
+- keep route ask and progress reading at route level
+
+### Risk: overview/detail drift
+
+Guardrail:
+
+- test that both render from the same summary source with only bounded detail differences
+
+### Risk: destabilizing baseline shell tests
+
+Guardrail:
+
+- account for the known current baseline drift in `page.route-shell.test.ts`
+- separate pre-existing failures from new regressions
+
+---
+
+## 7. Completion Criteria
+
+This wave is complete when:
+
+- route summary exists as a single projected read model
+- overview and detail use that read model consistently
+- route reading feels clearer for open, active, reviewable, and closed routes
+- lineage remains compact and correctly prioritized
+- verification passes for the touched surfaces, aside from any confirmed pre-existing baseline issues

--- a/docs/superpowers/specs/2026-05-02-action-center-route-summary-design.md
+++ b/docs/superpowers/specs/2026-05-02-action-center-route-summary-design.md
@@ -1,0 +1,318 @@
+# Action Center Route-Brede Voortgang en Samenvatting
+
+## Status
+Proposed
+
+## Intent
+This document defines Wave 1 of the Action Center commercial roadmap: making the route itself readable again as the main bestuurlijke object above actions, reviews, closeout, and lineage.
+
+This is deliberately a **readability and meaning** wave, not a new workflow wave.
+
+---
+
+## 1. Why This Wave Exists
+
+Action Center now carries materially richer route truth than before:
+
+- HR can open a route by assigning a manager
+- routes can close explicitly
+- routes can reopen or continue through a follow-up route
+- lineage is readable one step back and one step forward
+- route action cards and action-bound reviews have strong direction and partial runtime presence
+
+But that truth is still too fragmented in the product read.
+
+Today the route detail can show:
+
+- manager response
+- action cards
+- review log
+- closeout
+- lineage
+
+without yet giving HR or a manager a sufficiently calm answer to:
+
+- what is happening in this route right now
+- what kind of route is this
+- what needs attention next
+- whether this is still active, ready for review, historically closed, or only contextually relevant
+
+This wave exists to make that reading fast and bounded.
+
+---
+
+## 2. Product Boundary
+
+This wave is about **route-level reading**, not route-level workflow expansion.
+
+### In scope
+
+- a compact route summary layer above detailed route content
+- clearer route-level progress reading for HR and manager
+- calm route-level summary for open, reviewable, closed, reopened, and followed-up routes
+- stronger projection rules for what the route header and summary area should say
+- consistent route reading between overview and detail
+
+### Out of scope
+
+- new task management structures
+- new route statuses beyond already chosen semantics
+- reopening or follow-up redesign
+- broad reporting dashboards
+- heavy manager action workflow redesign
+- new audit or permission models beyond what this wave needs to read safely
+
+This wave must not pretend that manager action semantics are fully settled. It should read the current truth honestly and calmly, without overcommitting to a more mature action model than runtime can yet support.
+
+---
+
+## 3. Starting Foundation, Split by Reality
+
+### 3.1 Canonically decided
+
+The following are treated as semantically chosen:
+
+- route is the governing container
+- HR assignment opens the route
+- closeout is route-bound and explicit
+- reopen is a dedicated route event
+- follow-up is a distinct continuation route
+- lineage is intentionally compact and one-step
+- overview and detail should share one route reading rather than invent separate interpretations
+
+### 3.2 Product/runtime present enough to build on
+
+The following are already present enough in runtime to use in this wave:
+
+- route status and route identity are readable from the live projector
+- closeout summaries are rendered in detail
+- lineage labels are rendered in overview/detail
+- manager response context is rendered
+- route action cards are renderable on detail
+
+### 3.3 Directional but not yet hardened enough to let the route summary overfit to them
+
+The following should still be treated as hardening inputs rather than fixed pilot-grade assumptions:
+
+- multiple action cards as the stable repeated-use operating model
+- action-bound review as the final practical review shape
+- manager action creation as the fully crystallized standard next step
+- route-level summary expectations that depend on heavy action-detail fidelity
+
+### 3.4 Design consequence
+
+The route summary must therefore:
+
+- build from route, closeout, lineage, and currently projected action/review signals
+- stay calm even if action semantics simplify later
+- help HR and manager read the route without requiring the action model to be fully settled first
+
+---
+
+## 4. Desired Outcome
+
+After this wave, a user landing on a route should be able to understand in a few seconds:
+
+- what kind of route this is
+- whether it is still active or already historical
+- whether there is something immediate to discuss or review
+- whether it is contextually linked to an earlier or later route
+
+That reading should come from a compact route summary layer rather than from reconstructing meaning across multiple blocks.
+
+---
+
+## 5. Route Summary Model
+
+The route summary is a small projection above the detailed route content.
+
+It should answer four bounded questions:
+
+1. what is the route state at a high level
+2. what does this route currently ask for
+3. what is the best short reading of progress in this route
+4. does this route have immediate historical context
+
+The summary must not attempt to become:
+
+- a task dashboard
+- a long narrative
+- a second detail page
+
+---
+
+## 6. Summary Segments
+
+### 6.1 Route state
+
+The route summary should lead with one compact state reading:
+
+- `Open verzoek`
+- `In uitvoering`
+- `Reviewbaar`
+- `Afgerond`
+- `Gestopt`
+
+If a route is explicitly closed, closeout wins over open-route aggregation.
+
+This wave does not introduce additional route states.
+
+### 6.2 Route ask
+
+The summary should then express the current route ask in one calm sentence.
+
+Examples by semantics:
+
+- open request route: the manager still needs to define the first meaningful local follow-through
+- active route: there is active follow-through inside this route
+- reviewable route: at least one action or review moment now needs explicit reflection
+- closed route: the route is historically complete for now
+
+This route ask should remain phrased at route level, not at task level.
+
+### 6.3 Route progress reading
+
+The summary should include a compact progress reading derived from existing route truth.
+
+It may talk about:
+
+- whether the route already carries concrete follow-through
+- whether review is now due
+- whether the route is historically closed
+- whether a later follow-up exists
+
+It should not depend on every action field being perfect.
+
+### 6.4 Immediate lineage context
+
+The summary may include one compact lineage label:
+
+- `Heropend traject`
+- `Vervolg op eerdere route`
+- `Later opgevolgd`
+
+Overview stays compact. Detail may show a slightly richer two-sided reading, but the summary remains a route-reading layer, not a lineage panel.
+
+---
+
+## 7. Overview vs Detail
+
+### 7.1 Overview
+
+Overview should remain compact.
+
+It should show:
+
+- route state
+- a short route summary line
+- at most one compact lineage label
+
+If both backward and forward lineage context exist, overview shows only the backward reading because that best explains what the current route is.
+
+### 7.2 Detail
+
+Detail should show:
+
+- the same route state
+- the same route ask
+- a slightly richer route progress summary
+- lineage context in stable order when both sides exist
+
+Detail may show both:
+
+1. backward context
+2. forward context
+
+in that order.
+
+This wave should not create a separate "lineage section" lower on the page. The route summary belongs near the route header because it is an orientation layer.
+
+---
+
+## 8. Open-Route Reading Contract
+
+For routes without explicit closeout:
+
+### `Open verzoek`
+
+Use when the route exists but still lacks meaningful local follow-through.
+
+### `In uitvoering`
+
+Use when the route carries active local follow-through and nothing presently wins as review pressure.
+
+### `Reviewbaar`
+
+Use when review pressure is now the most important route-level reading.
+
+In mixed situations, `Reviewbaar` wins over `In uitvoering`.
+
+This wave does not change the underlying aggregation contract. It makes the read-model above that contract more legible.
+
+---
+
+## 9. Closed-Route Reading Contract
+
+For routes with explicit closeout:
+
+- the route reads as historical first
+- the route summary should not keep talking as though action execution is still primary
+- closeout remains the route-level meaning anchor
+
+If a closed route later receives a follow-up route, the old route should read as:
+
+- still closed
+- but later followed up
+
+This wave must not blur the distinction between:
+
+- historical route
+- active successor route
+
+---
+
+## 10. Relationship to Manager Action Semantics
+
+This wave must be explicit about a boundary:
+
+it is not assuming the final perfect manager action model is already settled.
+
+Instead, this wave should:
+
+- read the current manager-action truth as it exists today
+- avoid route summary copy that depends on dense task-style action detail
+- leave room for later Wave 2 hardening and simplification of manager action semantics
+
+So the output here is:
+
+- better route-level reading
+
+not:
+
+- proof that the manager action model is already commercially finished
+
+---
+
+## 11. Success Criteria
+
+This wave is successful when:
+
+- HR and manager can understand route meaning without scanning multiple lower-page blocks first
+- open, reviewable, and historical routes read differently and correctly
+- overview and detail do not drift into different route interpretations
+- route summary remains stable even if manager action semantics continue to harden later
+- the product feels more bestuurlijk and less like a pile of adjacent sub-panels
+
+---
+
+## 12. What This Wave Does Not Rebuild
+
+This wave does **not** re-open:
+
+- route open semantics
+- closeout semantics
+- reopen truth
+- follow-up truth
+- lineage truth
+
+It only makes those truths easier to read together at route level.

--- a/frontend/app/(dashboard)/action-center/page.route-shell.test.ts
+++ b/frontend/app/(dashboard)/action-center/page.route-shell.test.ts
@@ -547,6 +547,31 @@ describe("action center landing shell", () => {
     expect(markup).toContain(item.coreSemantics.actionProgress.expectedEffect ?? "");
   });
 
+  it("renders a compact route summary layer on detail from shared route semantics", () => {
+    const context = buildLiveContext();
+    const [item] = buildLiveActionCenterItems([context]);
+
+    const markup = renderToStaticMarkup(
+      createElement(ActionCenterPreview, {
+        initialItems: [item],
+        initialSelectedItemId: item.id,
+        initialView: "actions",
+        fallbackOwnerName: "Admin",
+        ownerOptions: ["Manager Operations"],
+        workbenchHref: "/action-center/dossier",
+        hideSidebar: true,
+        readOnly: true,
+      }),
+    );
+
+    expect(markup).toContain("Route-read");
+    expect(markup).toContain(item.coreSemantics.routeSummary.stateLabel);
+    expect(markup).toContain("Vraagt nu");
+    expect(markup).toContain(item.coreSemantics.routeSummary.routeAsk);
+    expect(markup).toContain("Voortgang");
+    expect(markup).toContain(item.coreSemantics.routeSummary.progressSummary);
+  });
+
   it("renders compact decision history from shared semantics on route detail", () => {
     const context = buildLiveContext();
     const [baseItem] = buildLiveActionCenterItems([context]);
@@ -1063,10 +1088,10 @@ describe("action center landing shell", () => {
     );
 
     expect(markup).toContain("Laatste route-read");
-    expect(markup).toContain("Besluit");
-    expect(markup).toContain("Bijstellen");
-    expect(markup).toContain("Stap");
-    expect(markup).toContain(item.coreSemantics.actionProgress.currentStep ?? "");
+    expect(markup).toContain("Route");
+    expect(markup).toContain(item.coreSemantics.routeSummary.stateLabel);
+    expect(markup).toContain("Lezing");
+    expect(markup).toContain(item.coreSemantics.routeSummary.overviewSummary);
     expect(markup).not.toContain("Laatste beslissing");
     expect(markup).not.toContain("Waarom dit besluit");
     expect(markup).not.toContain("Volgende toets");
@@ -1074,8 +1099,8 @@ describe("action center landing shell", () => {
     expect(markup).not.toContain("Huidige stap");
     expect(markup).not.toContain("Hierna");
     expect(markup).not.toContain("Beslisgeschiedenis");
-    expect((markup.match(/>Stap</g) ?? []).length).toBe(1);
-    expect((markup.match(/>Besluit</g) ?? []).length).toBe(1);
+    expect((markup.match(/>Route</g) ?? []).length).toBe(1);
+    expect((markup.match(/>Lezing</g) ?? []).length).toBe(1);
   });
 
   it("shows only the compact overview lineage label for a follow-up route in overview", () => {

--- a/frontend/components/dashboard/action-center-preview.tsx
+++ b/frontend/components/dashboard/action-center-preview.tsx
@@ -1703,6 +1703,12 @@ export function ActionCenterPreview({
                           </div>
                         ) : null}
 
+                        <div className="mt-7 grid gap-4 xl:grid-cols-3">
+                          <RouteSummaryCard label="Route-read" value={selectedItem.coreSemantics.routeSummary.stateLabel} />
+                          <RouteSummaryCard label="Vraagt nu" value={selectedItem.coreSemantics.routeSummary.routeAsk} />
+                          <RouteSummaryCard label="Voortgang" value={selectedItem.coreSemantics.routeSummary.progressSummary} />
+                        </div>
+
                         <div className="mt-7 grid gap-4 lg:grid-cols-[minmax(0,1fr),minmax(0,0.92fr)]">
                           <div className="rounded-[24px] border border-[#eadfce] bg-white px-5 py-5">
                             <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Waarom dit nu speelt</p>
@@ -3013,19 +3019,9 @@ function EmptySection({ title, body }: { title: string; body: string }) {
 }
 
 export function buildCompactLandingSummaryLines(item: ActionCenterPreviewItem) {
-  const latestDecision = item.coreSemantics.latestDecision
-  const currentStep = item.coreSemantics.actionProgress.currentStep
-  const managerResponse = item.managerResponse
-
   return [
-    !latestDecision && item.status === 'open-verzoek'
-      ? { label: 'Verzoek', value: 'Wacht op eerste managerreactie' }
-      : null,
-    !latestDecision && managerResponse
-      ? { label: 'Reactie', value: getActionCenterManagerResponseLabel(managerResponse.response_type) }
-      : null,
-    latestDecision ? { label: 'Besluit', value: getDecisionLabel(latestDecision.decision) } : null,
-    currentStep ? { label: 'Stap', value: currentStep } : null,
+    { label: 'Route', value: item.coreSemantics.routeSummary.stateLabel },
+    { label: 'Lezing', value: item.coreSemantics.routeSummary.overviewSummary },
   ]
     .filter((entry): entry is { label: string; value: string } => Boolean(entry?.value))
     .filter((entry, index, entries) => entries.findIndex((candidate) => candidate.value === entry.value) === index)
@@ -3097,6 +3093,15 @@ function buildDetailLineageEntries(
 function RouteFieldCard({ label, value }: { label: string; value: string }) {
   return (
     <div className="rounded-[18px] border border-[#eadfce] bg-[#fcfaf6] px-4 py-4">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">{label}</p>
+      <p className="mt-3 text-sm leading-7 text-[#32465d]">{value}</p>
+    </div>
+  )
+}
+
+function RouteSummaryCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-[20px] border border-[#eadfce] bg-white px-5 py-5">
       <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">{label}</p>
       <p className="mt-3 text-sm leading-7 text-[#32465d]">{value}</p>
     </div>

--- a/frontend/lib/action-center-core-semantics.ts
+++ b/frontend/lib/action-center-core-semantics.ts
@@ -25,12 +25,19 @@ import {
   type ActionCenterResultProgressEntry,
 } from './action-center-decision-history'
 import { getActionCenterDecisionProfile } from './action-center-review-decisions'
+import type { ActionCenterPreviewStatus } from './action-center-preview-model'
 
 export type ActionCenterVisibleReviewOutcome = Exclude<ActionCenterReviewOutcome, 'opschalen'>
 export type ActionCenterClosingStatus = 'lopend' | 'afgerond' | 'gestopt'
 
 export interface ActionCenterCoreSemantics {
   route: ActionCenterRouteContract
+  routeSummary: {
+    stateLabel: string
+    overviewSummary: string
+    routeAsk: string
+    progressSummary: string
+  }
   reviewSemantics: {
     reviewReason: string
     reviewQuestion: string
@@ -113,6 +120,7 @@ export type ActionCenterCoreSemanticsProjectionInput = Pick<
   route: ActionCenterRouteContract
   latestVisibleUpdateNote?: string | null
   decisionRecords?: ActionCenterDecisionRecord[]
+  surfaceStatus?: ActionCenterPreviewStatus
 }
 
 export interface ActionCenterPreviewCoreSemanticsProjectionInput {
@@ -133,6 +141,7 @@ export interface ActionCenterPreviewCoreSemanticsProjectionInput {
   managerResponse?: ActionCenterManagerResponse | null
   lineageSummary?: ActionCenterLineageSummary | null
   followUpSemantics?: ActionCenterProjectedFollowUpSemantics | null
+  surfaceStatus?: ActionCenterPreviewStatus
 }
 
 const UNASSIGNED_OWNER_LABEL = 'Nog niet toegewezen'
@@ -217,6 +226,152 @@ function getEmptyLineageSummary(): ActionCenterLineageSummary {
     forwardLabel: null,
     forwardRouteId: null,
     detailLabels: [],
+  }
+}
+
+function getSurfaceStatusLabel(status: ActionCenterPreviewStatus | null | undefined) {
+  switch (status) {
+    case 'open-verzoek':
+      return 'Open verzoek'
+    case 'reviewbaar':
+      return 'Reviewbaar'
+    case 'in-uitvoering':
+      return 'In uitvoering'
+    case 'afgerond':
+      return 'Afgerond'
+    case 'gestopt':
+      return 'Gestopt'
+    case 'geblokkeerd':
+      return 'Geblokkeerd'
+    case 'te-bespreken':
+    default:
+      return 'Te bespreken'
+  }
+}
+
+function countReviewPressure(routeActionCards: ActionCenterCoreSemantics['routeActionCards']) {
+  const today = new Date().toISOString().slice(0, 10)
+  return routeActionCards.filter(
+    (action) => action.status === 'in_review' || (action.status === 'open' && action.reviewScheduledFor <= today),
+  ).length
+}
+
+function buildRouteSummary(args: {
+  surfaceStatus: ActionCenterPreviewStatus | ActionCenterRouteContract['routeStatus'] | null | undefined
+  routeActionCards: ActionCenterCoreSemantics['routeActionCards']
+  managerResponse: ActionCenterManagerResponse | null | undefined
+  closingSemantics: ActionCenterCoreSemantics['closingSemantics']
+  lineageSummary: ActionCenterLineageSummary
+  actionProgress: ActionCenterCoreSemantics['actionProgress']
+}) {
+  const status = args.surfaceStatus ?? 'te-bespreken'
+  const stateLabel = getSurfaceStatusLabel(status)
+  const actionCount = args.routeActionCards.length
+  const reviewPressureCount = countReviewPressure(args.routeActionCards)
+  const hasManagerResponse = Boolean(args.managerResponse)
+  const hasCurrentStep = Boolean(args.actionProgress.currentStep)
+
+  if (status === 'afgerond') {
+    return {
+      stateLabel,
+      overviewSummary:
+        args.lineageSummary.forwardLabel === FOLLOWED_UP_LATER_LINEAGE_LABEL
+          ? 'Historische route die later een directe opvolger kreeg.'
+          : 'Historische route die voor nu bestuurlijk is afgerond.',
+      routeAsk: 'Lees deze route als afgerond traject en gebruik hem alleen nog als bestuurlijke context.',
+      progressSummary:
+        args.closingSemantics.summary ??
+        (actionCount > 0
+          ? `${actionCount} actie${actionCount === 1 ? '' : 's'} liepen binnen deze route voordat hij sloot.`
+          : 'Er loopt geen actieve follow-through meer in deze route.'),
+    }
+  }
+
+  if (status === 'gestopt') {
+    return {
+      stateLabel,
+      overviewSummary:
+        args.lineageSummary.forwardLabel === FOLLOWED_UP_LATER_LINEAGE_LABEL
+          ? 'Historische route die later via een opvolger opnieuw is opgepakt.'
+          : 'Historische route die bewust is gestopt.',
+      routeAsk: 'Lees deze route als gestopt traject en niet meer als actieve follow-through.',
+      progressSummary:
+        args.closingSemantics.summary ??
+        'De route draagt geen actieve follow-through meer en blijft alleen historisch leesbaar.',
+    }
+  }
+
+  if (status === 'reviewbaar') {
+    return {
+      stateLabel,
+      overviewSummary:
+        reviewPressureCount > 0
+          ? `Actieve route waarbij ${reviewPressureCount} reviewmoment${reviewPressureCount === 1 ? '' : 'en'} nu aandacht vraagt.`
+          : 'Actieve route die nu expliciete teruglezing en review vraagt.',
+      routeAsk: 'Kijk nu expliciet terug op de lopende follow-through en bepaal wat de route daarna vraagt.',
+      progressSummary:
+        reviewPressureCount > 0
+          ? `${reviewPressureCount} actie${reviewPressureCount === 1 ? '' : 's'} of reviewmoment${reviewPressureCount === 1 ? '' : 'en'} vragen nu expliciete teruglezing.`
+          : actionCount > 0
+            ? `${actionCount} actie${actionCount === 1 ? '' : 's'} dragen deze route, maar reviewdruk wint nu van uitvoering.`
+            : 'De route voelt actief, maar vraagt eerst een review voordat verdere uitvoering logisch wordt.',
+    }
+  }
+
+  if (status === 'in-uitvoering') {
+    return {
+      stateLabel,
+      overviewSummary:
+        actionCount > 0
+          ? `Actieve route met ${actionCount} concrete actie${actionCount === 1 ? '' : 's'} in dezelfde follow-through.`
+          : 'Actieve route waarin de eerste lokale follow-through al loopt.',
+      routeAsk: 'Bewaak of de huidige follow-through scherp, bounded en lokaal uitvoerbaar blijft.',
+      progressSummary:
+        actionCount > 0
+          ? `${actionCount} actie${actionCount === 1 ? '' : 's'} dragen nu de lokale follow-through in deze route.`
+          : hasCurrentStep
+            ? 'De route heeft al een concrete vervolgstap en draait nu in uitvoering.'
+            : 'De route is actief, maar de concrete vervolgcyclus blijft nog licht en bounded.',
+    }
+  }
+
+  if (status === 'open-verzoek') {
+    return {
+      stateLabel,
+      overviewSummary: 'Open route zonder concrete lokale follow-through of reviewcyclus.',
+      routeAsk: 'De manager moet nog de eerste betekenisvolle lokale opvolging en bijbehorende review kiezen.',
+      progressSummary:
+        hasManagerResponse || hasCurrentStep
+          ? 'Er zijn al eerste signalen van reactie, maar nog geen stabiele routecyclus.'
+          : 'Nog geen concrete actie, reviewcyclus of expliciete follow-through zichtbaar.',
+    }
+  }
+
+  if (status === 'geblokkeerd') {
+    return {
+      stateLabel,
+      overviewSummary: 'Open route waarbij een blokkade de volgende betekenisvolle stap tegenhoudt.',
+      routeAsk: 'Maak eerst de blokkade expliciet voordat verdere lokale opvolging zinvol wordt.',
+      progressSummary:
+        actionCount > 0
+          ? 'Er is al follow-through zichtbaar, maar de routelezing wordt nu door blokkade bepaald.'
+          : 'De route draagt nog geen stabiele follow-through zolang de blokkade niet is opgehelderd.',
+    }
+  }
+
+  return {
+    stateLabel,
+    overviewSummary: hasManagerResponse
+      ? 'Open route met eerste managerreactie, maar nog zonder volledig rustige routecyclus.'
+      : 'Open route waarbij de eerste expliciete route-read en vervolglijn nog scherp moeten worden.',
+    routeAsk: hasManagerResponse
+      ? 'Maak van de eerste reactie een duidelijke vervolglijn of reviewbare routecyclus.'
+      : 'Bepaal eerst welke bounded vervolglijn deze route nu echt vraagt.',
+    progressSummary: actionCount > 0
+      ? `${actionCount} actie${actionCount === 1 ? '' : 's'} zijn zichtbaar, maar de route vraagt nog expliciete bestuurlijke duiding.`
+      : hasManagerResponse
+        ? 'Er is al een eerste managerreactie, maar de route vraagt nog expliciete vervolgbepaling.'
+        : 'De route is geopend, maar de concrete vervolglijn is nog niet scherp genoeg vastgelegd.',
   }
 }
 
@@ -726,9 +881,24 @@ export function projectActionCenterPreviewCoreSemantics(
   const closingStatus = getPreviewClosingStatus(route.routeStatus)
   const lineageSummary = input.lineageSummary ?? getEmptyLineageSummary()
   const followUpSemantics = input.followUpSemantics ?? getEmptyFollowUpSemantics()
+  const routeActionCards: ActionCenterCoreSemantics['routeActionCards'] = []
+  const closingSemantics: ActionCenterCoreSemantics['closingSemantics'] = {
+    status: closingStatus,
+    summary: getClosingSummary(closingStatus, getPreviewClosingSummaryValues(route, closingStatus)),
+    historicalSummary: null,
+  }
+  const routeSummary = buildRouteSummary({
+    surfaceStatus: input.surfaceStatus ?? input.status,
+    routeActionCards,
+    managerResponse: input.managerResponse ?? null,
+    closingSemantics,
+    lineageSummary,
+    actionProgress,
+  })
 
   return {
     route,
+    routeSummary,
     reviewSemantics: {
       reviewReason: reviewReason ?? REVIEW_REASON_FALLBACK,
       reviewQuestion: reviewQuestion ?? REVIEW_QUESTION_FALLBACK,
@@ -759,14 +929,10 @@ export function projectActionCenterPreviewCoreSemantics(
     },
     resultProgression,
     decisionHistory,
-    routeActionCards: [],
+    routeActionCards,
     lineageSummary,
     followUpSemantics,
-    closingSemantics: {
-      status: closingStatus,
-      summary: getClosingSummary(closingStatus, getPreviewClosingSummaryValues(route, closingStatus)),
-      historicalSummary: null,
-    },
+    closingSemantics,
   }
 }
 
@@ -886,9 +1052,27 @@ export function projectActionCenterCoreSemantics(
       derivedExpectedEffect,
     suppressNextStepFallback: latestDecisionProfile?.hidesNextStep ?? false,
   })
+  const routeActionCards = buildRouteActionCards({
+    routeActions: context.routeActions,
+    actionReviews: context.actionReviews,
+  })
+  const closingSemantics: ActionCenterCoreSemantics['closingSemantics'] = {
+    status: closingStatus,
+    summary: getClosingSummary(closingStatus, getLiveClosingSummaryValues(context, route, closingStatus)),
+    historicalSummary: closingStatus === 'lopend' ? getHistoricalCloseoutSummary(context) : null,
+  }
+  const routeSummarySemantics = buildRouteSummary({
+    surfaceStatus: context.surfaceStatus ?? route.routeStatus,
+    routeActionCards,
+    managerResponse: context.managerResponse ?? null,
+    closingSemantics,
+    lineageSummary,
+    actionProgress,
+  })
 
   return {
     route,
+    routeSummary: routeSummarySemantics,
     reviewSemantics: {
       reviewReason: reviewReason ?? REVIEW_REASON_FALLBACK,
       reviewQuestion: reviewQuestion ?? REVIEW_QUESTION_FALLBACK,
@@ -927,16 +1111,9 @@ export function projectActionCenterCoreSemantics(
     },
     resultProgression,
     decisionHistory,
-    routeActionCards: buildRouteActionCards({
-      routeActions: context.routeActions,
-      actionReviews: context.actionReviews,
-    }),
+    routeActionCards,
     lineageSummary,
     followUpSemantics,
-    closingSemantics: {
-      status: closingStatus,
-      summary: getClosingSummary(closingStatus, getLiveClosingSummaryValues(context, route, closingStatus)),
-      historicalSummary: closingStatus === 'lopend' ? getHistoricalCloseoutSummary(context) : null,
-    },
+    closingSemantics,
   }
 }

--- a/frontend/lib/action-center-live.test.ts
+++ b/frontend/lib/action-center-live.test.ts
@@ -139,6 +139,38 @@ function buildRouteReopen(
   }
 }
 
+function buildLiveContext(
+  overrides: Partial<Parameters<typeof buildLiveActionCenterItems>[0][number]> = {},
+): Parameters<typeof buildLiveActionCenterItems>[0][number] {
+  return {
+    campaign: buildCampaign(),
+    stats: buildStats(),
+    organizationName: 'Acme BV',
+    memberRole: 'owner',
+    scopeType: 'department',
+    scopeValue: 'operations',
+    scopeLabel: 'Operations',
+    peopleCount: 38,
+    assignedManager: null,
+    deliveryRecord: buildDeliveryRecord({
+      lifecycle_stage: 'first_management_use',
+      first_management_use_confirmed_at: '2026-04-20T09:00:00.000Z',
+      next_step: 'Plan eerste managementgesprek met HR en sponsor.',
+      customer_handoff_note: 'Vertrekduiding is nu scherp genoeg voor een eerste MT-read.',
+    }),
+    deliveryCheckpoints: [],
+    learningDossier: buildDossier({
+      expected_first_value: 'Maak zichtbaar welk vertrekpatroon nu eerst bestuurlijke aandacht vraagt.',
+      first_management_value: 'Welke vertrekduiding vraagt nu als eerste managementeigenaarschap?',
+      review_moment: '2026-05-12',
+      management_action_outcome: 'bijstellen',
+    }),
+    learningCheckpoints: [],
+    reviewDecisions: [] as ActionCenterReviewDecision[],
+    ...overrides,
+  } as Parameters<typeof buildLiveActionCenterItems>[0][number]
+}
+
 describe('live action center builder', () => {
   it('accepts the current live product family as supported action-center carriers', () => {
     expect(isLiveActionCenterScanType('exit')).toBe(true)
@@ -385,6 +417,91 @@ describe('live action center builder', () => {
     })
   })
 
+  it('projects route summary semantics for open requests, review pressure, and historical closed routes', () => {
+    const [openRequestItem] = buildLiveActionCenterItems([
+      buildLiveContext({
+        assignedManager: {
+          userId: 'manager-open',
+          displayName: 'Manager Operations',
+          assignedAt: '2026-04-22T08:00:00.000Z',
+        },
+        deliveryRecord: buildDeliveryRecord({
+          lifecycle_stage: 'first_value_reached',
+          first_management_use_confirmed_at: null,
+          next_step: null,
+          customer_handoff_note: 'De route staat klaar voor de eerste managementread.',
+        }),
+        learningDossier: buildDossier({
+          expected_first_value: null,
+          first_management_value: null,
+          first_action_taken: null,
+          review_moment: null,
+          management_action_outcome: 'geen-uitkomst',
+        }),
+      }),
+    ])
+    const [reviewableItem] = buildLiveActionCenterItems([
+      buildLiveContext({
+        routeActions: [
+          {
+            actionId: 'action-reviewable',
+            routeId: buildActionCenterRouteId('campaign-exit', 'operations'),
+            themeKey: 'workload',
+            actionText: 'Plan een bounded herverdeling van piekwerk.',
+            expectedEffect: 'Maak zichtbaar of de piekbelasting binnen twee weken daalt.',
+            reviewScheduledFor: '2026-01-05',
+            status: 'open',
+            createdAt: '2026-05-01T09:00:00.000Z',
+            updatedAt: '2026-05-01T09:00:00.000Z',
+          },
+        ],
+      }),
+    ])
+    const [closedItem] = buildLiveActionCenterItems([
+      buildLiveContext({
+        learningDossier: buildDossier({
+          triage_status: 'uitgevoerd',
+          management_action_outcome: 'afronden',
+          next_route: 'Gebruik het vervolgtraject voor nieuw lokaal ritme.',
+          case_public_summary: 'De eerdere route is historisch afgerond.',
+        }),
+        routeFollowUpRelations: [
+          {
+            id: 'follow-up-1',
+            campaignId: 'campaign-exit',
+            orgId: 'org-1',
+            routeRelationType: 'follow-up-from',
+            sourceRouteId: buildActionCenterRouteId('campaign-exit', 'operations'),
+            sourceCampaignId: 'campaign-exit',
+            sourceRouteScopeValue: 'operations',
+            targetRouteId: 'campaign-next::org-1::department::operations',
+            targetCampaignId: 'campaign-next',
+            targetRouteScopeValue: 'operations',
+            triggerReason: 'hernieuwde-hr-beoordeling',
+            managerUserId: 'manager-next',
+            recordedAt: '2026-05-15T09:00:00.000Z',
+            recordedByRole: 'hr_owner',
+            recordedBy: 'user-1',
+            endedAt: null,
+          },
+        ],
+      }),
+    ])
+
+    expect(openRequestItem?.coreSemantics.routeSummary).toMatchObject({
+      stateLabel: 'Open verzoek',
+      overviewSummary: 'Open route zonder concrete lokale follow-through of reviewcyclus.',
+    })
+    expect(reviewableItem?.coreSemantics.routeSummary).toMatchObject({
+      stateLabel: 'Reviewbaar',
+      overviewSummary: 'Actieve route waarbij 1 reviewmoment nu aandacht vraagt.',
+    })
+    expect(closedItem?.coreSemantics.routeSummary).toMatchObject({
+      stateLabel: 'Afgerond',
+      overviewSummary: 'Historische route die later een directe opvolger kreeg.',
+    })
+  })
+
   it('finalizes local preview items with derived core semantics and synchronized open signals', () => {
     const item = finalizeActionCenterPreviewItem({
       id: 'local-1',
@@ -424,6 +541,10 @@ describe('live action center builder', () => {
 
     expect(item.coreSemantics.actionFrame.firstStep).toBe('Eerste vervolgstap vastleggen en reviewdatum bevestigen.')
     expect(item.coreSemantics.actionFrame.owner).toBe('Nog niet toegewezen')
+    expect(item.coreSemantics.routeSummary).toMatchObject({
+      stateLabel: 'Te bespreken',
+      overviewSummary: 'Open route waarbij de eerste expliciete route-read en vervolglijn nog scherp moeten worden.',
+    })
     expect(item.reason).toBe(item.coreSemantics.reviewSemantics.reviewReason)
     expect(item.nextStep).toBe(item.coreSemantics.actionFrame.firstStep)
     expect(item.openSignals).toEqual(['owner_missing', 'review_due'])
@@ -517,6 +638,12 @@ describe('live action center builder', () => {
           reviewReason: 'Canonieke previewreviewreden.',
           blockedBy: null,
         },
+        routeSummary: {
+          stateLabel: 'Te bespreken',
+          overviewSummary: 'Open route waarbij de eerste expliciete route-read en vervolglijn nog scherp moeten worden.',
+          routeAsk: 'Bepaal eerst welke bounded vervolglijn deze route nu echt vraagt.',
+          progressSummary: 'De route is geopend, maar de concrete vervolglijn is nog niet scherp genoeg vastgelegd.',
+        },
         reviewSemantics: {
           reviewReason: 'Canonieke previewreviewreden.',
           reviewQuestion: 'Canoniek previeweffect.',
@@ -576,6 +703,10 @@ describe('live action center builder', () => {
       owner: 'Manager Operations',
       reviewScheduledFor: '2026-05-12',
       routeStatus: 'in-uitvoering',
+    })
+    expect(recomputed.coreSemantics.routeSummary).toMatchObject({
+      stateLabel: 'In uitvoering',
+      overviewSummary: 'Actieve route waarin de eerste lokale follow-through al loopt.',
     })
     expect(recomputed.coreSemantics.resultLoop.whatWasTried).toBe(
       'Update: eigenaar bevestigd en review opnieuw ingepland.',
@@ -671,6 +802,12 @@ describe('live action center builder', () => {
           triggerReason: 'nieuw-segment-signaal',
           triggerReasonLabel: 'Nieuw segmentsignaal',
           sourceRouteId: 'campaign-source::operations',
+        },
+        routeSummary: {
+          stateLabel: 'Te bespreken',
+          overviewSummary: 'Open route waarbij de eerste expliciete route-read en vervolglijn nog scherp moeten worden.',
+          routeAsk: 'Bepaal eerst welke bounded vervolglijn deze route nu echt vraagt.',
+          progressSummary: 'De route is geopend, maar de concrete vervolglijn is nog niet scherp genoeg vastgelegd.',
         },
         closingSemantics: {
           status: 'lopend',

--- a/frontend/lib/action-center-live.ts
+++ b/frontend/lib/action-center-live.ts
@@ -388,6 +388,7 @@ export function finalizeActionCenterPreviewItem(
       id: item.id,
       title: item.title,
       status: getPreviewCoreRouteStatus(item.status),
+      surfaceStatus: item.status,
       ownerName: item.ownerName,
       reviewDate: item.reviewDate,
       expectedEffect: reuseExistingRouteTruth ? (existingRoute?.expectedEffect ?? null) : item.expectedEffect,
@@ -483,6 +484,7 @@ export function buildLiveActionCenterItems(contexts: LiveActionCenterCampaignCon
       const coreSemantics = projectActionCenterCoreSemantics({
         ...context,
         route,
+        surfaceStatus: status,
         latestVisibleUpdateNote: latestUpdate,
         reviewDecisions: context.reviewDecisions ?? ([] as ActionCenterReviewDecision[]),
         decisionRecords: [],


### PR DESCRIPTION
## Summary
- define the Wave 1 route summary spec and implementation plan
- project a canonical route summary layer from Action Center core semantics
- render the route summary consistently in overview and detail

## Verification
- `npm test -- "lib/action-center-live.test.ts"`
- `npm test -- "app/(dashboard)/action-center/page.route-shell.test.ts" -t "renders a compact route summary layer on detail from shared route semantics"`
- `npm test -- "app/(dashboard)/action-center/page.route-shell.test.ts" -t "keeps the landing summary compact with a last route-read instead of full detail semantics"`
- `npx eslint "lib/action-center-core-semantics.ts" "lib/action-center-live.ts" "lib/action-center-live.test.ts" "components/dashboard/action-center-preview.tsx" "app/(dashboard)/action-center/page.route-shell.test.ts"`
- `npm run build`

## Notes
- The full `app/(dashboard)/action-center/page.route-shell.test.ts` suite still has the same 4 pre-existing baseline failures already present on `main` around action cards, explicit closeout metadata, reopened lineage rendering, and ready-for-closeout rendering. This branch did not widen that baseline drift; the new route-summary assertions were verified separately.
