### PR TITLE
Routebeheer hub

### DIFF
--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.test.ts
@@ -1,0 +1,108 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { buildDeliveryAutoSignals } from '@/lib/ops-delivery'
+import {
+  buildRouteBeheerLifecycleSteps,
+  formatLatestActivityLabel,
+  formatRoutePeriodLabel,
+  getLatestActivityTimestamp,
+} from './beheer-data'
+
+describe('routebeheer data helpers', () => {
+  it('copies the quarter label from the campaign name when available', () => {
+    expect(formatRoutePeriodLabel('Exit Q3 2026', '2026-01-15T10:00:00.000Z')).toBe('Q3 2026')
+  })
+
+  it('prefers the newest timestamp between audit and delivery update', () => {
+    expect(
+      getLatestActivityTimestamp(
+        [{ action_key: 'launch_invites', outcome: 'completed', action_label: 'x', owner_label: 'y', actor_role: null, actor_label: null, summary: 'done', metadata: {}, created_at: '2026-05-03T09:00:00.000Z' }],
+        '2026-05-03T10:00:00.000Z',
+      ),
+    ).toBe('2026-05-03T10:00:00.000Z')
+  })
+
+  it('maps all delivery stages into the fixed six-step lifecycle', () => {
+    const stages = [
+      'setup_in_progress',
+      'import_cleared',
+      'invites_live',
+      'client_activation_pending',
+      'client_activation_confirmed',
+      'first_value_reached',
+      'first_management_use',
+      'follow_up_decided',
+      'learning_closed',
+    ] as const
+
+    const results = stages.map((stage) =>
+      buildRouteBeheerLifecycleSteps({
+        stage,
+        isActive: true,
+        hasMinDisplay: true,
+        hasEnoughData: true,
+      }),
+    )
+
+    expect(results[0][0]?.status).toBe('current')
+    expect(results[1][1]?.status).toBe('current')
+    expect(results[2][2]?.status).toBe('current')
+    expect(results[3][2]?.status).toBe('current')
+    expect(results[4][3]?.status).toBe('current')
+    expect(results[5][3]?.status).toBe('current')
+    expect(results[6][4]?.status).toBe('current')
+    expect(results[7][4]?.status).toBe('current')
+    expect(results[8][5]?.status).toBe('current')
+  })
+
+  it('formats latest activity in Dutch routebeheer copy', () => {
+    expect(formatLatestActivityLabel('2026-05-01T08:00:00.000Z')).toContain('Laatste activiteit:')
+  })
+
+  it('keeps missing import readiness explicit instead of treating it as not ready', () => {
+    const signals = buildDeliveryAutoSignals({
+      scanType: 'exit',
+      linkedLeadPresent: false,
+      totalInvited: 0,
+      totalCompleted: 0,
+      invitesNotSent: 0,
+      incompleteScores: 0,
+      hasMinDisplay: false,
+      hasEnoughData: false,
+      activeClientAccessCount: 0,
+      pendingClientInviteCount: 0,
+      importReady: null,
+    })
+
+    expect(signals.import_qa.autoState).toBe('unknown')
+    expect(signals.import_qa.summary).toContain('nog niet bekend')
+  })
+})
+
+describe('routebeheer source integration', () => {
+  it('adds the routebeheer bridge link to the existing campaign detail page', () => {
+    const source = readFileSync(new URL('../page.tsx', import.meta.url), 'utf8')
+    expect(source).toContain('Routebeheer openen')
+    expect(source).toContain('/campaigns/${id}/beheer')
+  })
+
+  it('does not silently coerce unknown import readiness into a false auto-signal', () => {
+    const source = readFileSync(new URL('./beheer-data.ts', import.meta.url), 'utf8')
+
+    expect(source).not.toContain('importReady: importReady === true')
+  })
+
+  it('keeps the operational route free from analytical or action-center detail imports', () => {
+    const source = readFileSync(new URL('./route-beheer-components.tsx', import.meta.url), 'utf8')
+
+    expect(source).toContain('Livegang')
+    expect(source).toContain('Respons')
+    expect(source).toContain('Dashboard leesbaarheid')
+    expect(source).toContain('Eerstvolgende stap')
+    expect(source).not.toContain('Frictiescore')
+    expect(source).not.toContain('SDT')
+    expect(source).not.toContain('buildExitNarratives')
+    expect(source).not.toContain('buildRetentionNarratives')
+    expect(source).not.toContain('ActionPlaybook')
+  })
+})

