### PR TITLE
Wave 6: mature action center UX states

### DIFF
--- a/docs/superpowers/plans/2026-05-02-action-center-ux-volwassenheid.md
+++ b/docs/superpowers/plans/2026-05-02-action-center-ux-volwassenheid.md
@@ -1,0 +1,45 @@
+# Plan: Action Center UX-Volwassenheid
+
+## Objective
+Make the existing Action Center runtime feel calmer and more intentional by improving state readability, empty-state meaning, and route-summary clarity without changing core truth or flow semantics.
+
+## Scope
+
+In scope:
+
+- Action Center preview/detail rendering
+- route summary copy and section empty states
+- tests covering preview render output and route shell expectations
+
+Out of scope:
+
+- new statuses
+- new APIs or schema work
+- governance logic
+- scan-to-route bridge changes
+
+## Steps
+
+1. Inspect the current preview surface and identify the route phases that still read as accidental emptiness or internal scaffolding.
+2. Update preview rendering so route summary and section copy better distinguish:
+   - awaiting first move
+   - bounded small route
+   - active action route
+   - closed historical route
+3. Tighten copy around historical and followed-up routes so they read as intentionally completed.
+4. Add or update focused render/shell tests that assert the new UX contract without widening semantics.
+5. Run targeted tests, lint, and build.
+6. Commit, push, open draft PR, and merge when clean.
+
+## Verification
+
+- targeted Vitest for preview/render/shell coverage
+- `eslint` on touched files
+- `npm run build`
+
+## Done When
+
+- the Action Center preview feels more phase-aware and less accidentally empty
+- closed and quiet states read intentionally
+- no truth/model changes were required
+- verification is green

--- a/docs/superpowers/specs/2026-05-02-action-center-ux-volwassenheid-design.md
+++ b/docs/superpowers/specs/2026-05-02-action-center-ux-volwassenheid-design.md
@@ -1,0 +1,125 @@
+# Action Center UX-Volwassenheid
+
+## Status
+Proposed
+
+## Intent
+This wave makes the existing Action Center runtime feel calmer, clearer, and more commercially credible without re-opening route semantics or introducing new workflow weight.
+
+This is explicitly a **state-clarity and confidence pass**, not a redesign of route truth, manager action truth, or governance.
+
+---
+
+## 1. Goal
+
+Wave 6 should make the current Action Center surface easier to trust in repeated pilot use.
+
+The user should more quickly understand:
+
+- what kind of route they are looking at
+- whether it still needs a first step, active follow-through, review, or only historical reading
+- why a section is empty
+- what to do next without feeling pushed into a heavier workflow than necessary
+
+---
+
+## 2. Product Boundary
+
+This wave may:
+
+- improve state copy
+- improve empty, quiet, and completed states
+- strengthen visual hierarchy inside the preview/detail surface
+- make route summary, lineage, manager-action phase, and follow-up affordances read more calmly
+- tighten scanability for HR and manager
+
+This wave must not:
+
+- invent new route statuses
+- re-open the manager action model
+- add new governance moves
+- add new reporting surfaces
+- add new required fields or workflow steps
+
+---
+
+## 3. Current Runtime Basis
+
+Already present in runtime and safe to build on:
+
+- route summary cards
+- lineage labels
+- follow-up route affordance
+- manager action phase distinction
+- route closeout and review history visibility
+
+Still rough in presentation:
+
+- several empty states read as technical absence instead of intentional boundedness
+- the same surface mixes active, quiet, historical, and blocked states with limited tonal separation
+- some copy still sounds like internal product scaffolding rather than mature pilot UX
+- some route sections tell the user that nothing is there, but not why that is acceptable
+
+---
+
+## 4. Desired UX Outcome
+
+The surface should feel:
+
+- calm rather than busy
+- bounded rather than incomplete
+- explicit rather than implicit
+- historical when closed
+- lightly operational when active
+
+In practice this means:
+
+- empty states explain the current route phase, not only the missing data
+- summary language reinforces route meaning before section detail
+- historical routes feel intentionally closed instead of abandoned
+- follow-up and lineage remain secondary context, not the main headline
+
+---
+
+## 5. Scope of the Implementation Slice
+
+This wave should stay inside the existing Action Center runtime surfaces:
+
+- `frontend/components/dashboard/action-center-preview.tsx`
+- existing route summary / preview render helpers
+- Action Center route shell assertions and preview rendering tests
+
+Preferred changes:
+
+- strengthen empty-state copy for first-step, action-card, review, and historical sections
+- make route-level summary lines more phase-aware
+- distinguish bounded small routes from genuinely missing data
+- make closed and followed-up routes feel intentionally finished
+- preserve the current route/action/review semantics while making them easier to read
+
+---
+
+## 6. Success Criteria
+
+This wave succeeds when:
+
+- an HR or manager user can distinguish "waiting for first step", "actively moving", and "historical/closed" more quickly
+- empty sections no longer feel like broken UI by default
+- route summary text better matches the actual route phase
+- no new truth or workflow concepts are introduced
+- the current browser/runtime behavior remains intact
+
+---
+
+## 7. What Stays Unchanged
+
+This wave does **not** change:
+
+- route status derivation
+- action truth
+- review truth
+- lineage truth
+- governance rules
+- scan-to-route bridge semantics
+
+It is a maturity pass on how the existing system reads in runtime.

