### PR TITLE
Wave 7: strengthen scan to action center handoff

### DIFF
--- a/docs/superpowers/plans/2026-05-02-action-center-scan-route-inbedding.md
+++ b/docs/superpowers/plans/2026-05-02-action-center-scan-route-inbedding.md
@@ -1,0 +1,42 @@
+# Plan: Action Center Inbedding in Scan -> Route Flow
+
+## Objective
+Make the campaign-detail to Action Center handoff feel like a coherent continuation of the scan route, while preserving the explicit product boundary between reading and follow-through.
+
+## Scope
+
+In scope:
+
+- campaign detail bridge copy and CTA presentation
+- Action Center continuity/focus behavior when entered from campaign detail
+- shell assertions around the bridge contract
+
+Out of scope:
+
+- new route truth
+- new manager actions from campaign detail
+- reporting, governance, or ops changes
+
+## Steps
+
+1. Inspect the current campaign detail bridge and identify where the handoff still reads as a generic module link.
+2. Update campaign detail bridge presentation so it explains:
+   - this page clarifies the signal
+   - Action Center opens ownership and follow-through
+3. Preserve or improve canonical focus continuity when entering Action Center from campaign detail.
+4. Add or tighten shell tests that lock the campaign -> Action Center boundary and continuity language.
+5. Run targeted tests, lint, and build.
+6. Commit, push, open draft PR, and merge when clean.
+
+## Verification
+
+- targeted Vitest for campaign detail and Action Center shells
+- `eslint` on touched files
+- `npm run build`
+
+## Done When
+
+- the handoff reads as scan-first, follow-through-second
+- the CTA is less generic and more contextual
+- Action Center entry preserves continuity
+- verification is green

--- a/docs/superpowers/specs/2026-05-02-action-center-scan-route-inbedding-design.md
+++ b/docs/superpowers/specs/2026-05-02-action-center-scan-route-inbedding-design.md
@@ -1,0 +1,118 @@
+# Action Center Inbedding in Scan -> Route Flow
+
+## Status
+Proposed
+
+## Intent
+This wave strengthens the product continuity from scan/campaign reading into Action Center so the follow-through layer feels like the next step of the same journey rather than a separate module.
+
+This is intentionally a **handoff and continuity wave**, not a new route system.
+
+---
+
+## 1. Goal
+
+Wave 7 should make it easier for HR to understand:
+
+- when a campaign detail page has reached the point where Action Center becomes the right next surface
+- what Action Center will contain for that route
+- why the bridge exists without collapsing campaign detail and Action Center into one page
+
+The result should be a stronger commercial read:
+
+scan first, Action Center second.
+
+---
+
+## 2. Product Boundary
+
+This wave may:
+
+- strengthen bridge copy on campaign detail
+- make the Action Center handoff more explicit and less generic
+- preserve continuity when a route is opened or revisited from campaign detail
+- improve scan-to-route deeplink behavior
+
+This wave must not:
+
+- move action authoring into campaign detail
+- blur the boundary between campaign reading and follow-through execution
+- create a second way of managing routes outside Action Center
+- re-open scan semantics or Action Center route truth
+
+---
+
+## 3. Current Runtime Basis
+
+Already present and safe to build on:
+
+- campaign detail has an Action Center bridge
+- route opening can happen from the campaign detail page
+- Action Center can already focus routes by canonical route/focus identity
+- campaign detail copy already states that commitment belongs in Action Center
+
+Still weak in runtime feel:
+
+- the handoff CTA is still fairly generic
+- the bridge explains the boundary, but not yet the continuity strongly enough
+- the transition from "this campaign tells you what to read" to "Action Center tells you how follow-through starts" can still feel like a module jump
+
+---
+
+## 4. Desired Product Read
+
+The user should experience:
+
+- campaign detail as the place where the signal and route-read are clarified
+- Action Center as the place where ownership and follow-through become explicit
+- a visible, intentional bridge between the two
+
+That means the bridge should answer:
+
+- why now
+- what happens next
+- where to continue
+
+without turning into a second workflow panel.
+
+---
+
+## 5. Scope of the Implementation Slice
+
+This wave should stay small and target the actual handoff surfaces:
+
+- campaign detail route bridge presentation
+- Action Center landing/focus continuity
+- shell tests around campaign detail and Action Center handoff wording
+
+Preferred changes:
+
+- sharpen campaign-detail bridge copy around "read here, follow-through there"
+- make the CTA/readback language describe what Action Center will open
+- preserve direct focus when jumping from a campaign into Action Center
+- reduce the feeling of a generic module switch
+
+---
+
+## 6. Success Criteria
+
+This wave succeeds when:
+
+- the campaign detail page more clearly explains why Action Center is the next step
+- opening or revisiting Action Center from campaign detail feels like a continuation, not a context drop
+- the boundary between scan reading and route execution remains explicit
+- no duplicate route-management surface is introduced
+
+---
+
+## 7. What Stays Unchanged
+
+This wave does **not** change:
+
+- campaign analytics truth
+- route truth
+- manager action truth
+- closeout / reopen / follow-up semantics
+- governance or operations layers
+
+It only strengthens how the scan-to-follow-through transition reads in runtime.

