### PR TITLE
Action Center pilot ops health and runbook

### DIFF
--- a/docs/ACTION_CENTER_PILOT_OPS_RUNBOOK.md
+++ b/docs/ACTION_CENTER_PILOT_OPS_RUNBOOK.md
@@ -1,0 +1,52 @@
+# Action Center Pilot Ops Runbook
+
+## Doel
+Dit runbook is de bounded supportlaag voor pilotgebruik van Action Center.
+Het is bedoeld voor Verisight-operators die moeten controleren of de kernflow nog geloofwaardig werkt zonder eerst in losse tabellen of browserworkarounds te verdwalen.
+
+## Dagelijkse health check
+Controleer in `Beheer -> Health review` minimaal:
+- `Action Center pilot-ops`
+- `Kritieke flow coverage`
+- laatste Action Center evidence timestamp
+
+Voor een gezonde pilotset wil je minimaal evidence kunnen teruglezen voor:
+- `Route geopend`
+- `Manager toegewezen`
+- `Review gepland`
+
+`Closeout vastgelegd` mag nog nul zijn in een jonge pilot, maar moet later zichtbaar kunnen worden.
+
+## Als HR meldt dat opvolging niet lijkt te landen
+Controleer in deze volgorde:
+1. bestaat er recente `Route geopend` evidence
+2. bestaat er recente `Manager toegewezen` evidence
+3. bestaat er een `Review gepland` event
+4. is de route in Action Center zichtbaar met de juiste owner en lineagecontext
+
+Als stap 1 of 2 ontbreekt:
+- controleer de route-open of follow-up write-path
+- controleer governance-role truth op de laatste write
+
+Als stap 3 ontbreekt:
+- controleer of de managerhandeling of reviewplanning daadwerkelijk is opgeslagen
+
+## Als manager aangeeft dat een route “verdwenen” is
+Controleer:
+1. `?focus=` navigatie of directe routefocus
+2. of de route gesloten, heropend of opgevolgd is
+3. of lineage alleen context geeft en niet per ongeluk de actuele route overschrijft
+4. of recente telemetry nog nieuw Action Center gebruik laat zien
+
+## Recovery-lijn
+Gebruik bij twijfel deze bounded herstelvolgorde:
+1. health review
+2. pilot seed opnieuw draaien in testomgeving
+3. kritieke route-API tests draaien
+4. browserflow opnieuw controleren
+5. pas daarna live data of schema-issues onderzoeken
+
+## Niet doen
+- niet meteen aannemen dat ontbrekende telemetry hetzelfde is als ontbrekende route-truth
+- niet direct productsemantiek aanpassen voor een operationeel incident
+- niet meerdere handmatige follow-up writes uitvoeren om een ontbrekende route te “forceren”

--- a/docs/superpowers/plans/2026-05-02-action-center-reliable-ops.md
+++ b/docs/superpowers/plans/2026-05-02-action-center-reliable-ops.md
@@ -1,0 +1,35 @@
+# Action Center Reliable Operation Plan
+
+## Objective
+Add a small but real operations-readiness slice for Action Center pilots by turning existing telemetry into a bounded health snapshot and documenting first-line recovery order.
+
+## Task 1: Add Action Center ops health summarizer
+- Build a helper that summarizes existing suite telemetry rows into:
+  - critical event coverage
+  - per-event counts
+  - latest Action Center evidence
+
+Verification:
+- helper test covers missing and present critical events
+
+## Task 2: Extend the admin health review page
+- Add a dedicated Action Center pilot-ops section to the existing Verisight admin health surface.
+- Keep it compact and operational.
+
+Verification:
+- health page test asserts the new section and coverage copy
+
+## Task 3: Add pilot ops runbook
+- Write a compact internal runbook that explains:
+  - what to check first
+  - what critical telemetry evidence means
+  - bounded recovery order
+
+Verification:
+- runbook exists in repo and matches the implemented health surface
+
+## Task 4: Verify and package
+- Run focused tests.
+- Run ESLint on touched files.
+- Run `npm run build`.
+- Commit, push, and open a draft PR.