--- a/frontend/components/dashboard/action-center-preview.tsx
+++ b/frontend/components/dashboard/action-center-preview.tsx
@@ -315,6 +315,16 @@ function getDecisionLabel(decision: ActionCenterDecision) {
   }
 }
 
+function getHistoricalRouteLabel(item: ActionCenterPreviewItem) {
+  const closingStatus = item.coreSemantics.closingSemantics.status
+
+  if (closingStatus === 'gestopt' || item.status === 'gestopt') {
+    return 'Bewust gestopt'
+  }
+
+  return 'Afgerond voor nu'
+}
+
 function compareReviewDate(left: string | null, right: string | null) {
   if (!left && !right) return 0
   if (!left) return 1
@@ -423,7 +433,8 @@ function getManagerActionSurfaceCopy(item: ActionCenterPreviewItem | null) {
             ? 'Deze route draagt nu een expliciete actiekaart. De eerste managerstap blijft zichtbaar als startcontext; uitvoering en review lopen nu primair via die actie.'
             : `Deze route draagt nu ${actionCardCount} expliciete actiekaarten. De eerste managerstap blijft zichtbaar als startcontext; uitvoering en review lopen nu primair via die acties.`,
         saveLabel: 'Managerstap bijwerken',
-        emptyText: 'Deze route wacht nog op de eerste managerstap.',
+        emptyText:
+          'Deze route wacht nog op een eerste lichte managerreactie. Tot die er is, blijft hij bewust klein en bestuurlijk leesbaar.',
         primaryActionToggle:
           'Gebruik dit alleen zolang één eerste concrete stap genoeg is. Zodra aparte actiekaarten bestaan, wordt die actielaag leidend.',
         readOnlyHint:
@@ -436,7 +447,8 @@ function getManagerActionSurfaceCopy(item: ActionCenterPreviewItem | null) {
         description:
           'Deze route heeft al een eerste concrete managerstap. Pas als er daarna extra parallelle follow-through nodig is, groeit dit door naar expliciete actiekaarten.',
         saveLabel: 'Managerstap bijwerken',
-        emptyText: 'Deze route wacht nog op de eerste managerstap.',
+        emptyText:
+          'Deze route wacht nog op een eerste lichte managerreactie. Tot die er is, blijft hij bewust klein en bestuurlijk leesbaar.',
         primaryActionToggle:
           'Gebruik dit alleen als één eerste concrete stap nu echt helpt. De route hoeft niet meteen rijker te worden dan dit.',
         readOnlyHint:
@@ -449,7 +461,8 @@ function getManagerActionSurfaceCopy(item: ActionCenterPreviewItem | null) {
         description:
           'Deze route heeft al een eerste managerstap en reviewafspraak. Houd de route bewust klein totdat een aparte concrete actie echt helpt.',
         saveLabel: 'Managerstap bijwerken',
-        emptyText: 'Deze route wacht nog op de eerste managerstap.',
+        emptyText:
+          'Deze route wacht nog op een eerste lichte managerreactie. Tot die er is, blijft hij bewust klein en bestuurlijk leesbaar.',
         primaryActionToggle:
           'Leg alleen als dit meteen helpt één eerste concrete stap vast. Zonder die stap blijft de route bewust klein en reviewbaar.',
         readOnlyHint:
@@ -463,7 +476,8 @@ function getManagerActionSurfaceCopy(item: ActionCenterPreviewItem | null) {
         description:
           'HR heeft deze route lokaal geopend. De manager reageert eerst klein: erken wat nu moet gebeuren, leg de eerste bounded stap vast en plan meteen het eerste reviewmoment.',
         saveLabel: 'Eerste managerstap opslaan',
-        emptyText: 'Deze route wacht nog op de eerste managerstap.',
+        emptyText:
+          'Deze route wacht nog op een eerste lichte managerreactie. Tot die er is, blijft hij bewust klein en bestuurlijk leesbaar.',
         primaryActionToggle:
           'Leg alleen als dit meteen helpt één eerste concrete stap vast. Zonder die stap blijft de route bewust klein en reviewbaar.',
         readOnlyHint: null,
@@ -474,7 +488,7 @@ function getManagerActionSurfaceCopy(item: ActionCenterPreviewItem | null) {
 function getRouteSummaryDisplay(item: ActionCenterPreviewItem) {
   return (
     item.coreSemantics.routeSummary ?? {
-      stateLabel: getStatusMeta(item.status).label,
+      stateLabel: isClosedRouteStatus(item.status) ? getHistoricalRouteLabel(item) : getStatusMeta(item.status).label,
       overviewSummary: item.summary || item.reason || 'Nog geen route-read beschikbaar.',
       routeAsk:
         item.reviewReason ||
@@ -483,7 +497,9 @@ function getRouteSummaryDisplay(item: ActionCenterPreviewItem) {
       progressSummary:
         item.nextStep ||
         item.expectedEffect ||
-        'Nog geen compacte voortgangssamenvatting zichtbaar.',
+        (isClosedRouteStatus(item.status)
+          ? 'Deze route is historisch gesloten; extra voortgang is hier niet meer nodig.'
+          : 'Nog geen compacte voortgangssamenvatting zichtbaar.'),
     }
   )
 }
@@ -1951,7 +1967,13 @@ export function ActionCenterPreview({
                               </div>
                             ) : (
                               <div className="mt-3">
-                                <EmptyBlock text="Nog geen expliciete reviewbeslissing vastgelegd in deze route." />
+                                <EmptyBlock
+                                  text={
+                                    isClosedRouteStatus(selectedItem.status)
+                                      ? 'Deze route is al historisch gesloten; een aparte laatste reviewbeslissing hoeft hier niet meer zichtbaar te zijn.'
+                                      : 'Nog geen expliciete reviewbeslissing vastgelegd in deze route.'
+                                  }
+                                />
                               </div>
                             )}
                           </div>
@@ -2008,7 +2030,13 @@ export function ActionCenterPreview({
                             <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/48">Resultaat over tijd</p>
                             <div className="mt-3 space-y-3">
                               {selectedItem.coreSemantics.resultProgression.length === 0 ? (
-                                <EmptyBlock text="Nog geen opeenvolgende resultaatmomenten zichtbaar in deze route." />
+                                <EmptyBlock
+                                  text={
+                                    isClosedRouteStatus(selectedItem.status)
+                                      ? 'Deze route is gesloten zonder extra resultaatmomenten in deze surfacelaag.'
+                                      : 'Nog geen opeenvolgende resultaatmomenten zichtbaar in deze route.'
+                                  }
+                                />
                               ) : (
                                 selectedItem.coreSemantics.resultProgression.map((entry) => (
                                   <ResultProgressionEntry key={entry.resultEntryId} entry={entry} />
@@ -2021,7 +2049,13 @@ export function ActionCenterPreview({
                             <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/48">Beslisgeschiedenis</p>
                             <div className="mt-3 space-y-3">
                               {selectedItem.coreSemantics.decisionHistory.length === 0 ? (
-                                <EmptyBlock text="Nog geen expliciete beslismomenten zichtbaar in deze route." />
+                                <EmptyBlock
+                                  text={
+                                    isClosedRouteStatus(selectedItem.status)
+                                      ? 'Deze route is gesloten zonder extra beslisgeschiedenis in deze surfacelaag.'
+                                      : 'Nog geen expliciete beslismomenten zichtbaar in deze route.'
+                                  }
+                                />
                               ) : (
                                 selectedItem.coreSemantics.decisionHistory.map((entry) => (
                                   <DecisionHistoryEntry key={entry.decisionEntryId} entry={entry} />
@@ -2407,7 +2441,7 @@ export function ActionCenterPreview({
               ) : (
                 <EmptySection
                   title="Nog geen acties beschikbaar"
-                  body="Zodra er zichtbare ExitScan-dossiers zijn, toont deze view automatisch de open opvolging."
+                  body="Zodra er routes live staan, verschijnt hier automatisch de eerstvolgende managerstap, begrensde reactie of actiekaart."
                 />
               )
             ) : null}
@@ -2437,7 +2471,7 @@ export function ActionCenterPreview({
                     <ReviewLane
                       title="Achterstallig"
                       items={overdueReviews}
-                      emptyText="Geen achterstallige reviews meer zichtbaar."
+                      emptyText="In deze selectie staan nu geen achterstallige reviews meer open."
                       onOpen={(item) => {
                         setSelectedItemId(item.id)
                         setActiveView('actions')
@@ -2446,7 +2480,7 @@ export function ActionCenterPreview({
                     <ReviewLane
                       title="Deze week"
                       items={thisWeekReviews}
-                      emptyText="Niets meer voor deze week."
+                      emptyText="Voor deze week staat nu geen nieuw reviewgesprek meer open."
                       onOpen={(item) => {
                         setSelectedItemId(item.id)
                         setActiveView('actions')
@@ -2455,7 +2489,7 @@ export function ActionCenterPreview({
                     <ReviewLane
                       title="Volgende week"
                       items={nextWeekReviews}
-                      emptyText="Nog geen follow-up voor volgende week."
+                      emptyText="Voor volgende week is nog geen nieuw reviewgesprek ingepland."
                       onOpen={(item) => {
                         setSelectedItemId(item.id)
                         setActiveView('actions')
@@ -2472,7 +2506,7 @@ export function ActionCenterPreview({
                       <p className="mt-4 text-[0.98rem] leading-8 text-white/72">
                         {upcomingReviews[0]
                           ? `Het eerstvolgende gesprek valt op ${upcomingReviews[0].reviewDateLabel} en blijft gekoppeld aan hetzelfde dossier en dezelfde eigenaar.`
-                          : 'Zodra er reviewdata live staan, verschijnt hier automatisch het eerstvolgende gesprek.'}
+                          : 'Deze selectie heeft nu geen open reviewvenster. Zodra een route een nieuwe hercheck vraagt, verschijnt het eerstvolgende gesprek hier automatisch.'}
                       </p>
 
                       <div className="mt-6 space-y-4 border-t border-white/10 pt-6">
@@ -3178,7 +3212,9 @@ function CompactLandingSummary({ item }: { item: ActionCenterPreviewItem }) {
 
   return (
     <div className="mt-4 rounded-[18px] border border-[#eadfce] bg-white px-4 py-4">
-      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Laatste route-read</p>
+      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">
+        {isClosedRouteStatus(item.status) ? 'Historische route-read' : 'Laatste route-read'}
+      </p>
       {overviewLineageLabel ? (
         <p className="mt-3 text-sm leading-6 text-[#7d7368]">{overviewLineageLabel}</p>
       ) : null}

--- a/frontend/lib/action-center-preview-display.test.ts
+++ b/frontend/lib/action-center-preview-display.test.ts
@@ -130,8 +130,101 @@ describe('action center preview display helpers', () => {
     } satisfies ActionCenterPreviewItem
 
     expect(buildCompactLandingSummaryLines(item)).toEqual([
-      { label: 'Besluit', value: 'Bijstellen' },
-      { label: 'Stap', value: 'Leg eigenaar en eerste correctie in het MT-overleg vast.' },
+      { label: 'Route', value: 'In uitvoering' },
+      { label: 'Lezing', value: 'Vertrekduiding is nu scherp genoeg voor een eerste MT-read.' },
+    ])
+  })
+
+  it('keeps historical routes readable even when they no longer expose a current step or decision', () => {
+    const item = {
+      id: 'route-closed',
+      code: 'ACT-1002',
+      title: 'Historische route',
+      summary: 'Deze route is bestuurlijk afgesloten.',
+      reason: 'Het effect bleef zichtbaar.',
+      sourceLabel: 'ExitScan',
+      teamId: 'operations',
+      teamLabel: 'Operations',
+      ownerName: 'Manager Operations',
+      ownerRole: 'Manager - Operations',
+      ownerSubtitle: 'Operations',
+      reviewOwnerName: 'HR lead',
+      priority: 'laag',
+      status: 'afgerond',
+      reviewDate: null,
+      expectedEffect: null,
+      reviewReason: null,
+      reviewOutcome: 'afronden',
+      reviewDateLabel: 'Nog niet gepland',
+      reviewRhythm: 'Maandelijks',
+      signalLabel: 'ExitScan - Exit voorjaar',
+      signalBody: 'De lokale correctie hield zichtbaar stand.',
+      nextStep: 'Nog niet van toepassing',
+      peopleCount: 38,
+      openSignals: [],
+      updates: [],
+      coreSemantics: {
+        route: {
+          campaignId: 'campaign-exit',
+          entryStage: 'active',
+          routeOpenedAt: '2026-04-20T09:00:00.000Z',
+          ownerAssignedAt: '2026-04-21T08:00:00.000Z',
+          routeStatus: 'afgerond',
+          reviewOutcome: 'afronden',
+          reviewCompletedAt: '2026-04-28T09:00:00.000Z',
+          outcomeRecordedAt: '2026-04-28T09:00:00.000Z',
+          outcomeSummary: 'De lokale correctie hield zichtbaar stand.',
+          intervention: null,
+          owner: 'Manager Operations',
+          expectedEffect: null,
+          reviewScheduledFor: null,
+          reviewReason: null,
+          blockedBy: null,
+        },
+        latestDecision: null,
+        actionProgress: {
+          currentStep: null,
+          nextStep: null,
+          expectedEffect: null,
+        },
+        reviewSemantics: {
+          reviewReason: null,
+          reviewQuestion: null,
+          reviewOutcomeRaw: 'afronden',
+          reviewOutcomeVisible: 'afronden',
+        },
+        actionFrame: {
+          whyNow: 'Het effect bleef zichtbaar.',
+          firstStep: null,
+          owner: 'Manager Operations',
+          expectedEffect: null,
+        },
+        resultLoop: {
+          whatWasTried: null,
+          whatWeObserved: null,
+          whatWasDecided: null,
+        },
+        resultProgression: [],
+        decisionHistory: [],
+        lineageSummary: {
+          overviewLabel: null,
+          backwardLabel: null,
+          backwardRouteId: null,
+          forwardLabel: null,
+          forwardRouteId: null,
+          detailLabels: [],
+        },
+        closingSemantics: {
+          status: 'afgerond',
+          summary: 'Afgerond voor nu',
+          historicalSummary: 'Deze route is bestuurlijk afgesloten.',
+        },
+      },
+    } satisfies ActionCenterPreviewItem
+
+    expect(buildCompactLandingSummaryLines(item)).toEqual([
+      { label: 'Route', value: 'Afgerond voor nu' },
+      { label: 'Lezing', value: 'Deze route is bestuurlijk afgesloten.' },
     ])
   })
 })

--- a/frontend/lib/action-center-preview-route-fields-render.test.ts
+++ b/frontend/lib/action-center-preview-route-fields-render.test.ts
@@ -570,4 +570,110 @@ describe('action center preview route fields render', () => {
     expect(html).not.toContain('Volgende toets')
     expect(html).not.toContain('Hierna')
   })
+
+  it('renders historical route empty states as intentional instead of missing data', () => {
+    const item = finalizeActionCenterPreviewItem({
+      id: 'route-3',
+      code: 'ACT-1003',
+      title: 'Historische route',
+      summary: 'De route is bestuurlijk gesloten.',
+      reason: 'Het effect bleef zichtbaar.',
+      sourceLabel: 'ExitScan',
+      orgId: 'org-1',
+      scopeType: 'department',
+      teamId: 'operations',
+      teamLabel: 'Operations',
+      ownerId: 'manager-1',
+      ownerName: 'Manager Operations',
+      ownerRole: 'Manager - Operations',
+      ownerSubtitle: 'Operations',
+      reviewOwnerName: 'HR lead',
+      priority: 'laag',
+      status: 'afgerond',
+      reviewDate: null,
+      expectedEffect: null,
+      reviewReason: null,
+      reviewOutcome: 'afronden',
+      reviewDateLabel: 'Nog niet gepland',
+      reviewRhythm: 'Maandelijks',
+      signalLabel: 'ExitScan - Exit voorjaar',
+      signalBody: 'De lokale correctie hield zichtbaar stand.',
+      nextStep: 'Nog niet van toepassing',
+      peopleCount: 38,
+      updates: [],
+      coreSemantics: {
+        route: {
+          campaignId: 'campaign-exit',
+          entryStage: 'active',
+          routeOpenedAt: '2026-04-20T09:00:00.000Z',
+          ownerAssignedAt: '2026-04-21T08:00:00.000Z',
+          routeStatus: 'afgerond',
+          reviewOutcome: 'afronden',
+          reviewCompletedAt: '2026-04-28T09:00:00.000Z',
+          outcomeRecordedAt: '2026-04-28T09:00:00.000Z',
+          outcomeSummary: 'De lokale correctie hield zichtbaar stand.',
+          intervention: null,
+          owner: 'Manager Operations',
+          expectedEffect: null,
+          reviewScheduledFor: null,
+          reviewReason: null,
+          blockedBy: null,
+        },
+        latestDecision: null,
+        actionProgress: {
+          currentStep: null,
+          nextStep: null,
+          expectedEffect: null,
+        },
+        reviewSemantics: {
+          reviewReason: null,
+          reviewQuestion: null,
+          reviewOutcomeRaw: 'afronden',
+          reviewOutcomeVisible: 'afronden',
+        },
+        actionFrame: {
+          whyNow: 'Het effect bleef zichtbaar.',
+          firstStep: null,
+          owner: 'Manager Operations',
+          expectedEffect: null,
+        },
+        resultLoop: {
+          whatWasTried: null,
+          whatWeObserved: null,
+          whatWasDecided: null,
+        },
+        resultProgression: [],
+        decisionHistory: [],
+        lineageSummary: {
+          overviewLabel: 'Later opgevolgd',
+          backwardLabel: null,
+          backwardRouteId: null,
+          forwardLabel: 'Later opgevolgd',
+          forwardRouteId: 'route-4',
+          detailLabels: ['Later opgevolgd'],
+        },
+        closingSemantics: {
+          status: 'afgerond',
+          summary: 'Afgerond voor nu',
+          historicalSummary: 'Deze route is bestuurlijk afgesloten.',
+        },
+      },
+    })
+
+    const html = renderToStaticMarkup(
+      React.createElement(ActionCenterPreview, {
+        initialItems: [item],
+        initialView: 'actions',
+        fallbackOwnerName: 'Verisight gebruiker',
+        ownerOptions: ['Manager Operations'],
+        workbenchHref: '/dashboard',
+        readOnly: true,
+      }),
+    )
+
+    expect(html).toContain('Afgerond voor nu')
+    expect(html).toContain('Deze route is al historisch gesloten; een aparte laatste reviewbeslissing hoeft hier niet meer zichtbaar te zijn.')
+    expect(html).toContain('Deze route is gesloten zonder extra resultaatmomenten in deze surfacelaag.')
+    expect(html).toContain('Deze route is gesloten zonder extra beslisgeschiedenis in deze surfacelaag.')
+  })
 })


### PR DESCRIPTION
## Summary
- add the Wave 6 UX-volwassenheid spec and implementation plan
- make route summaries and empty states calmer and more phase-aware
- make historical routes read intentionally instead of as missing data

## Verification
- `npm test -- "lib/action-center-preview-display.test.ts" "lib/action-center-preview-route-fields-render.test.ts"`
- `npx eslint components/dashboard/action-center-preview.tsx lib/action-center-preview-display.test.ts lib/action-center-preview-route-fields-render.test.ts`
- `npm run build`

## Notes
- build still shows the existing warning about unused `goTo` in `components/marketing/home-insight-action-demo.tsx`