### PR TITLE
Define the manager action hardening wave

### DIFF
--- a/docs/superpowers/plans/2026-05-02-action-center-manager-action-hardening.md
+++ b/docs/superpowers/plans/2026-05-02-action-center-manager-action-hardening.md
@@ -1,0 +1,196 @@
+# Implementation Plan: Action Center Manageractie-Semantiek Harden en Ervaring Verfijnen
+
+## Status
+Proposed
+
+## Objective
+Harden the manager action model into a smaller, calmer, and more pilot-ready operating flow without pretending the current runtime is already final.
+
+This plan focuses on reducing ambiguity between:
+
+- route response
+- first concrete action
+- action cards
+- review expectations
+
+---
+
+## 1. Scope
+
+### In scope
+
+- define the first standard manager move more clearly in product behavior
+- simplify the manager response surface where it currently overmixes route response and concrete intervention
+- make the handoff into explicit action cards calmer and more intentional
+- align review reading with the actual follow-through shape
+- add focused tests for the chosen manager-action contract
+
+### Out of scope
+
+- reporting additions
+- governance redesign
+- closeout, reopen, or follow-up redesign
+- adding richer workflow branching
+
+---
+
+## 2. Deliverables
+
+### 2.1 Manager-action contract refinement
+
+Codify in the live semantics and preview layer:
+
+- what the first manager move represents
+- what counts as route-level response
+- when explicit action-card truth becomes primary
+
+### 2.2 UI simplification
+
+Refine the manager-facing route detail so the response/action surface feels smaller and more sequential.
+
+Likely touchpoint:
+
+- `frontend/components/dashboard/action-center-preview.tsx`
+
+### 2.3 Read-model alignment
+
+Ensure route summary, manager response, and action-card rendering do not imply conflicting meanings.
+
+Likely touchpoints:
+
+- `frontend/lib/action-center-core-semantics.ts`
+- `frontend/lib/action-center-live.ts`
+
+### 2.4 Focused tests
+
+Add or update tests for:
+
+- open route -> first manager move
+- route response without rich action expansion
+- route with explicit action cards
+- review reading for lighter versus richer routes
+
+---
+
+## 3. Execution Sequence
+
+### Step 1: Audit the current runtime model
+
+Inspect how the current runtime expresses:
+
+- manager response
+- primary action fields
+- route action cards
+- review planning and review rendering
+
+Output:
+
+- a concrete list of duplicated meanings or confusing overlaps
+
+### Step 2: Settle the pilot-grade manager operating contract
+
+Before implementation, choose the pilot-grade runtime story for:
+
+- first bounded response
+- optional first concrete action
+- when action cards become primary
+
+This should be a hardening decision, not an open-ended redesign.
+
+### Step 3: Refine projection and naming
+
+Adjust core semantics and preview shaping so the manager layers read consistently:
+
+- route context
+- response context
+- action execution context
+- review context
+
+### Step 4: Simplify the UI surface
+
+Refine the manager-facing route panel so:
+
+- the first response feels lighter
+- explicit action detail appears only when needed
+- richer action-card routes feel intentional rather than bolted on
+
+### Step 5: Harden with tests
+
+Add focused assertions around the chosen operating contract and keep them separate from unrelated baseline shell drift.
+
+### Step 6: Verify and prepare PR
+
+Run targeted tests, lint, and build; then commit, push, and open a draft PR for the wave.
+
+---
+
+## 4. Design Constraints
+
+### 4.1 Do not overfit to the richest route shape
+
+Do not make multiple action cards feel mandatory in the first manager move.
+
+### 4.2 Do not collapse route response and action truth into one vague concept
+
+The wave should simplify the relationship, not erase the distinction.
+
+### 4.3 Keep route governance where it already belongs
+
+Manager hardening should not pull route-closeout, reopen, or follow-up semantics into the manager surface.
+
+### 4.4 Preserve the post-scan product boundary
+
+This remains a follow-through layer after scan truth, not a general action workspace.
+
+---
+
+## 5. Verification Strategy
+
+Minimum verification before completion:
+
+1. focused manager-response and route-semantics tests
+2. route-shell tests for the chosen manager-action rendering path
+3. `eslint` on touched semantics and preview files
+4. `npm run build`
+
+If the manager surface meaning changes materially, add an updated seeded browser flow before claiming pilot-grade improvement.
+
+---
+
+## 6. Risks and Guardrails
+
+### Risk: adding more manager options instead of clarifying the core move
+
+Guardrail:
+
+- prefer narrowing and sequencing over adding adjacent affordances
+
+### Risk: making the response flow too weak for real follow-through
+
+Guardrail:
+
+- preserve a route into explicit action truth when the route genuinely needs it
+
+### Risk: creating hidden semantic mismatch between route summary and manager surface
+
+Guardrail:
+
+- adjust route summary copy only when necessary to stay consistent with the hardened manager contract
+
+### Risk: treating current runtime as more stable than it is
+
+Guardrail:
+
+- test the exact pilot contract chosen in this wave, not assumptions from earlier specs
+
+---
+
+## 7. Completion Criteria
+
+This wave is complete when:
+
+- the first expected manager move is clearer than today
+- the product more clearly distinguishes route response from action execution
+- managers can use the main follow-through path without conceptual hesitation
+- richer routes with explicit action cards still fit naturally inside the same route model
+- the resulting behavior feels smaller and more supportable for pilots than the current mixed state

