### PR TITLE
Action Center reporting readback and governance hardening

### DIFF
--- a/docs/superpowers/plans/2026-05-02-action-center-governance-rights.md
+++ b/docs/superpowers/plans/2026-05-02-action-center-governance-rights.md
@@ -1,0 +1,51 @@
+# Action Center Governance and Rights Hardening Plan
+
+## Objective
+Execute a focused governance hardening slice for Action Center route-level writes without expanding scope into a full permissions redesign.
+
+## Task 1: Unify HR/admin write resolution
+- Add a shared governance helper that resolves whether a user can perform HR/admin route writes for a given org.
+- Preserve exact resolved audit roles instead of flattening everything to generic `hr`.
+
+Verification:
+- helper-level tests cover admin, org owner, workspace HR member, and denied access
+
+## Task 2: Align closeout and reopen writes
+- Update route closeout API to use the shared helper.
+- Update route reopen API to use the shared helper.
+- Persist the resolved governance role into `closed_by_role` and `reopened_by_role`.
+- Ensure route projections still accept legacy values for compatibility.
+
+Verification:
+- closeout tests cover denied actor, org-owner actor, and workspace `hr_member`
+- reopen tests cover denied actor, org-owner actor, and workspace `hr_member`
+
+## Task 3: Align follow-up write audit truth
+- Update follow-up route trigger API to use the same shared resolver.
+- Persist `recorded_by_role` as the exact resolved role.
+- Keep the cross-org and scope-safety fixes intact from earlier waves.
+
+Verification:
+- follow-up tests prove `hr_member` and `hr_owner` persistence
+- no existing follow-up trust regressions
+
+## Task 4: Add repo-side SQL compatibility patch
+- Add a dedicated SQL patch file that broadens role-check constraints for route-governance tables to include:
+  - `verisight_admin`
+  - `hr_owner`
+  - `hr_member`
+- Keep legacy compatibility values accepted where runtime still reads them.
+
+Verification:
+- patch is idempotent and scoped only to route-governance role constraints
+
+## Task 5: Verify and package Wave 4
+- Run focused API/helper tests.
+- Run ESLint on touched files.
+- Run `npm run build`.
+- Commit on the isolated governance branch.
+- Push and open a draft PR.
+
+Stop conditions:
+- repeated failing verification without a clear local fix
+- incompatible schema assumptions that require product decisions

--- a/docs/superpowers/plans/2026-05-02-action-center-reporting-readback.md
+++ b/docs/superpowers/plans/2026-05-02-action-center-reporting-readback.md
@@ -1,0 +1,184 @@
+# Implementation Plan: Action Center Rapportage en Bestuurlijke Teruglezing
+
+## Status
+Proposed
+
+## Objective
+Implement Wave 3 of the Action Center commercial roadmap by adding a compact workspace readback summary derived from existing route, decision, closeout, reopen, and follow-up truth.
+
+This plan assumes:
+
+- route-level truth already exists
+- route summary and lineage summary already exist
+- this wave is a bounded reporting/readback slice, not a new analytics product
+
+---
+
+## 1. Scope
+
+### In scope
+
+- enrich the live Action Center aggregate summary with bestuurlijke readback fields
+- render those fields in the overview surface
+- keep the rendering compact and route-level
+- add focused tests for summary projection and overview rendering
+
+### Out of scope
+
+- charts
+- exports
+- theme reporting
+- separate reporting pages
+- manager-action redesign
+- governance or audit redesign
+
+---
+
+## 2. Deliverables
+
+### 2.1 Live aggregate summary extension
+
+Extend the live summary layer so it can answer:
+
+- total visible routes
+- active versus closed visible routes
+- visible routes with explicit decision history
+- visible routes with continuation visibility
+- nearest review pressure
+
+Likely touchpoint:
+
+- `frontend/lib/action-center-live.ts`
+
+### 2.2 Overview rendering
+
+Render the new readback summary on the Action Center overview using existing card language and visual patterns.
+
+Likely touchpoint:
+
+- `frontend/components/dashboard/action-center-preview.tsx`
+
+### 2.3 Focused test coverage
+
+Add or extend tests covering:
+
+- route-deduplicated summary counts
+- decision-history count
+- continuation count through reopen/follow-up signals
+- overview rendering of the new readback block
+
+Likely tests:
+
+- `frontend/lib/action-center-live.test.ts`
+- `frontend/lib/action-center-preview-route-fields-render.test.ts`
+- `frontend/app/(dashboard)/action-center/page.route-shell.test.ts`
+
+---
+
+## 3. Execution Sequence
+
+### Step 1: Extend the aggregate summary shape
+
+Add the missing readback fields to the live summary layer while preserving current fields that already feed the page and subtitle.
+
+### Step 2: Derive new fields from route-level truth
+
+Compute the new summary fields from deduplicated route items, using:
+
+- route status
+- decision history presence
+- lineage/follow-up semantics
+- review dates
+
+Do not compute from UI-only strings.
+
+### Step 3: Add overview rendering
+
+Use the new summary in overview rendering to show a compact bestuurlijke readback block.
+
+Keep it:
+
+- readable for HR
+- harmless for managers
+- visually consistent with the current Action Center shell
+
+### Step 4: Harden with tests
+
+Add focused tests for summary counts and overview rendering.
+
+### Step 5: Verify and prepare PR
+
+Run focused verification, commit intentionally, push, and open a draft PR.
+
+---
+
+## 4. Design Constraints
+
+### 4.1 Stay compact
+
+If there is a choice between:
+
+- more metrics
+- or a calmer readback layer
+
+choose the calmer readback layer.
+
+### 4.2 Stay route-level
+
+The readback layer may use action and review truth, but it should summarize at route level.
+
+### 4.3 Do not overclaim action maturity
+
+Counts or summaries must not assume:
+
+- multiple action cards are already the final repeated-use model
+- every route has equally rich action history
+
+### 4.4 Reuse existing truth
+
+Do not invent:
+
+- new reporting tables
+- new persisted summary state
+- duplicated lineage models
+
+---
+
+## 5. Verification Strategy
+
+Minimum verification before completion:
+
+1. focused live summary tests
+2. overview rendering tests
+3. `npm run build`
+
+If the overview copy changes materially, ensure the existing Action Center route shell tests still pass or only retain documented baseline failures already present on `main`.
+
+---
+
+## 6. Risks and Guardrails
+
+### Risk: building a reporting module by accident
+
+Guardrail:
+
+- keep this wave inside the existing overview shell
+
+### Risk: counting route history inconsistently
+
+Guardrail:
+
+- deduplicate by route identity inside the live summary layer
+
+### Risk: reporting depends too much on still-hardening action semantics
+
+Guardrail:
+
+- count route-level presence of decisions and continuation
+- avoid deep action-shape metrics
+
+### Risk: overview becomes noisy
+
+Guardrail:
+
+- use a small number of bounded summary rows/cards