--- a/docs/superpowers/specs/2026-05-02-action-center-reliable-ops-design.md
+++ b/docs/superpowers/specs/2026-05-02-action-center-reliable-ops-design.md
@@ -1,0 +1,45 @@
+# Action Center Reliable Operation Design
+
+## Goal
+Wave 5 adds a bounded operations layer for Action Center pilots.
+The focus is not broad observability, but a compact health and runbook surface for the critical Action Center handoff and closeout flow.
+
+## Foundation Split
+
+### Canonically decided
+- Action Center is a post-scan follow-through layer.
+- Pilot-ready use requires not only product semantics, but also supportable operations evidence.
+
+### Product/runtime present
+- Suite telemetry already records Action Center route open, owner assignment, review scheduling, outcome, and closeout events.
+- A Verisight-only health review page already exists.
+
+### Directional but not yet hardened
+- Action Center evidence is present, but not yet summarized into a bounded pilot-ops read.
+- Support/recovery knowledge still lives too much in branch history and operator memory.
+
+## Scope
+- Add a compact Action Center operations snapshot to the existing health page.
+- Summarize coverage for critical Action Center events.
+- Add a small pilot ops runbook for support and recovery order.
+
+## Not in scope
+- Full observability stack
+- alerts
+- incident automation
+- cross-product SRE instrumentation
+
+## Design Rules
+- Reuse existing suite telemetry truth.
+- Show only the few Action Center events that matter most for pilot support:
+  - route opened
+  - owner assigned
+  - review scheduled
+  - closeout recorded
+- Keep the health read bounded and admin-facing.
+
+## Deliverables
+- `action-center-ops-health` helper
+- health page Action Center pilot-ops section
+- helper and page tests
+- compact Action Center pilot ops runbook

--- a/frontend/app/(dashboard)/beheer/health/page.test.ts
+++ b/frontend/app/(dashboard)/beheer/health/page.test.ts
@@ -34,6 +34,24 @@ vi.mock('@/lib/telemetry/store', () => ({
       payload: {},
       createdAt: '2026-04-27T11:00:00.000Z',
     },
+    {
+      id: 'evt_3',
+      eventType: 'action_center_route_opened',
+      orgId: 'org_1',
+      campaignId: 'cmp_1',
+      actorId: 'user_2',
+      payload: {},
+      createdAt: '2026-04-27T11:30:00.000Z',
+    },
+    {
+      id: 'evt_4',
+      eventType: 'action_center_review_scheduled',
+      orgId: 'org_1',
+      campaignId: 'cmp_1',
+      actorId: 'user_2',
+      payload: {},
+      createdAt: '2026-04-27T11:45:00.000Z',
+    },
   ],
 }))
 
@@ -45,6 +63,9 @@ describe('beheer health page', () => {
     expect(html).toContain('Suite health evidence')
     expect(html).toContain('Owner access confirmed')
     expect(html).toContain('Manager denied insights')
+    expect(html).toContain('Action Center pilot-ops')
+    expect(html).toContain('Kritieke flow coverage')
+    expect(html).toContain('Route geopend, Review gepland zichtbaar in de huidige telemetryset.')
     expect(html).toContain('Recente evidence')
   })
 })

--- a/frontend/app/(dashboard)/beheer/health/page.tsx
+++ b/frontend/app/(dashboard)/beheer/health/page.tsx
@@ -2,6 +2,10 @@ import React from 'react'
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { DashboardChip, DashboardHero, DashboardPanel, DashboardSection } from '@/components/dashboard/dashboard-primitives'
+import {
+  getActionCenterOpsEventLabel,
+  summarizeActionCenterOpsHealth,
+} from '@/lib/action-center-ops-health'
 import { countSuiteTelemetryEventRows, getSuiteTelemetryEventLabel } from '@/lib/telemetry/events'
 import { listSuiteTelemetryEventRows } from '@/lib/telemetry/store'
 import { createClient } from '@/lib/supabase/server'