--- a/frontend/app/(dashboard)/action-center/page.entry-shell.test.ts
+++ b/frontend/app/(dashboard)/action-center/page.entry-shell.test.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('action center campaign-entry shell', () => {
+  it('keeps campaign-detail entry continuity visible in the Action Center workspace subtitle', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+
+    expect(source).toContain("source === 'campaign-detail'")
+    expect(source).toContain('Geopend vanuit campaign detail')
+  })
+})

--- a/frontend/app/(dashboard)/action-center/page.tsx
+++ b/frontend/app/(dashboard)/action-center/page.tsx
@@ -125,10 +125,11 @@ function getManagerAssignment(
 export default async function ActionCenterPage({
   searchParams,
 }: {
-  searchParams?: Promise<{ focus?: string }>
+  searchParams?: Promise<{ focus?: string; source?: string }>
 }) {
   const params = (await searchParams) ?? {}
   const focusItemId = typeof params.focus === 'string' ? params.focus : null
+  const source = typeof params.source === 'string' ? params.source : null
   const supabase = await createClient()
   const {
     data: { user },
@@ -433,9 +434,11 @@ export default async function ActionCenterPage({
         null)
       : null
   const workspaceSubtitle =
-    summary.productCount > 0
-      ? `Live opvolging over ${summary.productCount} product${summary.productCount === 1 ? '' : 'en'}`
-      : 'Live opvolging'
+    source === 'campaign-detail'
+      ? 'Geopend vanuit campaign detail: hier worden eigenaarschap, eerste managerstap en reviewritme expliciet.'
+      : summary.productCount > 0
+        ? `Live opvolging over ${summary.productCount} product${summary.productCount === 1 ? '' : 'en'}`
+        : 'Live opvolging'
 
   if (items.length === 0) {
     return (

--- a/frontend/app/(dashboard)/campaigns/[id]/page.route-shell.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.route-shell.test.ts
@@ -38,4 +38,12 @@ describe('campaign detail first-next-step shell', () => {
     expect(source).toContain("label=\"Sterkste factor\"")
     expect(source).toContain('focusPanelItems')
   })
+
+  it('keeps the campaign-to-action-center handoff explicit instead of a generic module jump', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+
+    expect(source).toContain('buildActionCenterRouteOpenRedirect(id, "campaign-detail")')
+    expect(source).toContain('actionCenterBridge.presentation.ctaLabel')
+    expect(source).toContain('actionCenterBridge.presentation.body')
+  })
 })

--- a/frontend/app/(dashboard)/campaigns/[id]/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.tsx
@@ -853,6 +853,7 @@ export default async function CampaignPage({ params }: Props) {
       canOpenActionCenterFromDeliveryRecord,
     assessedAt: deliveryRecord?.updated_at ?? stats.created_at,
   });
+  const actionCenterRouteHref = buildActionCenterRouteOpenRedirect(id, "campaign-detail");
   const compositionStateMeta = {
     setup: {
       label: "Nog niet live",
@@ -1999,7 +2000,7 @@ export default async function CampaignPage({ params }: Props) {
     "use server";
 
     const admin = createAdminClient();
-    const actionCenterHref = buildActionCenterRouteOpenRedirect(id);
+    const actionCenterHref = buildActionCenterRouteOpenRedirect(id, "campaign-detail");
     const { data: currentDeliveryRecord, error: loadError } = await admin
       .from("campaign_delivery_records")
       .select("id, lifecycle_stage, first_management_use_confirmed_at")
@@ -2050,23 +2051,28 @@ export default async function CampaignPage({ params }: Props) {
   }
   const actionCenterRouteAction =
     actionCenterBridge.presentation.ctaKind === "open" ? (
-      actionCenterBridge.bridgeState === "candidate" ? (
-        <form action={openActionCenterRoute}>
-          <button
-            type="submit"
-            className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition-colors hover:border-slate-300 hover:bg-slate-50"
+      <div className="flex flex-col gap-2">
+        {actionCenterBridge.bridgeState === "candidate" ? (
+          <form action={openActionCenterRoute}>
+            <button
+              type="submit"
+              className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition-colors hover:border-slate-300 hover:bg-slate-50"
+            >
+              {actionCenterBridge.presentation.ctaLabel}
+            </button>
+          </form>
+        ) : (
+          <Link
+            href={actionCenterRouteHref}
+            className="inline-flex rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition-colors hover:border-slate-300 hover:bg-slate-50"
           >
-            Open in Action Center
-          </button>
-        </form>
-      ) : (
-        <Link
-          href={buildActionCenterRouteOpenRedirect(id)}
-          className="inline-flex rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition-colors hover:border-slate-300 hover:bg-slate-50"
-        >
-          Open in Action Center
-        </Link>
-      )
+            {actionCenterBridge.presentation.ctaLabel}
+          </Link>
+        )}
+        <p className="max-w-sm text-sm leading-6 text-slate-500">
+          {actionCenterBridge.presentation.body}
+        </p>
+      </div>
     ) : null;
   const summaryActions = (
     <>

--- a/frontend/lib/dashboard/hr-bridge-state.ts
+++ b/frontend/lib/dashboard/hr-bridge-state.ts
@@ -52,9 +52,9 @@ export function getHrBridgePresentation(args: {
     return {
       label: 'Actieve opvolging',
       tone: 'emerald' as const,
-      body: 'Deze opvolging loopt al in Action Center.',
+      body: 'Deze route loopt al in Action Center. Daar blijven eigenaarschap, eerste managerstap en reviewritme expliciet.',
       ctaKind: 'open' as const,
-      ctaLabel: 'Open in Action Center',
+      ctaLabel: 'Open route in Action Center',
     }
   }
 
@@ -82,9 +82,9 @@ export function getHrBridgePresentation(args: {
     return {
       label: 'Route-kandidaat',
       tone: 'amber' as const,
-      body: 'Dit signaal is klaar om als opvolging te openen.',
+      body: 'Deze campaign-read is scherp genoeg om de vervolgroute in Action Center te openen. Daar leg je eigenaarschap, eerste managerstap en reviewritme vast.',
       ctaKind: 'open' as const,
-      ctaLabel: 'Open in Action Center',
+      ctaLabel: 'Open route in Action Center',
     }
   }
 

--- a/frontend/lib/dashboard/open-action-center-route.test.ts
+++ b/frontend/lib/dashboard/open-action-center-route.test.ts
@@ -17,6 +17,9 @@ describe('open action center route', () => {
 
   it('redirects back into action center with the opened campaign in focus', () => {
     expect(buildActionCenterRouteOpenRedirect('cmp-1')).toBe('/action-center?focus=cmp-1')
+    expect(buildActionCenterRouteOpenRedirect('cmp-1', 'campaign-detail')).toBe(
+      '/action-center?focus=cmp-1&source=campaign-detail',
+    )
   })
 
   it('does not reopen a route after lifecycle has already advanced past first management use', () => {

--- a/frontend/lib/dashboard/open-action-center-route.ts
+++ b/frontend/lib/dashboard/open-action-center-route.ts
@@ -30,8 +30,16 @@ export function buildActionCenterRouteOpenPatch(openedAt: string): {
   }
 }
 
-export function buildActionCenterRouteOpenRedirect(campaignId: string) {
-  return `/action-center?focus=${campaignId}`
+export function buildActionCenterRouteOpenRedirect(
+  campaignId: string,
+  source: 'campaign-detail' | null = null,
+) {
+  const params = new URLSearchParams({ focus: campaignId })
+  if (source) {
+    params.set('source', source)
+  }
+
+  return `/action-center?${params.toString()}`
 }
 
 export function hasOpenedActionCenterRoute(record: ActionCenterRouteOpenRecord) {


### PR DESCRIPTION
## Summary
- add the Wave 7 scan->route inbedding spec and implementation plan
- make the campaign-detail bridge explain the Action Center continuation more explicitly
- preserve campaign-detail entry continuity inside the Action Center workspace subtitle

## Verification
- `npm test -- "lib/dashboard/open-action-center-route.test.ts" "app/(dashboard)/campaigns/[id]/page.route-shell.test.ts" "app/(dashboard)/action-center/page.entry-shell.test.ts"`
- `npx eslint lib/dashboard/hr-bridge-state.ts lib/dashboard/open-action-center-route.ts lib/dashboard/open-action-center-route.test.ts "app/(dashboard)/campaigns/[id]/page.tsx" "app/(dashboard)/campaigns/[id]/page.route-shell.test.ts" "app/(dashboard)/action-center/page.tsx" "app/(dashboard)/action-center/page.entry-shell.test.ts"`
- `npm run build`

## Notes
- build still shows the existing warning about unused `goTo` in `components/marketing/home-insight-action-demo.tsx`