--- a/docs/superpowers/specs/2026-05-02-action-center-governance-rights-design.md
+++ b/docs/superpowers/specs/2026-05-02-action-center-governance-rights-design.md
@@ -1,0 +1,85 @@
+# Action Center Governance and Rights Hardening
+
+## Goal
+Wave 4 hardens Action Center as a pilot-trustworthy follow-through layer by making a small set of authority boundaries and audit roles more canonical in runtime truth.
+
+This is intentionally not a broad RBAC redesign.
+It is a focused governance slice for the highest-trust write paths that already exist:
+- route closeout
+- route reopen
+- follow-up route trigger
+
+## Foundation Split
+
+### Canonically decided
+- HR / Verisight can perform route-level governance actions above manager-owned execution.
+- Closeout, reopen, and follow-up are all explicit write actions with stored actor truth.
+- These actions should remain authority-safe and later auditable.
+
+### Product/runtime present
+- Runtime APIs already gate closeout, reopen, and follow-up to HR/admin paths.
+- Follow-up already persists a more explicit admin role in some cases.
+- Closeout and reopen already persist canonical route records.
+
+### Directional but not yet hardened
+- Runtime still collapses some governance actor truth too aggressively.
+- Similar HR/admin checks are duplicated instead of resolved once.
+- Audit truth is not yet consistently preserved across all route-governance writes.
+
+## Scope
+
+### In scope
+- Introduce one shared helper for HR/admin write authority resolution.
+- Preserve more exact actor truth for governance writes:
+  - `verisight_admin`
+  - `hr_owner`
+  - `hr_member`
+- Align closeout, reopen, and follow-up APIs to the same authority resolution model.
+- Harden tests around exact audit-role persistence.
+- Provide a repo-side Supabase patch for compatible role constraints.
+
+### Not in scope
+- Full Action Center permissions redesign.
+- New viewer roles or new route-scope models.
+- UI redesign of governance surfaces.
+- Broad audit timeline features.
+
+## Design Rules
+
+### Shared write resolution
+Governance writes should resolve authority through one shared helper, not through ad hoc per-route logic.
+
+Resolution order:
+1. `verisight_admin`
+2. org owner as `hr_owner`
+3. workspace-level `hr_owner` or `hr_member` with `can_update`
+4. otherwise deny
+
+### Exact audit truth
+Governance writes should preserve the resolved actor role in stored route truth where runtime already stores an actor role.
+
+That means:
+- closeout should not always flatten to `hr`
+- reopen should not always flatten to `hr`
+- follow-up should not flatten org-owner and workspace-member writes into one generic bucket
+
+### Compatibility posture
+Legacy values such as `hr` and `manager` remain accepted in projection and read paths for compatibility.
+Wave 4 only hardens new writes and constraint compatibility.
+
+## Deliverables
+- Shared governance helper in frontend runtime.
+- Closeout API aligned to shared HR/admin write resolution.
+- Reopen API aligned to shared HR/admin write resolution.
+- Follow-up API aligned to shared HR/admin write resolution.
+- Focused tests proving exact audit-role persistence.
+- Dedicated SQL patch for role-constraint compatibility.
+
+## Pilot-Readiness Contribution
+This wave contributes to pilot readiness by making route-governance writes:
+- more authority-safe
+- less duplicated
+- easier to reason about
+- more auditable in stored truth
+
+It does not finish all governance work, but it makes the most important route-level write paths materially more trustworthy.

--- a/docs/superpowers/specs/2026-05-02-action-center-reporting-readback-design.md
+++ b/docs/superpowers/specs/2026-05-02-action-center-reporting-readback-design.md
@@ -1,0 +1,252 @@
+# Action Center Rapportage en Bestuurlijke Teruglezing
+
+## Status
+Proposed
+
+## Intent
+This document defines Wave 3 of the Action Center commercial roadmap: adding a compact reporting and bestuurlijke readback layer on top of existing Action Center route truth.
+
+This wave is intentionally **not** a broad analytics expansion. It is a bounded readback slice that helps HR and sponsors understand what has happened across visible routes without turning Action Center into a reporting suite.
+
+---
+
+## 1. Why This Wave Exists
+
+After Waves 1 and 2, Action Center reads better at route level and is more honest about the manager-action model. What is still missing is a calm answer to a bestuurlijke question:
+
+- what is happening across my visible routes
+- how many routes are still active versus historically closed
+- where have explicit decision moments already happened
+- where is continuation over time already visible
+
+Today much of this truth already exists in runtime:
+
+- route status
+- action and review aggregation
+- closeout truth
+- reopen truth
+- follow-up truth
+- one-step lineage reading
+- decision and result history per route
+
+But these truths are still mostly visible only route-by-route. That is enough for detail reading, but too thin for pilot-grade bestuurlijke readback.
+
+---
+
+## 2. Product Boundary
+
+This wave adds a **compact workspace readback layer**, not a full reporting module.
+
+### In scope
+
+- a small workspace-level readback summary built from existing runtime truth
+- compact route-over-time signals for HR and managers
+- summary counts for route state, explicit decision presence, and continuation visibility
+- calm rendering in the overview surface
+- no new write flows
+
+### Out of scope
+
+- trend graphs
+- exports
+- theme analytics
+- multi-period dashboards
+- chain-level lineage exploration
+- introducing a second product area next to the Action Center overview
+
+This wave must keep Action Center positioned as a post-scan follow-through layer, not a standalone reporting product.
+
+---
+
+## 3. Starting Foundation, Split by Reality
+
+### 3.1 Canonically decided
+
+The following are already decided and should not be reopened in this wave:
+
+- route is the bestuurlijke container
+- closeout is explicit route truth
+- reopen is a dedicated route-event truth
+- follow-up is distinct continuation truth
+- lineage reading stays compact and one-step
+- readback should be derived from canonical route truth, not separate reporting state
+
+### 3.2 Product/runtime present enough to build on
+
+The following are already materially present in runtime and can support this wave directly:
+
+- live Action Center items with route status and review dates
+- route summary projection
+- decision history and result progression per route
+- closeout semantics
+- lineage summary and follow-up semantics
+- existing `getLiveActionCenterSummary(...)` as a thin aggregate layer
+
+### 3.3 Directional but not yet hardened enough to overfit the reporting layer to them
+
+The following remain directional and should be read carefully rather than over-modeled:
+
+- multiple action cards as the final repeated-use operating model
+- action-bound review as the final practical review loop
+- manager action creation as the fully settled standard route move
+
+### 3.4 Design consequence
+
+The reporting/readback layer must therefore:
+
+- aggregate from route-level truth first
+- use action and review truth only where already stable enough to summarize safely
+- avoid metrics that assume the action model is already perfectly quiet
+- stay compact enough that later hardening of manager semantics does not force a redesign of the readback layer
+
+---
+
+## 4. Desired Outcome
+
+After this wave, an HR lead, sponsor, or manager should be able to open the Action Center overview and quickly understand:
+
+- how many visible routes are still open versus historically closed
+- how many visible routes already carry explicit decision history
+- where continuation over time is already visible through reopen or follow-up truth
+- what the nearest review pressure still looks like
+
+This should be possible without opening each route one by one.
+
+---
+
+## 5. Readback Model
+
+This wave introduces a small **workspace readback summary** derived from visible route items.
+
+It should answer four bounded questions:
+
+1. how many visible routes are still active versus closed
+2. how many visible routes already have explicit bestuurlijke decision history
+3. how many visible routes show continuation over time through reopen or follow-up truth
+4. what review pressure is nearest in the visible workspace
+
+This is intentionally a bounded pilot-grade readback model, not a broad BI layer.
+
+---
+
+## 6. Summary Segments
+
+### 6.1 Routebeeld
+
+The readback layer should summarize the visible route estate in a compact way:
+
+- active routes
+- closed routes
+- total visible routes
+
+This should remain route-level, not action-level.
+
+### 6.2 Besluitspoor
+
+The readback layer should show how many visible routes already carry explicit bestuurlijke readback through decision history.
+
+This does not mean “good outcome”.
+It only means the route already has an explicit decision track that can be read back.
+
+### 6.3 Vervolg over tijd
+
+The readback layer should summarize continuation visibility over time:
+
+- reopened route presence
+- direct follow-up visibility
+
+This is about whether the route story already spans more than one bestuurlijke round, not about showing the whole chain.
+
+### 6.4 Reviewdruk
+
+The readback layer should keep one compact review-pressure signal:
+
+- how many visible routes have a next review in view
+- what the earliest upcoming review date is
+
+This keeps the summary operationally useful without turning it into a planning board.
+
+---
+
+## 7. Placement
+
+### 7.1 Overview
+
+Overview is the main surface for this wave.
+
+It should show:
+
+- a compact readback block or card
+- summary signals for routebeeld, besluitspoor, vervolg over tijd, and reviewdruk
+
+This readback should sit alongside the current overview, not in a separate reporting screen.
+
+### 7.2 Detail
+
+This wave does not require a new heavy detail surface.
+
+Route detail already contains:
+
+- result progression
+- decision history
+- closeout
+- lineage context
+
+That remains the route-level supporting detail behind the new overview readback.
+
+---
+
+## 8. Projection Rules
+
+### 8.1 One summary source
+
+Workspace readback must project from one aggregate layer built from visible route items.
+
+Overview should not recompute ad hoc counts from different blocks of UI state.
+
+### 8.2 Route deduplication
+
+If a route is represented more than once in future surfaces, the readback layer must still count it once at route level.
+
+### 8.3 Continuation counting
+
+Reopen and direct follow-up should count from canonical route semantics already projected into the item, not from UI-only labels.
+
+### 8.4 Defensive fallback
+
+If a route has incomplete readback truth:
+
+- do not invent historical meaning
+- simply omit that route from the affected subcount
+- keep the rest of the readback summary stable
+
+---
+
+## 9. Pilot Contribution
+
+This wave matters for pilot readiness because it makes Action Center easier to explain and easier to trust.
+
+Without it:
+
+- HR must reconstruct history route by route
+- sponsors do not get a bounded readback layer
+- Action Center looks operational but not yet bestuurlijk mature
+
+With it:
+
+- the product can show that follow-through is not only being done, but also read back coherently
+- without overgrowing into a reporting platform
+
+---
+
+## 10. Non-Goals
+
+This wave must not:
+
+- add charts just to look “reporting-like”
+- create a separate reporting module
+- depend on complete manager-action maturity
+- expose chain-level lineage complexity
+- redefine route status or continuation truth
+
+This is a compact readback layer built from existing Action Center runtime truth.

