### PR TITLE
Action Center Reviewmomenten page

### DIFF
--- a/frontend/app/(dashboard)/action-center/reviewmomenten/page.entry-shell.test.ts
+++ b/frontend/app/(dashboard)/action-center/reviewmomenten/page.entry-shell.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('action center reviewmomenten entry shell', () => {
+  it('keeps the route on the shared action-center data helper and dedicated review client', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+
+    expect(source).toContain('ReviewMomentPageClient')
+    expect(source).toContain('getActionCenterPageData')
+    expect(source).toContain('computeReviewMomentGovernanceCounts')
+  })
+})

--- a/frontend/app/(dashboard)/action-center/reviewmomenten/page.route-shell.test.ts
+++ b/frontend/app/(dashboard)/action-center/reviewmomenten/page.route-shell.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('action center reviewmomenten route source', () => {
+  it('guards the route with the same Action Center access boundary as the overview page', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+
+    expect(source).toContain("redirect('/login')")
+    expect(source).toContain('canViewActionCenter')
+    expect(source).toContain("redirect('/dashboard')")
+  })
+
+  it('does not reuse the broad ActionCenterPreview suite or org_invites as a reviewmomenten workaround', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+
+    expect(source).not.toContain('ActionCenterPreview')
+    expect(source).not.toContain('org_invites')
+  })
+})

--- a/frontend/app/(dashboard)/action-center/reviewmomenten/page.tsx
+++ b/frontend/app/(dashboard)/action-center/reviewmomenten/page.tsx
@@ -1,0 +1,61 @@
+import { redirect } from 'next/navigation'
+import { ReviewMomentPageClient } from '@/components/dashboard/review-moment-page-client'
+import { getActionCenterPageData } from '@/lib/action-center-page-data'
+import { computeReviewMomentGovernanceCounts } from '@/lib/action-center-review-moments'
+import { createClient } from '@/lib/supabase/server'
+import { loadSuiteAccessContext } from '@/lib/suite-access-server'
+
+function getReviewOrganizationName(organizationNames: string[]) {
+  if (organizationNames.length === 1) {
+    return organizationNames[0]
+  }
+
+  if (organizationNames.length > 1) {
+    return 'Verisight organisaties'
+  }
+
+  return 'Verisight organisatie'
+}
+
+export default async function ActionCenterReviewmomentenPage() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/login')
+  }
+
+  const {
+    context,
+    orgMemberships,
+    workspaceMemberships: currentUserWorkspaceMemberships,
+  } = await loadSuiteAccessContext(supabase, user.id)
+
+  if (!context.canViewActionCenter) {
+    redirect('/dashboard')
+  }
+
+  const orgIds = [...new Set([...context.organizationIds, ...context.workspaceOrgIds])]
+
+  if (orgIds.length === 0 && !context.isVerisightAdmin) {
+    redirect('/dashboard')
+  }
+
+  const pageData = await getActionCenterPageData({
+    context,
+    orgMemberships,
+    currentUserWorkspaceMemberships,
+  })
+  const now = new Date()
+
+  return (
+    <ReviewMomentPageClient
+      items={pageData.items}
+      governanceCounts={computeReviewMomentGovernanceCounts(pageData.items, now)}
+      organizationName={getReviewOrganizationName(pageData.organizationNames)}
+      lastUpdated={now.toISOString()}
+    />
+  )
+}

--- a/frontend/components/dashboard/review-moment-card.tsx
+++ b/frontend/components/dashboard/review-moment-card.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { DashboardChip } from '@/components/dashboard/dashboard-primitives'
+import type { ActionCenterPreviewItem } from '@/lib/action-center-preview-model'
+import {
+  getReviewMomentActionLabel,
+  getReviewMomentManagerLabel,
+  getReviewMomentOutcomeSummary,
+  getReviewMomentScopeLabel,
+  getReviewMomentStatusLabel,
+  type ReviewMomentUrgency,
+} from '@/lib/action-center-review-moments'
+
+function getStatusTone(item: ActionCenterPreviewItem, urgency: ReviewMomentUrgency) {
+  if (item.status === 'afgerond' || item.status === 'gestopt') {
+    return 'slate' as const
+  }
+
+  if (urgency === 'overdue') {
+    return 'amber' as const
+  }
+
+  if (item.status === 'in-uitvoering') {
+    return 'emerald' as const
+  }
+
+  return 'slate' as const
+}
+
+export function ReviewMomentCard({
+  item,
+  urgency,
+  selected,
+  onSelect,
+}: {
+  item: ActionCenterPreviewItem
+  urgency: ReviewMomentUrgency
+  selected: boolean
+  onSelect: (id: string) => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(item.id)}
+      className={`w-full rounded-[20px] border p-4 text-left transition ${
+        selected
+          ? 'border-[color:var(--dashboard-accent)] bg-[color:var(--dashboard-muted-surface)]'
+          : 'border-[color:var(--dashboard-frame-border)] bg-white hover:border-[color:var(--dashboard-accent)]/50'
+      }`}
+    >
+      <div className="min-w-0 flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0 flex-1 space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--dashboard-muted)]">
+            {item.reviewDate ? item.reviewDateLabel : 'Niet gepland'}
+          </p>
+          <p className="max-w-full break-words text-lg font-semibold tracking-[-0.03em] text-[color:var(--dashboard-ink)]">
+            {item.title}
+          </p>
+        </div>
+        <DashboardChip
+          surface="ops"
+          tone={getStatusTone(item, urgency)}
+          label={getReviewMomentStatusLabel(item, urgency)}
+        />
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-center gap-2">
+        <DashboardChip surface="ops" tone="slate" label={item.sourceLabel} />
+        <DashboardChip surface="ops" tone="slate" label={getReviewMomentScopeLabel(item)} />
+      </div>
+
+      <p className="mt-4 text-sm text-[color:var(--dashboard-text)]">{getReviewMomentManagerLabel(item)}</p>
+
+      <blockquote className="mt-4 rounded-[16px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-muted-surface)] px-4 py-3 text-sm leading-6 text-[color:var(--dashboard-text)]">
+        {getReviewMomentOutcomeSummary(item)}
+      </blockquote>
+
+      <div className="mt-4 inline-flex rounded-full border border-[color:var(--dashboard-frame-border)] bg-white px-3 py-2 text-xs font-semibold text-[color:var(--dashboard-ink)]">
+        {getReviewMomentActionLabel(item)}
+      </div>
+    </button>
+  )
+}

--- a/frontend/components/dashboard/review-moment-counter-row.tsx
+++ b/frontend/components/dashboard/review-moment-counter-row.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import { DashboardSummaryBar } from '@/components/dashboard/dashboard-primitives'
+
+export function ReviewMomentCounterRow({
+  overdueCount,
+  thisWeekCount,
+  upcomingCount,
+  completedCount,
+  showCompleted,
+  onToggleCompleted,
+}: {
+  overdueCount: number
+  thisWeekCount: number
+  upcomingCount: number
+  completedCount: number
+  showCompleted: boolean
+  onToggleCompleted: () => void
+}) {
+  return (
+    <DashboardSummaryBar
+      surface="ops"
+      items={[
+        {
+          label: 'Achterstallig',
+          value: `${overdueCount}`,
+          tone: overdueCount > 0 ? 'amber' : 'slate',
+        },
+        {
+          label: 'Deze week',
+          value: `${thisWeekCount}`,
+          tone: thisWeekCount > 0 ? 'amber' : 'slate',
+        },
+        {
+          label: 'Binnenkort',
+          value: `${upcomingCount}`,
+          tone: upcomingCount > 0 ? 'emerald' : 'slate',
+        },
+        {
+          label: 'Afgerond',
+          value: `${completedCount}`,
+          tone: completedCount > 0 ? 'slate' : 'slate',
+        },
+      ]}
+      anchors={[
+        { id: 'review-lanes', label: 'Reviewlanes' },
+        { id: 'review-detail', label: 'Reviewdetail' },
+        { id: 'review-governance', label: 'Reviewgovernance' },
+      ]}
+      actions={
+        <button
+          type="button"
+          onClick={onToggleCompleted}
+          className="rounded-full border border-[color:var(--dashboard-frame-border)] bg-white px-3 py-2 text-xs font-semibold text-[color:var(--dashboard-ink)] transition hover:bg-[color:var(--dashboard-muted-surface)]"
+        >
+          {showCompleted ? 'Verberg afgeronde reviews' : 'Bekijk afgeronde reviews'}
+        </button>
+      }
+    />
+  )
+}