--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.ts
@@ -1,0 +1,541 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { buildGuidedSelfServeState, deriveGuidedSelfServeDiscipline } from '@/lib/guided-self-serve'
+import { getDeliveryModeLabel } from '@/lib/implementation-readiness'
+import {
+  buildDeliveryAutoSignals,
+  buildDeliveryGovernanceSnapshot,
+  type CampaignDeliveryCheckpoint,
+  type CampaignDeliveryRecord,
+  type DeliveryLifecycleStage,
+} from '@/lib/ops-delivery'
+import { FIRST_DASHBOARD_THRESHOLD, FIRST_INSIGHT_THRESHOLD } from '@/lib/response-activation'
+import {
+  SCAN_TYPE_LABELS,
+  type Campaign,
+  type CampaignStats,
+  type MemberRole,
+  type Respondent,
+  type ScanType,
+} from '@/lib/types'
+import type { CampaignAuditEventRecord } from '@/lib/campaign-audit'
+import { getCustomerActionPermission } from '@/lib/customer-permissions'
+
+type SupabaseLike = Pick<SupabaseClient, 'from'>
+
+export type RouteBeheerLifecycleStep = {
+  key: 'setup' | 'doelgroep' | 'uitnodigingen' | 'respons' | 'output' | 'afgerond'
+  label: string
+  status: 'done' | 'current' | 'pending'
+  sublabel: string
+}
+
+export interface RouteBeheerPageData {
+  campaignId: string
+  campaignName: string
+  organizationName: string | null
+  scanType: ScanType
+  scanTypeLabel: string
+  deliveryModeLabel: string | null
+  routePeriodLabel: string
+  isActive: boolean
+  statusBadgeLabel: string
+  statusBadgeTone: 'emerald' | 'amber' | 'slate'
+  lastActivityAt: string | null
+  launchDate: string | null
+  totalInvited: number
+  totalCompleted: number
+  pendingCount: number
+  completionRatePct: number | null
+  invitesNotSent: number
+  hasMinDisplay: boolean
+  hasEnoughData: boolean
+  readabilityLabel: string
+  readabilityBody: string
+  nextActionTitle: string | null
+  nextActionBody: string | null
+  blockers: string[]
+  lifecycleStage: DeliveryLifecycleStage | null
+  lifecycleSteps: RouteBeheerLifecycleStep[]
+  respondentCount: number
+  routeSettingsLabel: string
+  routeSettingsBody: string
+  outputStatusLabel: string
+  latestAuditSummary: string | null
+  reportAvailable: boolean
+  canExecuteCampaign: boolean
+  canManageCampaign: boolean
+  membershipRole: MemberRole | null
+}
+
+export type RouteBeeheerPageData = RouteBeheerPageData
+
+const LIFECYCLE_STEP_ORDER: Array<RouteBeheerLifecycleStep['key']> = [
+  'setup',
+  'doelgroep',
+  'uitnodigingen',
+  'respons',
+  'output',
+  'afgerond',
+]
+
+const LIFECYCLE_LABELS: Record<RouteBeheerLifecycleStep['key'], string> = {
+  setup: 'Setup',
+  doelgroep: 'Doelgroep',
+  uitnodigingen: 'Uitnodigingen',
+  respons: 'Respons',
+  output: 'Output',
+  afgerond: 'Afgerond',
+}
+
+export function formatRoutePeriodLabel(campaignName: string, createdAt: string) {
+  const quarterMatch = campaignName.match(/Q[1-4]\s?\d{4}/i)
+  if (quarterMatch) return quarterMatch[0].replace(/\s+/, ' ')
+
+  try {
+    return new Intl.DateTimeFormat('nl-NL', {
+      month: 'long',
+      year: 'numeric',
+      timeZone: 'Europe/Amsterdam',
+    }).format(new Date(createdAt))
+  } catch {
+    return createdAt
+  }
+}
+
+export function getRouteBeheerLifecycleIndex(stage: DeliveryLifecycleStage | null | undefined) {
+  switch (stage) {
+    case 'setup_in_progress':
+      return 0
+    case 'import_cleared':
+      return 1
+    case 'invites_live':
+    case 'client_activation_pending':
+      return 2
+    case 'client_activation_confirmed':
+    case 'first_value_reached':
+      return 3
+    case 'first_management_use':
+    case 'follow_up_decided':
+      return 4
+    case 'learning_closed':
+      return 5
+    default:
+      return 0
+  }
+}
+
+function getLifecycleSublabel(args: {
+  key: RouteBeheerLifecycleStep['key']
+  status: 'done' | 'current' | 'pending'
+  isActive: boolean
+  hasMinDisplay: boolean
+  hasEnoughData: boolean
+}) {
+  if (args.status === 'pending') return 'Nog niet'
+  if (args.status === 'done') return 'Voltooid'
+
+  switch (args.key) {
+    case 'setup':
+      return 'Loopt'
+    case 'doelgroep':
+      return 'Klaar'
+    case 'uitnodigingen':
+      return args.isActive ? 'Live' : 'Nog niet'
+    case 'respons':
+      return args.hasEnoughData ? 'Leesbaar' : args.hasMinDisplay ? 'Indicatief' : 'Loopt'
+    case 'output':
+      return args.hasMinDisplay ? 'Beschikbaar' : 'Nog niet'
+    case 'afgerond':
+      return 'Afgerond'
+    default:
+      return 'Nog niet'
+  }
+}
+
+export function buildRouteBeheerLifecycleSteps(args: {
+  stage: DeliveryLifecycleStage | null | undefined
+  isActive: boolean
+  hasMinDisplay: boolean
+  hasEnoughData: boolean
+}) {
+  const currentIndex = getRouteBeheerLifecycleIndex(args.stage)
+
+  return LIFECYCLE_STEP_ORDER.map((key, index) => {
+    const status = index < currentIndex ? 'done' : index === currentIndex ? 'current' : 'pending'
+
+    return {
+      key,
+      label: LIFECYCLE_LABELS[key],
+      status,
+      sublabel: getLifecycleSublabel({
+        key,
+        status,
+        isActive: args.isActive,
+        hasMinDisplay: args.hasMinDisplay,
+        hasEnoughData: args.hasEnoughData,
+      }),
+    } satisfies RouteBeheerLifecycleStep
+  })
+}
+
+export function getLatestActivityTimestamp(
+  auditEvents: CampaignAuditEventRecord[],
+  deliveryUpdatedAt: string | null | undefined,
+) {
+  const auditAt = auditEvents[0]?.created_at ?? null
+  const candidates = [auditAt, deliveryUpdatedAt ?? null].filter(
+    (value): value is string => typeof value === 'string' && value.trim().length > 0,
+  )
+
+  if (candidates.length === 0) {
+    return null
+  }
+
+  return candidates.reduce((latest, candidate) => {
+    if (!latest) return candidate
+    const latestDate = new Date(latest).getTime()
+    const candidateDate = new Date(candidate).getTime()
+    if (Number.isNaN(latestDate) || Number.isNaN(candidateDate)) {
+      return latest
+    }
+    return candidateDate > latestDate ? candidate : latest
+  }, candidates[0] ?? null)
+}
+
+export function formatLatestActivityLabel(value: string | null) {
+  if (!value) return 'Niet beschikbaar'
+
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) {
+    return 'Niet beschikbaar'
+  }
+
+  const now = new Date()
+  const sameDay =
+    parsed.getFullYear() === now.getFullYear() &&
+    parsed.getMonth() === now.getMonth() &&
+    parsed.getDate() === now.getDate()
+
+  return sameDay
+    ? `Laatste activiteit: vandaag om ${new Intl.DateTimeFormat('nl-NL', {
+        hour: '2-digit',
+        minute: '2-digit',
+        timeZone: 'Europe/Amsterdam',
+      }).format(parsed)}`
+    : `Laatste activiteit: ${new Intl.DateTimeFormat('nl-NL', {
+        day: '2-digit',
+        month: 'short',
+        timeZone: 'Europe/Amsterdam',
+      }).format(parsed)}`
+}
+
+function getReadabilityPresentation(totalCompleted: number) {
+  if (totalCompleted >= FIRST_INSIGHT_THRESHOLD) {
+    return {
+      label: 'Leesbaar',
+      body: 'Dashboard en rapport zijn nu veilig leesbaar voor eerste outputgebruik.',
+    }
+  }
+
+  if (totalCompleted >= FIRST_DASHBOARD_THRESHOLD) {
+    return {
+      label: 'Indicatief beeld',
+      body: 'Dashboard en rapport zijn zichtbaar, maar de responsbasis blijft nog compact.',
+    }
+  }
+
+  return {
+    label: 'Nog niet leesbaar',
+    body: 'Nog onvoldoende responses voor een veilige eerste dashboardread.',
+  }
+}
+
+function getStatusBadgeLabel(args: {
+  isActive: boolean
+  invitesNotSent: number
+}) {
+  if (!args.isActive) {
+    return { label: 'Gesloten', tone: 'slate' as const }
+  }
+
+  if (args.invitesNotSent > 0) {
+    return { label: 'Uitnodigingen nog niet gestart', tone: 'amber' as const }
+  }
+
+  return { label: 'Live', tone: 'emerald' as const }
+}
+
+function getLaunchValue(args: { isActive: boolean; launchDate: string | null }) {
+  if (!args.isActive) return 'Gesloten'
+  if (!args.launchDate) return 'Nog niet gestart'
+
+  try {
+    return new Intl.DateTimeFormat('nl-NL', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric',
+      timeZone: 'Europe/Amsterdam',
+    }).format(new Date(args.launchDate))
+  } catch {
+    return args.launchDate
+  }
+}
+
+function getRouteSettingsBody(args: {
+  launchDate: string | null
+  createdAt: string
+}) {
+  const sourceDate = args.launchDate ?? args.createdAt
+  try {
+    return `Startdatum: ${new Intl.DateTimeFormat('nl-NL', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric',
+      timeZone: 'Europe/Amsterdam',
+    }).format(new Date(sourceDate))}`
+  } catch {
+    return 'Startdatum: Niet beschikbaar'
+  }
+}
+
+function filterOperationalBlockers(snapshot: ReturnType<typeof buildDeliveryGovernanceSnapshot>) {
+  return [
+    ...snapshot.globalBlockers,
+    ...snapshot.intakeBlockers,
+    ...snapshot.importBlockers,
+    ...snapshot.inviteBlockers,
+    ...snapshot.launchControlBlockers,
+    ...snapshot.activationBlockers,
+    ...snapshot.firstValueBlockers,
+    ...snapshot.reportDeliveryBlockers,
+  ].filter((item, index, items) => item.trim().length > 0 && items.indexOf(item) === index)
+}
+
+export async function fetchRouteBeheerData(args: {
+  campaignId: string
+  supabase: SupabaseLike
+  userId: string
+}) {
+  const { campaignId, supabase, userId } = args
+  const { data: statsRow } = await supabase
+    .from('campaign_stats')
+    .select('*')
+    .eq('campaign_id', campaignId)
+    .single()
+
+  if (!statsRow) {
+    return null
+  }
+
+  const stats = statsRow as CampaignStats
+
+  const [
+    { data: profile },
+    { data: membership },
+    { data: organization },
+    { data: campaignMeta },
+    { count: activeClientAccessCount },
+    { count: pendingClientInviteCount },
+    { data: deliveryRecordRaw },
+    { data: respondentsRaw },
+    { data: responsesRaw },
+    { data: auditEventsRaw },
+  ] = await Promise.all([
+    supabase.from('profiles').select('is_verisight_admin').eq('id', userId).maybeSingle(),
+    supabase
+      .from('org_members')
+      .select('role')
+      .eq('org_id', stats.organization_id)
+      .eq('user_id', userId)
+      .maybeSingle(),
+    supabase.from('organizations').select('name').eq('id', stats.organization_id).maybeSingle(),
+    supabase.from('campaigns').select('delivery_mode, created_at').eq('id', campaignId).maybeSingle(),
+    supabase
+      .from('org_members')
+      .select('id', { count: 'exact', head: true })
+      .eq('org_id', stats.organization_id)
+      .in('role', ['viewer', 'member']),
+    supabase
+      .from('org_invites')
+      .select('id', { count: 'exact', head: true })
+      .eq('org_id', stats.organization_id)
+      .is('accepted_at', null),
+    supabase.from('campaign_delivery_records').select('*').eq('campaign_id', campaignId).maybeSingle(),
+    supabase
+      .from('respondents')
+      .select('id, sent_at, completed, completed_at')
+      .eq('campaign_id', campaignId)
+      .order('completed_at', { ascending: false, nullsFirst: false }),
+    supabase
+      .from('survey_responses')
+      .select('id, org_scores, sdt_scores, respondents!inner(campaign_id)')
+      .eq('respondents.campaign_id', campaignId),
+    supabase
+      .from('campaign_action_audit_events')
+      .select('id, action_key, outcome, action_label, owner_label, actor_role, actor_label, summary, metadata, created_at')
+      .eq('campaign_id', campaignId)
+      .order('created_at', { ascending: false })
+      .limit(8),
+  ])
+
+  const memberRole = (membership?.role ?? null) as MemberRole | null
+  const isVerisightAdmin = profile?.is_verisight_admin === true
+  const canManageCampaign =
+    isVerisightAdmin || getCustomerActionPermission(memberRole, 'review_launch')
+  const canExecuteCampaign =
+    isVerisightAdmin ||
+    getCustomerActionPermission(memberRole, 'import_respondents') ||
+    getCustomerActionPermission(memberRole, 'launch_invites') ||
+    getCustomerActionPermission(memberRole, 'send_reminders')
+
+  const deliveryRecord = (deliveryRecordRaw ?? null) as CampaignDeliveryRecord | null
+  const { data: deliveryCheckpointsRaw } = deliveryRecord
+    ? await supabase
+        .from('campaign_delivery_checkpoints')
+        .select('*')
+        .eq('delivery_record_id', deliveryRecord.id)
+        .order('created_at', { ascending: true })
+    : { data: [] }
+  const deliveryCheckpoints = (deliveryCheckpointsRaw ?? []) as CampaignDeliveryCheckpoint[]
+
+  const respondents = (respondentsRaw ?? []) as Pick<
+    Respondent,
+    'id' | 'sent_at' | 'completed' | 'completed_at'
+  >[]
+  const responseRows = (responsesRaw ?? []) as Array<{ id: string; org_scores: unknown; sdt_scores: unknown }>
+  const auditEvents = (auditEventsRaw ?? []) as CampaignAuditEventRecord[]
+  const campaign = (campaignMeta ?? null) as Pick<Campaign, 'delivery_mode' | 'created_at'> | null
+
+  const pendingCount = stats.total_invited - stats.total_completed
+  const invitesNotSent = respondents.filter((respondent) => !respondent.sent_at && !respondent.completed).length
+  const incompleteScores = responseRows.filter(
+    (response) => !response.org_scores || !response.sdt_scores,
+  ).length
+  const hasMinDisplay = responseRows.length >= FIRST_DASHBOARD_THRESHOLD
+  const hasEnoughData = responseRows.length >= FIRST_INSIGHT_THRESHOLD
+  const importQaCheckpoint = deliveryCheckpoints.find((checkpoint) => checkpoint.checkpoint_key === 'import_qa')
+  const importReady = importQaCheckpoint ? importQaCheckpoint.auto_state === 'ready' : null
+
+  const guidedSetupDiscipline = deriveGuidedSelfServeDiscipline(
+    deliveryCheckpoints
+      .filter(
+        (
+          checkpoint,
+        ): checkpoint is CampaignDeliveryCheckpoint & {
+          checkpoint_key: 'implementation_intake' | 'import_qa' | 'invite_readiness'
+        } =>
+          checkpoint.checkpoint_key === 'implementation_intake' ||
+          checkpoint.checkpoint_key === 'import_qa' ||
+          checkpoint.checkpoint_key === 'invite_readiness',
+      )
+      .map((checkpoint) => ({
+        checkpointKey: checkpoint.checkpoint_key,
+        manualState: checkpoint.manual_state,
+      })),
+  )
+
+  const autoSignals = buildDeliveryAutoSignals({
+    scanType: stats.scan_type,
+    linkedLeadPresent: Boolean(deliveryRecord?.contact_request_id),
+    totalInvited: stats.total_invited,
+    totalCompleted: stats.total_completed,
+    invitesNotSent,
+    incompleteScores,
+    hasMinDisplay,
+    hasEnoughData,
+    activeClientAccessCount: activeClientAccessCount ?? 0,
+    pendingClientInviteCount: pendingClientInviteCount ?? 0,
+    importReady,
+  })
+  const governance = buildDeliveryGovernanceSnapshot({
+    scanType: stats.scan_type,
+    record: deliveryRecord,
+    checkpoints: deliveryCheckpoints,
+    autoSignals,
+  })
+  const guidedState = buildGuidedSelfServeState({
+    isActive: stats.is_active,
+    totalInvited: stats.total_invited,
+    totalCompleted: stats.total_completed,
+    invitesNotSent,
+    hasMinDisplay,
+    hasEnoughData,
+    importQaConfirmed: guidedSetupDiscipline.importQaConfirmed,
+    launchTimingConfirmed: guidedSetupDiscipline.launchTimingConfirmed,
+    communicationReady: guidedSetupDiscipline.communicationReady,
+    importReady: importReady ?? undefined,
+  })
+  const readability = getReadabilityPresentation(responseRows.length)
+  const statusBadge = getStatusBadgeLabel({
+    isActive: stats.is_active,
+    invitesNotSent,
+  })
+  const lastActivityAt = getLatestActivityTimestamp(auditEvents, deliveryRecord?.updated_at)
+  const lifecycleStage = deliveryRecord?.lifecycle_stage ?? null
+  const routePeriodLabel = formatRoutePeriodLabel(stats.campaign_name, stats.created_at)
+  const deliveryModeLabel =
+    campaign?.delivery_mode != null
+      ? getDeliveryModeLabel(campaign.delivery_mode, stats.scan_type)
+      : null
+
+  const routeSettingsLabel = [
+    SCAN_TYPE_LABELS[stats.scan_type] ?? 'Onbekend scantype',
+    deliveryModeLabel,
+    routePeriodLabel,
+  ]
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    .join(' / ')
+
+  return {
+    campaignId,
+    campaignName: stats.campaign_name,
+    organizationName: organization?.name ?? null,
+    scanType: stats.scan_type,
+    scanTypeLabel: SCAN_TYPE_LABELS[stats.scan_type] ?? 'Onbekend scantype',
+    deliveryModeLabel,
+    routePeriodLabel,
+    isActive: stats.is_active,
+    statusBadgeLabel: statusBadge.label,
+    statusBadgeTone: statusBadge.tone,
+    lastActivityAt,
+    launchDate: deliveryRecord?.launch_date ?? deliveryRecord?.launch_confirmed_at ?? null,
+    totalInvited: stats.total_invited,
+    totalCompleted: stats.total_completed,
+    pendingCount,
+    completionRatePct:
+      typeof stats.completion_rate_pct === 'number' ? stats.completion_rate_pct : null,
+    invitesNotSent,
+    hasMinDisplay,
+    hasEnoughData,
+    readabilityLabel: readability.label,
+    readabilityBody: readability.body,
+    nextActionTitle: guidedState.nextAction.title,
+    nextActionBody: guidedState.nextAction.body,
+    blockers: filterOperationalBlockers(governance),
+    lifecycleStage,
+    lifecycleSteps: buildRouteBeheerLifecycleSteps({
+      stage: lifecycleStage,
+      isActive: stats.is_active,
+      hasMinDisplay,
+      hasEnoughData,
+    }),
+    respondentCount: respondents.length,
+    routeSettingsLabel,
+    routeSettingsBody: getRouteSettingsBody({
+      launchDate: deliveryRecord?.launch_date ?? deliveryRecord?.launch_confirmed_at ?? null,
+      createdAt: campaign?.created_at ?? stats.created_at,
+    }),
+    outputStatusLabel: hasMinDisplay
+      ? 'Dashboard leesbaar / Rapport beschikbaar'
+      : 'Nog onvoldoende data',
+    latestAuditSummary: auditEvents[0]?.summary ?? null,
+    reportAvailable: hasMinDisplay,
+    canExecuteCampaign,
+    canManageCampaign,
+    membershipRole: memberRole,
+  } satisfies RouteBeheerPageData
+}
+
+export function getLaunchCardValue(data: Pick<RouteBeheerPageData, 'isActive' | 'launchDate'>) {
+  return getLaunchValue(data)
+}