--- a/frontend/app/api/action-center-route-closeouts/route.test.ts
+++ b/frontend/app/api/action-center-route-closeouts/route.test.ts
@@ -127,7 +127,7 @@ describe('action center route closeouts route', () => {
         closeout_reason: 'voldoende-opgepakt',
         closeout_note: 'Voor nu voldoende opgepakt in teamritme.',
         closed_at: '2026-05-20T09:00:00.000Z',
-        closed_by_role: 'hr',
+        closed_by_role: 'hr_owner',
       },
       error: null,
     })
@@ -175,7 +175,7 @@ describe('action center route closeouts route', () => {
         closeout_status: 'afgerond',
         closeout_reason: 'voldoende-opgepakt',
         closeout_note: 'Voor nu voldoende opgepakt in teamritme.',
-        closed_by_role: 'hr',
+        closed_by_role: 'hr_owner',
         created_by: 'hr-owner-1',
         updated_by: 'hr-owner-1',
       }),
@@ -187,7 +187,94 @@ describe('action center route closeouts route', () => {
       routeId: 'campaign-1::org-1::department::operations',
       closeoutStatus: 'afgerond',
       closeoutReason: 'voldoende-opgepakt',
-      closedByRole: 'hr',
+      closedByRole: 'hr_owner',
+    })
+  })
+
+  it('persists the exact HR workspace role for closeout audit truth', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'hr-member-1' } },
+    })
+    mockLoadSuiteAccessContext.mockResolvedValue({
+      context: { isVerisightAdmin: false },
+      orgMemberships: [{ org_id: 'org-1', role: 'viewer' }],
+      workspaceMemberships: [
+        {
+          org_id: 'org-1',
+          user_id: 'hr-member-1',
+          display_name: 'HR Member',
+          login_email: 'hr.member@example.com',
+          access_role: 'hr_member',
+          scope_type: 'org',
+          scope_value: 'org-1::org::org-1',
+          can_view: true,
+          can_update: true,
+          can_assign: false,
+          can_schedule_review: true,
+        },
+      ],
+    })
+
+    const upsertQuery = createUpsertQuery({
+      data: {
+        route_id: 'campaign-1::org-1::department::operations',
+        campaign_id: 'campaign-1',
+        org_id: 'org-1',
+        route_scope_type: 'department',
+        route_scope_value: 'org-1::department::operations',
+        closeout_status: 'gestopt',
+        closeout_reason: 'bewust-niet-voortzetten',
+        closeout_note: null,
+        closed_at: '2026-05-20T09:00:00.000Z',
+        closed_by_role: 'hr_member',
+      },
+      error: null,
+    })
+
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === 'campaigns') {
+        return createCampaignQuery({
+          data: { id: 'campaign-1', organization_id: 'org-1' },
+          error: null,
+        })
+      }
+
+      if (table === 'respondents') {
+        return createRespondentsQuery({
+          data: [{ department: 'Operations' }],
+        })
+      }
+
+      if (table === 'action_center_route_closeouts') {
+        return upsertQuery
+      }
+
+      throw new Error(`Unexpected table ${table}`)
+    })
+
+    const response = await POST(
+      makeRequest({
+        campaign_id: 'campaign-1',
+        route_scope_type: 'department',
+        route_scope_value: 'org-1::department::operations',
+        closeout_status: 'gestopt',
+        closeout_reason: 'bewust-niet-voortzetten',
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(upsertQuery.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        closed_by_role: 'hr_member',
+        created_by: 'hr-member-1',
+        updated_by: 'hr-member-1',
+      }),
+      { onConflict: 'route_id' },
+    )
+
+    const payload = await response.json()
+    expect(payload.closeout).toMatchObject({
+      closedByRole: 'hr_member',
     })
   })
 })

--- a/frontend/app/api/action-center-route-closeouts/route.ts
+++ b/frontend/app/api/action-center-route-closeouts/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { createClient } from '@/lib/supabase/server'
 import { buildActionCenterRouteId } from '@/lib/action-center-route-contract'
+import { resolveActionCenterHrWriteAccess } from '@/lib/action-center-governance'
 import { loadSuiteAccessContext } from '@/lib/suite-access-server'
 import {
   projectActionCenterRouteCloseout,
@@ -146,7 +147,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ detail: 'Niet ingelogd.' }, { status: 401 })
   }
 
-  const { context, orgMemberships } = await loadSuiteAccessContext(supabase, user.id)
+  const { context, orgMemberships, workspaceMemberships } = await loadSuiteAccessContext(supabase, user.id)
   const routeTruth = await loadCloseoutRouteTruth({
     campaignId: parsed.campaign_id,
     routeScopeType: parsed.route_scope_type,
@@ -156,13 +157,14 @@ export async function POST(request: Request) {
     return NextResponse.json({ detail: 'Route closeout route bestaat niet voor deze campagne.' }, { status: 400 })
   }
 
-  const canCloseRoute =
-    context.isVerisightAdmin ||
-    orgMemberships.some(
-      (membership) => membership.org_id === routeTruth.campaign.organization_id && membership.role === 'owner',
-    )
+  const writeAccess = resolveActionCenterHrWriteAccess({
+    context,
+    orgMemberships,
+    workspaceMemberships,
+    orgId: routeTruth.campaign.organization_id,
+  })
 
-  if (!canCloseRoute) {
+  if (!writeAccess.allowed || !writeAccess.auditRole) {
     return NextResponse.json({ detail: 'Alleen HR of Verisight kan deze route afsluiten.' }, { status: 403 })
   }
 
@@ -188,7 +190,7 @@ export async function POST(request: Request) {
     closeout_reason: parsed.closeout_reason,
     closeout_note: parsed.closeout_note,
     closed_at: closedAt,
-    closed_by_role: 'hr',
+    closed_by_role: writeAccess.auditRole,
     created_by: user.id,
     updated_by: user.id,
     updated_at: closedAt,

--- a/frontend/app/api/action-center-route-follow-ups/route.test.ts
+++ b/frontend/app/api/action-center-route-follow-ups/route.test.ts
@@ -929,7 +929,7 @@ describe('action center route follow-up API contract', () => {
       target_route_scope_value: 'org-1::department::operations',
       trigger_reason: 'hernieuwde-hr-beoordeling',
       recorded_by: HR_USER_ID,
-      recorded_by_role: 'hr',
+      recorded_by_role: 'hr_member',
       manager_user_id: MANAGER_USER_ID,
       ended_at: null,
     })
@@ -938,6 +938,20 @@ describe('action center route follow-up API contract', () => {
         trigger_reason: 'hernieuwde-hr-beoordeling',
         manager_user_id: MANAGER_USER_ID,
       }),
+    })
+  })
+
+  it('persists hr_owner as the audit role when an org owner starts a follow-up route', async () => {
+    mockState.memberRole = 'owner'
+    mockState.workspaceMemberships = []
+
+    const response = await postFollowUp(buildFollowUpRequest())
+
+    expect(response.status).toBe(201)
+    expect(mockState.insertedRelations).toHaveLength(1)
+    expect(mockState.insertedRelations[0]).toMatchObject({
+      recorded_by_role: 'hr_owner',
+      recorded_by: HR_USER_ID,
     })
   })
 

--- a/frontend/app/api/action-center-route-follow-ups/route.ts
+++ b/frontend/app/api/action-center-route-follow-ups/route.ts
@@ -9,6 +9,10 @@ import {
   type ActionCenterManagerResponseWriteInput,
 } from '@/lib/action-center-manager-responses'
 import { buildActionCenterRouteId } from '@/lib/action-center-route-contract'
+import {
+  type ActionCenterGovernanceWriteRole,
+  resolveActionCenterHrWriteAccess,
+} from '@/lib/action-center-governance'
 import { projectActionCenterRouteFollowUpRelation } from '@/lib/action-center-route-reopen'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { createClient } from '@/lib/supabase/server'