@@ -28,6 +32,7 @@ export default async function HealthPage() {
 
   const rows = await listSuiteTelemetryEventRows()
   const counts = countSuiteTelemetryEventRows(rows)
+  const actionCenterOps = summarizeActionCenterOpsHealth(rows)
 
   return (
     <div className="space-y-6">
@@ -61,6 +66,37 @@ export default async function HealthPage() {
           <DashboardPanel title="Manager denied insights" value={`${counts.manager_denied_insights}`} body="Manager-only persona blijft buiten insight-routes." tone="amber" />
           <DashboardPanel title="Action Center review scheduled" value={`${counts.action_center_review_scheduled}`} body="Reviewmomenten die expliciet gepland zijn." tone="slate" />
           <DashboardPanel title="Action Center closeout recorded" value={`${counts.action_center_closeout_recorded}`} body="Follow-through items met expliciete closeout." tone="slate" />
+        </div>
+      </DashboardSection>
+
+      <DashboardSection
+        title="Action Center pilot-ops"
+        description="Compacte operations-read voor de kritieke Action Center handoff- en closeoutpaden. Bedoeld als bounded supportlaag, niet als full observability stack."
+      >
+        <div className="grid gap-4 lg:grid-cols-4">
+          <DashboardPanel title="Routes geopend" value={`${actionCenterOps.routeOpenedCount}`} body="Aantal zichtbare route-open events in de huidige evidence set." tone="slate" />
+          <DashboardPanel title="Managers toegewezen" value={`${actionCenterOps.ownerAssignedCount}`} body="Eigenaarschap bevestigd via Action Center telemetry." tone="slate" />
+          <DashboardPanel title="Reviews gepland" value={`${actionCenterOps.reviewScheduledCount}`} body="Reviewmomenten die operations direct kan terugvinden." tone="emerald" />
+          <DashboardPanel title="Closeouts vastgelegd" value={`${actionCenterOps.closeoutRecordedCount}`} body="Routes met expliciet bestuurlijk slot in de huidige evidence." tone="slate" />
+        </div>
+        <div className="rounded-[2rem] border border-slate-200 bg-white p-6">
+          <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-slate-500">Kritieke flow coverage</h3>
+          <p className="mt-3 text-sm text-slate-700">
+            {actionCenterOps.coveredEventTypes.length > 0
+              ? `${actionCenterOps.coveredEventTypes.map(getActionCenterOpsEventLabel).join(', ')} zichtbaar in de huidige telemetryset.`
+              : 'Nog geen Action Center operations-evidence zichtbaar in de huidige telemetryset.'}
+          </p>
+          <p className="mt-2 text-sm text-slate-600">
+            {actionCenterOps.missingEventTypes.length > 0
+              ? `Nog niet zichtbaar: ${actionCenterOps.missingEventTypes.map(getActionCenterOpsEventLabel).join(', ')}.`
+              : 'Alle bounded pilotkritieke Action Center flowstappen zijn minimaal een keer in telemetry terug te lezen.'}
+          </p>
+          <p className="mt-2 text-sm text-slate-500">
+            Laatste Action Center evidence:{' '}
+            {actionCenterOps.latestEventAt
+              ? new Date(actionCenterOps.latestEventAt).toLocaleString('nl-NL')
+              : 'nog niet aanwezig'}
+          </p>
         </div>
       </DashboardSection>
 

--- a/frontend/lib/action-center-ops-health.test.ts
+++ b/frontend/lib/action-center-ops-health.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getActionCenterOpsEventLabel,
+  summarizeActionCenterOpsHealth,
+} from './action-center-ops-health'
+import type { SuiteTelemetryEventRow } from '@/lib/telemetry/events'
+
+describe('action center ops health', () => {
+  it('summarizes critical action center telemetry evidence for pilot operations', () => {
+    const rows: SuiteTelemetryEventRow[] = [
+      {
+        id: 'evt-1',
+        eventType: 'action_center_route_opened',
+        orgId: 'org-1',
+        campaignId: 'cmp-1',
+        actorId: 'user-1',
+        payload: {},
+        createdAt: '2026-05-02T09:00:00.000Z',
+      },
+      {
+        id: 'evt-2',
+        eventType: 'action_center_owner_assigned',
+        orgId: 'org-1',
+        campaignId: 'cmp-1',
+        actorId: 'user-1',
+        payload: {},
+        createdAt: '2026-05-02T09:05:00.000Z',
+      },
+      {
+        id: 'evt-3',
+        eventType: 'action_center_review_scheduled',
+        orgId: 'org-1',
+        campaignId: 'cmp-1',
+        actorId: 'user-2',
+        payload: {},
+        createdAt: '2026-05-02T09:10:00.000Z',
+      },
+    ]
+
+    expect(summarizeActionCenterOpsHealth(rows)).toEqual({
+      totalEventCount: 3,
+      latestEventAt: '2026-05-02T09:10:00.000Z',
+      coveredEventTypes: [
+        'action_center_route_opened',
+        'action_center_owner_assigned',
+        'action_center_review_scheduled',
+      ],
+      missingEventTypes: ['action_center_closeout_recorded'],
+      routeOpenedCount: 1,
+      ownerAssignedCount: 1,
+      reviewScheduledCount: 1,
+      closeoutRecordedCount: 0,
+    })
+  })
+
+  it('returns stable Dutch labels for critical action center ops events', () => {
+    expect(getActionCenterOpsEventLabel('action_center_closeout_recorded')).toBe('Closeout vastgelegd')
+  })
+})

--- a/frontend/lib/action-center-ops-health.ts
+++ b/frontend/lib/action-center-ops-health.ts
@@ -1,0 +1,61 @@
+import type { SuiteTelemetryEventRow, SuiteTelemetryEventType } from '@/lib/telemetry/events'
+
+const ACTION_CENTER_CRITICAL_EVENT_TYPES = [
+  'action_center_route_opened',
+  'action_center_owner_assigned',
+  'action_center_review_scheduled',
+  'action_center_closeout_recorded',
+] as const satisfies readonly SuiteTelemetryEventType[]
+
+export type ActionCenterCriticalEventType = (typeof ACTION_CENTER_CRITICAL_EVENT_TYPES)[number]
+
+export interface ActionCenterOpsHealthSnapshot {
+  totalEventCount: number
+  latestEventAt: string | null
+  coveredEventTypes: ActionCenterCriticalEventType[]
+  missingEventTypes: ActionCenterCriticalEventType[]
+  routeOpenedCount: number
+  ownerAssignedCount: number
+  reviewScheduledCount: number
+  closeoutRecordedCount: number
+}
+
+export function getActionCenterOpsEventLabel(eventType: ActionCenterCriticalEventType) {
+  switch (eventType) {
+    case 'action_center_route_opened':
+      return 'Route geopend'
+    case 'action_center_owner_assigned':
+      return 'Manager toegewezen'
+    case 'action_center_review_scheduled':
+      return 'Review gepland'
+    case 'action_center_closeout_recorded':
+      return 'Closeout vastgelegd'
+  }
+}
+
+export function summarizeActionCenterOpsHealth(rows: SuiteTelemetryEventRow[]): ActionCenterOpsHealthSnapshot {
+  const actionCenterRows = rows.filter((row) =>
+    ACTION_CENTER_CRITICAL_EVENT_TYPES.includes(row.eventType as ActionCenterCriticalEventType),
+  )
+  const coveredEventTypes = ACTION_CENTER_CRITICAL_EVENT_TYPES.filter((eventType) =>
+    actionCenterRows.some((row) => row.eventType === eventType),
+  )
+  const missingEventTypes = ACTION_CENTER_CRITICAL_EVENT_TYPES.filter(
+    (eventType) => !coveredEventTypes.includes(eventType),
+  )
+  const latestEventAt =
+    actionCenterRows
+      .map((row) => row.createdAt)
+      .sort((left, right) => right.localeCompare(left))[0] ?? null
+
+  return {
+    totalEventCount: actionCenterRows.length,
+    latestEventAt,
+    coveredEventTypes,
+    missingEventTypes,
+    routeOpenedCount: actionCenterRows.filter((row) => row.eventType === 'action_center_route_opened').length,
+    ownerAssignedCount: actionCenterRows.filter((row) => row.eventType === 'action_center_owner_assigned').length,
+    reviewScheduledCount: actionCenterRows.filter((row) => row.eventType === 'action_center_review_scheduled').length,
+    closeoutRecordedCount: actionCenterRows.filter((row) => row.eventType === 'action_center_closeout_recorded').length,
+  }
+}


### PR DESCRIPTION
## Summary
- add a bounded Action Center pilot-ops snapshot to the admin health review surface
- summarize critical route-open, owner-assignment, review, and closeout telemetry into one compact operations read
- add a small Action Center pilot ops runbook plus focused helper and page tests

## Test Plan
- `npm test -- "lib/action-center-ops-health.test.ts" "app/(dashboard)/beheer/health/page.test.ts"`
- `npx eslint "lib/action-center-ops-health.ts" "lib/action-center-ops-health.test.ts" "app/(dashboard)/beheer/health/page.tsx" "app/(dashboard)/beheer/health/page.test.ts"`
- `npm run build`