--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/loading.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/loading.tsx
@@ -1,0 +1,35 @@
+export default function Loading() {
+  return (
+    <div className="space-y-6 animate-pulse">
+      <div className="rounded-lg border border-[color:var(--border)] bg-white p-6">
+        <div className="h-4 w-28 rounded bg-slate-200" />
+        <div className="mt-4 h-10 w-56 rounded bg-slate-200" />
+        <div className="mt-3 h-4 w-full max-w-2xl rounded bg-slate-100" />
+        <div className="mt-2 h-4 w-full max-w-xl rounded bg-slate-100" />
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div key={index} className="rounded-lg border border-[color:var(--border)] bg-white p-5">
+            <div className="h-3 w-24 rounded bg-slate-200" />
+            <div className="mt-4 h-8 w-32 rounded bg-slate-200" />
+            <div className="mt-3 h-4 w-full rounded bg-slate-100" />
+            <div className="mt-2 h-4 w-5/6 rounded bg-slate-100" />
+          </div>
+        ))}
+      </div>
+      <div className="rounded-lg border border-[color:var(--border)] bg-white p-6">
+        <div className="h-4 w-40 rounded bg-slate-200" />
+        <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-6">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <div key={index} className="rounded-[18px] border border-[color:var(--border)] bg-[color:var(--bg)] p-4">
+              <div className="h-9 w-9 rounded-full bg-slate-200" />
+              <div className="mt-3 h-3 w-20 rounded bg-slate-200" />
+              <div className="mt-2 h-4 w-16 rounded bg-slate-100" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/page.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/page.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('routebeheer page guardrails', () => {
+  it('keeps routebeheer as an operational hub and excludes analytical or action-center detail layers', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+    const componentSource = readFileSync(new URL('./route-beheer-components.tsx', import.meta.url), 'utf8')
+    const combined = `${source}\n${componentSource}`
+
+    expect(combined).toContain('Routebeheer')
+    expect(combined).toContain('Open dashboard')
+    expect(combined).not.toContain('Frictiescore')
+    expect(combined).not.toContain('factoren')
+    expect(combined).not.toContain('SDT')
+    expect(combined).not.toContain('reviewmoment')
+    expect(combined).not.toContain('ActionPlaybook')
+    expect(combined).not.toContain('route-acties')
+  })
+
+  it('keeps routebeheer labels clean and preserves the approved instellingen CTA', () => {
+    const componentSource = readFileSync(new URL('./route-beheer-components.tsx', import.meta.url), 'utf8')
+
+    expect(componentSource).toContain('Bekijk instellingen')
+    expect(componentSource).not.toContain('Ã')
+    expect(componentSource).not.toContain('Â')
+    expect(componentSource).not.toContain('â€¢')
+    expect(componentSource).not.toContain('�')
+  })
+
+  it('reuses the existing campaign access boundary instead of inventing a new route role model', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+
+    expect(source).toContain('loadSuiteAccessContext')
+    expect(source).toContain('context.canViewInsights')
+    expect(source).toContain('SuiteAccessDenied')
+    expect(source).not.toContain('managerOnly')
+  })
+})