--- a/docs/superpowers/specs/2026-05-02-action-center-manager-action-hardening-design.md
+++ b/docs/superpowers/specs/2026-05-02-action-center-manager-action-hardening-design.md
@@ -1,0 +1,290 @@
+# Action Center Manageractie-Semantiek Harden en Ervaring Verfijnen
+
+## Status
+Proposed
+
+## Intent
+This document defines Wave 2 of the Action Center commercial roadmap: hardening and simplifying the manager action model so it becomes trustworthy and usable in repeated pilot use.
+
+This wave is deliberately **not** framed as pure UX polish. It assumes the manager action layer has strong direction and real runtime pieces, but still needs semantic hardening before it counts as calm pilot-ready foundation.
+
+---
+
+## 1. Why This Wave Exists
+
+After Wave 1, route meaning is more readable at route level.
+
+That immediately exposes the next bottleneck:
+
+- what exactly the manager is expected to do first
+- how `manager response` relates to `first action`
+- when a route should stay light versus when it should carry explicit action cards
+- how review should feel when the route is still in an early, bounded state
+
+Today the runtime already contains meaningful manager-follow-through building blocks:
+
+- assignment-open route visibility
+- manager response form
+- optional primary action inside the response flow
+- route action cards
+- action-bound review direction
+
+But those pieces still risk reading as more settled than they really are.
+
+This wave exists to prevent three forms of drift:
+
+- semantic drift between manager response and action-card truth
+- UX drift where managers see too many overlapping ways to “do something”
+- pilot drift where the runtime technically supports multiple action paths but the actual expected operating model stays fuzzy
+
+---
+
+## 2. Product Boundary
+
+This wave is about **manager follow-through hardening**, not about broadening Action Center into a richer work-management system.
+
+### In scope
+
+- clarify the first standard manager move in an open route
+- simplify the relationship between route-level response and concrete action creation
+- reduce duplication between manager-response and action-card semantics
+- make review expectations calmer and more predictable for managers
+- tighten copy, defaults, and interaction sequence so managers do not need hidden product knowledge
+
+### Out of scope
+
+- new governance models
+- new reporting surfaces
+- route closeout redesign
+- follow-up or reopen redesign
+- generalized task-board capabilities
+- introducing broad workflow branching for managers
+
+This wave must keep Action Center as a bounded follow-through layer after a scan route.
+
+---
+
+## 3. Starting Foundation, Split by Reality
+
+### 3.1 Canonically decided
+
+The following are already semantically chosen:
+
+- the route remains the governing container
+- manager follow-through is the intended operational response inside a route
+- concrete actions belong inside the route rather than replacing the route
+- reviews are intended to bind primarily to concrete follow-through rather than float as generic route notes
+- multiple action cards are allowed when the route truly needs them
+
+### 3.2 Product/runtime present enough to build on
+
+The following already exist in runtime and should be used as starting material rather than reimagined from zero:
+
+- manager assignment opens a route
+- manager response save path exists and is server-side hardened
+- the manager response flow can already capture a response note, review date, and optional primary action fields
+- route action cards render in detail
+- route summary and route closeout now coexist in runtime
+
+### 3.3 Directional but not yet hardened enough to treat as final pilot operating model
+
+The following should still be treated as “strong direction under hardening,” not as fully settled:
+
+- whether the first standard manager move is best read as a response with optional first action, or as a direct first action in most pilot cases
+- how often routes should remain at bounded-response level without immediately becoming multi-action routes
+- how much structure the first manager action needs before it becomes administratively heavy
+- how the review loop should feel when the route is still early and lightly defined
+
+### 3.4 Design consequence
+
+This wave should not assume that the answer is “keep everything and polish the labels.”
+
+Instead it should explicitly harden:
+
+- what the default manager path is
+- what is supporting structure versus primary operating structure
+- how to keep the model small even when richer action truth exists underneath
+
+---
+
+## 4. Desired Outcome
+
+After this wave, a manager should be able to understand and perform the expected first meaningful move without guessing:
+
+- what kind of input is being asked for
+- whether this is still just a route response or already a concrete local intervention
+- what needs to be reviewed later
+- when additional action cards are actually warranted
+
+Pilot users should feel:
+
+- this is specific enough to act on
+- small enough to use
+- and stable enough that the product is not changing conceptual rules under them
+
+---
+
+## 5. The Hardening Problem to Solve
+
+The current model has four nearby concepts:
+
+- route summary
+- manager response
+- first concrete action
+- later action cards and reviews
+
+The product direction is strong, but the practical operating story is still too easy to blur:
+
+- a response can feel like an action
+- a primary action inside the response can feel like a second model parallel to action cards
+- reviews can feel route-level in copy while action-level in truth
+- multiple actions can exist, while the first manager affordance still feels like a one-shot response form
+
+Wave 2 should reduce that ambiguity.
+
+---
+
+## 6. Proposed Operating Model
+
+### 6.1 First manager move stays intentionally small
+
+The first manager move should remain small and bounded.
+
+For pilot readiness, the product should not force every open route immediately into a rich action-card workflow.
+
+The first move should let the manager say:
+
+- this route is acknowledged
+- here is the first bounded local response
+- here is when we look again
+
+### 6.2 Concrete action only becomes explicit when it really helps
+
+If the manager already knows the first concrete intervention, the flow may capture it immediately.
+
+But the product must make clear that:
+
+- concrete action is a more specific layer than route response
+- not every first response needs a fully articulated multi-action route
+
+This keeps the system small in early route states.
+
+### 6.3 Once action cards exist, they become the main execution surface
+
+If a route carries explicit action cards, those cards become the primary operational truth for follow-through.
+
+That means:
+
+- route response is context
+- action cards are execution
+- route summary remains bestuurlijke reading
+
+This avoids parallel primary surfaces.
+
+### 6.4 Multiple actions remain possible, but not the default story
+
+Multiple actions remain a valid route shape.
+
+But the product should present them as:
+
+- a route that has become operationally richer
+
+not as:
+
+- the assumption every manager sees or needs immediately
+
+This is important for pilot calm.
+
+### 6.5 Review must read consistently with the active action shape
+
+If there is a concrete action, review should read as review of concrete follow-through.
+
+If there is no concrete action yet, the product should not fake a rich action review loop. It should stay honest and light.
+
+---
+
+## 7. Simplification Goals
+
+This wave should aim for simplification in four places.
+
+### 7.1 Terminology
+
+The difference between:
+
+- `manager response`
+- `eerste stap`
+- `actie`
+- `review`
+
+must be easier to understand in product copy.
+
+### 7.2 Interaction order
+
+Managers should not have to decide between too many adjacent concepts at once.
+
+The flow should feel progressive:
+
+1. understand route
+2. give first bounded response
+3. add concrete action when helpful
+4. return later for review
+
+### 7.3 Field load
+
+The current first manager surface should feel lighter and more purposeful.
+
+It should ask only for what materially improves follow-through at that stage.
+
+### 7.4 Route-to-action handoff
+
+The product should make it clearer when a route has moved from:
+
+- response phase
+
+to:
+
+- concrete action phase
+
+without introducing extra workflow jargon.
+
+---
+
+## 8. Non-Goals
+
+This wave does not need to prove the ultimate perfect manager workflow for every future case.
+
+It only needs to create a pilot-grade operating model that is:
+
+- small
+- semantically honest
+- supportable
+- and hard to misuse
+
+It is acceptable for later waves to deepen manager capability once this base is calm.
+
+---
+
+## 9. Success Criteria
+
+This wave is successful when:
+
+- a manager can tell what the first expected move is without hidden product knowledge
+- the difference between route response and concrete action is clearer in product behavior
+- managers do not feel forced into multi-action complexity too early
+- routes with action cards clearly read as richer execution routes, not parallel workflow models
+- review language and review expectations match the actual follow-through shape
+- the manager action model feels more stable after this wave than before it
+
+---
+
+## 10. What This Wave Does Not Rebuild
+
+This wave does **not** re-open:
+
+- route summary semantics from Wave 1
+- closeout truth
+- reopen truth
+- follow-up truth
+- scan-origin route semantics
+
+It only hardens how managers work inside the already established route model.