--- a/frontend/components/dashboard/review-moment-detail-panel.tsx
+++ b/frontend/components/dashboard/review-moment-detail-panel.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import Link from 'next/link'
+import { DashboardChip, DashboardKeyValue, DashboardPanel } from '@/components/dashboard/dashboard-primitives'
+import type { ActionCenterPreviewItem } from '@/lib/action-center-preview-model'
+import {
+  getReviewMomentManagerLabel,
+  getReviewMomentOutcomeSummary,
+  getReviewMomentScopeLabel,
+  getReviewMomentScopeTypeLabel,
+  getReviewMomentStatusLabel,
+  type ReviewMomentUrgency,
+} from '@/lib/action-center-review-moments'
+
+function formatDateLabel(value: string | null) {
+  if (!value) {
+    return 'Niet beschikbaar'
+  }
+
+  return new Date(value).toLocaleDateString('nl-NL', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  })
+}
+
+export function ReviewMomentDetailPanel({
+  item,
+  urgency,
+}: {
+  item: ActionCenterPreviewItem | null
+  urgency: ReviewMomentUrgency | null
+}) {
+  if (!item) {
+    return (
+      <DashboardPanel
+        surface="ops"
+        eyebrow="Reviewdetail"
+        title="Geen reviewmoment geselecteerd"
+        body="Selecteer een reviewmoment om details te bekijken."
+        tone="slate"
+      />
+    )
+  }
+
+  return (
+    <div className="space-y-4 rounded-[22px] border border-[color:var(--dashboard-frame-border)] bg-white p-5 shadow-[0_10px_24px_rgba(19,32,51,0.05)]">
+      <div className="flex flex-wrap items-center gap-2">
+        <DashboardChip surface="ops" tone="slate" label="Reviewdetail" />
+        <DashboardChip surface="ops" tone="slate" label={getReviewMomentStatusLabel(item, urgency)} />
+      </div>
+
+      <div>
+        <p className="text-lg font-semibold text-[color:var(--dashboard-ink)]">{getReviewMomentScopeLabel(item)}</p>
+        <p className="mt-1 text-sm text-[color:var(--dashboard-text)]">{item.title}</p>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <DashboardKeyValue surface="ops" label="Reviewstatus" value={getReviewMomentStatusLabel(item, urgency)} />
+        <DashboardKeyValue
+          surface="ops"
+          label="Volgende datum"
+          value={item.reviewDate ? formatDateLabel(item.reviewDate) : 'Niet gepland'}
+        />
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <DashboardKeyValue surface="ops" label="Scope" value={getReviewMomentScopeTypeLabel(item.scopeType)} />
+        <DashboardKeyValue surface="ops" label="Manager" value={getReviewMomentManagerLabel(item)} />
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <DashboardKeyValue surface="ops" label="Route" value={item.coreSemantics.route.routeId} />
+        <DashboardKeyValue surface="ops" label="Open acties" value={`${item.openSignals.length}`} />
+      </div>
+
+      <blockquote className="rounded-[18px] bg-[color:var(--dashboard-topbar-strong)] px-4 py-4 text-sm leading-7 text-white">
+        {getReviewMomentOutcomeSummary(item)}
+      </blockquote>
+
+      <div className="flex flex-wrap gap-2">
+        <Link
+          href={`/action-center?focus=${encodeURIComponent(item.id)}`}
+          className="rounded-full border border-[color:var(--dashboard-frame-border)] bg-white px-3 py-2 text-xs font-semibold text-[color:var(--dashboard-ink)] transition hover:bg-[color:var(--dashboard-muted-surface)]"
+        >
+          Bekijk gekoppelde opvolging
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/frontend/components/dashboard/review-moment-governance-section.tsx
+++ b/frontend/components/dashboard/review-moment-governance-section.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { DashboardPanel, DashboardSection } from '@/components/dashboard/dashboard-primitives'
+import type { ReviewMomentGovernanceCounts } from '@/lib/action-center-review-moments'
+
+export function ReviewMomentGovernanceSection({
+  counts,
+}: {
+  counts: ReviewMomentGovernanceCounts
+}) {
+  if (counts.overdue + counts.missingOutcome + counts.missingScope + counts.missingManager === 0) {
+    return null
+  }
+
+  return (
+    <DashboardSection
+      id="review-governance"
+      surface="ops"
+      eyebrow="Governance"
+      title="Reviewgovernance"
+      description="Reviewmomenten blijven alleen bruikbaar als ze gekoppeld zijn aan een scope, manager of eigenaar en geldige opvolging."
+    >
+      <div className="grid gap-4 lg:grid-cols-2 xl:grid-cols-4">
+        {counts.overdue > 0 ? (
+          <DashboardPanel
+            surface="ops"
+            eyebrow="Achterstallig"
+            title={`${counts.overdue} open`}
+            body="Momenten zonder actuele status-update die de geplande datum met meer dan 48 uur hebben overschreden."
+            tone="amber"
+          />
+        ) : null}
+        {counts.missingOutcome > 0 ? (
+          <DashboardPanel
+            surface="ops"
+            eyebrow="Uitkomst ontbreekt"
+            title={`${counts.missingOutcome} open`}
+            body="Reviews die wel geopend zijn maar waar geen definitieve uitkomstvlag is gezet."
+            tone="slate"
+          />
+        ) : null}
+        {counts.missingScope > 0 ? (
+          <DashboardPanel
+            surface="ops"
+            eyebrow="Scope ontbreekt"
+            title={`${counts.missingScope} open`}
+            body="Momenten zonder koppeling aan een organisatorische eenheid of cluster."
+            tone="slate"
+          />
+        ) : null}
+        {counts.missingManager > 0 ? (
+          <DashboardPanel
+            surface="ops"
+            eyebrow="Manager ontbreekt"
+            title={`${counts.missingManager} open`}
+            body="Reviewmomenten zonder actieve eigenaar."
+            tone="slate"
+          />
+        ) : null}
+      </div>
+    </DashboardSection>
+  )
+}

--- a/frontend/components/dashboard/review-moment-lane.tsx
+++ b/frontend/components/dashboard/review-moment-lane.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import type { ActionCenterPreviewItem } from '@/lib/action-center-preview-model'
+import type { ReviewMomentUrgency } from '@/lib/action-center-review-moments'
+import { ReviewMomentCard } from '@/components/dashboard/review-moment-card'
+
+export function ReviewMomentLane({
+  urgency,
+  items,
+  selectedItemId,
+  onSelect,
+}: {
+  urgency: ReviewMomentUrgency
+  items: ActionCenterPreviewItem[]
+  selectedItemId: string | null
+  onSelect: (id: string) => void
+}) {
+  if (items.length === 0) {
+    return null
+  }
+
+  const title =
+    urgency === 'overdue'
+      ? 'Achterstallig'
+      : urgency === 'this-week'
+        ? 'Deze week'
+        : urgency === 'upcoming'
+          ? 'Binnenkort'
+          : 'Afgerond'
+
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-[1.35rem] font-semibold tracking-[-0.03em] text-[color:var(--dashboard-ink)]">{title}</h2>
+        <span className="text-sm text-[color:var(--dashboard-text)]">
+          {items.length} reviewmoment{items.length === 1 ? '' : 'en'}
+        </span>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        {items.map((item) => (
+          <ReviewMomentCard
+            key={item.id}
+            item={item}
+            urgency={urgency}
+            selected={selectedItemId === item.id}
+            onSelect={onSelect}
+          />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/frontend/components/dashboard/review-moment-page-client.test.tsx
+++ b/frontend/components/dashboard/review-moment-page-client.test.tsx
@@ -1,0 +1,53 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('review moment page client source', () => {
+  it('keeps the agreed reviewmomenten labels in the visible page shell', () => {
+    const source = readFileSync(new URL('./review-moment-page-client.tsx', import.meta.url), 'utf8')
+    const counterSource = readFileSync(new URL('./review-moment-counter-row.tsx', import.meta.url), 'utf8')
+    const laneSource = readFileSync(new URL('./review-moment-lane.tsx', import.meta.url), 'utf8')
+    const cardSource = readFileSync(new URL('./review-moment-card.tsx', import.meta.url), 'utf8')
+    const governanceSource = readFileSync(new URL('./review-moment-governance-section.tsx', import.meta.url), 'utf8')
+
+    expect(source).toContain('Reviewmomenten')
+    expect(source).toContain('Bewaak geplande opvolgmomenten, gekoppelde scopes en bekende uitkomsten.')
+    expect(source).toContain('Deze pagina toont reviewritme. Geen scananalyse, rapportduiding of generieke planning.')
+    expect(source).toContain("join(' · ')")
+    expect(counterSource).toContain('Achterstallig')
+    expect(counterSource).toContain('Deze week')
+    expect(counterSource).toContain('Binnenkort')
+    expect(counterSource).toContain('Afgerond')
+    expect(laneSource).toContain('Achterstallig')
+    expect(cardSource).toContain('min-w-0 flex-1')
+    expect(cardSource).toContain('max-w-full break-words')
+    expect(governanceSource).toContain('Reviewgovernance')
+    expect(source).toContain('Bekijk afgeronde reviews')
+    expect(source).toContain('Bekijk gekoppelde opvolging')
+    expect(source).toContain("Reviewmomenten tonen ritme en discipline. Acties, dashboardduiding en rapportinhoud staan op aparte pagina's.")
+  })
+
+  it('keeps forbidden automation, lifecycle copy and mojibake out of the page shell', () => {
+    const source = readFileSync(new URL('./review-moment-page-client.tsx', import.meta.url), 'utf8').toLowerCase()
+
+    for (const forbidden of [
+      'automation',
+      'recurring',
+      'advies',
+      'dashboardinterpretatie',
+      'planningstool',
+      'uitnodiging',
+      'activatie',
+      'pending',
+      'invited',
+      'activated',
+      'access requested',
+      'ã',
+      'â',
+      '�',
+    ]) {
+      expect(source).not.toContain(forbidden)
+    }
+
+    expect(source).not.toContain('Â·'.toLowerCase())
+  })
+})

--- a/frontend/components/dashboard/review-moment-page-client.tsx
+++ b/frontend/components/dashboard/review-moment-page-client.tsx
@@ -1,0 +1,263 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useMemo, useState } from 'react'
+import {
+  DashboardChip,
+  DashboardHero,
+  DashboardPanel,
+  DashboardSection,
+} from '@/components/dashboard/dashboard-primitives'
+import type { ActionCenterPreviewItem, ActionCenterPreviewStatus } from '@/lib/action-center-preview-model'
+import {
+  formatReviewMomentLastUpdated,
+  getReviewMomentManagerLabel,
+  getReviewMomentScopeLabel,
+  groupReviewMomentsByUrgency,
+  type ReviewMomentUrgency,
+  type ReviewMomentGovernanceCounts,
+} from '@/lib/action-center-review-moments'
+import { ReviewMomentCounterRow } from '@/components/dashboard/review-moment-counter-row'
+import { ReviewMomentDetailPanel } from '@/components/dashboard/review-moment-detail-panel'
+import { ReviewMomentGovernanceSection } from '@/components/dashboard/review-moment-governance-section'
+import { ReviewMomentLane } from '@/components/dashboard/review-moment-lane'
+
+const STATUS_OPTIONS: Array<{ value: 'all' | ActionCenterPreviewStatus; label: string }> = [
+  { value: 'all', label: 'Status' },
+  { value: 'open-verzoek', label: 'Open verzoek' },
+  { value: 'te-bespreken', label: 'Gepland' },
+  { value: 'reviewbaar', label: 'Gepland' },
+  { value: 'in-uitvoering', label: 'In uitvoering' },
+  { value: 'geblokkeerd', label: 'Gepland' },
+  { value: 'afgerond', label: 'Afgerond' },
+  { value: 'gestopt', label: 'Gestopt' },
+]
+
+function getOrganizationBreadcrumbLabel(organizationName: string) {
+  return [organizationName, 'Action Center', 'HR scope'].join(' · ')
+}
+
+function getFirstVisibleItem(items: ActionCenterPreviewItem[]) {
+  return items[0]?.id ?? null
+}
+
+export function ReviewMomentPageClient({
+  items,
+  governanceCounts,
+  organizationName,
+  lastUpdated,
+}: {
+  items: ActionCenterPreviewItem[]
+  governanceCounts: ReviewMomentGovernanceCounts
+  organizationName: string
+  lastUpdated: string
+}) {
+  const [statusFilter, setStatusFilter] = useState<'all' | ActionCenterPreviewStatus>('all')
+  const [scopeFilter, setScopeFilter] = useState<string>('all')
+  const [managerFilter, setManagerFilter] = useState<string>('all')
+  const [showCompleted, setShowCompleted] = useState(false)
+  const [selectedItemId, setSelectedItemId] = useState<string | null>(getFirstVisibleItem(items))
+
+  const referenceNow = useMemo(() => new Date(lastUpdated), [lastUpdated])
+  const scopeOptions = useMemo(
+    () => [...new Set(items.map((item) => getReviewMomentScopeLabel(item)))].sort((left, right) => left.localeCompare(right)),
+    [items],
+  )
+  const managerOptions = useMemo(
+    () =>
+      [...new Set(items.map((item) => getReviewMomentManagerLabel(item)))].sort((left, right) => left.localeCompare(right)),
+    [items],
+  )
+
+  const filteredItems = useMemo(
+    () =>
+      items.filter((item) => {
+        if (statusFilter !== 'all' && item.status !== statusFilter) return false
+        if (scopeFilter !== 'all' && getReviewMomentScopeLabel(item) !== scopeFilter) return false
+        if (managerFilter !== 'all' && getReviewMomentManagerLabel(item) !== managerFilter) return false
+        return true
+      }),
+    [items, managerFilter, scopeFilter, statusFilter],
+  )
+
+  const grouped = useMemo(() => groupReviewMomentsByUrgency(filteredItems, referenceNow), [filteredItems, referenceNow])
+  const visibleItems = useMemo(() => {
+    const base = [...grouped.overdue, ...grouped['this-week'], ...grouped.upcoming]
+    if (showCompleted || statusFilter === 'afgerond' || statusFilter === 'gestopt') {
+      base.push(...grouped.completed)
+    }
+    return base
+  }, [grouped, showCompleted, statusFilter])
+
+  useEffect(() => {
+    if (!visibleItems.some((item) => item.id === selectedItemId)) {
+      setSelectedItemId(getFirstVisibleItem(visibleItems))
+    }
+  }, [selectedItemId, visibleItems])
+
+  const selectedItem = visibleItems.find((item) => item.id === selectedItemId) ?? null
+  const selectedUrgency: ReviewMomentUrgency | null = selectedItem
+    ? grouped.overdue.some((item) => item.id === selectedItem.id)
+      ? 'overdue'
+      : grouped['this-week'].some((item) => item.id === selectedItem.id)
+        ? 'this-week'
+        : grouped.upcoming.some((item) => item.id === selectedItem.id)
+          ? 'upcoming'
+          : grouped.completed.some((item) => item.id === selectedItem.id)
+            ? 'completed'
+            : null
+    : null
+  const lastUpdatedLabel = formatReviewMomentLastUpdated(lastUpdated)
+
+  if (items.length === 0) {
+    return (
+      <DashboardPanel
+        surface="ops"
+        eyebrow="Reviewmomenten"
+        title="Nog geen reviewmomenten beschikbaar"
+        body="Zodra er actieve opvolging is met een geplande reviewdatum, verschijnen die hier."
+        tone="slate"
+      />
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <DashboardHero
+        surface="ops"
+        tone="slate"
+        eyebrow="Action Center"
+        title="Reviewmomenten"
+        description="Bewaak geplande opvolgmomenten, gekoppelde scopes en bekende uitkomsten."
+        meta={
+          <div className="flex flex-wrap gap-2">
+            <DashboardChip surface="ops" label={getOrganizationBreadcrumbLabel(organizationName)} />
+            {lastUpdatedLabel ? <DashboardChip surface="ops" tone="slate" label={lastUpdatedLabel} /> : null}
+          </div>
+        }
+        aside={
+          <div className="space-y-3 text-sm text-slate-700">
+            <p className="font-semibold text-slate-950">Context</p>
+            <p>Deze pagina toont reviewritme. Geen scananalyse, rapportduiding of generieke planning.</p>
+          </div>
+        }
+      />
+
+      <DashboardSection
+        surface="ops"
+        eyebrow="Filters"
+        title="Filter reviewmomenten"
+        description="Filter client-side op status, scope of manager zonder een tweede data- of planningslaag toe te voegen."
+      >
+        <div className="grid gap-3 lg:grid-cols-[repeat(3,minmax(0,220px)),1fr]">
+          <select
+            aria-label="Status"
+            value={statusFilter}
+            onChange={(event) => setStatusFilter(event.target.value as 'all' | ActionCenterPreviewStatus)}
+            className="rounded-[16px] border border-[color:var(--dashboard-frame-border)] bg-white px-4 py-3 text-sm text-[color:var(--dashboard-ink)]"
+          >
+            {STATUS_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <select
+            aria-label="Scope"
+            value={scopeFilter}
+            onChange={(event) => setScopeFilter(event.target.value)}
+            className="rounded-[16px] border border-[color:var(--dashboard-frame-border)] bg-white px-4 py-3 text-sm text-[color:var(--dashboard-ink)]"
+          >
+            <option value="all">Scope</option>
+            {scopeOptions.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+          <select
+            aria-label="Manager"
+            value={managerFilter}
+            onChange={(event) => setManagerFilter(event.target.value)}
+            className="rounded-[16px] border border-[color:var(--dashboard-frame-border)] bg-white px-4 py-3 text-sm text-[color:var(--dashboard-ink)]"
+          >
+            <option value="all">Manager</option>
+            {managerOptions.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+        </div>
+      </DashboardSection>
+
+      <ReviewMomentCounterRow
+        overdueCount={grouped.overdue.length}
+        thisWeekCount={grouped['this-week'].length}
+        upcomingCount={grouped.upcoming.length}
+        completedCount={grouped.completed.length}
+        showCompleted={showCompleted}
+        onToggleCompleted={() => setShowCompleted((current) => !current)}
+      />
+
+      <div id="review-lanes" className="grid gap-6 xl:grid-cols-[minmax(0,1.45fr),minmax(320px,0.82fr)]">
+        <div className="space-y-8">
+          <ReviewMomentLane
+            urgency="overdue"
+            items={grouped.overdue}
+            selectedItemId={selectedItemId}
+            onSelect={setSelectedItemId}
+          />
+          <ReviewMomentLane
+            urgency="this-week"
+            items={grouped['this-week']}
+            selectedItemId={selectedItemId}
+            onSelect={setSelectedItemId}
+          />
+          <ReviewMomentLane
+            urgency="upcoming"
+            items={grouped.upcoming}
+            selectedItemId={selectedItemId}
+            onSelect={setSelectedItemId}
+          />
+          {showCompleted || statusFilter === 'afgerond' || statusFilter === 'gestopt' ? (
+            <ReviewMomentLane
+              urgency="completed"
+              items={grouped.completed}
+              selectedItemId={selectedItemId}
+              onSelect={setSelectedItemId}
+            />
+          ) : null}
+        </div>
+        <div id="review-detail" className="xl:sticky xl:top-[8rem] xl:self-start">
+          <ReviewMomentDetailPanel item={selectedItem} urgency={selectedUrgency} />
+        </div>
+      </div>
+
+      <ReviewMomentGovernanceSection counts={governanceCounts} />
+
+      <DashboardSection
+        surface="ops"
+        eyebrow="Footer"
+        title="Reviewmomenten blijven bounded"
+        description="Reviewmomenten tonen ritme en discipline. Acties, dashboardduiding en rapportinhoud staan op aparte pagina's."
+      >
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <button
+            type="button"
+            onClick={() => setShowCompleted((current) => !current)}
+            className="rounded-full border border-[color:var(--dashboard-frame-border)] bg-white px-3 py-2 text-xs font-semibold text-[color:var(--dashboard-ink)] transition hover:bg-[color:var(--dashboard-muted-surface)]"
+          >
+            Bekijk afgeronde reviews
+          </button>
+          <Link
+            href="/action-center"
+            className="rounded-full border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-muted-surface)] px-3 py-2 text-xs font-semibold text-[color:var(--dashboard-ink)] transition hover:bg-white"
+          >
+            Bekijk gekoppelde opvolging
+          </Link>
+        </div>
+      </DashboardSection>
+    </div>
+  )
+}

--- a/frontend/lib/action-center-page-data.ts
+++ b/frontend/lib/action-center-page-data.ts
@@ -1,0 +1,447 @@
+import { buildLiveActionCenterItems, getLiveActionCenterSummary } from '@/lib/action-center-live'
+import type { ActionCenterPreviewManagerOption } from '@/lib/action-center-preview-model'
+import { buildActionCenterRouteId } from '@/lib/action-center-route-contract'
+import { projectActionCenterRouteCloseout } from '@/lib/action-center-route-closeout'
+import {
+  projectActionCenterRouteFollowUpRelation,
+  projectActionCenterRouteReopen,
+} from '@/lib/action-center-route-reopen'
+import { createAdminClient } from '@/lib/supabase/admin'
+import {
+  isScopeVisibleToActionCenterContext,
+  type ActionCenterWorkspaceMember,
+  type SuiteAccessContext,
+  type SuiteOrgMembership,
+} from '@/lib/suite-access'
+import type { CampaignDeliveryCheckpoint, CampaignDeliveryRecord } from '@/lib/ops-delivery'
+import type {
+  ActionCenterManagerResponse,
+  ActionCenterReviewDecision,
+  PilotLearningCheckpoint,
+  PilotLearningDossier,
+} from '@/lib/pilot-learning'
+import type { Campaign, CampaignStats, Organization } from '@/lib/types'
+
+type RespondentDepartmentRow = {
+  campaign_id: string
+  department: string | null
+}
+
+type ActionCenterRouteRelationRow = {
+  id: string | null
+  source_campaign_id: string | null
+  target_campaign_id: string | null
+  route_relation_type: string | null
+  source_route_id: string | null
+  target_route_id: string | null
+  trigger_reason: string | null
+  recorded_at: string | null
+  recorded_by_role: string | null
+  ended_at: string | null
+}
+
+type ActionCenterRouteReopenRow = {
+  id: string | null
+  route_id: string | null
+  reopened_at: string | null
+  reopened_by_role: string | null
+}
+
+type ActionCenterRouteCloseoutRow = {
+  route_id: string | null
+  closeout_status: string | null
+  closeout_reason: string | null
+  closeout_note: string | null
+  closed_at: string | null
+  closed_by_role: string | null
+}
+
+type ActionCenterScopeRow = {
+  scopeType: 'department' | 'item'
+  scopeValue: string
+  scopeLabel: string
+  peopleCount: number
+}
+
+export interface ActionCenterPageData {
+  items: ReturnType<typeof buildLiveActionCenterItems>
+  summary: ReturnType<typeof getLiveActionCenterSummary>
+  ownerOptions: string[]
+  managerOptions: ActionCenterPreviewManagerOption[]
+  itemHrefs: Record<string, string>
+  organizationNames: string[]
+}
+
+function normalizeDepartmentLabel(value: string | null | undefined) {
+  return value?.trim() || null
+}
+
+function buildDepartmentScopeValue(orgId: string, departmentLabel: string) {
+  return `${orgId}::department::${departmentLabel.toLowerCase()}`
+}
+
+function buildCampaignFallbackScopeValue(orgId: string, campaignId: string) {
+  return `${orgId}::campaign::${campaignId}`
+}
+
+function buildActionCenterScopes(args: {
+  campaign: Campaign
+  departmentLabels: string[]
+  fallbackPeopleCount: number
+}) {
+  const departmentCounts = args.departmentLabels.reduce<Record<string, number>>((acc, label) => {
+    acc[label] = (acc[label] ?? 0) + 1
+    return acc
+  }, {})
+  const departmentEntries = Object.entries(departmentCounts)
+
+  if (departmentEntries.length > 0) {
+    return departmentEntries.map<ActionCenterScopeRow>(([departmentLabel, peopleCount]) => ({
+      scopeType: 'department',
+      scopeValue: buildDepartmentScopeValue(args.campaign.organization_id, departmentLabel),
+      scopeLabel: departmentLabel,
+      peopleCount,
+    }))
+  }
+
+  return [
+    {
+      scopeType: 'item' as const,
+      scopeValue: buildCampaignFallbackScopeValue(args.campaign.organization_id, args.campaign.id),
+      scopeLabel: args.campaign.name,
+      peopleCount: args.fallbackPeopleCount,
+    },
+  ]
+}
+
+function getManagerAssignment(
+  workspaceRows: ActionCenterWorkspaceMember[],
+  orgId: string,
+  scopeValue: string,
+) {
+  return (
+    workspaceRows.find(
+      (row) =>
+        row.org_id === orgId &&
+        row.access_role === 'manager_assignee' &&
+        row.scope_value === scopeValue &&
+        row.can_view,
+    ) ?? null
+  )
+}
+
+export async function getActionCenterPageData({
+  context,
+  orgMemberships,
+  currentUserWorkspaceMemberships,
+}: {
+  context: SuiteAccessContext
+  orgMemberships: SuiteOrgMembership[]
+  currentUserWorkspaceMemberships: ActionCenterWorkspaceMember[]
+}): Promise<ActionCenterPageData> {
+  const orgIds = [...new Set([...context.organizationIds, ...context.workspaceOrgIds])]
+  const dataClient = createAdminClient()
+
+  const [
+    { data: organizationsRaw },
+    { data: campaignsRaw },
+    { data: statsRaw },
+    { data: deliveryRecordsRaw },
+    { data: dossiersRaw },
+    { data: managerWorkspaceRowsRaw },
+    { data: routeRelationsRaw },
+  ] = await Promise.all([
+    orgIds.length > 0
+      ? dataClient.from('organizations').select('id, name, slug, contact_email, is_active, created_at').in('id', orgIds)
+      : Promise.resolve({ data: [] }),
+    orgIds.length > 0
+      ? dataClient.from('campaigns').select('*').in('organization_id', orgIds).order('created_at', { ascending: false })
+      : Promise.resolve({ data: [] }),
+    orgIds.length > 0
+      ? dataClient.from('campaign_stats').select('*').in('organization_id', orgIds).order('created_at', { ascending: false })
+      : Promise.resolve({ data: [] }),
+    orgIds.length > 0
+      ? dataClient.from('campaign_delivery_records').select('*').in('organization_id', orgIds)
+      : Promise.resolve({ data: [] }),
+    orgIds.length > 0
+      ? dataClient.from('pilot_learning_dossiers').select('*').in('organization_id', orgIds)
+      : Promise.resolve({ data: [] }),
+    orgIds.length > 0
+      ? dataClient
+          .from('action_center_workspace_members')
+          .select(
+            'id, org_id, user_id, display_name, login_email, access_role, scope_type, scope_value, can_view, can_update, can_assign, can_schedule_review, created_at, updated_at',
+          )
+          .in('org_id', orgIds)
+      : Promise.resolve({ data: [] }),
+    orgIds.length > 0
+      ? dataClient
+          .from('action_center_route_relations')
+          .select(
+            'id, source_campaign_id, target_campaign_id, route_relation_type, source_route_id, target_route_id, trigger_reason, recorded_at, recorded_by_role, ended_at',
+          )
+          .in('org_id', orgIds)
+          .eq('route_relation_type', 'follow-up-from')
+      : Promise.resolve({ data: [] }),
+  ])
+
+  const organizations = (organizationsRaw ?? []) as Organization[]
+  const campaigns = ((campaignsRaw ?? []) as Campaign[]).filter((campaign) =>
+    ['exit', 'retention', 'onboarding', 'pulse', 'leadership'].includes(campaign.scan_type),
+  )
+  const campaignIds = campaigns.map((campaign) => campaign.id)
+  const stats = (statsRaw ?? []) as CampaignStats[]
+  const deliveryRecords = (deliveryRecordsRaw ?? []) as CampaignDeliveryRecord[]
+  const dossiers = ((dossiersRaw ?? []) as PilotLearningDossier[]).filter((dossier) =>
+    dossier.campaign_id ? campaignIds.includes(dossier.campaign_id) : false,
+  )
+  const managerWorkspaceRows = (
+    context.canManageActionCenterAssignments ? managerWorkspaceRowsRaw ?? [] : currentUserWorkspaceMemberships
+  ) as ActionCenterWorkspaceMember[]
+  const statsByCampaignId = new Map(stats.map((entry) => [entry.campaign_id, entry]))
+  const routeRelations = ((routeRelationsRaw ?? []) as ActionCenterRouteRelationRow[]).reduce<
+    ReturnType<typeof projectActionCenterRouteFollowUpRelation>[]
+  >((acc, relation) => {
+    const belongsToVisibleCampaign =
+      (relation.source_campaign_id ? campaignIds.includes(relation.source_campaign_id) : false) ||
+      (relation.target_campaign_id ? campaignIds.includes(relation.target_campaign_id) : false)
+
+    if (!belongsToVisibleCampaign) {
+      return acc
+    }
+
+    try {
+      acc.push(projectActionCenterRouteFollowUpRelation(relation))
+    } catch {
+      // Ignore malformed legacy rows so one broken relation does not take down the full Action Center page.
+    }
+
+    return acc
+  }, [])
+
+  const { data: respondentsWithDepartmentsRaw } =
+    campaignIds.length > 0
+      ? await dataClient.from('respondents').select('campaign_id, department').in('campaign_id', campaignIds)
+      : { data: [] }
+
+  const respondentsWithDepartments = (respondentsWithDepartmentsRaw ?? []) as RespondentDepartmentRow[]
+  const respondentDepartmentsByCampaign = respondentsWithDepartments.reduce<Record<string, string[]>>((acc, row) => {
+    const departmentLabel = normalizeDepartmentLabel(row.department)
+    if (!departmentLabel) return acc
+    acc[row.campaign_id] ??= []
+    acc[row.campaign_id].push(departmentLabel)
+    return acc
+  }, {})
+  const visibleScopesByCampaignId = campaigns.reduce<Record<string, ActionCenterScopeRow[]>>((acc, campaign) => {
+    const scopes = buildActionCenterScopes({
+      campaign,
+      departmentLabels: respondentDepartmentsByCampaign[campaign.id] ?? [],
+      fallbackPeopleCount:
+        statsByCampaignId.get(campaign.id)?.total_completed ?? statsByCampaignId.get(campaign.id)?.total_invited ?? 0,
+    }).filter((scope) => isScopeVisibleToActionCenterContext(context, scope.scopeValue))
+
+    if (scopes.length > 0) {
+      acc[campaign.id] = scopes
+    }
+
+    return acc
+  }, {})
+  const visibleRouteIds = campaigns.flatMap((campaign) =>
+    (visibleScopesByCampaignId[campaign.id] ?? []).map((scope) => buildActionCenterRouteId(campaign.id, scope.scopeValue)),
+  )
+  const visibleRouteIdSet = new Set(visibleRouteIds)
+
+  const [
+    { data: deliveryCheckpointsRaw },
+    { data: learningCheckpointsRaw },
+    { data: reviewDecisionsRaw },
+    { data: managerResponsesRaw },
+    { data: routeReopensRaw },
+    { data: routeCloseoutsRaw },
+  ] = await Promise.all([
+    deliveryRecords.length > 0
+      ? dataClient
+          .from('campaign_delivery_checkpoints')
+          .select('*')
+          .in(
+            'delivery_record_id',
+            deliveryRecords.map((record) => record.id),
+          )
+      : Promise.resolve({ data: [] }),
+    dossiers.length > 0
+      ? dataClient
+          .from('pilot_learning_checkpoints')
+          .select('*')
+          .in(
+            'dossier_id',
+            dossiers.map((dossier) => dossier.id),
+          )
+      : Promise.resolve({ data: [] }),
+    campaignIds.length > 0
+      ? dataClient
+          .from('action_center_review_decisions')
+          .select('*')
+          .eq('route_source_type', 'campaign')
+          .in('route_source_id', campaignIds)
+      : Promise.resolve({ data: [] }),
+    campaignIds.length > 0
+      ? dataClient
+          .from('action_center_manager_responses')
+          .select('*')
+          .in('campaign_id', campaignIds)
+      : Promise.resolve({ data: [] }),
+    visibleRouteIds.length > 0
+      ? dataClient
+          .from('action_center_route_reopens')
+          .select('id, route_id, reopened_at, reopened_by_role')
+          .in('route_id', visibleRouteIds)
+      : Promise.resolve({ data: [] }),
+    visibleRouteIds.length > 0
+      ? dataClient
+          .from('action_center_route_closeouts')
+          .select('route_id, closeout_status, closeout_reason, closeout_note, closed_at, closed_by_role')
+          .in('route_id', visibleRouteIds)
+      : Promise.resolve({ data: [] }),
+  ])
+
+  const deliveryCheckpoints = (deliveryCheckpointsRaw ?? []) as CampaignDeliveryCheckpoint[]
+  const learningCheckpoints = (learningCheckpointsRaw ?? []) as PilotLearningCheckpoint[]
+  const reviewDecisions = (reviewDecisionsRaw ?? []) as ActionCenterReviewDecision[]
+  const managerResponses = (managerResponsesRaw ?? []) as ActionCenterManagerResponse[]
+  const routeReopens = ((routeReopensRaw ?? []) as ActionCenterRouteReopenRow[]).reduce<
+    ReturnType<typeof projectActionCenterRouteReopen>[]
+  >((acc, routeReopen) => {
+    try {
+      const parsedRouteReopen = projectActionCenterRouteReopen(routeReopen)
+      if (visibleRouteIdSet.has(parsedRouteReopen.routeId)) {
+        acc.push(parsedRouteReopen)
+      }
+    } catch {
+      // Ignore malformed legacy rows so one broken reopen does not take down the full Action Center page.
+    }
+
+    return acc
+  }, [])
+  const routeCloseoutMap = ((routeCloseoutsRaw ?? []) as ActionCenterRouteCloseoutRow[]).reduce<
+    Record<string, ReturnType<typeof projectActionCenterRouteCloseout>>
+  >((acc, routeCloseout) => {
+    try {
+      const parsedRouteCloseout = projectActionCenterRouteCloseout(routeCloseout)
+      if (visibleRouteIdSet.has(parsedRouteCloseout.routeId)) {
+        acc[parsedRouteCloseout.routeId] = parsedRouteCloseout
+      }
+    } catch {
+      // Ignore malformed legacy closeout rows so one broken record does not take down the full Action Center page.
+    }
+
+    return acc
+  }, {})
+
+  const organizationById = new Map(organizations.map((organization) => [organization.id, organization]))
+  const roleByOrgId = orgMemberships.reduce<Record<string, 'owner' | 'member' | 'viewer'>>((acc, membership) => {
+    if (!acc[membership.org_id]) {
+      acc[membership.org_id] = membership.role
+    }
+    return acc
+  }, {})
+  const deliveryRecordByCampaignId = new Map(deliveryRecords.map((record) => [record.campaign_id, record]))
+  const deliveryCheckpointMap = deliveryCheckpoints.reduce<Record<string, CampaignDeliveryCheckpoint[]>>((acc, checkpoint) => {
+    acc[checkpoint.delivery_record_id] ??= []
+    acc[checkpoint.delivery_record_id].push(checkpoint)
+    return acc
+  }, {})
+  const learningDossierByCampaignId = new Map(dossiers.map((dossier) => [dossier.campaign_id ?? dossier.id, dossier]))
+  const learningCheckpointMap = learningCheckpoints.reduce<Record<string, PilotLearningCheckpoint[]>>((acc, checkpoint) => {
+    acc[checkpoint.dossier_id] ??= []
+    acc[checkpoint.dossier_id].push(checkpoint)
+    return acc
+  }, {})
+  const reviewDecisionMap = reviewDecisions.reduce<Record<string, ActionCenterReviewDecision[]>>((acc, record) => {
+    acc[record.route_source_id] ??= []
+    acc[record.route_source_id].push(record)
+    return acc
+  }, {})
+  const managerResponseByRouteId = new Map(
+    managerResponses.map((response) => [
+      buildActionCenterRouteId(response.campaign_id, response.route_scope_value),
+      response,
+    ]),
+  )
+  const routeFollowUpRelationMap = routeRelations.reduce<Record<string, typeof routeRelations>>((acc, relation) => {
+    acc[relation.sourceRouteId] ??= []
+    acc[relation.targetRouteId] ??= []
+    acc[relation.sourceRouteId].push(relation)
+    acc[relation.targetRouteId].push(relation)
+    return acc
+  }, {})
+  const routeReopenMap = routeReopens.reduce<Record<string, typeof routeReopens>>((acc, routeReopen) => {
+    acc[routeReopen.routeId] ??= []
+    acc[routeReopen.routeId].push(routeReopen)
+    return acc
+  }, {})
+
+  const liveContexts = campaigns.flatMap((campaign) => {
+    return (visibleScopesByCampaignId[campaign.id] ?? []).map((scope) => {
+      const deliveryRecord = deliveryRecordByCampaignId.get(campaign.id) ?? null
+      const learningDossier = learningDossierByCampaignId.get(campaign.id) ?? null
+      const assignment = getManagerAssignment(managerWorkspaceRows, campaign.organization_id, scope.scopeValue)
+      const routeId = buildActionCenterRouteId(campaign.id, scope.scopeValue)
+
+      return {
+        campaign,
+        stats: statsByCampaignId.get(campaign.id) ?? null,
+        organizationName: organizationById.get(campaign.organization_id)?.name ?? 'Verisight organisatie',
+        memberRole: roleByOrgId[campaign.organization_id] ?? null,
+        scopeType: scope.scopeType,
+        scopeValue: scope.scopeValue,
+        scopeLabel: scope.scopeLabel,
+        peopleCount: scope.peopleCount,
+        assignedManager: assignment
+          ? {
+              userId: assignment.user_id,
+              displayName: assignment.display_name ?? assignment.login_email ?? null,
+              assignedAt: assignment.created_at ?? null,
+            }
+          : null,
+        deliveryRecord,
+        deliveryCheckpoints: deliveryRecord ? (deliveryCheckpointMap[deliveryRecord.id] ?? []) : [],
+        learningDossier,
+        learningCheckpoints: learningDossier ? (learningCheckpointMap[learningDossier.id] ?? []) : [],
+        managerResponse: managerResponseByRouteId.get(routeId) ?? null,
+        reviewDecisions: reviewDecisionMap[campaign.id] ?? [],
+        routeCloseout: routeCloseoutMap[routeId] ?? null,
+        routeFollowUpRelations: routeFollowUpRelationMap[routeId] ?? [],
+        routeReopens: routeReopenMap[routeId] ?? [],
+      }
+    })
+  })
+
+  const items = buildLiveActionCenterItems(liveContexts)
+  const summary = getLiveActionCenterSummary(items)
+  const ownerOptions = [...new Set(items.map((item) => item.ownerName).filter((value): value is string => Boolean(value)))].sort(
+    (left, right) => left.localeCompare(right),
+  )
+  const managerOptions = [...new Map(
+    managerWorkspaceRows
+      .filter((row) => row.access_role === 'manager_assignee')
+      .map((row) => [
+        row.user_id,
+        {
+          value: row.user_id,
+          label: row.display_name ?? row.login_email ?? 'Manager',
+        },
+      ]),
+  ).values()].sort((left, right) => left.label.localeCompare(right.label))
+  const itemHrefs = context.canViewInsights
+    ? Object.fromEntries(items.map((item) => [item.id, `/campaigns/${item.coreSemantics.route.campaignId}`]))
+    : {}
+
+  return {
+    items,
+    summary,
+    ownerOptions,
+    managerOptions,
+    itemHrefs,
+    organizationNames: [...new Set(organizations.map((organization) => organization.name).filter(Boolean))],
+  }
+}

--- a/frontend/lib/action-center-review-moments.test.ts
+++ b/frontend/lib/action-center-review-moments.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest'
+import type { ActionCenterPreviewItem } from '@/lib/action-center-preview-model'
+import {
+  classifyReviewMoment,
+  computeReviewMomentGovernanceCounts,
+  formatReviewMomentLastUpdated,
+  getReviewMomentActionLabel,
+  getReviewMomentManagerLabel,
+  getReviewMomentOutcomeSummary,
+  getReviewMomentScopeLabel,
+  getReviewMomentScopeTypeLabel,
+  groupReviewMomentsByUrgency,
+} from './action-center-review-moments'
+
+function buildItem(overrides: Partial<ActionCenterPreviewItem> = {}): ActionCenterPreviewItem {
+  return {
+    id: 'route-1',
+    code: 'AC-101',
+    title: 'Exit voorjaar',
+    summary: 'Compacte route-read',
+    reason: 'Frictie vraagt opvolging.',
+    sourceLabel: 'ExitScan',
+    orgId: 'org-1',
+    scopeType: 'department',
+    teamId: 'org-1::department::operations',
+    teamLabel: 'Operations',
+    ownerId: 'manager-1',
+    ownerName: 'Manager Operations',
+    ownerRole: 'Manager',
+    ownerSubtitle: 'Operations',
+    reviewOwnerName: 'HR lead',
+    priority: 'hoog',
+    status: 'te-bespreken',
+    reviewDate: '2026-05-06T10:00:00.000Z',
+    expectedEffect: 'Maak duidelijk wat eerst bestuurlijke aandacht vraagt.',
+    reviewReason: null,
+    reviewOutcome: 'geen-uitkomst',
+    managerResponse: null,
+    reviewDateLabel: '6 mei',
+    reviewRhythm: 'Tweewekelijks',
+    signalLabel: 'ExitScan',
+    signalBody: 'Exit-signaal',
+    nextStep: 'Plan de eerste review.',
+    peopleCount: 23,
+    coreSemantics: {} as ActionCenterPreviewItem['coreSemantics'],
+    openSignals: [],
+    updates: [],
+    ...overrides,
+  }
+}
+
+describe('action center review moments helpers', () => {
+  const referenceNow = new Date('2026-05-05T12:00:00.000Z')
+
+  it('classifies overdue, this-week, upcoming and completed moments from existing item data', () => {
+    expect(
+      classifyReviewMoment(
+        buildItem({
+          reviewDate: '2026-05-02T08:00:00.000Z',
+          reviewOutcome: 'geen-uitkomst',
+        }),
+        referenceNow,
+      ),
+    ).toBe('overdue')
+
+    expect(
+      classifyReviewMoment(
+        buildItem({
+          reviewDate: '2026-05-08T08:00:00.000Z',
+        }),
+        referenceNow,
+      ),
+    ).toBe('this-week')
+
+    expect(
+      classifyReviewMoment(
+        buildItem({
+          reviewDate: '2026-05-20T08:00:00.000Z',
+        }),
+        referenceNow,
+      ),
+    ).toBe('upcoming')
+
+    expect(
+      classifyReviewMoment(
+        buildItem({
+          status: 'afgerond',
+          reviewOutcome: 'afronden',
+          reviewDate: '2026-05-01T08:00:00.000Z',
+        }),
+        referenceNow,
+      ),
+    ).toBe('completed')
+  })
+
+  it('keeps unscheduled items out of urgency lanes instead of masking them as dated work', () => {
+    expect(classifyReviewMoment(buildItem({ reviewDate: null }), referenceNow)).toBeNull()
+  })
+
+  it('groups items by urgency and keeps unscheduled records separate', () => {
+    const grouped = groupReviewMomentsByUrgency(
+      [
+        buildItem({ id: 'overdue', reviewDate: '2026-05-02T08:00:00.000Z' }),
+        buildItem({ id: 'this-week', reviewDate: '2026-05-08T08:00:00.000Z' }),
+        buildItem({ id: 'upcoming', reviewDate: '2026-05-20T08:00:00.000Z' }),
+        buildItem({
+          id: 'completed',
+          status: 'afgerond',
+          reviewOutcome: 'afronden',
+          reviewDate: '2026-05-01T08:00:00.000Z',
+        }),
+        buildItem({ id: 'unscheduled', reviewDate: null }),
+      ],
+      referenceNow,
+    )
+
+    expect(grouped.overdue.map((item) => item.id)).toEqual(['overdue'])
+    expect(grouped['this-week'].map((item) => item.id)).toEqual(['this-week'])
+    expect(grouped.upcoming.map((item) => item.id)).toEqual(['upcoming'])
+    expect(grouped.completed.map((item) => item.id)).toEqual(['completed'])
+    expect(grouped.unscheduled.map((item) => item.id)).toEqual(['unscheduled'])
+  })
+
+  it('counts overdue, missing outcome, missing scope and missing manager without silent fallbacks', () => {
+    const counts = computeReviewMomentGovernanceCounts(
+      [
+        buildItem({
+          reviewDate: '2026-05-02T08:00:00.000Z',
+          ownerName: null,
+          teamLabel: '',
+        }),
+        buildItem({
+          id: 'closed',
+          status: 'afgerond',
+          reviewOutcome: 'afronden',
+          reviewDate: '2026-05-01T08:00:00.000Z',
+        }),
+      ],
+      referenceNow,
+    )
+
+    expect(counts).toEqual({
+      overdue: 1,
+      missingOutcome: 1,
+      missingScope: 1,
+      missingManager: 1,
+    })
+  })
+
+  it('keeps agreed reviewmomenten copy and scope fallbacks', () => {
+    expect(getReviewMomentActionLabel(buildItem())).toBe('Leg uitkomst vast')
+    expect(
+      getReviewMomentActionLabel(
+        buildItem({
+          status: 'afgerond',
+          reviewOutcome: 'afronden',
+        }),
+      ),
+    ).toBe('Open reviewmoment')
+    expect(getReviewMomentOutcomeSummary(buildItem())).toBe('Nog geen reviewuitkomst vastgelegd.')
+    expect(getReviewMomentManagerLabel(buildItem({ ownerName: null }))).toBe('Geen manager gekoppeld')
+    expect(getReviewMomentScopeLabel(buildItem({ teamLabel: '' }))).toBe('Geen scope')
+    expect(getReviewMomentScopeTypeLabel('department')).toBe('Afdeling')
+    expect(getReviewMomentScopeTypeLabel('item')).toBe('Campagne')
+    expect(getReviewMomentScopeTypeLabel('org')).toBe('Organisatie')
+    expect(getReviewMomentScopeTypeLabel(undefined)).toBe('Niet beschikbaar')
+  })
+
+  it('formats the last updated label for the filter row timestamp', () => {
+    expect(formatReviewMomentLastUpdated('2026-05-05T12:10:00.000Z')).toContain('Laatste update')
+  })
+})

--- a/frontend/lib/action-center-review-moments.ts
+++ b/frontend/lib/action-center-review-moments.ts
@@ -1,0 +1,249 @@
+import type { ActionCenterPreviewItem, ActionCenterPreviewStatus } from '@/lib/action-center-preview-model'
+
+export type ReviewMomentUrgency = 'overdue' | 'this-week' | 'upcoming' | 'completed'
+
+export interface ReviewMomentGovernanceCounts {
+  overdue: number
+  missingOutcome: number
+  missingScope: number
+  missingManager: number
+}
+
+export interface ReviewMomentGroups {
+  overdue: ActionCenterPreviewItem[]
+  'this-week': ActionCenterPreviewItem[]
+  upcoming: ActionCenterPreviewItem[]
+  completed: ActionCenterPreviewItem[]
+  unscheduled: ActionCenterPreviewItem[]
+}
+
+const DUTCH_SHORT_DAY = new Intl.DateTimeFormat('nl-NL', {
+  weekday: 'short',
+  day: 'numeric',
+  month: 'short',
+})
+
+function parseDate(value: string | null | undefined) {
+  if (!value) return null
+
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}
+
+function isClosedStatus(status: ActionCenterPreviewStatus) {
+  return status === 'afgerond' || status === 'gestopt'
+}
+
+function hasRecordedOutcome(item: ActionCenterPreviewItem) {
+  return item.reviewOutcome !== 'geen-uitkomst'
+}
+
+function getStartOfIsoWeek(now: Date) {
+  const start = new Date(now)
+  start.setHours(0, 0, 0, 0)
+  const day = start.getDay()
+  const isoOffset = day === 0 ? -6 : 1 - day
+  start.setDate(start.getDate() + isoOffset)
+  return start
+}
+
+function getEndOfIsoWeek(now: Date) {
+  const end = getStartOfIsoWeek(now)
+  end.setDate(end.getDate() + 7)
+  return end
+}
+
+function isReviewOverdue(reviewDate: Date, now: Date) {
+  return reviewDate.getTime() < now.getTime() - 48 * 60 * 60 * 1000
+}
+
+function isWithinThisIsoWeek(reviewDate: Date, now: Date) {
+  const start = getStartOfIsoWeek(now)
+  const end = getEndOfIsoWeek(now)
+  return reviewDate >= start && reviewDate < end
+}
+
+function isUpcomingWithinThirtyDays(reviewDate: Date, now: Date) {
+  const oneDayAhead = new Date(now)
+  oneDayAhead.setHours(0, 0, 0, 0)
+  oneDayAhead.setDate(oneDayAhead.getDate() + 1)
+
+  const thirtyDaysAhead = new Date(now)
+  thirtyDaysAhead.setHours(23, 59, 59, 999)
+  thirtyDaysAhead.setDate(thirtyDaysAhead.getDate() + 30)
+
+  return reviewDate >= oneDayAhead && reviewDate <= thirtyDaysAhead
+}
+
+export function classifyReviewMoment(item: ActionCenterPreviewItem, now: Date): ReviewMomentUrgency | null {
+  if (isClosedStatus(item.status) && hasRecordedOutcome(item)) {
+    return 'completed'
+  }
+
+  const reviewDate = parseDate(item.reviewDate)
+  if (!reviewDate) {
+    return null
+  }
+
+  if (!hasRecordedOutcome(item) && isReviewOverdue(reviewDate, now)) {
+    return 'overdue'
+  }
+
+  if (isWithinThisIsoWeek(reviewDate, now)) {
+    return 'this-week'
+  }
+
+  if (isUpcomingWithinThirtyDays(reviewDate, now)) {
+    return 'upcoming'
+  }
+
+  return null
+}
+
+function compareReviewMoments(left: ActionCenterPreviewItem, right: ActionCenterPreviewItem) {
+  const leftTime = parseDate(left.reviewDate)?.getTime() ?? Number.POSITIVE_INFINITY
+  const rightTime = parseDate(right.reviewDate)?.getTime() ?? Number.POSITIVE_INFINITY
+
+  if (leftTime !== rightTime) {
+    return leftTime - rightTime
+  }
+
+  return left.title.localeCompare(right.title)
+}
+
+export function groupReviewMomentsByUrgency(items: ActionCenterPreviewItem[], now: Date): ReviewMomentGroups {
+  const groups: ReviewMomentGroups = {
+    overdue: [],
+    'this-week': [],
+    upcoming: [],
+    completed: [],
+    unscheduled: [],
+  }
+
+  for (const item of items) {
+    const urgency = classifyReviewMoment(item, now)
+
+    if (urgency) {
+      groups[urgency].push(item)
+      continue
+    }
+
+    if (!item.reviewDate) {
+      groups.unscheduled.push(item)
+    }
+  }
+
+  groups.overdue.sort(compareReviewMoments)
+  groups['this-week'].sort(compareReviewMoments)
+  groups.upcoming.sort(compareReviewMoments)
+  groups.completed.sort(compareReviewMoments)
+  groups.unscheduled.sort(compareReviewMoments)
+
+  return groups
+}
+
+export function computeReviewMomentGovernanceCounts(
+  items: ActionCenterPreviewItem[],
+  now: Date,
+): ReviewMomentGovernanceCounts {
+  return items.reduce<ReviewMomentGovernanceCounts>(
+    (counts, item) => {
+      const reviewDate = parseDate(item.reviewDate)
+      const overdue = reviewDate && !hasRecordedOutcome(item) && isReviewOverdue(reviewDate, now)
+
+      return {
+        overdue: counts.overdue + (overdue ? 1 : 0),
+        missingOutcome:
+          counts.missingOutcome +
+          (!isClosedStatus(item.status) && item.reviewOutcome === 'geen-uitkomst' ? 1 : 0),
+        missingScope:
+          counts.missingScope +
+          (!item.teamLabel.trim() || !item.scopeType ? 1 : 0),
+        missingManager: counts.missingManager + (item.ownerName ? 0 : 1),
+      }
+    },
+    {
+      overdue: 0,
+      missingOutcome: 0,
+      missingScope: 0,
+      missingManager: 0,
+    },
+  )
+}
+
+export function formatReviewMomentLastUpdated(value: string) {
+  const parsed = parseDate(value)
+  if (!parsed) return null
+
+  const dateLabel = DUTCH_SHORT_DAY.format(parsed).replace('.', '')
+  const timeLabel = parsed.toLocaleTimeString('nl-NL', {
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+
+  return `Laatste update ${dateLabel} om ${timeLabel}`
+}
+
+export function getReviewMomentOutcomeSummary(item: ActionCenterPreviewItem) {
+  if (item.reviewReason?.trim()) {
+    return item.reviewReason.trim()
+  }
+
+  if (item.reviewOutcome === 'geen-uitkomst') {
+    return 'Nog geen reviewuitkomst vastgelegd.'
+  }
+
+  return `Laatste uitkomst: ${item.reviewOutcome}.`
+}
+
+export function getReviewMomentActionLabel(item: ActionCenterPreviewItem) {
+  if (!isClosedStatus(item.status) && item.reviewOutcome === 'geen-uitkomst') {
+    return 'Leg uitkomst vast'
+  }
+
+  return 'Open reviewmoment'
+}
+
+export function getReviewMomentScopeLabel(item: ActionCenterPreviewItem) {
+  return item.teamLabel.trim() || 'Geen scope'
+}
+
+export function getReviewMomentManagerLabel(item: ActionCenterPreviewItem) {
+  return item.ownerName?.trim() || 'Geen manager gekoppeld'
+}
+
+export function getReviewMomentStatusLabel(
+  item: ActionCenterPreviewItem,
+  urgency: ReviewMomentUrgency | null = null,
+) {
+  if (urgency === 'overdue') {
+    return 'Achterstallig'
+  }
+
+  switch (item.status) {
+    case 'te-bespreken':
+    case 'reviewbaar':
+      return 'Gepland'
+    case 'in-uitvoering':
+      return 'In uitvoering'
+    case 'afgerond':
+      return 'Afgerond'
+    case 'gestopt':
+      return 'Gestopt'
+    default:
+      return 'Gepland'
+  }
+}
+
+export function getReviewMomentScopeTypeLabel(scopeType: ActionCenterPreviewItem['scopeType']) {
+  switch (scopeType) {
+    case 'department':
+      return 'Afdeling'
+    case 'org':
+      return 'Organisatie'
+    case 'item':
+      return 'Campagne'
+    default:
+      return 'Niet beschikbaar'
+  }
+}


### PR DESCRIPTION
## Samenvatting
- voegt de zelfstandige reviewmomenten-pagina toe onder Action Center
- houdt de pagina bounded tot reviewritme, status, scope en bekende uitkomsten
- vermijdt dashboardduiding, automation en generieke planningstool-drift

## Scope
- reviewmomenten route
- review helperlaag en page data projection
- reviewmomenten UI-componenten en guardrails

## Verificatie
- reviewmomenten-slice vitest groen
- eslint groen
- desktop/mobile browser-QA lokaal