--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/page.tsx
@@ -1,0 +1,60 @@
+import { notFound } from 'next/navigation'
+import { SuiteAccessDenied } from '@/components/dashboard/suite-access-denied'
+import { createClient } from '@/lib/supabase/server'
+import { loadSuiteAccessContext } from '@/lib/suite-access-server'
+import { fetchRouteBeheerData } from './beheer-data'
+import {
+  RouteBeheerBlockerPanel,
+  RouteBeheerHeader,
+  RouteBeheerLifecycleSection,
+  RouteBeheerSectionsWrapper,
+  RouteBeheerStatusCards,
+} from './route-beheer-components'
+
+interface Props {
+  params: Promise<{ id: string }>
+}
+
+export default async function RouteBeheerPage({ params }: Props) {
+  const { id } = await params
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    notFound()
+  }
+
+  const { context } = await loadSuiteAccessContext(supabase, user.id)
+
+  if (!context.canViewInsights) {
+    return (
+      <SuiteAccessDenied
+        title="Je ziet hier geen routebeheer"
+        description="Jouw login opent alleen Action Center voor toegewezen teams. Routebeheer, campagnedetails en rapporten blijven zichtbaar voor HR en Verisight."
+      />
+    )
+  }
+
+  const data = await fetchRouteBeheerData({
+    campaignId: id,
+    supabase,
+    userId: user.id,
+  })
+
+  if (!data) {
+    notFound()
+  }
+
+  return (
+    <div className="space-y-6">
+      <RouteBeheerHeader data={data} />
+      <RouteBeheerStatusCards data={data} />
+      <RouteBeheerBlockerPanel blockers={data.blockers} />
+      <RouteBeheerLifecycleSection data={data} />
+      <RouteBeheerSectionsWrapper data={data} />
+    </div>
+  )
+}
+