--- a/frontend/components/dashboard/action-center-preview.tsx
+++ b/frontend/components/dashboard/action-center-preview.tsx
@@ -89,6 +89,12 @@ interface FollowUpRouteFormState {
   triggerReason: ActionCenterRouteFollowUpTriggerReason
 }
 
+type ManagerActionPhase =
+  | 'awaiting-first-move'
+  | 'bounded-response'
+  | 'first-concrete-action'
+  | 'action-cards'
+
 type FollowUpRouteBlockReason =
   | 'already-has-direct-active-successor'
   | 'no-same-scope-target'
@@ -322,7 +328,7 @@ function buildManagerResponseDefaults(item: ActionCenterPreviewItem | null): Man
     responseNote:
       response?.response_note ??
       (item?.status === 'open-verzoek'
-        ? 'We pakken dit op via een eerste bounded follow-through in het team.'
+        ? 'We pakken dit eerst klein op in het team en toetsen daarna of een concretere stap nodig is.'
         : ''),
     reviewScheduledFor: response?.review_scheduled_for ?? item?.reviewDate ?? '',
     includePrimaryAction: hasPrimaryAction,
@@ -353,6 +359,93 @@ function getManagerResponseProjectedStatus(
   }
 
   return hasPrimaryManagerAction(response) ? 'in-uitvoering' : 'te-bespreken'
