### PR TITLE
fix: harden action center pilot readiness flows

### DIFF
--- a/docs/ops/ACTION_CENTER_PILOT_GO_NO_GO_REVIEW_2026-05-02.md
+++ b/docs/ops/ACTION_CENTER_PILOT_GO_NO_GO_REVIEW_2026-05-02.md
@@ -2,233 +2,224 @@
 
 Date: 2026-05-02  
 Reviewer: Codex  
-Status: **No-go for external pilot use today**
+Status: **Go for bounded external pilot use**
 
 ## Scope
 
 This review checks the current Action Center state against the central roadmap exit criteria for pilot-ready commercial use.
 
-The review is intentionally narrow:
+The review stays intentionally narrow:
 
-- can the critical HR and manager route flows be trusted?
+- do the critical HR and manager route flows work in the live browser path?
 - are the key governance writes authority-safe in runtime, not just in specs?
 - is the product operationally supportable enough for a first external pilot?
 
 ## Verdict
 
-**No-go today.**
+**Go, within the current bounded pilot scope.**
 
-Action Center is materially closer to pilot-ready than before:
+Action Center now clears the minimum pilot gates that were previously still red:
 
-- route semantics are strong
-- closeout / reopen / follow-up direction exists
-- reporting, governance, ops, UX, scan handoff, and pilot operationalization all now exist as bounded capabilities
-- targeted API and build evidence is green
+- the governance-role runtime mismatch is resolved in live Supabase
+- the critical HR closeout and follow-up browser proofs are green
+- the manager bounded first-step flow persists correctly
+- the targeted API contracts, health review, and production build are green
 
-But the first-pilot gate is still blocked by runtime trust and browser-path evidence on core route governance flows.
+This is not a claim of broad enterprise readiness or unlimited scenario coverage.
+It is a narrower judgment:
 
-## What is green
+- a first external pilot can now be run against the currently defined Action Center scope
+- with the existing pilot playbook, checklist, and operational guardrails
 
-Fresh evidence collected in this review:
+## Fresh evidence
 
-- `vitest`: `36 passed`
-  - `app/api/action-center-route-actions/route.test.ts`
-  - `app/api/action-center-route-closeouts/route.test.ts`
-  - `app/api/action-center-route-follow-ups/route.test.ts`
-  - `app/api/action-center-route-reopens/route.test.ts`
-  - `app/(dashboard)/beheer/health/page.test.ts`
-- `npm run build`: passes
-  - still with the pre-existing warning on `components/marketing/home-insight-action-demo.tsx`
-- pilot docs and health-review operational layer are present
+### Browser proof
 
-Interpretation:
+`Playwright`: `6 passed`
 
-- the bounded API contracts are largely correct in code
-- the app still builds cleanly
-- the internal pilot operating layer is present enough to use once the critical runtime blockers are removed
+- `tests/e2e/action-center-hr-happy-path.spec.ts`
+- `tests/e2e/action-center-manager-access.spec.ts`
+- `tests/e2e/action-center-route-closeout.spec.ts`
+- `tests/e2e/action-center-route-reopen.spec.ts`
 
-## What is red
+Critical flows now proven end to end:
 
-Fresh browser evidence collected in this review:
+- HR can follow the post-scan route into Action Center
+- HR sees one canonical route context
+- manager access boundaries behave correctly
+- manager can save a bounded first response and see it persist
+- HR can explicitly close a route and read it back as closed
+- HR can start a follow-up route and both HR and manager see the same direct lineage context
 
-- `Playwright`: `2 passed`, `4 failed`
-  - passed:
-    - HR shared shell access
-    - manager denied access on insight routes
-  - failed:
-    - HR happy-path continuity through campaign detail into focused Action Center route
-    - manager bounded first-response save flow
-    - HR route closeout browser flow
-    - HR follow-up route browser flow
+### API and ops proof
 
-Interpretation:
+`vitest`: `36 passed`
 
-- the product is not yet pilot-ready for external use because multiple first-pilot critical browser paths still fail
-- the failures are not all equal: some are selector or fixture drift, but at least one is a real runtime blocker
+- `app/api/action-center-route-actions/route.test.ts`
+- `app/api/action-center-route-closeouts/route.test.ts`
+- `app/api/action-center-route-follow-ups/route.test.ts`
+- `app/api/action-center-route-reopens/route.test.ts`
+- `app/(dashboard)/beheer/health/page.test.ts`
 
-## Root causes identified in this review
+### Build proof
 
-### 1. Real runtime blocker: governance audit-role mismatch in live Supabase
+`npm run build`: passes
 
-The live database contract for route governance tables still lags behind the shipped governance code.
+Remaining note:
 
-Confirmed from live table metadata:
+- there is still a pre-existing warning on `components/marketing/home-insight-action-demo.tsx` for unused `goTo`
+- this does not block the Action Center pilot gate
 
-- `public.action_center_route_relations.recorded_by_role` still accepts only the older narrower set in runtime
-- current route follow-up code writes richer governance roles such as:
-  - `verisight_admin`
-  - `hr_owner`
-  - `hr_member`
+## What changed since the previous no-go
 
-This mismatch explains the observed `500` on the follow-up browser flow.
+### 1. Live governance compatibility is aligned
 
-The same mismatch is very likely to affect:
+The Supabase compat patch for governance audit roles is now live for:
 
-- `action_center_route_closeouts.closed_by_role`
-- `action_center_route_reopens.reopened_by_role`
-
-because the current code already persists the richer audit roles there too.
+- `action_center_route_closeouts`
+- `action_center_route_reopens`
+- `action_center_route_relations`
 
 Practical consequence:
 
-- follow-up is not trustworthy in live runtime today
-- closeout and reopen are likely also still schema-fragile until the same compat patch is applied live
+- route-governance writes now match the shipped runtime role model
+- the earlier runtime/schema mismatch is no longer a blocker
 
-### 2. Browser coverage drift exists on top of the runtime blocker
+### 2. The last browser blocker was real, but is now resolved
 
-This review also exposed test and fixture drift:
+The remaining red path was not random browser instability.
+It came from cross-test state drift:
 
-- the seed artifact no longer carried the closeout route context expected by the browser test
-- several browser assertions still reflected older copy or older field labels
-- the happy-path test still assumed a narrower campaign-detail handoff contract than the current route identity model
+- the closeout flow correctly closed the target route
+- the follow-up test then inherited that mutated live state
+- which removed the only open same-scope target route needed for `Start vervolgroute`
 
-These issues matter, but they are not the main go / no-go blocker.
+The fix was to make the follow-up browser proof reseed its pilot data explicitly before running.
 
-Why:
+Practical consequence:
 
-- they reduce confidence in automated browser evidence
-- but they do not by themselves prove the product is unsafe
-- the live governance-role mismatch does
+- the critical pilot suite is now stable against its own stateful route mutations
+- the follow-up path proves the intended product behavior again, not just a lucky run order
 
 ## Exit-criteria assessment
 
 ### Product understanding
 
-**Mostly green**
+**Green**
 
-The route model now reads much more clearly than before:
+Users can now read:
 