--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/route-beheer-components.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/route-beheer-components.tsx
@@ -1,0 +1,352 @@
+import Link from 'next/link'
+import { DashboardChip, DashboardPanel, DashboardSection } from '@/components/dashboard/dashboard-primitives'
+import { CampaignActions } from '../campaign-actions'
+import { PdfDownloadButton } from '../pdf-download-button'
+import {
+  formatLatestActivityLabel,
+  getLaunchCardValue,
+  type RouteBeheerLifecycleStep,
+  type RouteBeheerPageData,
+} from './beheer-data'
+
+function joinClasses(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(' ')
+}
+
+function sectionButtonClass(kind: 'primary' | 'secondary') {
+  return kind === 'primary'
+    ? 'inline-flex items-center justify-center rounded-full bg-[color:var(--teal)] px-4 py-2 text-sm font-semibold text-white transition hover:brightness-95'
+    : 'inline-flex items-center justify-center rounded-full border border-[color:var(--border)] bg-white px-4 py-2 text-sm font-semibold text-[color:var(--text)] transition hover:border-[color:var(--teal)] hover:text-[color:var(--ink)]'
+}
+
+function MetricRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-[16px] border border-[color:var(--border)] bg-[color:var(--bg)] px-4 py-3">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
+        {label}
+      </p>
+      <p className="mt-2 text-sm font-semibold text-[color:var(--ink)]">{value}</p>
+    </div>
+  )
+}
+
+export function RouteBeheerHeader({ data }: { data: RouteBeheerPageData }) {
+  return (
+    <section
+      id="route-meta"
+      className="rounded-lg border border-[color:var(--border)] bg-white p-5 shadow-[0_1px_4px_rgba(10,25,47,0.04)] sm:p-6"
+    >
+      <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0">
+          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[color:var(--muted)]">
+            Routebeheer
+          </p>
+          <h1 className="mt-3 text-[1.9rem] font-bold tracking-tight text-[color:var(--ink)] sm:text-[2.15rem]">
+            Routebeheer
+          </h1>
+          <p className="mt-3 max-w-3xl text-sm leading-6 text-[color:var(--text)]">
+            Beheer livegang, respons en output-readiness voor deze route.
+          </p>
+          <div className="mt-4 flex flex-wrap items-center gap-2.5 text-sm text-[color:var(--text)]">
+            <span>{data.organizationName ?? 'Niet beschikbaar'}</span>
+            <span aria-hidden="true">&middot;</span>
+            <span>
+              {data.scanTypeLabel}
+              {data.deliveryModeLabel ? ` ${data.deliveryModeLabel}` : ''}
+            </span>
+            <span aria-hidden="true">&middot;</span>
+            <span>{data.routePeriodLabel}</span>
+          </div>
+        </div>
+
+        <div className="flex flex-col items-start gap-3 lg:items-end">
+          <DashboardChip label={data.statusBadgeLabel} tone={data.statusBadgeTone} surface="ops" />
+          <p className="text-sm text-[color:var(--text)]">{formatLatestActivityLabel(data.lastActivityAt)}</p>
+          <div className="flex flex-wrap gap-2">
+            <Link href={`/campaigns/${data.campaignId}`} className={sectionButtonClass('secondary')}>
+              Open dashboard
+            </Link>
+            {data.reportAvailable ? (
+              <PdfDownloadButton
+                campaignId={data.campaignId}
+                campaignName={data.campaignName}
+                scanType={data.scanType}
+              />
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export function RouteBeheerStatusCards({ data }: { data: RouteBeheerPageData }) {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      <DashboardPanel
+        title="Livegang"
+        value={getLaunchCardValue(data)}
+        body={
+          data.isActive
+            ? 'Laat zien of de route live staat en welk operationeel startmoment nu geldt.'
+            : 'Deze route is gesloten; livegang is niet meer actief.'
+        }
+        tone={data.isActive ? 'emerald' : 'slate'}
+        surface="ops"
+      />
+      <DashboardPanel
+        title="Respons"
+        value={`${data.totalCompleted}/${data.totalInvited} ingevuld`}
+        body={
+          data.pendingCount > 0
+            ? `${data.pendingCount} openstaand / ${data.completionRatePct != null ? `${data.completionRatePct}% afgerond` : 'Niet beschikbaar'}`
+            : 'Alle uitgenodigde respondenten hebben afgerond.'
+        }
+        tone={data.totalCompleted > 0 ? 'blue' : 'slate'}
+        surface="ops"
+      />
+      <DashboardPanel
+        title="Dashboard leesbaarheid"
+        value={data.readabilityLabel}
+        body={data.readabilityBody}
+        tone={data.hasEnoughData ? 'emerald' : data.hasMinDisplay ? 'amber' : 'slate'}
+        surface="ops"
+      />
+      <div className="rounded-lg border border-[color:var(--border)] border-l-4 border-l-[color:var(--teal)] bg-white p-4 shadow-[0_1px_4px_rgba(10,25,47,0.04)] sm:p-5">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
+          Eerstvolgende stap
+        </p>
+        <p className="mt-3 text-lg font-semibold text-[color:var(--ink)]">
+          {data.nextActionTitle ?? 'Niet beschikbaar'}
+        </p>
+        <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">
+          {data.nextActionBody ?? 'Niet beschikbaar'}
+        </p>
+        <div className="mt-4">
+          <a href="#beheer-onderdelen" className={sectionButtonClass('primary')}>
+            Ga naar beheeronderdelen
+          </a>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function RouteBeheerBlockerPanel({ blockers }: { blockers: string[] }) {
+  if (blockers.length === 0) {
+    return null
+  }
+
+  return (
+    <section className="rounded-lg border border-amber-200 bg-amber-50 p-5 shadow-[0_1px_4px_rgba(10,25,47,0.04)]">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0">
+          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-amber-900">
+            Actie nodig
+          </p>
+          <h2 className="mt-2 text-lg font-semibold text-amber-950">Route vraagt nu operationele aandacht</h2>
+          <ul className="mt-3 space-y-2 text-sm leading-6 text-amber-900">
+            {blockers.map((blocker) => (
+              <li key={blocker} className="flex gap-2">
+                <span aria-hidden="true">&bull;</span>
+                <span>{blocker}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <a
+            href="#beheer-onderdelen"
+            className="inline-flex items-center justify-center rounded-full bg-amber-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-950"
+          >
+            Ga naar beheeronderdelen
+          </a>
+          <Link href="#route-meta" className="inline-flex items-center justify-center rounded-full px-3 py-2 text-sm font-semibold text-amber-900 underline underline-offset-4">
+            Bekijk routestatus
+          </Link>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export function RouteBeheerLifecycleBar({ steps }: { steps: RouteBeheerLifecycleStep[] }) {
+  return (
+    <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-6">
+      {steps.map((step, index) => {
+        const dotClass =
+          step.status === 'done'
+            ? 'border-[#3C8D8A] bg-[#3C8D8A] text-white'
+            : step.status === 'current'
+              ? 'border-[color:var(--teal)] bg-[color:var(--teal)] text-white'
+              : 'border-[color:var(--border)] bg-[color:var(--bg)] text-[color:var(--muted)]'
+
+        return (
+          <div
+            key={step.key}
+            className="rounded-[18px] border border-[color:var(--border)] bg-[color:var(--bg)] px-4 py-4"
+          >
+            <div className="flex items-center gap-3">
+              <span
+                className={joinClasses(
+                  'inline-flex h-9 w-9 items-center justify-center rounded-full border text-sm font-semibold',
+                  dotClass,
+                )}
+              >
+                {index + 1}
+              </span>
+              <div>
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
+                  {step.label}
+                </p>
+                <p className="mt-1 text-sm font-semibold text-[color:var(--ink)]">{step.sublabel}</p>
+              </div>
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export function RouteBeheerSectionCards({ data }: { data: RouteBeheerPageData }) {
+  return (
+    <div className="grid gap-4 lg:grid-cols-2">
+      <div className="rounded-lg border border-[color:var(--border)] bg-white p-5 shadow-[0_1px_4px_rgba(10,25,47,0.04)]">
+        <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[color:var(--muted)]">
+          Doelgroep controleren
+        </p>
+        <p className="mt-2 text-lg font-semibold text-[color:var(--ink)]">
+          Bekijk importstatus en geimporteerde deelnemers.
+        </p>
+        <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">
+          {data.respondentCount} deelnemers geimporteerd
+        </p>
+        <div className="mt-4">
+          <Link href={`/campaigns/${data.campaignId}#operatie`} className={sectionButtonClass('secondary')}>
+            Open doelgroep
+          </Link>
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-[color:var(--border)] bg-white p-5 shadow-[0_1px_4px_rgba(10,25,47,0.04)]">
+        <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[color:var(--muted)]">
+          Uitnodigingen beheren
+        </p>
+        <p className="mt-2 text-lg font-semibold text-[color:var(--ink)]">Stuur uitnodigingen of herinnering naar deelnemers.</p>
+        <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">
+          {data.totalCompleted} ingevuld / {data.pendingCount} openstaand
+        </p>
+        <div className="mt-4">
+          {data.canManageCampaign || data.canExecuteCampaign ? (
+            <CampaignActions
+              campaignId={data.campaignId}
+              isActive={data.isActive}
+              pendingCount={data.pendingCount}
+              canResendInvites={data.canExecuteCampaign}
+              canArchiveCampaign={data.canManageCampaign}
+            />
+          ) : (
+            <p className="text-sm leading-6 text-[color:var(--text)]">
+              Alleen de klant owner of Verisight kan uitnodigingen en herinneringen hier verder uitvoeren.
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div
+        id="route-instellingen"
+        className="rounded-lg border border-[color:var(--border)] bg-white p-5 shadow-[0_1px_4px_rgba(10,25,47,0.04)]"
+      >
+        <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[color:var(--muted)]">
+          Route-instellingen
+        </p>
+        <p className="mt-2 text-lg font-semibold text-[color:var(--ink)]">Bekijk startdatum, scantype en uitvoermodus.</p>
+        <div className="mt-3 space-y-3">
+          <MetricRow label="Route" value={data.routeSettingsLabel} />
+          <MetricRow label="Startdatum" value={data.routeSettingsBody.replace('Startdatum: ', '')} />
+        </div>
+        <div className="mt-4">
+          <a href="#route-meta" className={sectionButtonClass('secondary')}>
+            Bekijk instellingen
+          </a>
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-[color:var(--border)] bg-white p-5 shadow-[0_1px_4px_rgba(10,25,47,0.04)]">
+        <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[color:var(--muted)]">
+          Output openen
+        </p>
+        <p className="mt-2 text-lg font-semibold text-[color:var(--ink)]">Ga naar dashboard of download het rapport.</p>
+        <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">{data.outputStatusLabel}</p>
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <Link href={`/campaigns/${data.campaignId}`} className={sectionButtonClass('secondary')}>
+            Open dashboard
+          </Link>
+          {data.reportAvailable ? (
+            <PdfDownloadButton
+              campaignId={data.campaignId}
+              campaignName={data.campaignName}
+              scanType={data.scanType}
+            />
+          ) : (
+            <span className="text-sm text-[color:var(--text)]">Open rapport zodra de eerste dashboardread beschikbaar is.</span>
+          )}
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-[color:var(--border)] bg-white p-5 shadow-[0_1px_4px_rgba(10,25,47,0.04)] lg:col-span-2">
+        <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[color:var(--muted)]">
+          Logboek bekijken
+        </p>
+        <p className="mt-2 text-lg font-semibold text-[color:var(--ink)]">Bekijk imports, uitnodigingen en lifecycle-mutaties.</p>
+        <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">
+          {data.latestAuditSummary ?? 'Geen activiteit'}
+        </p>
+        <div className="mt-4">
+          <Link href={`/campaigns/${data.campaignId}#operatie`} className={sectionButtonClass('secondary')}>
+            Bekijk logboek
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function RouteBeheerEmptyState({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="rounded-lg border border-dashed border-[color:var(--border)] bg-[color:var(--bg)] px-5 py-5 text-sm leading-6 text-[color:var(--text)]">
+      <p className="font-semibold text-[color:var(--ink)]">{title}</p>
+      <p className="mt-2">{body}</p>
+    </div>
+  )
+}
+
+export function RouteBeheerLifecycleSection({ data }: { data: RouteBeheerPageData }) {
+  return (
+    <DashboardSection
+      title="Lifecycle voortgang"
+      description="Volg waar de route staat tussen setup, doelgroep, uitnodigingen, respons, output en afronding."
+      eyebrow="Lifecycle"
+      surface="ops"
+      tone="slate"
+    >
+      <RouteBeheerLifecycleBar steps={data.lifecycleSteps} />
+    </DashboardSection>
+  )
+}
+
+export function RouteBeheerSectionsWrapper({ data }: { data: RouteBeheerPageData }) {
+  return (
+    <DashboardSection
+      id="beheer-onderdelen"
+      title="Beheer onderdelen"
+      description="Gebruik deze laag voor doelgroep, uitnodigingen, route-instellingen, output en logboek."
+      eyebrow="Onderdelen"
+      surface="ops"
+      tone="slate"
+    >
+      <RouteBeheerSectionCards data={data} />
+    </DashboardSection>
+  )
+}

--- a/frontend/app/(dashboard)/campaigns/[id]/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.tsx
@@ -3030,6 +3030,17 @@ export default async function CampaignPage({ params }: Props) {
             aside={<DashboardChip label="Klantuitvoering" tone="slate" />}
             variant="quiet"
           >
+            <div className="mb-4 flex flex-wrap items-center gap-3 rounded-[18px] border border-slate-200 bg-slate-50 px-4 py-3">
+              <p className="text-sm leading-6 text-slate-700">
+                Gebruik Routebeheer voor livegang, respons, output-readiness en blokkades zonder de analytische dashboardlaag te openen.
+              </p>
+              <Link
+                href={`/campaigns/${id}/beheer`}
+                className="inline-flex items-center rounded-full bg-[#2DD4BF] px-4 py-2 text-sm font-semibold text-white transition hover:brightness-95"
+              >
+                Routebeheer openen
+              </Link>
+            </div>
             <GuidedSelfServePanel
               campaignId={id}
               scanType={stats.scan_type}

--- a/frontend/lib/ops-delivery.ts
+++ b/frontend/lib/ops-delivery.ts
@@ -156,7 +156,7 @@ type DeliveryAutoSignalArgs = {
   hasEnoughData: boolean
   activeClientAccessCount: number
   pendingClientInviteCount: number
-  importReady: boolean
+  importReady: boolean | null
 }
 
 export const DELIVERY_LIFECYCLE_OPTIONS: Array<{ value: DeliveryLifecycleStage; label: string }> = [
@@ -483,7 +483,7 @@ export function buildDeliveryAutoSignals({
             : 'Nog geen gekoppelde lead of intakeharde handoff zichtbaar.',
         },
     import_qa:
-      importReady
+      importReady === true
         ? {
             autoState: 'ready',
             summary:
@@ -491,13 +491,18 @@ export function buildDeliveryAutoSignals({
                 ? 'Het deelnemersbestand is gecontroleerd en 1 deelnemer staat vrijgegeven voor launch.'
                 : `Het deelnemersbestand is gecontroleerd en ${totalInvited} deelnemers staan vrijgegeven voor launch.`,
           }
-        : {
-            autoState: 'not_ready',
-            summary:
-              totalInvited > 0
-                ? 'Het deelnemersbestand is nog niet vrijgegeven voor launch.'
-                : 'Nog geen gecontroleerd deelnemersbestand beschikbaar.',
-          },
+        : importReady === false
+          ? {
+              autoState: 'not_ready',
+              summary:
+                totalInvited > 0
+                  ? 'Het deelnemersbestand is nog niet vrijgegeven voor launch.'
+                  : 'Nog geen gecontroleerd deelnemersbestand beschikbaar.',
+            }
+          : {
+              autoState: 'unknown',
+              summary: 'Importstatus is nog niet bekend.',
+            },
     invite_readiness:
       totalInvited === 0
         ? {


### PR DESCRIPTION
## Samenvatting
- voegt de bounded routebeheer-hub toe onder `campaigns/[id]/beheer`
- splitst operationeel routebeheer los van het analytische dashboard
- gebruikt alleen slice-relevante beheerbestanden

## Scope
- nieuwe beheerroute met data/helper/component-slice
- kleine update aan `ops-delivery`

## Verificatie
- eslint op de geraakte routebeheerbestanden
- bestaande route-slice lokaal nagekeken