@@ -42,7 +46,7 @@ type ManagerResponseCarrierRow = {
 }
 
 type FollowUpWriteAccess = {
-  recordedByRole: 'verisight_admin' | 'hr'
+  recordedByRole: ActionCenterGovernanceWriteRole
 }
 
 type ManagerAssignmentRow = {
@@ -229,27 +233,17 @@ async function loadManagerAssignment(args: {
 async function resolveFollowUpWriteAccess(args: { supabase: SupabaseClient; userId: string; orgId: string }) {
   const { context, orgMemberships, workspaceMemberships } = await loadSuiteAccessContext(args.supabase, args.userId)
 
-  if (context.isVerisightAdmin) {
-    return { access: { recordedByRole: 'verisight_admin' } satisfies FollowUpWriteAccess, error: null }
-  }
+  const writeAccess = resolveActionCenterHrWriteAccess({
+    context,
+    orgMemberships,
+    workspaceMemberships,
+    orgId: args.orgId,
+  })
 
-  const orgMembership = orgMemberships.find((membership) => membership.org_id === args.orgId) ?? null
-  if (orgMembership?.role === 'owner') {
-    return { access: { recordedByRole: 'hr' } satisfies FollowUpWriteAccess, error: null }
-  }
-
-  const hrWorkspaceMembership =
-    workspaceMemberships.find(
-      (membership) =>
-        membership.org_id === args.orgId &&
-        (membership.access_role === 'hr_owner' || membership.access_role === 'hr_member') &&
-        membership.can_update,
-    ) ?? null
-
-  if (hrWorkspaceMembership) {
+  if (writeAccess.allowed && writeAccess.auditRole) {
     return {
       access: {
-        recordedByRole: 'hr',
+        recordedByRole: writeAccess.auditRole,
       } satisfies FollowUpWriteAccess,
       error: null,
     }

--- a/frontend/app/api/action-center-route-reopens/route.test.ts
+++ b/frontend/app/api/action-center-route-reopens/route.test.ts
@@ -116,7 +116,7 @@ describe('action center route reopens route', () => {
         route_scope_value: 'org-1::department::operations',
         reopen_reason: 'te-vroeg-afgesloten',
         reopened_at: '2026-05-21T09:00:00.000Z',
-        reopened_by_role: 'hr',
+        reopened_by_role: 'hr_owner',
       },
       error: null,
     })
@@ -155,7 +155,7 @@ describe('action center route reopens route', () => {
         campaign_id: 'campaign-1',
         org_id: 'org-1',
         reopen_reason: 'te-vroeg-afgesloten',
-        reopened_by_role: 'hr',
+        reopened_by_role: 'hr_owner',
         created_by: 'hr-owner-1',
       }),
     )
@@ -164,7 +164,84 @@ describe('action center route reopens route', () => {
     expect(payload.reopen).toMatchObject({
       routeId: 'campaign-1::org-1::department::operations',
       reopenReason: 'te-vroeg-afgesloten',
-      reopenedByRole: 'hr',
+      reopenedByRole: 'hr_owner',
+    })
+  })
+
+  it('persists the exact HR workspace role for reopen audit truth', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'hr-member-1' } } })
+    mockLoadSuiteAccessContext.mockResolvedValue({
+      context: { isVerisightAdmin: false },
+      orgMemberships: [{ org_id: 'org-1', role: 'viewer' }],
+      workspaceMemberships: [
+        {
+          org_id: 'org-1',
+          user_id: 'hr-member-1',
+          display_name: 'HR Member',
+          login_email: 'hr.member@example.com',
+          access_role: 'hr_member',
+          scope_type: 'org',
+          scope_value: 'org-1::org::org-1',
+          can_view: true,
+          can_update: true,
+          can_assign: false,
+          can_schedule_review: true,
+        },
+      ],
+    })
+
+    const insertQuery = createInsertQuery({
+      data: {
+        route_id: 'campaign-1::org-1::department::operations',
+        campaign_id: 'campaign-1',
+        org_id: 'org-1',
+        route_scope_type: 'department',
+        route_scope_value: 'org-1::department::operations',
+        reopen_reason: 'herbeoordeling',
+        reopened_at: '2026-05-21T09:00:00.000Z',
+        reopened_by_role: 'hr_member',
+      },
+      error: null,
+    })
+
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === 'campaigns') {
+        return createCampaignQuery({
+          data: { id: 'campaign-1', organization_id: 'org-1' },
+          error: null,
+        })
+      }
+      if (table === 'respondents') {
+        return createRespondentsQuery({ data: [{ department: 'Operations' }] })
+      }
+      if (table === 'action_center_route_reopens') {
+        return insertQuery
+      }
+
+      throw new Error(`Unexpected table ${table}`)
+    })
+
+    const response = await POST(
+      makeRequest({
+        route_id: 'campaign-1::org-1::department::operations',
+        campaign_id: 'campaign-1',
+        route_scope_type: 'department',
+        route_scope_value: 'org-1::department::operations',
+        reopen_reason: 'herbeoordeling',
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(insertQuery.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reopened_by_role: 'hr_member',
+        created_by: 'hr-member-1',
+      }),
+    )
+
+    const payload = await response.json()
+    expect(payload.reopen).toMatchObject({
+      reopenedByRole: 'hr_member',
     })
   })
 })

--- a/frontend/app/api/action-center-route-reopens/route.ts
+++ b/frontend/app/api/action-center-route-reopens/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { buildActionCenterRouteId } from '@/lib/action-center-route-contract'
+import { resolveActionCenterHrWriteAccess } from '@/lib/action-center-governance'
 import {
   projectActionCenterRouteReopen,
   type ActionCenterRouteReopenReason,
@@ -147,7 +148,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ detail: 'Niet ingelogd.' }, { status: 401 })
   }
 