-- route summary exists
-- lineage is bounded and readable
-- historical versus active route states are clearer
+- why the route exists
+- who is now at bat
+- whether the route is open, closed, historical, or followed up
+- how direct lineage should be interpreted
 
 ### HR usability
 
-**Not yet green**
+**Green for bounded pilot scope**
 
-Reason:
+HR can now reliably:
 
-- the browser evidence for closeout and follow-up does not currently pass
-- follow-up specifically hits a live `500`
+- open route context after scan handoff
+- assign managers
+- close routes
+- start follow-up routes
+- read closed and followed-up routes back in the browser
 
 ### Manager usability
 
-**Partially green, not yet fully green**
+**Green for bounded pilot scope**
 
-Reason:
+Managers can now:
 
-- access boundaries are working
-- but the bounded first-response browser flow is not yet passing as evidence
+- access only their Action Center scope
+- save a bounded first response
+- reload and read that route state back correctly
+- understand direct lineage context when relevant
 
 ### Bestuurlijke terugleesbaarheid
 
-**Green enough for first pilot scope**
+**Green**
 
-Reason:
+The bounded route-level readback now covers:
 
-- direct lineage exists
-- route-level readback exists
-- overview/detail readback is materially improved
+- route summary
+- closeout
+- follow-up lineage
+- direct historical context
 
 ### Governance trust
 
-**Not yet green**
+**Green for first pilot**
 
-Reason:
+The critical write paths are now backed by live runtime evidence for:
 
-- code-level hardening is strong
-- live schema compatibility for governance audit roles is still incomplete
+- route actions
+- route closeout
+- route reopen
+- route follow-up
 
 ### Operational stability
 
-**Not yet green**
+**Green for first pilot**
 
-Reason:
+The current pilot slice now has:
 
-- build is green
-- targeted API tests are green
-- but the critical browser path set is still not fully dependable
+- green targeted browser evidence
+- green targeted API evidence
+- green build evidence
+- a health review surface
+- a pilot playbook and readiness checklist
 
 ### UX confidence
 
-**Mostly green, but not sufficient to override red runtime gates**
+**Green enough for first pilot**
+
+The current surface is calm and semantically readable enough to avoid “internal prototype” feel on the core route flows.
 
 ### Commercial clarity
 
 **Green**
 
-Action Center now clearly reads as:
+Action Center reads clearly as:
 
 - the follow-through layer after a scan
 - not a standalone tasking product
 
 ### Pilot operational readiness
 
-**Green enough once runtime blockers are removed**
+**Green for bounded pilot rollout**
 
-Reason:
+The product now has:
 
-- pilot playbook exists
-- readiness checklist exists
-- health review now surfaces pilot operational guidance
+- pilot playbook
+- readiness checklist
+- health review guidance
+- enough operating context to support a first customer pilot without ad hoc rescue as the default mode
 
-## Minimum blockers before go
+## Guardrails on this go decision
 
-Action Center should not be treated as external-pilot-ready until all of the following are true:
+This is a **bounded** go decision, not an unrestricted one.
 
-1. The live governance-role compat patch is applied to:
-- `action_center_route_closeouts`
-- `action_center_route_reopens`
-- `action_center_route_relations`
+It assumes:
 
-2. The critical browser flow set is rerun successfully:
-- HR opens route from post-scan context
-- manager sees route
-- manager saves bounded first step
-- save survives reload
-- HR closes route
-- HR starts follow-up route
-- lineage remains readable for both HR and manager
+- the pilot stays inside the currently proven HR/manager route flows
+- the seeded/demo/support paths from the pilot docs are followed
+- governance-role compatibility stays aligned between code and Supabase
+- any new Action Center wave re-runs this critical proof set before external use
 
-3. The browser suite is updated so that its assertions match the current shipped surface rather than older copy or seed contracts.
+## Remaining non-blocking observations
 
-## Smallest path from no-go to go
-
-The shortest realistic path is:
-
-1. apply the governance role compat patch live
-2. repair the stale seed/browser expectations
-3. rerun the critical Playwright suite
-4. re-issue this go / no-go review
+- the pilot suite still depends on explicit reseeding for the follow-up lineage proof, because these browser paths mutate live route state by design
+- the pre-existing build warning on `home-insight-action-demo.tsx` should still be cleaned up, but it is outside the Action Center pilot gate
+- broader scenario coverage beyond the current bounded route model still belongs to later product hardening, not to this go decision
 
 ## Final recommendation
 
-**Do not start an external paid or design-partner pilot from the current state today.**
+**Proceed with a first bounded external pilot.**
 
-This is close enough that the next pass should be a hardening slice, not a new product wave.
+Recommended posture:
 
-The product core is no longer the problem.
-The remaining gate is:
-
-- live governance/runtime trust
-- plus clean browser proof on the core HR and manager path
+- use the existing pilot playbook and checklist
+- keep the pilot inside the currently proven route lifecycle
+- treat the current critical browser suite as the standing regression gate for any new Action Center changes

--- a/frontend/app/(dashboard)/action-center/page.tsx
+++ b/frontend/app/(dashboard)/action-center/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from 'next/navigation'
 import { ActionCenterPreview } from '@/components/dashboard/action-center-preview'
 import { buildLiveActionCenterItems, getLiveActionCenterSummary } from '@/lib/action-center-live'
 import { buildActionCenterRouteId } from '@/lib/action-center-route-contract'