+}
+
+function getManagerActionPhase(item: ActionCenterPreviewItem | null): ManagerActionPhase {
+  if (!item) return 'awaiting-first-move'
+  if ((item.coreSemantics.routeActionCards?.length ?? 0) > 0) return 'action-cards'
+  if (hasPrimaryManagerAction(item.managerResponse)) return 'first-concrete-action'
+  if (item.managerResponse) return 'bounded-response'
+  return 'awaiting-first-move'
+}
+
+function getManagerActionSurfaceCopy(item: ActionCenterPreviewItem | null) {
+  const phase = getManagerActionPhase(item)
+  const actionCardCount = item?.coreSemantics.routeActionCards?.length ?? 0
+
+  switch (phase) {
+    case 'action-cards':
+      return {
+        eyebrow: 'Actieroute',
+        title: 'Actieroute is gestart',
+        description:
+          actionCardCount === 1
+            ? 'Deze route draagt nu een expliciete actiekaart. De eerste managerstap blijft zichtbaar als startcontext; uitvoering en review lopen nu primair via die actie.'
+            : `Deze route draagt nu ${actionCardCount} expliciete actiekaarten. De eerste managerstap blijft zichtbaar als startcontext; uitvoering en review lopen nu primair via die acties.`,
+        saveLabel: 'Managerstap bijwerken',
+        emptyText: 'Deze route wacht nog op de eerste managerstap.',
+        primaryActionToggle:
+          'Gebruik dit alleen zolang één eerste concrete stap genoeg is. Zodra aparte actiekaarten bestaan, wordt die actielaag leidend.',
+        readOnlyHint:
+          'Uitvoering loopt nu via de actiekaarten in deze route. Deze eerste managerstap blijft alleen zichtbaar als startcontext.',
+      }
+    case 'first-concrete-action':
+      return {
+        eyebrow: 'Managerstap',
+        title: 'Eerste concrete managerstap',
+        description:
+          'Deze route heeft al een eerste concrete managerstap. Pas als er daarna extra parallelle follow-through nodig is, groeit dit door naar expliciete actiekaarten.',
+        saveLabel: 'Managerstap bijwerken',
+        emptyText: 'Deze route wacht nog op de eerste managerstap.',
+        primaryActionToggle:
+          'Gebruik dit alleen als één eerste concrete stap nu echt helpt. De route hoeft niet meteen rijker te worden dan dit.',
+        readOnlyHint:
+          'De route heeft al een eerste concrete managerstap, maar blijft nog bewust kleiner dan een rijkere actieroute.',
+      }
+    case 'bounded-response':
+      return {
+        eyebrow: 'Managerstap',
+        title: 'Eerste managerstap staat vast',
+        description:
+          'Deze route heeft al een eerste managerstap en reviewafspraak. Houd de route bewust klein totdat een aparte concrete actie echt helpt.',
+        saveLabel: 'Managerstap bijwerken',
+        emptyText: 'Deze route wacht nog op de eerste managerstap.',
+        primaryActionToggle:
+          'Leg alleen als dit meteen helpt één eerste concrete stap vast. Zonder die stap blijft de route bewust klein en reviewbaar.',
+        readOnlyHint:
+          'Nog geen aparte concrete actie vastgelegd; deze route blijft bewust klein tot een expliciete actielaag echt helpt.',
+      }
+    case 'awaiting-first-move':
+    default:
+      return {
+        eyebrow: 'Open verzoek',
+        title: 'Eerste managerstap',
+        description:
+          'HR heeft deze route lokaal geopend. De manager reageert eerst klein: erken wat nu moet gebeuren, leg de eerste bounded stap vast en plan meteen het eerste reviewmoment.',
+        saveLabel: 'Eerste managerstap opslaan',
+        emptyText: 'Deze route wacht nog op de eerste managerstap.',
+        primaryActionToggle:
+          'Leg alleen als dit meteen helpt één eerste concrete stap vast. Zonder die stap blijft de route bewust klein en reviewbaar.',
+        readOnlyHint: null,
+      }
+  }
+}
+
+function getRouteSummaryDisplay(item: ActionCenterPreviewItem) {
+  return (
+    item.coreSemantics.routeSummary ?? {
+      stateLabel: getStatusMeta(item.status).label,
+      overviewSummary: item.summary || item.reason || 'Nog geen route-read beschikbaar.',
+      routeAsk:
+        item.reviewReason ||
+        item.reason ||
+        'Bepaal welke eerste bounded vervolgstap deze route nu echt vraagt.',
+      progressSummary:
+        item.nextStep ||
+        item.expectedEffect ||
+        'Nog geen compacte voortgangssamenvatting zichtbaar.',
+    }
+  )
 }
 
 function applyManagerResponseToItem(
@@ -714,6 +807,8 @@ export function ActionCenterPreview({
     })
 
   const selectedItem = filteredItems.find((item) => item.id === selectedItemId) ?? items.find((item) => item.id === selectedItemId) ?? filteredItems[0] ?? items[0] ?? null
+  const managerActionSurfaceCopy = getManagerActionSurfaceCopy(selectedItem)
+  const selectedRouteSummary = selectedItem ? getRouteSummaryDisplay(selectedItem) : null
   useEffect(() => {
     setManagerResponseForm(buildManagerResponseDefaults(selectedItem))
     setManagerResponseError(null)
@@ -1704,9 +1799,9 @@ export function ActionCenterPreview({
                         ) : null}
 
                         <div className="mt-7 grid gap-4 xl:grid-cols-3">
-                          <RouteSummaryCard label="Route-read" value={selectedItem.coreSemantics.routeSummary.stateLabel} />
-                          <RouteSummaryCard label="Vraagt nu" value={selectedItem.coreSemantics.routeSummary.routeAsk} />
-                          <RouteSummaryCard label="Voortgang" value={selectedItem.coreSemantics.routeSummary.progressSummary} />
+                          <RouteSummaryCard label="Route-read" value={selectedRouteSummary?.stateLabel ?? 'Nog geen route-read'} />
+                          <RouteSummaryCard label="Vraagt nu" value={selectedRouteSummary?.routeAsk ?? 'Nog te bepalen'} />
+                          <RouteSummaryCard label="Voortgang" value={selectedRouteSummary?.progressSummary ?? 'Nog geen voortgangssamenvatting'} />
                         </div>
 
                         <div className="mt-7 grid gap-4 lg:grid-cols-[minmax(0,1fr),minmax(0,0.92fr)]">
@@ -2030,24 +2125,18 @@ export function ActionCenterPreview({
                       {supportsManagerResponseFlow(selectedItem) ? (
                         <div className="rounded-[24px] border border-[#e4d9cb] bg-white px-6 py-6 shadow-[0_12px_36px_rgba(19,32,51,0.06)]">
                           <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">
-                            {selectedItem.status === 'open-verzoek' && !selectedItem.managerResponse
-                              ? 'Open verzoek'
-                              : 'Managerreactie'}
+                            {managerActionSurfaceCopy.eyebrow}
                           </p>
                           <h3 className="mt-3 text-[1.35rem] font-semibold tracking-[-0.03em] text-[#132033]">
-                            {selectedItem.status === 'open-verzoek' && !selectedItem.managerResponse
-                              ? 'Route staat klaar voor eerste reactie'
-                              : 'Eerste lokale follow-through'}
+                            {managerActionSurfaceCopy.title}
                           </h3>
                           <p className="mt-3 text-sm leading-7 text-[#4f6175]">
-                            {selectedItem.status === 'open-verzoek' && !selectedItem.managerResponse
-                              ? 'HR heeft deze route lokaal geopend. De manager hoeft niet opnieuw te bewijzen dat dit thema speelt, maar reageert klein: bevestigen, aanscherpen, inplannen of begrenzen.'
-                              : 'Deze route draagt al een eerste managerreactie. Alleen als een echte lokale interventie nodig is, hangt daar in deze fase maximaal één primaire actie aan.'}
+                            {managerActionSurfaceCopy.description}
                           </p>
 
                           {canUseManagerResponseFlow ? (
                             <div className="mt-5 space-y-5">
-                              <FormField label="Eerste reactie">
+                              <FormField label="Hoe pak je deze route als eerste op?">
                                 <div className="grid gap-3 sm:grid-cols-2">
                                   {(['confirm', 'sharpen', 'schedule', 'watch'] as ActionCenterManagerResponseType[]).map((option) => (
                                     <button
@@ -2071,7 +2160,7 @@ export function ActionCenterPreview({
                                 </div>
                               </FormField>
 
-                              <FormField label="Wat is nu de bounded reactie?">
+                              <FormField label="Wat leg je nu klein en reviewbaar vast?">
                                 <textarea
                                   value={managerResponseForm.responseNote}
                                   onChange={(event) =>
@@ -2080,12 +2169,12 @@ export function ActionCenterPreview({
                                       responseNote: event.target.value,
                                     }))
                                   }
-                                  placeholder="Bijv. eerst bespreken in het weekoverleg, of gericht aanscherpen wat de eerstvolgende stap moet zijn."
+                                  placeholder="Bijv. eerst bespreken in het weekoverleg, of gericht vastleggen wat de eerstvolgende lokale stap moet zijn."
                                   className="min-h-[110px] w-full rounded-2xl border border-[#ddd3c7] bg-[#fbf8f4] px-4 py-3 text-sm leading-7 text-[#132033] outline-none transition focus:border-[#ff9b4a]"
                                 />
                               </FormField>
 
-                              <FormField label="Wanneer reviewen we dit?">
+                              <FormField label="Wanneer toetsen we deze eerste stap?">
                                 <input
                                   type="date"
                                   value={managerResponseForm.reviewScheduledFor}
@@ -2112,13 +2201,17 @@ export function ActionCenterPreview({
                                   className="mt-1 h-4 w-4 rounded border-[#d6cbbb] text-[#132033]"
                                 />
                                 <span className="leading-7">
-                                  Voeg alleen als nodig één primaire lokale stap toe. Zonder deze stap blijft de route bewust klein en reviewbaar.
+                                  {managerActionSurfaceCopy.primaryActionToggle}
                                 </span>
                               </label>
 
                               {managerResponseForm.includePrimaryAction ? (
                                 <div className="space-y-4 rounded-[20px] border border-[#ece4d8] bg-[#fcfaf7] px-4 py-4">
-                                  <FormField label="Thema">
+                                  <p className="text-sm leading-7 text-[#4f6175]">
+                                    Deze extra stap maakt de route concreter, maar houdt de uitvoering nog steeds klein totdat aparte actiekaarten echt helpen.
+                                  </p>
+
+                                  <FormField label="Thema van deze eerste concrete stap">
                                     <select
                                       value={managerResponseForm.primaryActionThemeKey}
                                       onChange={(event) =>
@@ -2138,7 +2231,7 @@ export function ActionCenterPreview({
                                     </select>
                                   </FormField>
 
-                                  <FormField label="Wat ga je concreet doen?">
+                                  <FormField label="Wat is die eerste concrete stap?">
                                     <textarea
                                       value={managerResponseForm.primaryActionText}
                                       onChange={(event) =>
@@ -2152,7 +2245,7 @@ export function ActionCenterPreview({
                                     />
                                   </FormField>
 
-                                  <FormField label="Wat moet dit zichtbaar maken?">
+                                  <FormField label="Wat moet deze stap zichtbaar maken?">
                                     <textarea
                                       value={managerResponseForm.primaryActionExpectedEffect}
                                       onChange={(event) =>
@@ -2180,20 +2273,20 @@ export function ActionCenterPreview({
                                 disabled={managerResponsePending}
                                 onClick={() => void handleManagerResponseSave()}
                               >
-                                {managerResponsePending ? 'Opslaan...' : 'Managerreactie opslaan'}
+                                {managerResponsePending ? 'Opslaan...' : managerActionSurfaceCopy.saveLabel}
                               </button>
                             </div>
                           ) : selectedItem.managerResponse ? (
                             <div className="mt-5 space-y-3">
                               <SummaryRow
-                                label="Reactie"
+                                label="Managerstap"
                                 value={getActionCenterManagerResponseLabel(selectedItem.managerResponse.response_type)}
                               />
                               <SummaryRow
-                                label="Review"
+                                label="Reviewmoment"
                                 value={formatLongDate(selectedItem.managerResponse.review_scheduled_for)}
                               />
-                              <SignalRow label="Toelichting" value={selectedItem.managerResponse.response_note} />
+                              <SignalRow label="Bounded stap" value={selectedItem.managerResponse.response_note} />
                               {selectedItem.managerResponse.primary_action_theme_key ? (
                                 <SignalRow
                                   label="Thema"
@@ -2210,10 +2303,21 @@ export function ActionCenterPreview({
                                   value={selectedItem.managerResponse.primary_action_text}
                                 />
                               ) : null}
+                              {selectedItem.managerResponse.primary_action_expected_effect ? (
+                                <SignalRow
+                                  label="Zichtbaar effect"
+                                  value={selectedItem.managerResponse.primary_action_expected_effect}
+                                />
+                              ) : null}
+                              {managerActionSurfaceCopy.readOnlyHint ? (
+                                <p className="rounded-[18px] border border-[#ece4d8] bg-[#fcfaf7] px-4 py-4 text-sm leading-7 text-[#4f6175]">
+                                  {managerActionSurfaceCopy.readOnlyHint}
+                                </p>
+                              ) : null}
                             </div>
                           ) : (
                             <div className="mt-5">
-                              <EmptyBlock text="Deze route wacht nog op de eerste lichte managerreactie." />
+                              <EmptyBlock text={managerActionSurfaceCopy.emptyText} />
                             </div>
                           )}
                         </div>
@@ -3019,9 +3123,10 @@ function EmptySection({ title, body }: { title: string; body: string }) {
 }
 
 export function buildCompactLandingSummaryLines(item: ActionCenterPreviewItem) {
+  const routeSummary = getRouteSummaryDisplay(item)
   return [
-    { label: 'Route', value: item.coreSemantics.routeSummary.stateLabel },
-    { label: 'Lezing', value: item.coreSemantics.routeSummary.overviewSummary },
+    { label: 'Route', value: routeSummary.stateLabel },
+    { label: 'Lezing', value: routeSummary.overviewSummary },
   ]
     .filter((entry): entry is { label: string; value: string } => Boolean(entry?.value))
     .filter((entry, index, entries) => entries.findIndex((candidate) => candidate.value === entry.value) === index)

--- a/frontend/lib/action-center-core-semantics.ts
+++ b/frontend/lib/action-center-core-semantics.ts
@@ -11,6 +11,7 @@ import {
   type ActionCenterRouteReopenRecord,
   type ActionCenterRouteFollowUpTriggerReason,
 } from './action-center-route-reopen'
+import { hasPrimaryManagerAction } from './action-center-manager-responses'
 import type { ActionCenterRouteActionRecord } from './action-center-route-actions'
 import type {
   ActionCenterManagerResponse,
@@ -269,6 +270,7 @@ function buildRouteSummary(args: {
   const actionCount = args.routeActionCards.length
   const reviewPressureCount = countReviewPressure(args.routeActionCards)
   const hasManagerResponse = Boolean(args.managerResponse)
+  const hasPrimaryAction = hasPrimaryManagerAction(args.managerResponse)
   const hasCurrentStep = Boolean(args.actionProgress.currentStep)
 
   if (status === 'afgerond') {
@@ -323,27 +325,32 @@ function buildRouteSummary(args: {
       stateLabel,
       overviewSummary:
         actionCount > 0
-          ? `Actieve route met ${actionCount} concrete actie${actionCount === 1 ? '' : 's'} in dezelfde follow-through.`
-          : 'Actieve route waarin de eerste lokale follow-through al loopt.',
-      routeAsk: 'Bewaak of de huidige follow-through scherp, bounded en lokaal uitvoerbaar blijft.',
+          ? `Actieve route met ${actionCount} expliciete actie${actionCount === 1 ? '' : 's'} in dezelfde follow-through.`
+          : hasPrimaryAction
+            ? 'Actieve route met één eerste concrete managerstap, nog zonder rijkere actieroute.'
+            : 'Actieve route waarin de eerste bounded managerstap nu loopt.',
+      routeAsk:
+        actionCount > 0
+          ? 'Houd de actielaag klein en zorg dat review per actie leidend blijft voor verdere uitvoering.'
+          : 'Bewaar deze eerste managerstap klein en maak hem pas rijker als een aparte actielaag echt helpt.',
       progressSummary:
         actionCount > 0
           ? `${actionCount} actie${actionCount === 1 ? '' : 's'} dragen nu de lokale follow-through in deze route.`
-          : hasCurrentStep
-            ? 'De route heeft al een concrete vervolgstap en draait nu in uitvoering.'
-            : 'De route is actief, maar de concrete vervolgcyclus blijft nog licht en bounded.',
+          : hasPrimaryAction || hasCurrentStep
+            ? 'De route heeft al een eerste concrete stap, maar hoeft nog niet meteen uit te groeien tot meerdere acties.'
+            : 'De route is actief, maar blijft bewust op een eerste bounded managerstap en reviewafspraak.',
     }
   }
 
   if (status === 'open-verzoek') {
     return {
       stateLabel,
-      overviewSummary: 'Open route zonder concrete lokale follow-through of reviewcyclus.',
-      routeAsk: 'De manager moet nog de eerste betekenisvolle lokale opvolging en bijbehorende review kiezen.',
+      overviewSummary: 'Open route die nog wacht op de eerste managerstap en het eerste reviewmoment.',
+      routeAsk: 'De manager moet nog klein vastleggen hoe deze route nu als eerste wordt opgepakt en wanneer die stap wordt getoetst.',
       progressSummary:
         hasManagerResponse || hasCurrentStep
-          ? 'Er zijn al eerste signalen van reactie, maar nog geen stabiele routecyclus.'
-          : 'Nog geen concrete actie, reviewcyclus of expliciete follow-through zichtbaar.',
+          ? 'Er zijn al eerste signalen van reactie, maar de eerste managerstap staat nog niet rustig vast.'
+          : 'Nog geen eerste managerstap, concrete actie of rustige reviewafspraak zichtbaar.',
     }
   }
 
@@ -362,15 +369,15 @@ function buildRouteSummary(args: {
   return {
     stateLabel,
     overviewSummary: hasManagerResponse
-      ? 'Open route met eerste managerreactie, maar nog zonder volledig rustige routecyclus.'
+      ? 'Open route met een eerste managerstap en reviewafspraak, maar nog zonder expliciete actieroute.'
       : 'Open route waarbij de eerste expliciete route-read en vervolglijn nog scherp moeten worden.',
     routeAsk: hasManagerResponse
-      ? 'Maak van de eerste reactie een duidelijke vervolglijn of reviewbare routecyclus.'
+      ? 'Bepaal of deze route bewust klein kan blijven, of dat één expliciete concrete actie nu echt helpt.'
       : 'Bepaal eerst welke bounded vervolglijn deze route nu echt vraagt.',
     progressSummary: actionCount > 0
-      ? `${actionCount} actie${actionCount === 1 ? '' : 's'} zijn zichtbaar, maar de route vraagt nog expliciete bestuurlijke duiding.`
+      ? `${actionCount} actie${actionCount === 1 ? '' : 's'} zijn zichtbaar, maar de route vraagt nog expliciete duiding over welke laag nu leidend is.`
       : hasManagerResponse
-        ? 'Er is al een eerste managerreactie, maar de route vraagt nog expliciete vervolgbepaling.'
+        ? 'Er is al een eerste managerstap vastgelegd, maar de route hoeft nog niet rijker te worden dan dit bounded niveau.'
         : 'De route is geopend, maar de concrete vervolglijn is nog niet scherp genoeg vastgelegd.',
   }
 }

--- a/frontend/lib/action-center-live.test.ts
+++ b/frontend/lib/action-center-live.test.ts
@@ -490,7 +490,7 @@ describe('live action center builder', () => {
 
     expect(openRequestItem?.coreSemantics.routeSummary).toMatchObject({
       stateLabel: 'Open verzoek',
-      overviewSummary: 'Open route zonder concrete lokale follow-through of reviewcyclus.',
+      overviewSummary: 'Open route die nog wacht op de eerste managerstap en het eerste reviewmoment.',
     })
     expect(reviewableItem?.coreSemantics.routeSummary).toMatchObject({
       stateLabel: 'Reviewbaar',
@@ -706,7 +706,7 @@ describe('live action center builder', () => {
     })
     expect(recomputed.coreSemantics.routeSummary).toMatchObject({
       stateLabel: 'In uitvoering',
-      overviewSummary: 'Actieve route waarin de eerste lokale follow-through al loopt.',
+      overviewSummary: 'Actieve route waarin de eerste bounded managerstap nu loopt.',
     })
     expect(recomputed.coreSemantics.resultLoop.whatWasTried).toBe(
       'Update: eigenaar bevestigd en review opnieuw ingepland.',

--- a/frontend/lib/action-center-preview-route-fields-render.test.ts
+++ b/frontend/lib/action-center-preview-route-fields-render.test.ts
@@ -239,8 +239,8 @@ describe('action center preview route fields render', () => {
     })
 
     expect(buildCompactLandingSummaryLines(item)).toEqual([
-      { label: 'Besluit', value: 'Bijstellen' },
-      { label: 'Stap', value: 'Plan een gerichte teamreview met de manager.' },
+      { label: 'Route', value: 'In uitvoering' },
+      { label: 'Lezing', value: 'De route vraagt een nieuwe lokale stap.' },
     ])
   })
 

--- a/frontend/lib/action-center-route-action-preview.test.ts
+++ b/frontend/lib/action-center-route-action-preview.test.ts
@@ -6,7 +6,7 @@ import { finalizeActionCenterPreviewItem } from '@/lib/action-center-live'
 import type { ActionCenterManagerResponse } from '@/lib/pilot-learning'
 
 describe('action center route action preview', () => {
-  it('surfaces route action cards and editor controls when a manager can continue inside one route', () => {
+  it('keeps richer action routes semantically distinct even while the manager surface starts from one first step', () => {
     const managerResponse: ActionCenterManagerResponse = {
       id: 'response-1',
       campaign_id: 'campaign-exit',
@@ -100,6 +100,14 @@ describe('action center route action preview', () => {
         },
         resultProgression: [],
         decisionHistory: [],
+        lineageSummary: {
+          overviewLabel: null,
+          backwardLabel: null,
+          backwardRouteId: null,
+          forwardLabel: null,
+          forwardRouteId: null,
+          detailLabels: [],
+        },
         routeActionCards: [
           {
             actionId: 'action-1',
@@ -148,13 +156,65 @@ describe('action center route action preview', () => {
       }),
     )
 
-    expect(html).toContain('Acties in deze route')
-    expect(html).toContain('Plan twee teamgesprekken over leiderschapsfeedback.')
-    expect(html).toContain('Leg groeigesprekken vast in het volgende teamoverleg.')
-    expect(html).toContain('Leiderschap')
-    expect(html).toContain('Groei en perspectief')
-    expect(html).toContain('Het team noemt groei explicieter dan in de vorige ronde.')
-    expect(html).toContain('Actie toevoegen')
-    expect(html).toContain('Review toevoegen')
+    expect(html).toContain('Actieroute is gestart')
+    expect(html).toContain('Deze route draagt nu 2 expliciete actiekaarten.')
+    expect(html).toContain('Thema van deze eerste concrete stap')
+    expect(html).toContain('Gebruik dit alleen zolang één eerste concrete stap genoeg is.')
+    expect(html).toContain('Plan een eerste teamgesprek over feedbackritme.')
+    expect(html).toContain('Zichtbaar maken of feedbackritme lokaal het vertrekbeeld beïnvloedt.')
+    expect(html).toContain('Managerstap bijwerken')
+  })
+
+  it('keeps the first manager move visibly small before a route grows into explicit actions', () => {
+    const item = finalizeActionCenterPreviewItem({
+      id: 'route-open-request',
+      code: 'ACT-1002',
+      title: 'Nieuwe route voor Operations',
+      summary: 'De route wacht op de eerste lokale managerstap.',
+      reason: 'Welke vertrekduiding vraagt nu als eerste managementeigenaarschap?',
+      sourceLabel: 'ExitScan',
+      orgId: 'org-1',
+      scopeType: 'department',
+      teamId: 'operations',
+      teamLabel: 'Operations',
+      ownerId: 'manager-1',
+      ownerName: 'Manager Operations',
+      ownerRole: 'Manager - Operations',
+      ownerSubtitle: 'Operations',
+      reviewOwnerName: 'HR lead',
+      priority: 'hoog',
+      status: 'open-verzoek',
+      reviewDate: null,
+      expectedEffect: null,
+      reviewReason: null,
+      reviewOutcome: 'geen-uitkomst',
+      reviewDateLabel: 'Nog niet gepland',
+      reviewRhythm: 'Maandelijks',
+      signalLabel: 'ExitScan - Operations',
+      signalBody: 'HR heeft de route geopend na een nieuwe scanread.',
+      nextStep: null,
+      peopleCount: 38,
+      updates: [],
+    })
+
+    const html = renderToStaticMarkup(
+      React.createElement(ActionCenterPreview, {
+        initialItems: [item],
+        initialView: 'actions',
+        fallbackOwnerName: 'Verisight gebruiker',
+        ownerOptions: ['Manager Operations'],
+        canRespondToRequests: true,
+        managerResponseEndpoint: '/api/action-center-manager-responses',
+        currentUserId: 'manager-1',
+        workbenchHref: '/action-center',
+      }),
+    )
+
+    expect(html).toContain('Eerste managerstap')
+    expect(html).toContain('Hoe pak je deze route als eerste op?')
+    expect(html).toContain('Wat leg je nu klein en reviewbaar vast?')
+    expect(html).toContain('Wanneer toetsen we deze eerste stap?')
+    expect(html).toContain('Leg alleen als dit meteen helpt één eerste concrete stap vast.')
+    expect(html).toContain('Eerste managerstap opslaan')
   })
 })


### PR DESCRIPTION
## Summary
- define Wave 2 of the Action Center commercial roadmap
- treat manager action semantics as a hardening problem rather than pure UX polish
- add the implementation plan for clarifying route response, first action, and action-card execution

## Included Docs
- `docs/superpowers/specs/2026-05-02-action-center-manager-action-hardening-design.md`
- `docs/superpowers/plans/2026-05-02-action-center-manager-action-hardening.md`

## Notes
- this PR is intentionally documentation-only
- it builds directly on the merged roadmap and Wave 1 route-summary work
- the focus is to harden the manager operating model without widening Action Center into a broader workflow tool