-  const { context, orgMemberships } = await loadSuiteAccessContext(supabase, user.id)
+  const { context, orgMemberships, workspaceMemberships } = await loadSuiteAccessContext(supabase, user.id)
   const routeTruth = await loadRouteTruth({
     campaignId: parsed.campaign_id,
     routeScopeType: parsed.route_scope_type,
@@ -157,13 +158,14 @@ export async function POST(request: Request) {
     return NextResponse.json({ detail: 'Route reopen route bestaat niet voor deze campagne.' }, { status: 400 })
   }
 
-  const canReopenRoute =
-    context.isVerisightAdmin ||
-    orgMemberships.some(
-      (membership) => membership.org_id === routeTruth.campaign.organization_id && membership.role === 'owner',
-    )
+  const writeAccess = resolveActionCenterHrWriteAccess({
+    context,
+    orgMemberships,
+    workspaceMemberships,
+    orgId: routeTruth.campaign.organization_id,
+  })
 
-  if (!canReopenRoute) {
+  if (!writeAccess.allowed || !writeAccess.auditRole) {
     return NextResponse.json({ detail: 'Alleen HR of Verisight kan deze route heropenen.' }, { status: 403 })
   }
 
@@ -187,7 +189,7 @@ export async function POST(request: Request) {
     ...identity,
     reopen_reason: parsed.reopen_reason,
     reopened_at: reopenedAt,
-    reopened_by_role: 'hr',
+    reopened_by_role: writeAccess.auditRole,
     created_by: user.id,
     updated_by: user.id,
     updated_at: reopenedAt,

--- a/frontend/components/dashboard/action-center-preview.tsx
+++ b/frontend/components/dashboard/action-center-preview.tsx
@@ -17,7 +17,11 @@ import {
   getActionCenterFollowUpTriggerReasonLabel,
   type ActionCenterRouteFollowUpTriggerReason,
 } from '@/lib/action-center-route-reopen'
-import { finalizeActionCenterPreviewItem } from '@/lib/action-center-live'
+import {
+  finalizeActionCenterPreviewItem,
+  getLiveActionCenterSummary,
+  type ActionCenterWorkspaceReadbackSummary,
+} from '@/lib/action-center-live'
 import type {
   ActionCenterPreviewItem,
   ActionCenterPreviewManagerOption,
@@ -142,6 +146,42 @@ function formatLongDate(value: string | null) {
   const parsed = new Date(value)
   if (Number.isNaN(parsed.getTime())) return value
   return DUTCH_LONG_DATE.format(parsed)
+}
+
+function formatCountLabel(count: number, singular: string, plural = `${singular}s`) {
+  return `${count} ${count === 1 ? singular : plural}`
+}
+
+function getWorkspaceRouteImageSummary(summary: ActionCenterWorkspaceReadbackSummary) {
+  if (summary.routeCount === 0) {
+    return 'Nog geen zichtbare routes in deze workspace.'
+  }
+
+  return `${formatCountLabel(summary.activeRouteCount, 'open route')} en ${formatCountLabel(summary.closedRouteCount, 'gesloten route')} van ${formatCountLabel(summary.routeCount, 'zichtbare route')}.`
+}
+
+function getWorkspaceDecisionTrailSummary(summary: ActionCenterWorkspaceReadbackSummary) {
+  if (summary.decisionRouteCount === 0) {
+    return 'Nog geen routes met expliciet besluitspoor zichtbaar.'
+  }
+
+  return `${formatCountLabel(summary.decisionRouteCount, 'route')} met expliciet besluitspoor in de huidige selectie.`
+}
+
+function getWorkspaceContinuationSummary(summary: ActionCenterWorkspaceReadbackSummary) {
+  if (summary.continuationVisibleRouteCount === 0) {
+    return 'Nog geen heropening of vervolg over tijd zichtbaar.'
+  }
+
+  return `${formatCountLabel(summary.reopenedRouteCount, 'heropende route')} en ${formatCountLabel(summary.followUpVisibleRouteCount, 'route')} met vervolgcontext zichtbaar.`
+}
+
+function getWorkspaceReviewPressureSummary(summary: ActionCenterWorkspaceReadbackSummary) {
+  if (summary.reviewCount === 0 || !summary.nextReviewDate) {
+    return 'Nog geen reviewmomenten zichtbaar in deze selectie.'
+  }
+
+  return `${formatCountLabel(summary.reviewCount, 'route')} met review in beeld, eerstvolgend ${formatShortDate(summary.nextReviewDate)}.`
 }
 
 function getInitials(name: string | null) {
@@ -843,6 +883,7 @@ export function ActionCenterPreview({
   const teamRows = buildTeamRows(items)
   const selectedTeam = teamRows.find((team) => team.id === selectedTeamId) ?? teamRows[0] ?? null
   const allSources = [...new Set(items.map((item) => item.sourceLabel))]
+  const workspaceReadbackSummary = useMemo(() => getLiveActionCenterSummary(items), [items])
   const selectedItemLineage = selectedItem ? buildDetailLineageEntries(selectedItem, previewRouteTitles) : []
   const today = new Date()
   const dueItems = items.filter((item) => isOpenAttentionStatus(item.status))
@@ -1591,27 +1632,21 @@ export function ActionCenterPreview({
                   </section>
 
                   <section className="rounded-[28px] border border-[#e4d9cb] bg-[#fcfaf7] px-7 py-7 shadow-[0_12px_36px_rgba(19,32,51,0.06)]">
-                    <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[#8d8377]">Modulewaarheid</p>
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[#8d8377]">Bestuurlijke teruglezing</p>
                     <h2 className="mt-3 text-[1.45rem] font-semibold tracking-[-0.04em] text-[#132033]">
-                      Action Center blijft een eigen suite-module
+                      Wat is over deze zichtbare routes al bestuurlijk leesbaar?
                     </h2>
                     <p className="mt-4 text-sm leading-8 text-[#4f6175]">
                       {readOnly
-                        ? 'Deze landing leest rustig mee met campagnes, uitvoering en bestaande dossiers. Bewerkbare opvolging openen we alleen waar je rol dat al toelaat.'
-                        : 'Voor echte wijzigingen blijft het onderliggende dossier leidend. Deze preview laat dezelfde werkwijze zien zonder extra routes toe te voegen.'}
+                        ? 'Deze readback blijft bewust compact: hoeveel routes nog lopen, waar expliciete besluitmomenten zichtbaar zijn en waar vervolg over tijd al in beeld komt.'
+                        : 'Deze readback blijft bewust compact: routebeeld, besluitspoor, reviewdruk en vervolg over tijd blijven in dezelfde Action Center-overview leesbaar.'}
                     </p>
 
                     <div className="mt-6 space-y-3">
-                      <SignalRow label="Broncampagnes" value={`${allSources.length} actief in deze selectie`} />
-                      <SignalRow label="Omgeving" value={workspaceSubtitle} />
-                      <SignalRow
-                        label="Eigenaarschap"
-                        value={
-                          missingManagerCount > 0
-                            ? `${missingManagerCount} team${missingManagerCount === 1 ? '' : 's'} vragen nog expliciete toewijzing`
-                            : 'Alle zichtbare teams hebben een expliciete manager'
-                        }
-                      />
+                      <SignalRow label="Routebeeld" value={getWorkspaceRouteImageSummary(workspaceReadbackSummary)} />
+                      <SignalRow label="Besluitspoor" value={getWorkspaceDecisionTrailSummary(workspaceReadbackSummary)} />
+                      <SignalRow label="Vervolg over tijd" value={getWorkspaceContinuationSummary(workspaceReadbackSummary)} />
+                      <SignalRow label="Reviewdruk" value={getWorkspaceReviewPressureSummary(workspaceReadbackSummary)} />
                     </div>
 
                     <Link

--- a/frontend/lib/action-center-governance.test.ts
+++ b/frontend/lib/action-center-governance.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getActionCenterGovernanceActorRoleLabel,
+  isActionCenterGovernanceActorRole,
+  resolveActionCenterHrWriteAccess,
+} from './action-center-governance'
+
+describe('action center governance helpers', () => {
+  it('recognizes canonical governance actor roles', () => {
+    expect(isActionCenterGovernanceActorRole('verisight_admin')).toBe(true)
+    expect(isActionCenterGovernanceActorRole('hr_member')).toBe(true)
+    expect(isActionCenterGovernanceActorRole('unknown')).toBe(false)
+    expect(getActionCenterGovernanceActorRoleLabel('hr_owner')).toBe('HR owner')
+  })
+
+  it('prefers verisight admin when resolving HR write access', () => {
+    expect(
+      resolveActionCenterHrWriteAccess({
+        context: { isVerisightAdmin: true },
+        orgMemberships: [],
+        workspaceMemberships: [],
+        orgId: 'org-1',
+      }),
+    ).toEqual({
+      allowed: true,
+      auditRole: 'verisight_admin',
+    })
+  })
+
+  it('resolves org ownership to hr_owner audit truth', () => {
+    expect(
+      resolveActionCenterHrWriteAccess({
+        context: { isVerisightAdmin: false },
+        orgMemberships: [{ org_id: 'org-1', role: 'owner' }],
+        workspaceMemberships: [],
+        orgId: 'org-1',
+      }),
+    ).toEqual({
+      allowed: true,
+      auditRole: 'hr_owner',
+    })
+  })
+
+  it('resolves hr_member workspace access when no org owner access exists', () => {
+    expect(
+      resolveActionCenterHrWriteAccess({
+        context: { isVerisightAdmin: false },
+        orgMemberships: [{ org_id: 'org-1', role: 'viewer' }],
+        workspaceMemberships: [
+          {
+            org_id: 'org-1',
+            user_id: 'hr-member-1',
+            display_name: 'HR Member',
+            login_email: 'hr.member@example.com',
+            access_role: 'hr_member',
+            scope_type: 'org',
+            scope_value: 'org-1::org::org-1',
+            can_view: true,
+            can_update: true,
+            can_assign: false,
+            can_schedule_review: true,
+          },
+        ],
+        orgId: 'org-1',
+      }),
+    ).toEqual({
+      allowed: true,
+      auditRole: 'hr_member',
+    })
+  })
+
+  it('denies write access without verisight or HR authority', () => {
+    expect(
+      resolveActionCenterHrWriteAccess({
+        context: { isVerisightAdmin: false },
+        orgMemberships: [{ org_id: 'org-1', role: 'viewer' }],
+        workspaceMemberships: [],
+        orgId: 'org-1',
+      }),
+    ).toEqual({
+      allowed: false,
+      auditRole: null,
+    })
+  })
+})

--- a/frontend/lib/action-center-governance.ts
+++ b/frontend/lib/action-center-governance.ts
@@ -1,0 +1,100 @@
+import type {
+  ActionCenterWorkspaceMember,
+  SuiteAccessContext,
+  SuiteOrgMembership,
+} from '@/lib/suite-access'
+
+export type ActionCenterGovernanceActorRole =
+  | 'verisight_admin'
+  | 'verisight'
+  | 'hr_owner'
+  | 'hr_member'
+  | 'hr'
+  | 'manager'
+
+export type ActionCenterGovernanceWriteRole = 'verisight_admin' | 'hr_owner' | 'hr_member'
+
+const ACTION_CENTER_GOVERNANCE_ROLE_SET = new Set<ActionCenterGovernanceActorRole>([
+  'verisight_admin',
+  'verisight',
+  'hr_owner',
+  'hr_member',
+  'hr',
+  'manager',
+])
+
+export function isActionCenterGovernanceActorRole(
+  value: string | null | undefined,
+): value is ActionCenterGovernanceActorRole {
+  return Boolean(value && ACTION_CENTER_GOVERNANCE_ROLE_SET.has(value as ActionCenterGovernanceActorRole))
+}
+
+export function getActionCenterGovernanceActorRoleLabel(role: ActionCenterGovernanceActorRole) {
+  switch (role) {
+    case 'verisight_admin':
+      return 'Verisight admin'
+    case 'verisight':
+      return 'Verisight'
+    case 'hr_owner':
+      return 'HR owner'
+    case 'hr_member':
+      return 'HR member'
+    case 'hr':
+      return 'HR'
+    case 'manager':
+      return 'Manager'
+  }
+}
+
+export function resolveActionCenterHrWriteAccess(args: {
+  context: Pick<SuiteAccessContext, 'isVerisightAdmin'>
+  orgMemberships: SuiteOrgMembership[]
+  workspaceMemberships: ActionCenterWorkspaceMember[]
+  orgId: string
+}):
+  | {
+      allowed: true
+      auditRole: ActionCenterGovernanceWriteRole
+    }
+  | {
+      allowed: false
+      auditRole: null
+    } {
+  if (args.context.isVerisightAdmin) {
+    return {
+      allowed: true,
+      auditRole: 'verisight_admin' as const,
+    }
+  }
+
+  const orgMembership = args.orgMemberships.find((membership) => membership.org_id === args.orgId) ?? null
+  if (orgMembership?.role === 'owner') {
+    return {
+      allowed: true,
+      auditRole: 'hr_owner' as const,
+    }
+  }
+
+  const hrWorkspaceMembership =
+    args.workspaceMemberships.find(
+      (membership) =>
+        membership.org_id === args.orgId &&
+        (membership.access_role === 'hr_owner' || membership.access_role === 'hr_member') &&
+        membership.can_update,
+    ) ?? null
+
+  if (hrWorkspaceMembership) {
+    const auditRole =
+      hrWorkspaceMembership.access_role === 'hr_owner' ? ('hr_owner' as const) : ('hr_member' as const)
+
+    return {
+      allowed: true,
+      auditRole,
+    }
+  }
+
+  return {
+    allowed: false,
+    auditRole: null,
+  }
+}

--- a/frontend/lib/action-center-live.test.ts
+++ b/frontend/lib/action-center-live.test.ts
@@ -6,6 +6,7 @@ import {
   buildActionCenterTelemetryEvents,
   buildLiveActionCenterItems,
   finalizeActionCenterPreviewItem,
+  getLiveActionCenterSummary,
   isLiveActionCenterScanType,
 } from './action-center-live'
 import { buildActionCenterRouteId, projectActionCenterRoute } from './action-center-route-contract'
@@ -499,6 +500,91 @@ describe('live action center builder', () => {
     expect(closedItem?.coreSemantics.routeSummary).toMatchObject({
       stateLabel: 'Afgerond',
       overviewSummary: 'Historische route die later een directe opvolger kreeg.',
+    })
+  })
+
+  it('builds a compact workspace readback summary from visible route truth', () => {
+    const [baseItem] = buildLiveActionCenterItems([buildLiveContext()])
+
+    const decisionItem = {
+      ...baseItem,
+      id: 'route-readback-open',
+      coreSemantics: {
+        ...baseItem.coreSemantics,
+        latestDecision: {
+          decisionEntryId: 'decision-readback-1',
+          sourceRouteId: 'route-readback-open',
+          decision: 'bijstellen',
+          decisionReason: 'De eerste bounded stap vroeg nog aanscherping.',
+          nextCheck: 'Bevestig binnen twee weken of de nieuwe managementstap effect heeft.',
+          decisionRecordedAt: '2026-05-01T10:00:00.000Z',
+          reviewCompletedAt: '2026-05-01T09:30:00.000Z',
+        },
+        decisionHistory: [
+          {
+            decisionEntryId: 'decision-readback-1',
+            sourceRouteId: 'route-readback-open',
+            decision: 'bijstellen',
+            decisionReason: 'De eerste bounded stap vroeg nog aanscherping.',
+            nextCheck: 'Bevestig binnen twee weken of de nieuwe managementstap effect heeft.',
+            decisionRecordedAt: '2026-05-01T10:00:00.000Z',
+            reviewCompletedAt: '2026-05-01T09:30:00.000Z',
+          },
+        ],
+      },
+    }
+    const reopenedItem = {
+      ...baseItem,
+      id: 'route-readback-reopen',
+      title: 'Heropende route',
+      coreSemantics: {
+        ...baseItem.coreSemantics,
+        lineageSummary: {
+          overviewLabel: 'Heropend traject',
+          backwardLabel: 'Heropend traject',
+          backwardRouteId: null,
+          forwardLabel: null,
+          forwardRouteId: null,
+          detailLabels: ['Heropend traject'],
+        },
+      },
+    }
+    const followedUpItem = {
+      ...baseItem,
+      id: 'route-readback-closed',
+      title: 'Historisch afgesloten route',
+      status: 'afgerond' as const,
+      coreSemantics: {
+        ...baseItem.coreSemantics,
+        routeSummary: {
+          stateLabel: 'Afgerond',
+          overviewSummary: 'Historische route die later een directe opvolger kreeg.',
+          routeAsk: 'Lees deze route alleen nog als historische context.',
+          progressSummary: 'Er loopt geen actieve follow-through meer in deze route.',
+        },
+        lineageSummary: {
+          overviewLabel: 'Later opgevolgd',
+          backwardLabel: null,
+          backwardRouteId: null,
+          forwardLabel: 'Later opgevolgd',
+          forwardRouteId: 'route-readback-next',
+          detailLabels: ['Later opgevolgd'],
+        },
+      },
+    }
+
+    const summary = getLiveActionCenterSummary([decisionItem, reopenedItem, followedUpItem])
+
+    expect(summary).toMatchObject({
+      routeCount: 3,
+      activeRouteCount: 2,
+      closedRouteCount: 1,
+      decisionRouteCount: 1,
+      reopenedRouteCount: 1,
+      followUpVisibleRouteCount: 1,
+      continuationVisibleRouteCount: 2,
+      reviewCount: 3,
+      nextReviewDate: '2026-05-12',
     })
   })
 

--- a/frontend/lib/action-center-live.ts
+++ b/frontend/lib/action-center-live.ts
@@ -274,6 +274,22 @@ function getSummaryRouteKey(item: ActionCenterPreviewItem) {
   return item.id.replace(/::action-[^:]+$/, '')
 }
 
+export interface ActionCenterWorkspaceReadbackSummary {
+  routeCount: number
+  productCount: number
+  organizationCount: number
+  actionCount: number
+  blockedCount: number
+  reviewCount: number
+  nextReviewDate: string | null
+  activeRouteCount: number
+  closedRouteCount: number
+  decisionRouteCount: number
+  reopenedRouteCount: number
+  followUpVisibleRouteCount: number
+  continuationVisibleRouteCount: number
+}
+
 function summarizeLiveActionCenterRoutes(items: ActionCenterPreviewItem[]) {
   const routeBuckets = new Map<
     string,
@@ -288,6 +304,9 @@ function summarizeLiveActionCenterRoutes(items: ActionCenterPreviewItem[]) {
         status: 'open' | 'in_review' | 'afgerond' | 'gestopt'
         reviewScheduledFor: string | null
       }>
+      hasDecisionHistory: boolean
+      hasReopenedLineage: boolean
+      hasFollowUpVisibility: boolean
     }
   >()
 
@@ -301,7 +320,17 @@ function summarizeLiveActionCenterRoutes(items: ActionCenterPreviewItem[]) {
       routeStatus: item.status,
       fallbackReviewDate: item.reviewDate,
       actions: [],
+      hasDecisionHistory: false,
+      hasReopenedLineage: false,
+      hasFollowUpVisibility: false,
     }
+
+    const hasDecisionHistory =
+      item.coreSemantics.decisionHistory.length > 0 || Boolean(item.coreSemantics.latestDecision)
+    const hasReopenedLineage = item.coreSemantics.lineageSummary.backwardLabel === 'Heropend traject'
+    const hasFollowUpVisibility =
+      item.coreSemantics.lineageSummary.backwardLabel === 'Vervolg op eerdere route' ||
+      item.coreSemantics.lineageSummary.forwardLabel === 'Later opgevolgd'
 
     routeBuckets.set(routeKey, {
       sourceLabel: current.sourceLabel,
@@ -309,6 +338,9 @@ function summarizeLiveActionCenterRoutes(items: ActionCenterPreviewItem[]) {
       hasBlockedAction: current.hasBlockedAction || item.status === 'geblokkeerd',
       routeStatus: current.routeStatus,
       fallbackReviewDate: current.fallbackReviewDate,
+      hasDecisionHistory: current.hasDecisionHistory || hasDecisionHistory,
+      hasReopenedLineage: current.hasReopenedLineage || hasReopenedLineage,
+      hasFollowUpVisibility: current.hasFollowUpVisibility || hasFollowUpVisibility,
       actions:
         routeActionCards.length > 0
           ? routeActionCards.map((action) => ({
@@ -333,6 +365,9 @@ function summarizeLiveActionCenterRoutes(items: ActionCenterPreviewItem[]) {
       hasBlockedAction: route.hasBlockedAction,
       routeStatus: routeSummary?.routeStatus ?? route.routeStatus,
       nextReviewDate: routeSummary?.nextReviewScheduledFor ?? route.fallbackReviewDate,
+      hasDecisionHistory: route.hasDecisionHistory,
+      hasReopenedLineage: route.hasReopenedLineage,
+      hasFollowUpVisibility: route.hasFollowUpVisibility,
     }
   })
 }
@@ -562,7 +597,7 @@ export function buildLiveActionCenterItems(contexts: LiveActionCenterCampaignCon
     })
 }
 
-export function getLiveActionCenterSummary(items: ActionCenterPreviewItem[]) {
+export function getLiveActionCenterSummary(items: ActionCenterPreviewItem[]): ActionCenterWorkspaceReadbackSummary {
   const routeSummaries = summarizeLiveActionCenterRoutes(items)
   const productLabels = new Set(routeSummaries.map((item) => item.sourceLabel))
   const organizations = new Set(routeSummaries.map((item) => item.ownerSubtitle))
@@ -580,6 +615,14 @@ export function getLiveActionCenterSummary(items: ActionCenterPreviewItem[]) {
     blockedCount: routeSummaries.filter((route) => route.hasBlockedAction).length,
     reviewCount: routeSummaries.filter((route) => route.nextReviewDate).length,
     nextReviewDate,
+    activeRouteCount: routeSummaries.filter((route) => route.routeStatus !== 'afgerond' && route.routeStatus !== 'gestopt').length,
+    closedRouteCount: routeSummaries.filter((route) => route.routeStatus === 'afgerond' || route.routeStatus === 'gestopt').length,
+    decisionRouteCount: routeSummaries.filter((route) => route.hasDecisionHistory).length,
+    reopenedRouteCount: routeSummaries.filter((route) => route.hasReopenedLineage).length,
+    followUpVisibleRouteCount: routeSummaries.filter((route) => route.hasFollowUpVisibility).length,
+    continuationVisibleRouteCount: routeSummaries.filter(
+      (route) => route.hasReopenedLineage || route.hasFollowUpVisibility,
+    ).length,
   }
 }
 

--- a/frontend/lib/action-center-preview-route-fields-render.test.ts
+++ b/frontend/lib/action-center-preview-route-fields-render.test.ts
@@ -244,6 +244,200 @@ describe('action center preview route fields render', () => {
     ])
   })
 
+  it('renders a compact bestuurlijke readback block on the overview surface', () => {
+    const activeItem = finalizeActionCenterPreviewItem({
+      id: 'route-readback-open',
+      code: 'ACT-3001',
+      title: 'Operations vraagt een nieuwe stap',
+      summary: 'De route vraagt een nieuwe lokale stap.',
+      reason: 'Werkdruk bleef zichtbaar na de eerste interventie.',
+      sourceLabel: 'ExitScan',
+      orgId: 'org-1',
+      scopeType: 'department',
+      teamId: 'operations',
+      teamLabel: 'Operations',
+      ownerId: 'manager-1',
+      ownerName: 'Sanne de Vries',
+      ownerRole: 'Manager - Operations',
+      ownerSubtitle: 'Operations',
+      reviewOwnerName: 'Sanne de Vries',
+      priority: 'hoog',
+      status: 'in-uitvoering',
+      reviewDate: '2026-05-12',
+      expectedEffect: 'Zichtbaar maken of de werkdruk lokaal afneemt.',
+      reviewReason: 'De eerste teamreview gaf nog geen stabiele verbetering.',
+      reviewOutcome: 'bijstellen',
+      reviewDateLabel: '12 mei',
+      reviewRhythm: 'Wekelijks',
+      signalLabel: 'ExitScan - Operations',
+      signalBody: 'Werkdruk bleef zichtbaar in hetzelfde team.',
+      nextStep: 'Herplan de teamreview voor volgende week.',
+      peopleCount: 14,
+      updates: [],
+      coreSemantics: {
+        route: {} as never,
+        routeSummary: {
+          stateLabel: 'In uitvoering',
+          overviewSummary: 'De route vraagt een nieuwe lokale stap.',
+          routeAsk: 'Bepaal welke vervolgstap nu verder helpt.',
+          progressSummary: 'Er loopt nu actieve follow-through in deze route.',
+        },
+        reviewSemantics: {} as never,
+        latestDecision: {
+          decisionEntryId: 'decision-1',
+          sourceRouteId: 'route-readback-open',
+          decision: 'bijstellen',
+          decisionReason: 'De eerste teamreview gaf nog geen stabiele verbetering.',
+          nextCheck: 'Toets over een week of de teamdruk zichtbaar daalt.',
+          decisionRecordedAt: '2026-04-25T10:00:00.000Z',
+          reviewCompletedAt: '2026-04-25T09:30:00.000Z',
+        },
+        actionProgress: {
+          currentStep: 'Plan een gerichte teamreview met de manager.',
+          nextStep: 'Herplan de teamreview voor volgende week.',
+          expectedEffect: 'Zichtbaar maken of de werkdruk lokaal afneemt.',
+        },
+        actionFrame: {
+          whyNow: 'Werkdruk bleef zichtbaar na de eerste interventie.',
+          firstStep: 'Plan een gerichte teamreview met de manager.',
+          owner: 'Sanne de Vries',
+          expectedEffect: 'Zichtbaar maken of de werkdruk lokaal afneemt.',
+        },
+        resultLoop: {} as never,
+        resultProgression: [],
+        decisionHistory: [
+          {
+            decisionEntryId: 'decision-1',
+            sourceRouteId: 'route-readback-open',
+            decision: 'bijstellen',
+            decisionReason: 'De eerste teamreview gaf nog geen stabiele verbetering.',
+            nextCheck: 'Toets over een week of de teamdruk zichtbaar daalt.',
+            decisionRecordedAt: '2026-04-25T10:00:00.000Z',
+            reviewCompletedAt: '2026-04-25T09:30:00.000Z',
+          },
+        ],
+        routeActionCards: [],
+        lineageSummary: {
+          overviewLabel: null,
+          backwardLabel: null,
+          backwardRouteId: null,
+          forwardLabel: null,
+          forwardRouteId: null,
+          detailLabels: [],
+        },
+        followUpSemantics: {
+          isDirectSuccessor: false,
+          lineageLabel: null,
+          triggerReason: null,
+          triggerReasonLabel: null,
+          sourceRouteId: null,
+        },
+        closingSemantics: {
+          status: 'lopend',
+          summary: null,
+          historicalSummary: null,
+        },
+      },
+    })
+
+    const historicalItem = finalizeActionCenterPreviewItem({
+      id: 'route-readback-closed',
+      code: 'ACT-3002',
+      title: 'Eerdere route sloot en kreeg vervolg',
+      summary: 'Deze route sloot historisch en kreeg later een opvolger.',
+      reason: 'De eerdere interventie hoeft niet opnieuw geopend te worden.',
+      sourceLabel: 'Pulse',
+      orgId: 'org-1',
+      scopeType: 'department',
+      teamId: 'operations',
+      teamLabel: 'Operations',
+      ownerId: 'manager-2',
+      ownerName: 'Manager Operations',
+      ownerRole: 'Manager - Operations',
+      ownerSubtitle: 'Operations',
+      reviewOwnerName: 'HR lead',
+      priority: 'midden',
+      status: 'afgerond',
+      reviewDate: '2026-05-30',
+      expectedEffect: 'Historische route blijft alleen nog bestuurlijke context.',
+      reviewReason: 'Gebruik de oude route alleen nog als context.',
+      reviewOutcome: 'afronden',
+      reviewDateLabel: '30 mei',
+      reviewRhythm: 'Maandelijks',
+      signalLabel: 'Pulse - Operations',
+      signalBody: 'Een nieuwe opvolger nam het traject over.',
+      nextStep: 'Lees alleen nog terug wat eerder is besloten.',
+      peopleCount: 14,
+      updates: [],
+      coreSemantics: {
+        route: {} as never,
+        routeSummary: {
+          stateLabel: 'Afgerond',
+          overviewSummary: 'Historische route die later een directe opvolger kreeg.',
+          routeAsk: 'Lees deze route alleen nog als historische context.',
+          progressSummary: 'Er loopt geen actieve follow-through meer in deze route.',
+        },
+        reviewSemantics: {} as never,
+        latestDecision: null,
+        actionProgress: {
+          currentStep: null,
+          nextStep: null,
+          expectedEffect: null,
+        },
+        actionFrame: {
+          whyNow: 'Gebruik de oude route alleen nog als context.',
+          firstStep: 'Lees alleen nog terug wat eerder is besloten.',
+          owner: 'Manager Operations',
+          expectedEffect: 'Historische route blijft alleen nog bestuurlijke context.',
+        },
+        resultLoop: {} as never,
+        resultProgression: [],
+        decisionHistory: [],
+        routeActionCards: [],
+        lineageSummary: {
+          overviewLabel: 'Later opgevolgd',
+          backwardLabel: null,
+          backwardRouteId: null,
+          forwardLabel: 'Later opgevolgd',
+          forwardRouteId: 'route-readback-next',
+          detailLabels: ['Later opgevolgd'],
+        },
+        followUpSemantics: {
+          isDirectSuccessor: false,
+          lineageLabel: null,
+          triggerReason: null,
+          triggerReasonLabel: null,
+          sourceRouteId: null,
+        },
+        closingSemantics: {
+          status: 'afgesloten',
+          summary: 'Historische route die later een directe opvolger kreeg.',
+          historicalSummary: 'Gebruik deze route alleen nog als context.',
+        },
+      },
+    })
+
+    const html = renderToStaticMarkup(
+      React.createElement(ActionCenterPreview, {
+        initialItems: [activeItem, historicalItem],
+        fallbackOwnerName: 'Verisight gebruiker',
+        ownerOptions: ['Sanne de Vries', 'Manager Operations'],
+        workbenchHref: '/dashboard',
+        readOnly: true,
+      }),
+    )
+
+    expect(html).toContain('Bestuurlijke teruglezing')
+    expect(html).toContain('Routebeeld')
+    expect(html).toContain('1 open route en 1 gesloten route van 2 zichtbare routes.')
+    expect(html).toContain('Besluitspoor')
+    expect(html).toContain('1 route met expliciet besluitspoor in de huidige selectie.')
+    expect(html).toContain('Vervolg over tijd')
+    expect(html).toContain('0 heropende routes en 1 route met vervolgcontext zichtbaar.')
+    expect(html).toContain('Reviewdruk')
+    expect(html).toContain('2 routes met review in beeld, eerstvolgend 12 mei.')
+  })
+
   it('hides next-check and next-step detail blocks for closing decisions', () => {
     const item = finalizeActionCenterPreviewItem({
       id: 'route-2',

--- a/frontend/lib/action-center-route-closeout.ts
+++ b/frontend/lib/action-center-route-closeout.ts
@@ -1,3 +1,5 @@
+import type { ActionCenterGovernanceActorRole } from './action-center-governance'
+
 export type ActionCenterRouteCloseoutStatus = 'afgerond' | 'gestopt'
 
 export type ActionCenterRouteCloseoutReason =
@@ -8,7 +10,7 @@ export type ActionCenterRouteCloseoutReason =
   | 'bewust-niet-voortzetten'
   | 'elders-opgepakt'
 
-export type ActionCenterRouteCloseoutRole = 'hr' | 'manager'
+export type ActionCenterRouteCloseoutRole = ActionCenterGovernanceActorRole | 'manager'
 
 export interface ActionCenterRouteCloseoutRecord {
   routeId: string
@@ -37,7 +39,14 @@ const CLOSEOUT_REASONS = new Set<ActionCenterRouteCloseoutReason>([
   'bewust-niet-voortzetten',
   'elders-opgepakt',
 ])
-const CLOSEOUT_ROLES = new Set<ActionCenterRouteCloseoutRole>(['hr', 'manager'])
+const CLOSEOUT_ROLES = new Set<ActionCenterRouteCloseoutRole>([
+  'verisight_admin',
+  'verisight',
+  'hr_owner',
+  'hr_member',
+  'hr',
+  'manager',
+])
 
 function normalizeText(value: string | null | undefined) {
   const trimmed = value?.trim() ?? ''

--- a/frontend/lib/action-center-route-reopen.ts
+++ b/frontend/lib/action-center-route-reopen.ts
@@ -1,12 +1,7 @@
+import type { ActionCenterGovernanceActorRole } from './action-center-governance'
 import type { ActionCenterRouteCloseoutRecord } from './action-center-route-closeout'
 
-export type ActionCenterRouteReopenRole =
-  | 'hr'
-  | 'manager'
-  | 'verisight'
-  | 'hr_owner'
-  | 'hr_member'
-  | (string & {})
+export type ActionCenterRouteReopenRole = ActionCenterGovernanceActorRole | 'manager'
 
 export type ActionCenterRouteReopenReason =
   | 'te-vroeg-afgesloten'
@@ -75,6 +70,7 @@ const FOLLOW_UP_TRIGGER_REASONS = new Set<ActionCenterRouteFollowUpTriggerReason
   'hernieuwde-hr-beoordeling',
 ])
 const REOPEN_ROLES = new Set<ActionCenterRouteReopenRole>([
+  'verisight_admin',
   'hr',
   'manager',
   'verisight',

--- a/supabase/action_center_governance_roles_patch.sql
+++ b/supabase/action_center_governance_roles_patch.sql
@@ -1,0 +1,48 @@
+alter table public.action_center_route_closeouts
+  drop constraint if exists action_center_route_closeouts_closed_by_role_check;
+
+alter table public.action_center_route_closeouts
+  add constraint action_center_route_closeouts_closed_by_role_check
+  check (
+    closed_by_role in (
+      'verisight_admin',
+      'verisight',
+      'hr_owner',
+      'hr_member',
+      'hr',
+      'manager'
+    )
+  );
+
+alter table public.action_center_route_reopens
+  drop constraint if exists action_center_route_reopens_reopened_by_role_check;
+
+alter table public.action_center_route_reopens
+  add constraint action_center_route_reopens_reopened_by_role_check
+  check (
+    reopened_by_role in (
+      'verisight_admin',
+      'verisight',
+      'hr_owner',
+      'hr_member',
+      'hr',
+      'manager'
+    )
+  );
+
+alter table public.action_center_route_relations
+  drop constraint if exists action_center_route_relations_recorded_by_role_check;
+
+alter table public.action_center_route_relations
+  add constraint action_center_route_relations_recorded_by_role_check
+  check (
+    recorded_by_role in (
+      'verisight_admin',
+      'hr_owner',
+      'hr_member',
+      'hr',
+      'manager'
+    )
+  );
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- add the Wave 3 bestuurlijke readback summary layer to the Action Center preview surface
- harden Wave 4 governance writes with shared HR/admin resolution and exact audit roles
- add focused docs, tests, and a Supabase compatibility patch for governance actor roles

## Test Plan
- `npm test -- "lib/action-center-live.test.ts" "lib/action-center-preview-route-fields-render.test.ts"`
- `npm test -- "app/api/action-center-route-closeouts/route.test.ts" "app/api/action-center-route-reopens/route.test.ts" "app/api/action-center-route-follow-ups/route.test.ts" "lib/action-center-governance.test.ts"`
- `npx eslint "lib/action-center-live.ts" "components/dashboard/action-center-preview.tsx" "lib/action-center-live.test.ts" "lib/action-center-preview-route-fields-render.test.ts" "lib/action-center-governance.ts" "lib/action-center-route-closeout.ts" "lib/action-center-route-reopen.ts" "app/api/action-center-route-closeouts/route.ts" "app/api/action-center-route-reopens/route.ts" "app/api/action-center-route-follow-ups/route.ts" "app/api/action-center-route-closeouts/route.test.ts" "app/api/action-center-route-reopens/route.test.ts" "app/api/action-center-route-follow-ups/route.test.ts" "lib/action-center-governance.test.ts"`
- `npm run build`