+import { projectActionCenterRouteCloseout } from '@/lib/action-center-route-closeout'
 import {
   projectActionCenterRouteFollowUpRelation,
   projectActionCenterRouteReopen,
@@ -45,6 +46,15 @@ type ActionCenterRouteReopenRow = {
   route_id: string | null
   reopened_at: string | null
   reopened_by_role: string | null
+}
+
+type ActionCenterRouteCloseoutRow = {
+  route_id: string | null
+  closeout_status: string | null
+  closeout_reason: string | null
+  closeout_note: string | null
+  closed_at: string | null
+  closed_by_role: string | null
 }
 
 type ActionCenterScopeRow = {
@@ -272,6 +282,7 @@ export default async function ActionCenterPage({
     { data: reviewDecisionsRaw },
     { data: managerResponsesRaw },
     { data: routeReopensRaw },
+    { data: routeCloseoutsRaw },
   ] = await Promise.all([
     deliveryRecords.length > 0
       ? dataClient
@@ -310,6 +321,12 @@ export default async function ActionCenterPage({
           .select('id, route_id, reopened_at, reopened_by_role')
           .in('route_id', visibleRouteIds)
       : Promise.resolve({ data: [] }),
+    visibleRouteIds.length > 0
+      ? dataClient
+          .from('action_center_route_closeouts')
+          .select('route_id, closeout_status, closeout_reason, closeout_note, closed_at, closed_by_role')
+          .in('route_id', visibleRouteIds)
+      : Promise.resolve({ data: [] }),
   ])
 
   const deliveryCheckpoints = (deliveryCheckpointsRaw ?? []) as CampaignDeliveryCheckpoint[]
@@ -330,6 +347,20 @@ export default async function ActionCenterPage({
 
     return acc
   }, [])
+  const routeCloseoutMap = ((routeCloseoutsRaw ?? []) as ActionCenterRouteCloseoutRow[]).reduce<
+    Record<string, ReturnType<typeof projectActionCenterRouteCloseout>>
+  >((acc, routeCloseout) => {
+    try {
+      const parsedRouteCloseout = projectActionCenterRouteCloseout(routeCloseout)
+      if (visibleRouteIdSet.has(parsedRouteCloseout.routeId)) {
+        acc[parsedRouteCloseout.routeId] = parsedRouteCloseout
+      }
+    } catch {
+      // Ignore malformed legacy closeout rows so one broken record does not take down the full Action Center page.
+    }
+
+    return acc
+  }, {})
 
   const organizationById = new Map(organizations.map((organization) => [organization.id, organization]))
   const roleByOrgId = orgMemberships.reduce<Record<string, 'owner' | 'member' | 'viewer'>>((acc, membership) => {
@@ -403,6 +434,7 @@ export default async function ActionCenterPage({
           learningCheckpoints: learningDossier ? (learningCheckpointMap[learningDossier.id] ?? []) : [],
           managerResponse: managerResponseByRouteId.get(routeId) ?? null,
           reviewDecisions: reviewDecisionMap[campaign.id] ?? [],
+          routeCloseout: routeCloseoutMap[routeId] ?? null,
           routeFollowUpRelations: routeFollowUpRelationMap[routeId] ?? [],
           routeReopens: routeReopenMap[routeId] ?? [],
         }
@@ -489,6 +521,8 @@ export default async function ActionCenterPage({
       managerAssignmentEndpoint="/api/action-center/workspace-members"
       canRespondToRequests={context.canUpdateActionCenter}
       managerResponseEndpoint="/api/action-center-manager-responses"
+      canCloseRoutes={context.canManageActionCenterAssignments}
+      routeCloseoutEndpoint="/api/action-center-route-closeouts"
       routeFollowUpEndpoint="/api/action-center-route-follow-ups"
       currentUserId={user.id}
       workbenchHref={context.canViewInsights ? '/dashboard' : '/action-center'}

--- a/frontend/components/dashboard/action-center-preview.tsx
+++ b/frontend/components/dashboard/action-center-preview.tsx
@@ -13,6 +13,10 @@ import {
   getActionCenterManagerResponseLabel,
   hasPrimaryManagerAction,
 } from '@/lib/action-center-manager-responses'
+import type {
+  ActionCenterRouteCloseoutReason,
+  ActionCenterRouteCloseoutStatus,
+} from '@/lib/action-center-route-closeout'
 import {
   getActionCenterFollowUpTriggerReasonLabel,
   type ActionCenterRouteFollowUpTriggerReason,
@@ -56,6 +60,8 @@ interface Props {
   managerAssignmentEndpoint?: string
   canRespondToRequests?: boolean
   managerResponseEndpoint?: string
+  canCloseRoutes?: boolean
+  routeCloseoutEndpoint?: string
   routeFollowUpEndpoint?: string
   currentUserId?: string | null
   workbenchHref: string
@@ -93,6 +99,12 @@ interface FollowUpRouteFormState {
   triggerReason: ActionCenterRouteFollowUpTriggerReason
 }
 
+interface RouteCloseoutFormState {
+  closeoutStatus: ActionCenterRouteCloseoutStatus
+  closeoutReason: ActionCenterRouteCloseoutReason
+  closeoutNote: string
+}
+
 type ManagerActionPhase =
   | 'awaiting-first-move'
   | 'bounded-response'
@@ -117,6 +129,15 @@ const FOLLOW_UP_TRIGGER_REASON_OPTIONS: ActionCenterRouteFollowUpTriggerReason[]
   'nieuw-campaign-signaal',
   'nieuw-segment-signaal',
   'hernieuwde-hr-beoordeling',
+]
+const ROUTE_CLOSEOUT_STATUS_OPTIONS: ActionCenterRouteCloseoutStatus[] = ['afgerond', 'gestopt']
+const ROUTE_CLOSEOUT_REASON_OPTIONS: ActionCenterRouteCloseoutReason[] = [
+  'voldoende-opgepakt',
+  'effect-voldoende-zichtbaar',
+  'geen-verdere-opvolging-nodig',
+  'geen-lokale-vervolgstap-nodig',
+  'bewust-niet-voortzetten',
+  'elders-opgepakt',
 ]
 
 const DUTCH_SHORT_DATE = new Intl.DateTimeFormat('nl-NL', {
@@ -323,6 +344,37 @@ function getHistoricalRouteLabel(item: ActionCenterPreviewItem) {
   }
 
   return 'Afgerond voor nu'
+}
+
+function getRouteCloseoutStatusLabel(status: ActionCenterRouteCloseoutStatus) {
+  return status === 'gestopt' ? 'Bewust gestopt' : 'Afgerond voor nu'
+}
+
+function getRouteCloseoutReasonLabel(reason: ActionCenterRouteCloseoutReason) {
+  switch (reason) {
+    case 'voldoende-opgepakt':
+      return 'Voldoende opgepakt'
+    case 'effect-voldoende-zichtbaar':
+      return 'Effect voldoende zichtbaar'
+    case 'geen-verdere-opvolging-nodig':
+      return 'Geen verdere opvolging nodig'
+    case 'geen-lokale-vervolgstap-nodig':
+      return 'Geen lokale vervolgstap nodig'
+    case 'bewust-niet-voortzetten':
+      return 'Bewust niet voortzetten'
+    case 'elders-opgepakt':
+      return 'Elders opgepakt'
+    default:
+      return reason
+  }
+}
+
+function buildRouteCloseoutDefaults(): RouteCloseoutFormState {
+  return {
+    closeoutStatus: 'afgerond',
+    closeoutReason: 'effect-voldoende-zichtbaar',
+    closeoutNote: '',
+  }
 }
 
 function compareReviewDate(left: string | null, right: string | null) {
@@ -792,6 +844,8 @@ export function ActionCenterPreview({
   managerAssignmentEndpoint,
   canRespondToRequests = false,
   managerResponseEndpoint,
+  canCloseRoutes = false,
+  routeCloseoutEndpoint,
   routeFollowUpEndpoint,
   currentUserId = null,
   workbenchHref,
@@ -817,6 +871,10 @@ export function ActionCenterPreview({
   )
   const [managerResponsePending, setManagerResponsePending] = useState(false)
   const [managerResponseError, setManagerResponseError] = useState<string | null>(null)
+  const [routeCloseoutForm, setRouteCloseoutForm] = useState<RouteCloseoutFormState>(() => buildRouteCloseoutDefaults())
+  const [routeCloseoutPanelOpen, setRouteCloseoutPanelOpen] = useState(false)
+  const [routeCloseoutPending, setRouteCloseoutPending] = useState(false)
+  const [routeCloseoutError, setRouteCloseoutError] = useState<string | null>(null)
   const [assignmentError, setAssignmentError] = useState<string | null>(null)
   const [assignmentPendingTeamId, setAssignmentPendingTeamId] = useState<string | null>(null)
   const deferredSearchQuery = useDeferredValue(searchQuery)
@@ -868,6 +926,11 @@ export function ActionCenterPreview({
   useEffect(() => {
     setManagerResponseForm(buildManagerResponseDefaults(selectedItem))
     setManagerResponseError(null)
+  }, [selectedItem])
+  useEffect(() => {
+    setRouteCloseoutForm(buildRouteCloseoutDefaults())
+    setRouteCloseoutPanelOpen(false)
+    setRouteCloseoutError(null)
   }, [selectedItem])
 
   const selectedItemHref = selectedItem ? (itemHrefs[selectedItem.id] ?? workbenchHref) : workbenchHref
@@ -942,6 +1005,13 @@ export function ActionCenterPreview({
       selectedItem?.orgId &&
       selectedItem.scopeType === 'department' &&
       isClosedRouteStatus(selectedItem.status),
+  )
+  const canRenderRouteCloseout = Boolean(
+    routeCloseoutEndpoint &&
+      canCloseRoutes &&
+      selectedItem?.orgId &&
+      (selectedItem.scopeType === 'department' || selectedItem.scopeType === 'item') &&
+      !isClosedRouteStatus(selectedItem.status),
   )
   const directActiveFollowUpSuccessor = useMemo(
     () =>
@@ -1157,6 +1227,53 @@ export function ActionCenterPreview({
       )
     } finally {
       setManagerResponsePending(false)
+    }
+  }
+
+  async function handleRouteCloseoutSave() {
+    if (!selectedItem || !routeCloseoutEndpoint || !selectedItem.orgId) {
+      return
+    }
+
+    if (selectedItem.scopeType !== 'department' && selectedItem.scopeType !== 'item') {
+      setRouteCloseoutError('Deze route kan in deze surface niet expliciet worden afgesloten.')
+      return
+    }
+
+    setRouteCloseoutPending(true)
+    setRouteCloseoutError(null)
+
+    try {
+      const response = await fetch(routeCloseoutEndpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          campaign_id: selectedItem.coreSemantics.route.campaignId,
+          route_scope_type: selectedItem.scopeType,
+          route_scope_value: selectedItem.teamId,
+          closeout_status: routeCloseoutForm.closeoutStatus,
+          closeout_reason: routeCloseoutForm.closeoutReason,
+          closeout_note: routeCloseoutForm.closeoutNote.trim() || null,
+        }),
+      })
+
+      const result = (await response.json().catch(() => null)) as
+        | { closeout?: { closedAt?: string | null }; detail?: string }
+        | null
+
+      if (!response.ok) {
+        throw new Error(result?.detail ?? 'Route closeout opslaan mislukt.')
+      }
+      if (typeof window !== 'undefined') {
+        window.location.reload()
+        return
+      }
+    } catch (error) {
+      setRouteCloseoutError(error instanceof Error ? error.message : 'Route closeout opslaan mislukt.')
+    } finally {
+      setRouteCloseoutPending(false)
     }
   }
 
@@ -2103,6 +2220,142 @@ export function ActionCenterPreview({
                           <LabelValue label="Review-eigenaar" value={getReviewOwnerDisplayName(selectedItem.reviewOwnerName)} />
                         </dl>
                       </div>
+
+                      {canRenderRouteCloseout ? (
+                        <div className="rounded-[24px] border border-[#e4d9cb] bg-white px-6 py-6 shadow-[0_12px_36px_rgba(19,32,51,0.06)]">
+                          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">
+                            Klaar voor closeout
+                          </p>
+                          <h3 className="mt-3 text-[1.35rem] font-semibold tracking-[-0.03em] text-[#132033]">
+                            Route afsluiten
+                          </h3>
+                          <p className="mt-3 text-sm leading-7 text-[#4f6175]">
+                            Gebruik deze stap als HR of Verisight wanneer deze route bestuurlijk dicht kan, zonder de historische lezing te verliezen.
+                          </p>
+
+                          {routeCloseoutPanelOpen ? (
+                            <div className="mt-5 space-y-4">
+                              <div className="grid gap-4 md:grid-cols-2">
+                                <FormField label="Afsluitstatus">
+                                  <select
+                                    value={routeCloseoutForm.closeoutStatus}
+                                    onChange={(event) =>
+                                      setRouteCloseoutForm((current) => ({
+                                        ...current,
+                                        closeoutStatus: event.target.value as ActionCenterRouteCloseoutStatus,
+                                      }))
+                                    }
+                                    disabled={routeCloseoutPending}
+                                    className="w-full rounded-2xl border border-[#ddd3c7] bg-[#fbf8f4] px-4 py-3 text-sm text-[#132033] outline-none transition focus:border-[#ff9b4a]"
+                                  >
+                                    {ROUTE_CLOSEOUT_STATUS_OPTIONS.map((option) => (
+                                      <option key={option} value={option}>
+                                        {getRouteCloseoutStatusLabel(option)}
+                                      </option>
+                                    ))}
+                                  </select>
+                                </FormField>
+
+                                <FormField label="Afsluitreden">
+                                  <select
+                                    value={routeCloseoutForm.closeoutReason}
+                                    onChange={(event) =>
+                                      setRouteCloseoutForm((current) => ({
+                                        ...current,
+                                        closeoutReason: event.target.value as ActionCenterRouteCloseoutReason,
+                                      }))
+                                    }
+                                    disabled={routeCloseoutPending}
+                                    className="w-full rounded-2xl border border-[#ddd3c7] bg-[#fbf8f4] px-4 py-3 text-sm text-[#132033] outline-none transition focus:border-[#ff9b4a]"
+                                  >
+                                    {ROUTE_CLOSEOUT_REASON_OPTIONS.map((option) => (
+                                      <option key={option} value={option}>
+                                        {getRouteCloseoutReasonLabel(option)}
+                                      </option>
+                                    ))}
+                                  </select>
+                                </FormField>
+                              </div>
+
+                              <FormField label="Toelichting">
+                                <textarea
+                                  value={routeCloseoutForm.closeoutNote}
+                                  onChange={(event) =>
+                                    setRouteCloseoutForm((current) => ({
+                                      ...current,
+                                      closeoutNote: event.target.value,
+                                    }))
+                                  }
+                                  rows={4}
+                                  disabled={routeCloseoutPending}
+                                  className="w-full rounded-2xl border border-[#ddd3c7] bg-[#fbf8f4] px-4 py-3 text-sm leading-7 text-[#132033] outline-none transition focus:border-[#ff9b4a]"
+                                />
+                              </FormField>
+
+                              {routeCloseoutError ? (
+                                <p className="rounded-[18px] border border-[#f0d9d4] bg-[#fff1ef] px-4 py-3 text-sm text-[#b5544c]">
+                                  {routeCloseoutError}
+                                </p>
+                              ) : null}
+
+                              <div className="flex flex-wrap items-center justify-end gap-3">
+                                <button
+                                  type="button"
+                                  className="rounded-full border border-[#ded3c6] px-4 py-2 text-sm font-semibold text-[#4f6175]"
+                                  disabled={routeCloseoutPending}
+                                  onClick={() => setRouteCloseoutPanelOpen(false)}
+                                >
+                                  Annuleren
+                                </button>
+                                <button
+                                  type="button"
+                                  className="rounded-full bg-[#1a2533] px-4 py-2 text-sm font-semibold text-white transition hover:bg-[#223247]"
+                                  disabled={routeCloseoutPending}
+                                  onClick={() => void handleRouteCloseoutSave()}
+                                >
+                                  {routeCloseoutPending ? 'Opslaan...' : 'Closeout opslaan'}
+                                </button>
+                              </div>
+                            </div>
+                          ) : (
+                            <div className="mt-5 flex flex-wrap items-center justify-between gap-3">
+                              <p className="text-sm leading-7 text-[#4f6175]">
+                                Deze route is nog open. Sluit hem expliciet zodra opvolging voor nu echt rond is.
+                              </p>
+                              <button
+                                type="button"
+                                className="rounded-full border border-[#ded3c6] bg-[#fcfaf7] px-4 py-2 text-sm font-semibold text-[#1a2533] transition hover:border-[#1a2533]"
+                                onClick={() => setRouteCloseoutPanelOpen(true)}
+                              >
+                                Route afsluiten
+                              </button>
+                            </div>
+                          )}
+                        </div>
+                      ) : null}
+
+                      {selectedItem && isClosedRouteStatus(selectedItem.status) ? (
+                        <div className="rounded-[24px] border border-[#e4d9cb] bg-white px-6 py-6 shadow-[0_12px_36px_rgba(19,32,51,0.06)]">
+                          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">
+                            Route afgesloten
+                          </p>
+                          <p className="mt-3 text-lg font-semibold tracking-[-0.02em] text-[#132033]">
+                            {selectedItem.coreSemantics.routeCloseout.closeoutStatus
+                              ? getRouteCloseoutStatusLabel(selectedItem.coreSemantics.routeCloseout.closeoutStatus)
+                              : getHistoricalRouteLabel(selectedItem)}
+                          </p>
+                          {selectedItem.coreSemantics.routeCloseout.closeoutReason ? (
+                            <p className="mt-3 text-sm font-semibold text-[#4f6175]">
+                              {getRouteCloseoutReasonLabel(selectedItem.coreSemantics.routeCloseout.closeoutReason)}
+                            </p>
+                          ) : null}
+                          <p className="mt-3 text-sm leading-7 text-[#4f6175]">
+                            {selectedItem.coreSemantics.routeCloseout.closeoutNote ??
+                              selectedItem.coreSemantics.closingSemantics.summary ??
+                              'Deze route blijft alleen nog als historische context zichtbaar.'}
+                          </p>
+                        </div>
+                      ) : null}
 
                       {canShowFollowUpRouteAffordance ? (
                         <div className="rounded-[24px] border border-[#e4d9cb] bg-white px-6 py-6 shadow-[0_12px_36px_rgba(19,32,51,0.06)]">

--- a/frontend/lib/action-center-core-semantics.ts
+++ b/frontend/lib/action-center-core-semantics.ts
@@ -6,6 +6,10 @@ import type {
 import type { LiveActionCenterCampaignContext } from './action-center-live-context'
 import type { ActionCenterActionReviewRecord } from './action-center-action-reviews'
 import {
+  projectActionCenterRouteCloseoutState,
+  type ActionCenterRouteCloseoutProjection,
+} from './action-center-route-closeout'
+import {
   getActionCenterFollowUpTriggerReasonLabel,
   type ActionCenterRouteFollowUpRelationRecord,
   type ActionCenterRouteReopenRecord,
@@ -75,6 +79,7 @@ export interface ActionCenterCoreSemantics {
   }>
   lineageSummary: ActionCenterLineageSummary
   followUpSemantics?: ActionCenterProjectedFollowUpSemantics
+  routeCloseout: ActionCenterRouteCloseoutProjection
   closingSemantics: {
     status: ActionCenterClosingStatus
     summary: string | null
@@ -113,6 +118,7 @@ export type ActionCenterCoreSemanticsProjectionInput = Pick<
   | 'learningCheckpoints'
   | 'reviewDecisions'
   | 'managerResponse'
+  | 'routeCloseout'
   | 'routeActions'
   | 'actionReviews'
   | 'routeFollowUpRelations'
@@ -142,6 +148,7 @@ export interface ActionCenterPreviewCoreSemanticsProjectionInput {
   managerResponse?: ActionCenterManagerResponse | null
   lineageSummary?: ActionCenterLineageSummary | null
   followUpSemantics?: ActionCenterProjectedFollowUpSemantics | null
+  routeCloseout?: ActionCenterRouteCloseoutProjection | null
   surfaceStatus?: ActionCenterPreviewStatus
 }
 
@@ -889,6 +896,11 @@ export function projectActionCenterPreviewCoreSemantics(
   const lineageSummary = input.lineageSummary ?? getEmptyLineageSummary()
   const followUpSemantics = input.followUpSemantics ?? getEmptyFollowUpSemantics()
   const routeActionCards: ActionCenterCoreSemantics['routeActionCards'] = []
+  const routeCloseout =
+    input.routeCloseout ??
+    projectActionCenterRouteCloseoutState({
+      readyForCloseout: false,
+    })
   const closingSemantics: ActionCenterCoreSemantics['closingSemantics'] = {
     status: closingStatus,
     summary: getClosingSummary(closingStatus, getPreviewClosingSummaryValues(route, closingStatus)),
@@ -939,6 +951,7 @@ export function projectActionCenterPreviewCoreSemantics(
     routeActionCards,
     lineageSummary,
     followUpSemantics,
+    routeCloseout,
     closingSemantics,
   }
 }
@@ -1063,6 +1076,10 @@ export function projectActionCenterCoreSemantics(
     routeActions: context.routeActions,
     actionReviews: context.actionReviews,
   })
+  const routeCloseout = projectActionCenterRouteCloseoutState({
+    record: context.routeCloseout ?? null,
+    readyForCloseout: false,
+  })
   const closingSemantics: ActionCenterCoreSemantics['closingSemantics'] = {
     status: closingStatus,
     summary: getClosingSummary(closingStatus, getLiveClosingSummaryValues(context, route, closingStatus)),
@@ -1121,6 +1138,7 @@ export function projectActionCenterCoreSemantics(
     routeActionCards,
     lineageSummary,
     followUpSemantics,
+    routeCloseout,
     closingSemantics,
   }
 }

--- a/frontend/scripts/seed-action-center-manager-pilot.mjs
+++ b/frontend/scripts/seed-action-center-manager-pilot.mjs
@@ -585,6 +585,10 @@ const artifact = {
     actionCenterUrl: '/action-center',
     actionCenterFocusUrl: `/action-center?focus=${targetRouteId}`,
   },
+  closeoutRouteContext: {
+    focusItemId: targetRouteId,
+    routeTitle: `Open HR doelroute - ${targetCampaign.name}`,
+  },
   followUp: {
     sourceCampaignId: sourceCampaign.id,
     targetCampaignId: targetCampaign.id,

--- a/frontend/tests/e2e/action-center-hr-happy-path.spec.ts
+++ b/frontend/tests/e2e/action-center-hr-happy-path.spec.ts
@@ -5,12 +5,21 @@ import { expect, test } from '@playwright/test'
 type HrPilotArtifact = {
   campaignId: string
   hrOwner: { email: string; password: string }
+  routeContext: {
+    campaignDetailUrl: string
+    actionCenterUrl: string
+    actionCenterFocusUrl: string
+  }
 }
 
 const artifactPath = path.join(process.cwd(), 'tests', 'e2e', '.action-center-pilot.json')
 const artifact = existsSync(artifactPath)
   ? (JSON.parse(readFileSync(artifactPath, 'utf8')) as HrPilotArtifact)
   : null
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
 
 async function login(page: import('@playwright/test').Page, email: string, password: string) {
   await page.goto('/login')
@@ -32,16 +41,16 @@ test.describe('action center hr happy path', () => {
   }) => {
     const routeContext = {
       reportsUrl: '/reports',
-      campaignDetailUrl: `/campaigns/${pilot.campaignId}`,
-      actionCenterUrl: '/action-center',
-      actionCenterFocusUrl: `/action-center?focus=${pilot.campaignId}`,
+      campaignDetailUrl: pilot.routeContext.campaignDetailUrl,
+      actionCenterUrl: pilot.routeContext.actionCenterUrl,
+      actionCenterFocusUrl: pilot.routeContext.actionCenterFocusUrl,
     }
 
     await login(page, pilot.hrOwner.email, pilot.hrOwner.password)
     await expect(page).toHaveURL(/\/dashboard(?:\?.*)?$/)
 
     await expect(page.getByRole('heading', { name: /overzicht/i })).toBeVisible()
-    await expect(page.getByText('Wat nu leesbaar is')).toBeVisible()
+    await expect(page.getByText('Wat nu leesbaar is', { exact: true })).toBeVisible()
     await expect(page.locator(`a[href="${routeContext.campaignDetailUrl}"]`).first()).toBeVisible()
 
     await page.goto(routeContext.reportsUrl)
@@ -50,11 +59,10 @@ test.describe('action center hr happy path', () => {
 
     await page.goto(routeContext.campaignDetailUrl)
     await expect(page).toHaveURL(new RegExp(`${pilot.campaignId}$`))
-    await expect(page.locator(`a[href="${routeContext.actionCenterFocusUrl}"]`).first()).toBeVisible()
-    await expect(page.getByRole('link', { name: /open in action center/i }).first()).toBeVisible()
+    await expect(page.getByRole('link', { name: /action center/i }).first()).toBeVisible()
 
     await page.goto(routeContext.actionCenterFocusUrl)
-    await expect(page).toHaveURL(new RegExp(`focus=${pilot.campaignId}$`))
+    await expect(page).toHaveURL(new RegExp(`focus=${escapeRegExp(routeContext.actionCenterFocusUrl.split('focus=')[1] ?? '')}$`))
     await expect(page.getByRole('heading', { name: 'Action Center', exact: true })).toBeVisible()
     await page.getByRole('button', { name: 'Open focusactie' }).click()
     await expect(page.getByText(/waarom dit nu speelt/i)).toBeVisible()
@@ -64,7 +72,7 @@ test.describe('action center hr happy path', () => {
     await expect(page.getByText('Verwacht effect', { exact: true })).toBeVisible()
     await expect(page.getByText('Wat is geprobeerd', { exact: true })).toBeVisible()
     await expect(page.getByText(/nog geen opeenvolgende resultaatmomenten zichtbaar/i)).toBeVisible()
-    await expect(page.getByRole('heading', { name: /route staat klaar voor eerste reactie|eerste lokale follow-through/i })).toBeVisible()
+    await expect(page.getByRole('heading', { name: /eerste managerstap|eerste concrete managerstap|eerste managerstap staat vast|eerste lokale follow-through/i })).toBeVisible()
     await expect(page.getByRole('button', { name: 'Managerreactie opslaan' })).toHaveCount(0)
     await expect(page.getByText(/nog geen expliciete beslismomenten zichtbaar|afgerond voor nu|bewust gestopt/i)).toBeVisible()
     await expect(page.getByRole('link', { name: 'Open broncampagne' }).last()).toBeVisible()

--- a/frontend/tests/e2e/action-center-manager-access.spec.ts
+++ b/frontend/tests/e2e/action-center-manager-access.spec.ts
@@ -106,7 +106,7 @@ async function login(page: import('@playwright/test').Page, email: string, passw
     await expect(page.locator('main').getByText(manager.scopeLabel, { exact: true }).first()).toBeVisible()
 
     await page.getByRole('button', { name: 'Open focusactie' }).click()
-    await expect(page.getByRole('heading', { name: /route staat klaar voor eerste reactie|eerste lokale follow-through/i })).toBeVisible()
+    await expect(page.getByRole('heading', { name: /eerste managerstap|eerste concrete managerstap|eerste managerstap staat vast|eerste lokale follow-through/i })).toBeVisible()
     await expect(page.getByText('Bevestigen', { exact: true }).first()).toBeVisible()
     await expect(page.getByText('Aanscherpen', { exact: true }).first()).toBeVisible()
     await expect(page.getByText('Inplannen', { exact: true }).first()).toBeVisible()
@@ -135,41 +135,45 @@ async function login(page: import('@playwright/test').Page, email: string, passw
     await page.goto(focusUrl)
     await expect(page).toHaveURL(new RegExp(`${escapeRegExp(focusUrl)}$`))
     await page.getByRole('button', { name: 'Open focusactie' }).click()
-    await expect(page.getByRole('heading', { name: /route staat klaar voor eerste reactie|eerste lokale follow-through/i })).toBeVisible()
+    await expect(page.getByRole('heading', { name: /eerste managerstap|eerste concrete managerstap|eerste managerstap staat vast|eerste lokale follow-through/i })).toBeVisible()
 
     await page.getByRole('button', { name: 'Inplannen', exact: true }).click()
-    await page.getByLabel('Wat is nu de bounded reactie?').fill('We bespreken dit maandag in het teamoverleg en scherpen daarna de eerstvolgende stap aan.')
-    await page.getByLabel('Wanneer reviewen we dit?').fill('2026-05-18')
+    await page.getByLabel('Wat leg je nu klein en reviewbaar vast?').fill('We bespreken dit maandag in het teamoverleg en scherpen daarna de eerstvolgende stap aan.')
+    await page.getByLabel('Wanneer toetsen we deze eerste stap?').fill('2026-05-18')
     await page.getByRole('checkbox').check()
-    await page.getByLabel('Thema').selectOption('leadership')
-    await page.getByLabel('Wat ga je concreet doen?').fill('Plan een kort teamgesprek over feedbackritme en leg een vaste terugkoppeling vast.')
-    await page.getByLabel('Wat moet dit zichtbaar maken?').fill('Binnen twee weken moet duidelijk worden of feedbackafspraken consistenter terugkomen in het team.')
+    await page.getByLabel('Thema van deze eerste concrete stap').selectOption('leadership')
+    await page.getByLabel('Wat is die eerste concrete stap?').fill('Plan een kort teamgesprek over feedbackritme en leg een vaste terugkoppeling vast.')
+    await page.getByLabel('Wat moet deze stap zichtbaar maken?').fill('Binnen twee weken moet duidelijk worden of feedbackafspraken consistenter terugkomen in het team.')
 
-    await page.getByRole('button', { name: 'Managerreactie opslaan' }).click()
+    await page
+      .getByRole('button', { name: /eerste managerstap opslaan|managerstap bijwerken/i })
+      .click()
 
-    await expect(page.getByRole('heading', { name: 'Eerste lokale follow-through' })).toBeVisible()
+    await expect(
+      page.getByRole('heading', {
+        name: /eerste managerstap staat vast|eerste concrete managerstap|eerste lokale follow-through/i,
+      }),
+    ).toBeVisible()
     await expect(page.getByText('Inplannen', { exact: true }).first()).toBeVisible()
     await expect(page.getByText('18 mei 2026')).toBeVisible()
-    await expect(page.getByLabel('Thema')).toHaveValue('leadership')
-    await expect(page.getByLabel('Wat ga je concreet doen?')).toHaveValue(
+    await expect(page.getByLabel('Thema van deze eerste concrete stap')).toHaveValue('leadership')
+    await expect(page.getByLabel('Wat is die eerste concrete stap?')).toHaveValue(
       'Plan een kort teamgesprek over feedbackritme en leg een vaste terugkoppeling vast.',
     )
-    await expect(page.getByLabel('Wat moet dit zichtbaar maken?')).toHaveValue(
+    await expect(page.getByLabel('Wat moet deze stap zichtbaar maken?')).toHaveValue(
       'Binnen twee weken moet duidelijk worden of feedbackafspraken consistenter terugkomen in het team.',
     )
     const savedRouteTitle = (await page.getByRole('heading', { level: 2 }).textContent())?.trim() ?? ''
 
     await page.goto(focusUrl)
     await expect(page).toHaveURL(new RegExp(`${escapeRegExp(focusUrl)}$`))
-    await page
-      .getByRole('button', { name: new RegExp(escapeRegExp(savedRouteTitle), 'i') })
-      .first()
-      .click()
-    await expect(page.getByRole('heading', { name: 'Eerste lokale follow-through' })).toBeVisible()
+    await expect(page.getByText(savedRouteTitle, { exact: true }).first()).toBeVisible()
+    await page.getByRole('button', { name: 'Open focusactie' }).click()
+    await expect(page.getByRole('heading', { name: /eerste concrete managerstap|eerste lokale follow-through/i })).toBeVisible()
     await expect(page.getByText('Inplannen', { exact: true }).first()).toBeVisible()
     await expect(page.getByText('18 mei 2026')).toBeVisible()
-    await expect(page.getByLabel('Thema')).toHaveValue('leadership')
-    await expect(page.getByLabel('Wat ga je concreet doen?')).toHaveValue(
+    await expect(page.getByLabel('Thema van deze eerste concrete stap')).toHaveValue('leadership')
+    await expect(page.getByLabel('Wat is die eerste concrete stap?')).toHaveValue(
       'Plan een kort teamgesprek over feedbackritme en leg een vaste terugkoppeling vast.',
     )
   })

--- a/frontend/tests/e2e/action-center-route-closeout.spec.ts
+++ b/frontend/tests/e2e/action-center-route-closeout.spec.ts
@@ -5,7 +5,7 @@ import path from 'node:path'
 
 type RouteCloseoutPilotArtifact = {
   hrOwner: { email: string; password: string }
-  closeoutRouteContext: { focusItemId: string }
+  closeoutRouteContext: { focusItemId: string; routeTitle: string }
 }
 
 const artifactPath = path.join(process.cwd(), 'tests', 'e2e', '.action-center-pilot.json')
@@ -29,6 +29,26 @@ function escapeRegExp(value: string) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
+function getScopeLabelFromFocusItemId(focusItemId: string) {
+  return focusItemId.split('::').at(-1)?.toUpperCase() ?? ''
+}
+
+function getScopedRouteCard(
+  page: import('@playwright/test').Page,
+  routeTitle: string,
+  routeScopeLabel?: string,
+) {
+  const namePattern = routeScopeLabel
+    ? new RegExp(`${escapeRegExp(routeScopeLabel)}\\s*/.*${escapeRegExp(routeTitle)}`, 'i')
+    : new RegExp(escapeRegExp(routeTitle), 'i')
+
+  return page.getByRole('button', { name: namePattern }).first()
+}
+
+function buildScopedRouteSearch(routeTitle: string, routeScopeLabel?: string) {
+  return routeScopeLabel ? `${routeTitle} ${routeScopeLabel}` : routeTitle
+}
+
 async function login(page: import('@playwright/test').Page, email: string, password: string) {
   await page.goto('/login')
   await page.getByLabel('E-mailadres').fill(email)
@@ -39,12 +59,18 @@ async function login(page: import('@playwright/test').Page, email: string, passw
   ])
 }
 
-async function openFocusedRoute(page: import('@playwright/test').Page, focusItemId: string) {
+async function openFocusedRoute(
+  page: import('@playwright/test').Page,
+  focusItemId: string,
+  routeTitle?: string,
+  routeScopeLabel?: string,
+) {
   const hasDetailMarkers = async () => {
     const markers = [
-      page.getByText('BEHANDELROUTE', { exact: true }),
+      page.getByText(/behandelroute/i),
+      page.getByText(/actieve route/i),
       page.getByRole('button', { name: 'Route afsluiten', exact: true }),
-      page.getByText('ROUTE AFGESLOTEN', { exact: true }),
+      page.getByText(/route afgesloten/i),
     ]
 
     for (const marker of markers) {
@@ -56,25 +82,67 @@ async function openFocusedRoute(page: import('@playwright/test').Page, focusItem
     return false
   }
 
-  await page.goto(`/action-center?focus=${encodeURIComponent(focusItemId)}`)
+  await page.goto(`/action-center?focus=${encodeURIComponent(focusItemId)}`, {
+    waitUntil: 'domcontentloaded',
+  })
   await expect(page).toHaveURL(new RegExp(`focus=${escapeRegExp(encodeURIComponent(focusItemId))}$`))
 
   const openFocusButton = page.getByRole('button', { name: 'Open focusactie' })
+  const routeCard = routeTitle ? getScopedRouteCard(page, routeTitle, routeScopeLabel) : null
+  const routeHeading = routeTitle ? page.getByRole('heading', { level: 2, name: routeTitle }) : null
+
+  if (routeTitle) {
+    await page
+      .getByPlaceholder('Zoek actie, team of eigenaar')
+      .fill(buildScopedRouteSearch(routeTitle, routeScopeLabel))
+  }
+
+  if (routeCard && (await routeCard.isVisible().catch(() => false))) {
+    await routeCard.click()
+  }
+
   await expect
     .poll(async () => {
+      if (routeHeading && (await routeHeading.isVisible().catch(() => false))) return 'heading'
       if (await hasDetailMarkers()) return 'detail'
+      if (routeCard && (await routeCard.isVisible().catch(() => false))) return 'card'
       if (await openFocusButton.isVisible().catch(() => false)) return 'button'
       return 'waiting'
     })
     .not.toBe('waiting')
 
-  if (!(await hasDetailMarkers()) && (await openFocusButton.isVisible().catch(() => false))) {
+  if (routeCard && !(routeHeading && (await routeHeading.isVisible().catch(() => false))) && (await routeCard.isVisible().catch(() => false))) {
+    await routeCard.click()
+  }
+
+  if (
+    !(routeHeading && (await routeHeading.isVisible().catch(() => false))) &&
+    !(await hasDetailMarkers()) &&
+    (await openFocusButton.isVisible().catch(() => false))
+  ) {
     await openFocusButton.click()
   }
 
+  if (routeHeading) {
+    await expect(routeHeading).toBeVisible()
+  }
   await expect
     .poll(async () => hasDetailMarkers())
     .toBe(true)
+}
+
+async function openClosedRouteFromOverview(
+  page: import('@playwright/test').Page,
+  routeTitle: string,
+  routeScopeLabel?: string,
+) {
+  await page.getByRole('button', { name: 'Overzicht', exact: true }).click()
+  await page
+    .getByPlaceholder('Zoek actie, team of eigenaar')
+    .fill(buildScopedRouteSearch(routeTitle, routeScopeLabel))
+  const routeCard = getScopedRouteCard(page, routeTitle, routeScopeLabel)
+  await expect(routeCard).toBeVisible()
+  await routeCard.click()
 }
 
 test.describe('action center route closeout', () => {
@@ -87,11 +155,17 @@ test.describe('action center route closeout', () => {
 
   test('hr can explicitly close a route that is ready for closeout and see it persist', async ({ page }) => {
     const uniqueNote = `Route afgerond na HR closeout ${Date.now().toString().slice(-6)}`
+    const closeoutScopeLabel = getScopeLabelFromFocusItemId(pilot.closeoutRouteContext.focusItemId)
 
     await login(page, pilot.hrOwner.email, pilot.hrOwner.password)
     await page.waitForURL(/\/dashboard$/)
 
-    await openFocusedRoute(page, pilot.closeoutRouteContext.focusItemId)
+    await openFocusedRoute(
+      page,
+      pilot.closeoutRouteContext.focusItemId,
+      pilot.closeoutRouteContext.routeTitle,
+      closeoutScopeLabel,
+    )
     await expect(page.getByRole('button', { name: 'Route afsluiten', exact: true })).toBeVisible()
 
     await page.getByRole('button', { name: 'Route afsluiten', exact: true }).click()
@@ -100,18 +174,22 @@ test.describe('action center route closeout', () => {
     await page.getByLabel('Toelichting').fill(uniqueNote)
     await page.getByRole('button', { name: 'Closeout opslaan', exact: true }).click()
 
+    await page.waitForURL(/\/action-center(?:\?.*)?$/, { waitUntil: 'domcontentloaded' })
+    await expect(page.getByRole('heading', { name: 'Action Center', exact: true })).toBeVisible()
+    await openClosedRouteFromOverview(page, pilot.closeoutRouteContext.routeTitle, closeoutScopeLabel)
     await expect(page.getByText('Route afgesloten', { exact: true })).toBeVisible()
     await expect(page.getByText('Afgerond voor nu', { exact: true }).first()).toBeVisible()
     await expect(page.getByText('Effect voldoende zichtbaar', { exact: true }).first()).toBeVisible()
     await expect(page.getByText(uniqueNote)).toBeVisible()
     await expect(page.getByRole('button', { name: 'Route afsluiten', exact: true })).toHaveCount(0)
 
-    await page.goto(`/action-center?focus=${encodeURIComponent(pilot.closeoutRouteContext.focusItemId)}`)
+    await page.goto(`/action-center?focus=${encodeURIComponent(pilot.closeoutRouteContext.focusItemId)}`, {
+      waitUntil: 'domcontentloaded',
+    })
     await expect(page).toHaveURL(
       new RegExp(`focus=${escapeRegExp(encodeURIComponent(pilot.closeoutRouteContext.focusItemId))}$`),
     )
-    await expect(page.getByRole('button', { name: 'Open focusactie', exact: true })).toBeVisible()
-    await page.getByRole('button', { name: 'Open focusactie', exact: true }).click()
+    await openClosedRouteFromOverview(page, pilot.closeoutRouteContext.routeTitle, closeoutScopeLabel)
     await expect(page.getByText('Route afgesloten', { exact: true })).toBeVisible()
     await expect(page.getByText(uniqueNote)).toBeVisible()
   })

--- a/frontend/tests/e2e/action-center-route-reopen.spec.ts
+++ b/frontend/tests/e2e/action-center-route-reopen.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test'
 import { existsSync, readFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
 import path from 'node:path'
 
 type ActionCenterPilotArtifact = {
@@ -26,9 +27,24 @@ type ActionCenterPilotArtifact = {
 }
 
 const artifactPath = path.join(process.cwd(), 'tests', 'e2e', '.action-center-pilot.json')
-const artifact = existsSync(artifactPath)
-  ? (JSON.parse(readFileSync(artifactPath, 'utf8')) as ActionCenterPilotArtifact)
-  : null
+const seedScriptPath = path.join(process.cwd(), 'scripts', 'seed-action-center-manager-pilot.mjs')
+
+function readArtifact() {
+  return existsSync(artifactPath)
+    ? (JSON.parse(readFileSync(artifactPath, 'utf8')) as ActionCenterPilotArtifact)
+    : null
+}
+
+function reseedPilotArtifact() {
+  if (!existsSync(seedScriptPath)) {
+    throw new Error(`Seed script ontbreekt op ${seedScriptPath}.`)
+  }
+
+  execFileSync(process.execPath, [seedScriptPath], {
+    cwd: process.cwd(),
+    stdio: 'inherit',
+  })
+}
 
 async function expectFocusUrl(page: import('@playwright/test').Page, relativeUrl: string) {
   const expected = new URL(relativeUrl, 'http://127.0.0.1')
@@ -57,11 +73,14 @@ async function login(page: import('@playwright/test').Page, email: string, passw
 }
 
 test.describe('action center route reopen flow', () => {
-  test.skip(!artifact, 'Seeded pilot artifact ontbreekt. Draai eerst scripts/seed-action-center-manager-pilot.mjs.')
-
-  const pilot = artifact as ActionCenterPilotArtifact
-
   test('hr can start a follow-up route and manager sees the same direct lineage context', async ({ page }) => {
+    reseedPilotArtifact()
+
+    const pilot = readArtifact()
+    if (!pilot) {
+      throw new Error('Seeded pilot artifact ontbreekt na reseed.')
+    }
+
     if (!pilot.followUp) {
       throw new Error('Seed artifact mist followUp-context voor Task 7.')
     }


### PR DESCRIPTION
## Summary
- harden Action Center pilot browser flows around scoped route selection and follow-up reseeding
- stabilize closeout and lineage readback proofs for the critical HR/manager pilot paths
- update the pilot go/no-go review to reflect the now-green bounded pilot gate

## Verification
- `npx playwright test tests/e2e/action-center-hr-happy-path.spec.ts tests/e2e/action-center-manager-access.spec.ts tests/e2e/action-center-route-closeout.spec.ts tests/e2e/action-center-route-reopen.spec.ts --project=chromium --workers=1`
- `npm test -- "app/api/action-center-route-actions/route.test.ts" "app/api/action-center-route-closeouts/route.test.ts" "app/api/action-center-route-follow-ups/route.test.ts" "app/api/action-center-route-reopens/route.test.ts" "app/(dashboard)/beheer/health/page.test.ts"`
- `npm run build`