### PR TITLE
Dashboard overview cockpit

### DIFF
--- a/frontend/app/(dashboard)/dashboard/page.test.ts
+++ b/frontend/app/(dashboard)/dashboard/page.test.ts
@@ -39,42 +39,58 @@ const campaigns: CampaignStats[] = [
 ]
 
 describe('dashboard home UX guardrails', () => {
-  it('keeps the overview route focused on HR regie with one dominant lead line and lighter supporting sections', () => {
+  it('renders the overview route as a cockpit with explicit triage buckets and sections', () => {
     const pageSource = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
 
-    expect(pageSource).toContain('highlightLabel={index === 0 ? \'Nu eerst\' : undefined}')
-    expect(pageSource).toContain('Ook aandacht')
-    expect(pageSource).toContain('Actieve routes')
-    expect(pageSource).toContain('Wat nu leesbaar is')
-    expect(pageSource).toContain('Wat blokkeert')
-    expect(pageSource).toContain('Opvolging preview')
-    expect(pageSource).toContain('OverviewRouteRow')
-    expect(pageSource).not.toContain('OverviewLeadCard')
-    expect(pageSource).not.toContain('Overige actieve routes')
-    expect(pageSource).not.toContain('Portfolio samenvatting')
-    expect(pageSource).not.toContain('Aanbevolen focus')
+    expect(pageSource).toContain('Dashboard overview')
+    expect(pageSource).toContain('Cockpit')
+    expect(pageSource).toContain('ACTIE NODIG')
+    expect(pageSource).toContain('BIJNA KLAAR')
+    expect(pageSource).toContain('LIVE EN LEESBAAR')
+    expect(pageSource).toContain('GEBLOKKEERD / NIET GESTART')
+    expect(pageSource).toContain('Nu eerst')
+    expect(pageSource).toContain('Geblokkeerd / niet gestart')
+    expect(pageSource).toContain('Recente afgeronde routes')
+    expect(pageSource).toContain('WAAROM')
+    expect(pageSource).toContain('VOLGENDE STAP')
   })
 
-  it('keeps overview language compact and bounded instead of turning the page into a mini action surface', () => {
+  it('drops the old flat overview IA and keeps product boundaries sharp', () => {
     const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
 
-    expect(source).toContain('Wat nu leesbaar is, wat blokkeert en waar opvolging openstaat.')
-    expect(source).toContain('Dashboard beschikbaar.')
-    expect(source).toContain('Eerste read beschikbaar.')
-    expect(source).toContain('Nog geen open opvolging.')
-    expect(source).not.toContain('Welke route nu het eerst logisch is.')
+    expect(source).not.toContain('Ook aandacht')
+    expect(source).not.toContain('Actieve routes')
+    expect(source).not.toContain('Wat nu leesbaar is')
+    expect(source).not.toContain('Wat blokkeert')
+    expect(source).not.toContain('OverviewLeadCard')
+    expect(source).not.toContain('Overige actieve routes')
+    expect(source).not.toContain('Portfolio samenvatting')
+    expect(source).not.toContain('Aanbevolen focus')
+    expect(source).not.toContain('factor-breakdown')
+    expect(source).not.toContain('setupwizard')
   })
 
-  it('keeps action center as a light bridge instead of reintroducing commitment structure on overview', () => {
+  it('keeps access boundaries and route scope intact on overview', () => {
     const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
 
-    expect(source).toContain('Opvolging preview')
-    expect(source).toContain('canOpenActionCenterRoute')
-    expect(source).toContain('first_management_use_confirmed_at')
-    expect(source).toContain('Open Action Center')
-    expect(source).toContain('Open prioriteit')
-    expect(source).toContain('Zonder bevestiging')
-    expect(source).not.toContain('Actieve opvolging')
+    expect(source).toContain("if (context.managerOnly) redirect('/action-center')")
+    expect(source).toContain("const requestedModuleFilter = normalizeDashboardModuleFilter(")
+    expect(source).toContain("const requestedStatusFilter = normalizeDashboardStatusFilter(")
+    expect(source).toContain("if (state === 'ready_to_launch' || state === 'running' || state === 'sparse') return 'action_needed'")
+    expect(source).toContain(".filter((entry) => entry.state === 'setup')")
+    expect(source).toContain('Geen routes met deze status.')
+    expect(source).not.toContain('Accepteren')
+    expect(source).not.toContain('Afwijzen')
+    expect(source).not.toContain('Toewijzen')
+    expect(source).not.toContain('Reviewmoment')
+  })
+
+  it('keeps signal scoring out of the visible overview card metrics', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+
+    expect(source).toContain('MetricBlock label="RESPONS" value={item.responseValue} compact')
+    expect(source).not.toContain('MetricBlock label={item.signalLabel.toUpperCase()}')
+    expect(source).not.toContain('signalValue:')
   })
 
   it('allows the seeded HR demo campaign to override the default overview focus route', () => {

--- a/frontend/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/page.tsx
@@ -1,4 +1,4 @@
-﻿import Link from 'next/link'
+import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { DashboardSection } from '@/components/dashboard/dashboard-primitives'
 import {
@@ -6,14 +6,16 @@ import {
   type CampaignCompositionState,
 } from '@/lib/dashboard/dashboard-state-composition'
 import {
+  getDashboardModuleKeyForScanType,
   getDashboardModuleLabel,
   getScanTypeForDashboardModule,
   normalizeDashboardModuleFilter,
+  type DashboardCategoryModuleKey,
 } from '@/lib/dashboard/shell-navigation'
+import { getScanDefinition } from '@/lib/scan-definitions'
 import { loadSuiteAccessContext } from '@/lib/suite-access-server'
 import { createClient } from '@/lib/supabase/server'
-import { getScanDefinition } from '@/lib/scan-definitions'
-import type { CampaignStats } from '@/lib/types'
+import { getCampaignAverageSignalScore, type CampaignStats } from '@/lib/types'
 
 type CampaignHomeEntry = {
   campaign: CampaignStats
@@ -21,22 +23,52 @@ type CampaignHomeEntry = {
   invitesNotSent: number
 }
 
-type OverviewRouteTone = 'emerald' | 'amber' | 'slate'
+type OverviewRouteTone = 'slate' | 'blue' | 'emerald' | 'amber'
+type CockpitBucket =
+  | 'action_needed'
+  | 'nearly_ready'
+  | 'live_readable'
+  | 'blocked_not_started'
+  | 'recent_closed'
+type CockpitStatusFilter = Exclude<CockpitBucket, 'recent_closed'> | 'all'
 
-type OverviewRouteItem = {
+type CockpitRouteItem = {
   entry: CampaignHomeEntry
-  routeLabel: string
+  bucket: CockpitBucket
+  productLabel: string
   contextLabel: string
   stateLabel: string
   stateTone: OverviewRouteTone
-  summary: string
-  metricLabel: string
-  metricValue: string
-  secondaryMetricLabel?: string
-  secondaryMetricValue?: string
+  why: string
+  nextStep: string
   ctaLabel: string
-  bounded: boolean
+  ctaHref: string
+  responseValue: string
 }
+
+type CockpitCounter = {
+  key: Exclude<CockpitBucket, 'recent_closed'>
+  label: string
+  tone: OverviewRouteTone
+  count: number
+  body: string
+}
+
+const STATUS_FILTERS: Array<{ key: CockpitStatusFilter; label: string }> = [
+  { key: 'all', label: 'Alle statussen' },
+  { key: 'action_needed', label: 'Actie nodig' },
+  { key: 'nearly_ready', label: 'Bijna klaar' },
+  { key: 'live_readable', label: 'Live en leesbaar' },
+  { key: 'blocked_not_started', label: 'Geblokkeerd / niet gestart' },
+]
+
+const MODULE_ORDER: DashboardCategoryModuleKey[] = [
+  'exit',
+  'retention',
+  'onboarding',
+  'pulse',
+  'leadership',
+]
 
 export default async function DashboardHomePage({
   searchParams,
@@ -46,6 +78,9 @@ export default async function DashboardHomePage({
   const resolvedSearchParams = searchParams ? await searchParams : undefined
   const requestedModuleFilter = normalizeDashboardModuleFilter(
     typeof resolvedSearchParams?.module === 'string' ? resolvedSearchParams.module : undefined,
+  )
+  const requestedStatusFilter = normalizeDashboardStatusFilter(
+    typeof resolvedSearchParams?.status === 'string' ? resolvedSearchParams.status : undefined,
   )
   const supabase = await createClient()
   const {
@@ -78,61 +113,60 @@ export default async function DashboardHomePage({
     completed: boolean
   }>
   const invitesNotSentByCampaign = buildInvitesNotSentByCampaign(campaigns, respondentStateRows)
-  const campaignEntries = campaigns.map((campaign) => ({
-    campaign,
-    invitesNotSent: invitesNotSentByCampaign.get(campaign.campaign_id) ?? 0,
-    state: getCampaignCompositionState({
-      isActive: campaign.is_active,
-      totalInvited: campaign.total_invited,
-      totalCompleted: campaign.total_completed,
-      invitesNotSent: invitesNotSentByCampaign.get(campaign.campaign_id) ?? 0,
-      incompleteScores: 0,
-      hasMinDisplay: campaign.total_completed >= 5,
-      hasEnoughData: campaign.total_completed >= 10,
-    }),
-  }))
-  const fullCount = campaignEntries.filter((entry) => entry.state === 'full').length
-  const partialCount = campaignEntries.filter((entry) => entry.state === 'partial').length
-  const closedCount = campaignEntries.filter((entry) => entry.state === 'closed').length
-  const managementReadyCount = fullCount + partialCount
-  const notReadableCount = campaignEntries.filter((entry) =>
-    ['setup', 'ready_to_launch', 'running', 'sparse'].includes(entry.state),
-  ).length
-  const openFollowUpCount = campaignEntries.filter((entry) => ['full', 'partial'].includes(entry.state)).length
+  const campaignEntries = campaigns.map((campaign) => {
+    const invitesNotSent = invitesNotSentByCampaign.get(campaign.campaign_id)
+    if (invitesNotSent === undefined) {
+      throw new Error(`Missing invite state for campaign ${campaign.campaign_id}`)
+    }
+
+    return {
+      campaign,
+      invitesNotSent,
+      state: getCampaignCompositionState({
+        isActive: campaign.is_active,
+        totalInvited: campaign.total_invited,
+        totalCompleted: campaign.total_completed,
+        invitesNotSent,
+        incompleteScores: 0,
+        hasMinDisplay: campaign.total_completed >= 5,
+        hasEnoughData: campaign.total_completed >= 10,
+      }),
+    }
+  })
+
+  const moduleLabel = requestedModuleFilter ? getDashboardModuleLabel(requestedModuleFilter) : null
+  const productFilters = buildAvailableModuleFilters(allCampaigns)
+  const counters = buildCockpitCounters(campaignEntries)
+  const activeEntries = campaignEntries.filter((entry) => entry.campaign.is_active)
+  const primaryActiveEntries = activeEntries.filter((entry) =>
+    ['exit', 'retention'].includes(entry.campaign.scan_type),
+  )
   const readableEntries = [...campaignEntries]
     .filter((entry) => ['full', 'partial', 'closed'].includes(entry.state))
     .sort(
       (left, right) =>
         new Date(right.campaign.created_at).getTime() - new Date(left.campaign.created_at).getTime(),
     )
-  const recentOutputEntries = buildRecentOutputEntries(campaignEntries).slice(0, 3)
-  const moduleLabel = requestedModuleFilter ? getDashboardModuleLabel(requestedModuleFilter) : null
-  const moduleIntro = moduleLabel
-    ? `Wat nu leesbaar is, wat blokkeert en waar opvolging openstaat.`
-    : 'Wat nu leesbaar is, wat blokkeert en waar opvolging openstaat.'
-  const activeEntries = campaignEntries.filter((entry) => entry.campaign.is_active)
-  const primaryActiveEntries = activeEntries.filter((entry) =>
-    ['exit', 'retention'].includes(entry.campaign.scan_type),
-  )
-  const boundedActiveEntries = activeEntries.filter(
-    (entry) => !['exit', 'retention'].includes(entry.campaign.scan_type),
-  )
   const primaryLeadEntry = selectPrimaryLeadEntry(primaryActiveEntries, readableEntries)
-  const primaryLeadItem = primaryLeadEntry ? buildOverviewRouteItem(primaryLeadEntry) : null
-  const primaryRouteItems = (
-    requestedModuleFilter ? activeEntries : primaryActiveEntries
-  )
-    .filter((entry) => entry.campaign.campaign_id !== primaryLeadEntry?.campaign.campaign_id)
-    .sort(compareOverviewEntries)
-    .map(buildOverviewRouteItem)
-  const boundedItems = boundedActiveEntries.sort(compareOverviewEntries).map(buildOverviewRouteItem)
-  const activeRouteItems = [
-    ...(primaryLeadItem ? [primaryLeadItem] : []),
-    ...primaryRouteItems,
-    ...(!requestedModuleFilter ? boundedItems : []),
-  ]
-  const attentionItems = buildOverviewAttentionItems(campaignEntries, primaryLeadEntry).slice(0, 3)
-  const blockerItems = buildOverviewBlockerItems(campaignEntries).slice(0, 3)
+  const triageItems = buildTriageItems(campaignEntries, primaryLeadEntry)
+  const blockedItems = buildBlockedItems(campaignEntries)
+  const closedItems = buildRecentClosedItems(campaignEntries).slice(0, 3)
+  const hasStatusFilter = requestedStatusFilter !== 'all'
+  const filteredTriageItems =
+    requestedStatusFilter === 'all'
+      ? triageItems
+      : triageItems.filter((item) => item.bucket === requestedStatusFilter)
+  const showTriageSection =
+    requestedStatusFilter === 'all' ||
+    requestedStatusFilter === 'action_needed' ||
+    requestedStatusFilter === 'nearly_ready' ||
+    requestedStatusFilter === 'live_readable'
+  const showBlockedSection =
+    blockedItems.length > 0 &&
+    (requestedStatusFilter === 'all' || requestedStatusFilter === 'blocked_not_started')
+  const showClosedSection = closedItems.length > 0 && requestedStatusFilter === 'all'
+  const filterEmptyMessage = hasStatusFilter && !showBlockedSection && filteredTriageItems.length === 0
+  const contextLabel = moduleLabel ?? 'Alle routes'
 
   return (
     <div className="space-y-8">
@@ -159,129 +193,143 @@ export default async function DashboardHomePage({
         )
       ) : (
         <>
-          <div className="space-y-4">
+          <header className="space-y-6 border-b border-[color:var(--dashboard-frame-border)] pb-6">
             {requestedModuleFilter ? (
               <Link
-                href="/dashboard"
+                href={buildDashboardOverviewHref({ statusFilter: requestedStatusFilter })}
                 className="inline-flex text-sm font-semibold text-[color:var(--dashboard-accent-strong)] transition-colors hover:text-[color:var(--dashboard-ink)]"
               >
                 Terug naar alle routes
               </Link>
             ) : null}
-            <div className="space-y-1">
-              <h1 className="font-serif text-[2.2rem] leading-[0.95] tracking-[-0.05em] text-[color:var(--dashboard-ink)] sm:text-[2.7rem]">
-                {moduleLabel ?? 'Overzicht'}
-              </h1>
-              <p className="max-w-2xl text-[0.98rem] leading-7 text-[color:var(--dashboard-text)]">
-                {moduleIntro}
-              </p>
-            </div>
-            <div className="grid gap-3 border-t border-[color:var(--dashboard-frame-border)] pt-4 md:grid-cols-3 xl:grid-cols-4">
-              <OverviewSummaryCard label="Leesbaar" value={managementReadyCount} />
-              <OverviewSummaryCard label="Nog niet leesbaar" value={notReadableCount} />
-              <OverviewSummaryCard label="Afgerond" value={closedCount} />
-              {openFollowUpCount > 0 ? (
-                <OverviewSummaryCard label="Opvolging open" value={openFollowUpCount} />
-              ) : null}
-            </div>
-          </div>
-
-          {attentionItems.length > 0 ? (
-            <section className="space-y-3">
-              <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-[color:var(--dashboard-muted)]">
-                Ook aandacht
-              </p>
-              <div className="rounded-xl border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)]/68 px-4 py-3 shadow-[0_1px_3px_rgba(10,25,47,0.03)]">
-                <div className="space-y-2.5">
-                  {attentionItems.map((item) => (
-                    <Link
-                      key={item.entry.campaign.campaign_id}
-                      href={`/campaigns/${item.entry.campaign.campaign_id}`}
-                      className="flex flex-wrap items-center justify-between gap-3 rounded-lg px-2 py-2 transition-colors hover:bg-white/70"
-                    >
-                      <div className="min-w-0 flex items-center gap-3">
-                        <span
-                          className={`inline-flex h-2.5 w-2.5 rounded-full ${
-                            item.stateTone === 'emerald'
-                              ? 'bg-[#3C8D8A]'
-                              : item.stateTone === 'amber'
-                                ? 'bg-[#C88C20]'
-                                : 'bg-[#8A7D6E]'
-                          }`}
-                        />
-                        <div className="min-w-0">
-                          <p className="truncate text-sm font-semibold tracking-[-0.02em] text-[color:var(--dashboard-ink)]">
-                            {item.entry.campaign.campaign_name}
-                          </p>
-                          <p className="mt-1 text-sm text-[color:var(--dashboard-text)]">{item.summary}</p>
-                        </div>
-                      </div>
-                      <span className="shrink-0 text-sm font-semibold text-[color:var(--dashboard-accent-strong)]">
-                        Open route
-                      </span>
-                    </Link>
-                  ))}
+            <div className="flex flex-col gap-5 xl:flex-row xl:items-end xl:justify-between">
+              <div className="space-y-3">
+                <div className="flex flex-wrap items-center gap-3">
+                  <span className="inline-flex rounded-full bg-[color:var(--dashboard-accent-soft)] px-3 py-1 text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-[color:var(--dashboard-accent-strong)]">
+                    Cockpit
+                  </span>
+                  <span className="text-sm font-medium text-[color:var(--dashboard-muted)]">{contextLabel}</span>
+                </div>
+                <div className="space-y-2">
+                  <h1 className="font-serif text-[2.25rem] leading-[0.95] tracking-[-0.05em] text-[color:var(--dashboard-ink)] sm:text-[2.8rem]">
+                    Dashboard overview
+                  </h1>
+                  <p className="max-w-3xl text-[0.98rem] leading-7 text-[color:var(--dashboard-text)]">
+                    Bekijk welke routes aandacht vragen en ga direct naar de juiste vervolglaag.
+                  </p>
                 </div>
               </div>
+              <div className="space-y-3 xl:max-w-[26rem] xl:text-right">
+                <div className="space-y-2">
+                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
+                    Product
+                  </p>
+                  <div className="flex flex-wrap gap-2 xl:justify-end">
+                    <FilterPill
+                      href={buildDashboardOverviewHref({ statusFilter: requestedStatusFilter })}
+                      active={requestedModuleFilter === null}
+                      label="Alle routes"
+                    />
+                    {productFilters.map((filterKey) => (
+                      <FilterPill
+                        key={filterKey}
+                        href={buildDashboardOverviewHref({
+                          moduleFilter: filterKey,
+                          statusFilter: requestedStatusFilter,
+                        })}
+                        active={requestedModuleFilter === filterKey}
+                        label={getDashboardModuleLabel(filterKey)}
+                      />
+                    ))}
+                  </div>
+                </div>
+                <div className="space-y-2">
+                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
+                    Status
+                  </p>
+                  <div className="flex flex-wrap gap-2 xl:justify-end">
+                    {STATUS_FILTERS.map((filter) => (
+                      <FilterPill
+                        key={filter.key}
+                        href={buildDashboardOverviewHref({
+                          moduleFilter: requestedModuleFilter,
+                          statusFilter: filter.key,
+                        })}
+                        active={requestedStatusFilter === filter.key}
+                        label={filter.label}
+                      />
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </header>
+
+          <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {counters.map((counter) => (
+              <StatusCounterCard key={counter.key} counter={counter} />
+            ))}
+          </section>
+
+          {showTriageSection ? (
+            <section className="space-y-4">
+              <div className="space-y-1.5">
+                <h2 className="text-[1.55rem] font-semibold tracking-[-0.04em] text-[color:var(--dashboard-ink)]">
+                  Nu eerst
+                </h2>
+                <p className="max-w-3xl text-sm leading-6 text-[color:var(--dashboard-text)]">
+                  Deze routes vragen als eerste aandacht op basis van status, volgende stap of beschikbare output.
+                </p>
+              </div>
+              {filteredTriageItems.length === 0 ? (
+                <InlineEmptyState message="Geen routes vragen op dit moment actie." />
+              ) : (
+                <div className="space-y-4">
+                  {filteredTriageItems.map((item, index) => (
+                    <TriageRouteCard
+                      key={item.entry.campaign.campaign_id}
+                      item={item}
+                      highlightLabel={index === 0 && requestedStatusFilter === 'all' ? 'Nu eerst' : undefined}
+                    />
+                  ))}
+                </div>
+              )}
             </section>
           ) : null}
 
-          <section className="space-y-4">
-            <div className="flex items-end justify-between gap-3">
-              <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-[color:var(--dashboard-muted)]">
-                Actieve routes
-              </p>
-              {moduleLabel ? (
-                <p className="text-sm text-[color:var(--dashboard-muted)]">{moduleLabel}</p>
-              ) : null}
-            </div>
-            <div className="rounded-[22px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)] px-4 py-2 shadow-[0_1px_3px_rgba(10,25,47,0.03)] sm:px-5">
-              {activeRouteItems.map((item, index) => (
-                <OverviewRouteRow
-                  key={item.entry.campaign.campaign_id}
-                  item={item}
-                  highlightLabel={index === 0 ? 'Nu eerst' : undefined}
-                />
-              ))}
-            </div>
-          </section>
-
-          {blockerItems.length > 0 ? (
+          {showBlockedSection ? (
             <section className="space-y-4">
               <div className="space-y-1.5">
-                <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-[color:var(--dashboard-muted)]">
-                  Wat blokkeert
-                </p>
+                <h2 className="text-[1.35rem] font-semibold tracking-[-0.04em] text-[color:var(--dashboard-ink)]">
+                  Geblokkeerd / niet gestart
+                </h2>
                 <p className="text-sm leading-6 text-[color:var(--dashboard-text)]">
-                  Wat nog voorkomt dat een route open of volledig live is.
+                  Deze routes missen nog livegang en vragen eerst een operationele startstap.
                 </p>
               </div>
-              <div className="rounded-xl border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)] px-4 py-2 shadow-[0_1px_3px_rgba(10,25,47,0.03)] sm:px-5">
-                {blockerItems.map((item) => (
-                  <Link
-                    key={item.entry.campaign.campaign_id}
-                    href={`/campaigns/${item.entry.campaign.campaign_id}`}
-                    className="grid gap-2 border-b border-[color:var(--dashboard-frame-border)]/75 py-3.5 last:border-b-0 sm:grid-cols-[minmax(0,1.3fr),minmax(0,1fr),auto] sm:items-center sm:gap-4"
-                  >
-                    <p className="text-sm font-semibold tracking-[-0.02em] text-[color:var(--dashboard-ink)]">
-                      {item.entry.campaign.campaign_name}
-                    </p>
-                    <p className="text-sm text-[color:var(--dashboard-text)]">{item.blocker}</p>
-                    <span className="text-sm font-semibold text-[color:var(--dashboard-accent-strong)]">
-                      Open route
-                    </span>
-                  </Link>
+              <div className="space-y-3">
+                {blockedItems.map((item) => (
+                  <BlockerRouteRow key={item.entry.campaign.campaign_id} item={item} />
                 ))}
               </div>
             </section>
           ) : null}
 
-          {recentOutputEntries.length > 0 ? (
+          {filterEmptyMessage ? (
+            <InlineEmptyState message="Geen routes met deze status." />
+          ) : null}
+
+          {showClosedSection ? (
             <section className="space-y-4">
-              <div className="flex items-end justify-between gap-3">
-                <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-[color:var(--dashboard-muted)]">
-                  Wat nu leesbaar is
-                </p>
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+                <div className="space-y-1.5">
+                  <h2 className="text-[1.35rem] font-semibold tracking-[-0.04em] text-[color:var(--dashboard-ink)]">
+                    Recente afgeronde routes
+                  </h2>
+                  <p className="text-sm leading-6 text-[color:var(--dashboard-text)]">
+                    Gesloten routes die nu vooral rapport-first gelezen worden.
+                  </p>
+                </div>
                 <Link
                   href="/reports"
                   className="text-sm font-semibold text-[color:var(--dashboard-accent-strong)] transition-colors hover:text-[color:var(--dashboard-ink)]"
@@ -289,32 +337,10 @@ export default async function DashboardHomePage({
                   Open rapporten
                 </Link>
               </div>
-              <div className="rounded-xl border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)] px-4 py-2 shadow-[0_1px_3px_rgba(10,25,47,0.03)] sm:px-5">
-                {recentOutputEntries.map((entry) => {
-                  const scanDefinition = getScanDefinition(entry.campaign.scan_type)
-
-                  return (
-                    <div
-                      key={entry.campaign.campaign_id}
-                      className="flex flex-wrap items-center justify-between gap-3 border-b border-[color:var(--dashboard-frame-border)]/75 py-3.5 last:border-b-0"
-                    >
-                      <div className="min-w-0">
-                        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
-                          {scanDefinition.productName} · {entry.state === 'partial' ? 'Begrensde read' : 'Kernoutput'}
-                        </p>
-                        <p className="mt-1.5 text-sm font-semibold tracking-[-0.02em] text-[color:var(--dashboard-ink)]">
-                          {entry.campaign.campaign_name}
-                        </p>
-                      </div>
-                      <Link
-                        href={`/campaigns/${entry.campaign.campaign_id}`}
-                        className="text-sm font-semibold text-[color:var(--dashboard-accent-strong)] transition-colors hover:text-[color:var(--dashboard-ink)]"
-                      >
-                        {entry.state === 'closed' ? 'Open rapport' : 'Open route'}
-                      </Link>
-                    </div>
-                  )
-                })}
+              <div className="space-y-3">
+                {closedItems.map((item) => (
+                  <ClosedRouteRow key={item.entry.campaign.campaign_id} item={item} />
+                ))}
               </div>
             </section>
           ) : null}
@@ -324,140 +350,170 @@ export default async function DashboardHomePage({
   )
 }
 
-function buildRecentOutputEntries(entries: CampaignHomeEntry[]) {
-  return [...entries]
-    .filter((entry) => ['partial', 'full', 'closed'].includes(entry.state))
-    .sort((left, right) => {
-      const stateWeight = (entry: CampaignHomeEntry) =>
-        entry.state === 'partial' ? 1 : entry.state === 'closed' ? 2 : 3
-      const scanWeight = (entry: CampaignHomeEntry) =>
-        entry.campaign.scan_type === 'exit' || entry.campaign.scan_type === 'retention' ? 2 : 1
-      const weightDelta = stateWeight(right) - stateWeight(left)
-      if (weightDelta !== 0) return weightDelta
-      const scanDelta = scanWeight(right) - scanWeight(left)
-      if (scanDelta !== 0) return scanDelta
-      return new Date(right.campaign.created_at).getTime() - new Date(left.campaign.created_at).getTime()
-    })
+function normalizeDashboardStatusFilter(value: string | undefined): CockpitStatusFilter {
+  if (
+    value === 'action_needed' ||
+    value === 'nearly_ready' ||
+    value === 'live_readable' ||
+    value === 'blocked_not_started'
+  ) {
+    return value
+  }
+
+  return 'all'
 }
 
-function buildInvitesNotSentByCampaign(
-  campaigns: CampaignStats[],
-  respondents: Array<{ campaign_id: string; sent_at: string | null; completed: boolean }>,
-) {
-  const counts = new Map<string, number>()
-
-  for (const respondent of respondents) {
-    if (!respondent.sent_at && !respondent.completed) {
-      counts.set(respondent.campaign_id, (counts.get(respondent.campaign_id) ?? 0) + 1)
-    }
+function buildDashboardOverviewHref(args: {
+  moduleFilter?: DashboardCategoryModuleKey | null
+  statusFilter?: CockpitStatusFilter
+}) {
+  const params = new URLSearchParams()
+  if (args.moduleFilter) {
+    params.set('module', args.moduleFilter)
   }
+  if (args.statusFilter && args.statusFilter !== 'all') {
+    params.set('status', args.statusFilter)
+  }
+
+  const query = params.toString()
+  return query ? `/dashboard?${query}` : '/dashboard'
+}
+
+function buildAvailableModuleFilters(campaigns: CampaignStats[]) {
+  const availableKeys = new Set<DashboardCategoryModuleKey>()
 
   for (const campaign of campaigns) {
-    if (!counts.has(campaign.campaign_id)) {
-      counts.set(
-        campaign.campaign_id,
-        campaign.total_invited === 0 ? 0 : campaign.total_completed >= 5 ? 0 : 1,
-      )
-    }
+    if (campaign.scan_type === 'team') continue
+    availableKeys.add(getDashboardModuleKeyForScanType(campaign.scan_type))
   }
 
-  return counts
+  return MODULE_ORDER.filter((key) => availableKeys.has(key))
 }
 
-function getHomeStateMeta(state: CampaignCompositionState) {
-  const meta = {
-    setup: {
-      label: 'Nog niet live',
-      tone: 'amber' as const,
-      nextStepLabel: 'Setup eerst',
-      viewerCta: 'Open uitvoerflow',
-      sectionTitle: 'Setup / nog niet live',
-      sectionDescription:
-        'Campagnes zonder live uitnodigingen of zonder echte respondentlaag. Hier telt eerst setup en launchdiscipline.',
-      body: 'Blocker: respondentimport of launchcontrole ontbreekt. Volgende stap: maak de route eerst live.',
-      trust: '',
-    },
-    ready_to_launch: {
-      label: 'Nog in opbouw',
-      tone: 'amber' as const,
-      nextStepLabel: 'Invites versturen',
-      viewerCta: 'Open uitvoerflow',
-      sectionTitle: 'Ready to launch',
-      sectionDescription:
-        'Campagnes waar de respondentlaag klaarstaat, maar waar uitnodigingen nog niet volledig live zijn gezet.',
-      body: 'Blocker: uitnodigingen zijn nog niet volledig live. Volgende stap: start eerst de inviteflow.',
-      trust: '',
-    },
-    running: {
-      label: 'Nog in opbouw',
-      tone: 'amber' as const,
-      nextStepLabel: 'Respons volgen',
-      viewerCta: 'Open uitvoerflow',
-      sectionTitle: 'Invites live / running',
-      sectionDescription:
-        'Campagnes waar uitnodigingen lopen, maar waar nog geen eerste veilige responslaag zichtbaar hoort te worden.',
-      body: 'Blocker: er is nog geen veilige responslaag. Volgende stap: wacht op meer responses.',
-      trust: '',
-    },
-    sparse: {
-      label: 'Nog in opbouw',
-      tone: 'amber' as const,
-      nextStepLabel: 'Meer respons nodig',
-      viewerCta: 'Open uitvoerflow',
-      sectionTitle: 'Sparse / indicatief',
-      sectionDescription:
-        'Campagnes met eerste responses, maar nog onder de veilige dashboarddrempel voor een eerlijke eerste duiding.',
-      body: 'Eerste read beschikbaar.',
-      trust: '',
-    },
-    partial: {
-      label: 'Deels zichtbaar',
-      tone: 'amber' as const,
-      nextStepLabel: 'Compacte read',
-      viewerCta: 'Open compacte read',
-      sectionTitle: 'Deels zichtbaar',
-      sectionDescription:
-        'Campagnes waar de eerste veilige dashboardlaag open is, maar waar thresholds of privacy de verdiepingslaag nog begrenzen.',
-      body: 'Eerste read beschikbaar.',
-      trust: '',
-    },
-    full: {
-      label: 'Leesbaar',
-      tone: 'emerald' as const,
-      nextStepLabel: 'Open dashboard',
-      viewerCta: 'Open dashboard',
-      sectionTitle: 'Volledig / klaar voor bespreking',
-      sectionDescription:
-        'Campagnes met genoeg respons en voldoende zichtbaarheid om dashboard, aanbevelingen en rapport als managementinstrument te gebruiken.',
-      body: 'Dashboard beschikbaar.',
-      trust: '',
-    },
-    closed: {
-      label: 'Afgerond',
-      tone: 'slate' as const,
-      nextStepLabel: 'Rapport beschikbaar',
-      viewerCta: 'Open rapport en dashboard',
-      sectionTitle: 'Gesloten / rapport eerst',
-      sectionDescription:
-        'Gesloten campagnes waar de nadruk nu op rapportage, terugblik en bestuurlijke opvolging hoort te liggen.',
-      body: 'Rapport beschikbaar.',
-      trust: '',
-    },
-  } satisfies Record<
-    CampaignCompositionState,
-    {
-      label: string
-      tone: 'slate' | 'blue' | 'emerald' | 'amber'
-      nextStepLabel: string
-      viewerCta: string
-      sectionTitle: string
-      sectionDescription: string
-      body: string
-      trust: string
-    }
-  >
+function mapStateToCockpitBucket(state: CampaignCompositionState): CockpitBucket {
+  if (state === 'setup') return 'blocked_not_started'
+  if (state === 'ready_to_launch' || state === 'running' || state === 'sparse') return 'action_needed'
+  if (state === 'partial') return 'nearly_ready'
+  if (state === 'full') return 'live_readable'
+  return 'recent_closed'
+}
 
-  return meta[state]
+function buildCockpitCounters(entries: CampaignHomeEntry[]): CockpitCounter[] {
+  return [
+    {
+      key: 'action_needed',
+      label: 'ACTIE NODIG',
+      tone: 'amber',
+      count: entries.filter((entry) => mapStateToCockpitBucket(entry.state) === 'action_needed').length,
+      body: 'Routes waar livegang of extra respons eerst expliciet aandacht vraagt.',
+    },
+    {
+      key: 'nearly_ready',
+      label: 'BIJNA KLAAR',
+      tone: 'blue',
+      count: entries.filter((entry) => mapStateToCockpitBucket(entry.state) === 'nearly_ready').length,
+      body: 'Routes waar de eerste leeslaag open is, maar de read nog begrensd blijft.',
+    },
+    {
+      key: 'live_readable',
+      label: 'LIVE EN LEESBAAR',
+      tone: 'emerald',
+      count: entries.filter((entry) => mapStateToCockpitBucket(entry.state) === 'live_readable').length,
+      body: 'Routes die nu veilig genoeg zijn voor dashboardlezing.',
+    },
+    {
+      key: 'blocked_not_started',
+      label: 'GEBLOKKEERD / NIET GESTART',
+      tone: 'slate',
+      count: entries.filter((entry) => mapStateToCockpitBucket(entry.state) === 'blocked_not_started').length,
+      body: 'Routes die nog niet live zijn en eerst operationeel gestart moeten worden.',
+    },
+  ]
+}
+
+function buildTriageItems(
+  entries: CampaignHomeEntry[],
+  primaryLeadEntry: CampaignHomeEntry | null,
+) {
+  const activeEntries = entries.filter((entry) => entry.campaign.is_active)
+  const primaryEntries = activeEntries.filter((entry) => ['exit', 'retention'].includes(entry.campaign.scan_type))
+  const boundedEntries = activeEntries.filter((entry) => !['exit', 'retention'].includes(entry.campaign.scan_type))
+  const orderedEntries = [
+    ...(primaryLeadEntry ? [primaryLeadEntry] : []),
+    ...primaryEntries
+      .filter((entry) => entry.campaign.campaign_id !== primaryLeadEntry?.campaign.campaign_id)
+      .sort(compareOverviewEntries),
+    ...boundedEntries.sort(compareOverviewEntries),
+  ]
+
+  return orderedEntries
+    .filter((entry) => {
+      const bucket = mapStateToCockpitBucket(entry.state)
+      return bucket === 'action_needed' || bucket === 'nearly_ready' || bucket === 'live_readable'
+    })
+    .map(buildCockpitRouteItem)
+}
+
+function buildBlockedItems(entries: CampaignHomeEntry[]) {
+  return entries
+    .filter((entry) => entry.state === 'setup')
+    .sort(compareOverviewEntries)
+    .map(buildCockpitRouteItem)
+}
+
+function buildRecentClosedItems(entries: CampaignHomeEntry[]) {
+  return entries
+    .filter((entry) => entry.state === 'closed')
+    .sort(
+      (left, right) =>
+        new Date(right.campaign.created_at).getTime() - new Date(left.campaign.created_at).getTime(),
+    )
+    .map(buildCockpitRouteItem)
+}
+
+function buildCockpitRouteItem(entry: CampaignHomeEntry): CockpitRouteItem {
+  const scanDefinition = getScanDefinition(entry.campaign.scan_type)
+  const stateMeta = getHomeStateMeta(entry.state)
+  const completionValue = Number.isFinite(entry.campaign.completion_rate_pct)
+    ? `${entry.campaign.completion_rate_pct}%`
+    : '—'
+  const ctaLabel = getCtaLabelForState(entry.state)
+  const bucket = mapStateToCockpitBucket(entry.state)
+
+  return {
+    entry,
+    bucket,
+    productLabel: scanDefinition.productName,
+    contextLabel: `${formatCampaignPeriod(entry.campaign)} · ${scanDefinition.productName}`,
+    stateLabel: stateMeta.label,
+    stateTone: getToneForBucket(bucket),
+    why: getWhyCopy(entry),
+    nextStep: ctaLabel,
+    ctaLabel,
+    ctaHref: `/campaigns/${entry.campaign.campaign_id}`,
+    responseValue: completionValue,
+  }
+}
+
+function getToneForBucket(bucket: CockpitBucket): OverviewRouteTone {
+  if (bucket === 'live_readable') return 'emerald'
+  if (bucket === 'nearly_ready') return 'blue'
+  if (bucket === 'action_needed') return 'amber'
+  return 'slate'
+}
+
+function getCtaLabelForState(state: CampaignCompositionState) {
+  if (state === 'partial' || state === 'full') return 'Open dashboard'
+  if (state === 'closed') return 'Open rapport'
+  return 'Beheer route'
+}
+
+function getWhyCopy(entry: CampaignHomeEntry) {
+  if (entry.state === 'setup' || entry.state === 'running') {
+    return getOverviewBlockerCopy(entry)
+  }
+
+  return getHomeStateMeta(entry.state).body
 }
 
 function compareOverviewEntries(left: CampaignHomeEntry, right: CampaignHomeEntry) {
@@ -465,8 +521,8 @@ function compareOverviewEntries(left: CampaignHomeEntry, right: CampaignHomeEntr
     full: 0,
     partial: 1,
     sparse: 2,
-    running: 3,
-    ready_to_launch: 4,
+    ready_to_launch: 3,
+    running: 4,
     setup: 5,
     closed: 6,
   }
@@ -474,7 +530,8 @@ function compareOverviewEntries(left: CampaignHomeEntry, right: CampaignHomeEntr
   const rankDelta = stateRank[left.state] - stateRank[right.state]
   if (rankDelta !== 0) return rankDelta
 
-  const scoreDelta = (right.campaign.avg_risk_score ?? -1) - (left.campaign.avg_risk_score ?? -1)
+  const scoreDelta =
+    (getCampaignAverageSignalScore(right.campaign) ?? -1) - (getCampaignAverageSignalScore(left.campaign) ?? -1)
   if (scoreDelta !== 0) return scoreDelta
 
   return new Date(right.campaign.created_at).getTime() - new Date(left.campaign.created_at).getTime()
@@ -499,166 +556,70 @@ function selectPrimaryLeadEntry(
   return primaryActiveEntries.sort(compareOverviewEntries)[0] ?? null
 }
 
-function buildOverviewRouteItem(entry: CampaignHomeEntry): OverviewRouteItem {
-  const scanDefinition = getScanDefinition(entry.campaign.scan_type)
-  const stateMeta = getHomeStateMeta(entry.state)
-  const signalValue =
-    entry.campaign.avg_risk_score !== null ? `${entry.campaign.avg_risk_score.toFixed(1)}/10` : 'Nog niet vrij'
-  const completionValue = `${entry.campaign.completion_rate_pct ?? 0}%`
-
-  return {
-    entry,
-    routeLabel: scanDefinition.productName,
-    contextLabel: `${formatCampaignPeriod(entry.campaign)} · ${scanDefinition.productName}`,
-    stateLabel: stateMeta.label,
-    stateTone: stateMeta.tone,
-    summary: stateMeta.body,
-    metricLabel: 'Respons',
-    metricValue: completionValue,
-    secondaryMetricLabel: scanDefinition.signalLabel,
-    secondaryMetricValue: signalValue,
-    ctaLabel:
-      entry.state === 'closed'
-        ? 'Open rapport'
-        : entry.state === 'partial'
-          ? 'Open compacte read'
-          : stateMeta.viewerCta,
-    bounded: !['exit', 'retention'].includes(entry.campaign.scan_type),
-  }
-}
-
-function buildOverviewAttentionItems(
-  entries: CampaignHomeEntry[],
-  primaryLeadEntry: CampaignHomeEntry | null,
+function buildInvitesNotSentByCampaign(
+  campaigns: CampaignStats[],
+  respondents: Array<{ campaign_id: string; sent_at: string | null; completed: boolean }>,
 ) {
-  return [...entries]
-    .filter((entry) => entry.campaign.campaign_id !== primaryLeadEntry?.campaign.campaign_id)
-    .filter((entry) => ['partial', 'running', 'sparse', 'full'].includes(entry.state))
-    .sort(compareOverviewEntries)
-    .map(buildOverviewRouteItem)
-}
+  const counts = new Map<string, number>()
 
-function getOverviewToneClasses(tone: OverviewRouteTone) {
-  if (tone === 'emerald') {
-    return {
-      dot: 'bg-[#3C8D8A]',
-      chip: 'border-[color:var(--dashboard-accent-soft-border)] bg-[color:var(--dashboard-accent-soft)] text-[color:var(--dashboard-accent-strong)]',
+  for (const respondent of respondents) {
+    if (!respondent.sent_at && !respondent.completed) {
+      counts.set(respondent.campaign_id, (counts.get(respondent.campaign_id) ?? 0) + 1)
     }
   }
 
-  if (tone === 'amber') {
-    return {
-      dot: 'bg-[#C88C20]',
-      chip: 'border-[#E7D7AF] bg-[#FBF4DF] text-[#7A5B18]',
+  for (const campaign of campaigns) {
+    if (!counts.has(campaign.campaign_id)) {
+      counts.set(campaign.campaign_id, campaign.total_invited === 0 ? 0 : campaign.total_completed >= 5 ? 0 : 1)
     }
   }
 
-  return {
-    dot: 'bg-[#8A7D6E]',
-    chip: 'border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)] text-[color:var(--dashboard-text)]',
-  }
+  return counts
 }
 
-function OverviewSummaryCard({ label, value }: { label: string; value: number }) {
-  return (
-    <div className="rounded-[18px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)] px-4 py-3 shadow-[0_1px_2px_rgba(15,23,42,0.03)]">
-      <p className="text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-[color:var(--dashboard-muted)]">
-        {label}
-      </p>
-      <div className="mt-2 flex items-end justify-between gap-3">
-        <p className="dash-number text-[1.45rem] leading-none text-[color:var(--dashboard-ink)]">{value}</p>
-        <p className="text-sm text-[color:var(--dashboard-text)]">
-          {value} {value === 1 ? 'route' : 'routes'}
-        </p>
-      </div>
-    </div>
-  )
-}
+function getHomeStateMeta(state: CampaignCompositionState) {
+  const meta = {
+    setup: {
+      label: 'Nog niet live',
+      body: 'Respondentimport of livegang ontbreekt nog.',
+    },
+    ready_to_launch: {
+      label: 'Nog in opbouw',
+      body: 'Uitnodigingen zijn nog niet volledig live gezet.',
+    },
+    running: {
+      label: 'Nog in opbouw',
+      body: 'Er is nog geen eerste veilige responslaag zichtbaar.',
+    },
+    sparse: {
+      label: 'Nog in opbouw',
+      body: 'Meer respons nodig voordat deze route echt leesbaar wordt.',
+    },
+    partial: {
+      label: 'Deels zichtbaar',
+      body: 'Eerste read beschikbaar.',
+    },
+    full: {
+      label: 'Leesbaar',
+      body: 'Dashboard beschikbaar.',
+    },
+    closed: {
+      label: 'Afgerond',
+      body: 'Rapport beschikbaar.',
+    },
+  } satisfies Record<
+    CampaignCompositionState,
+    {
+      label: string
+      body: string
+    }
+  >
 
-function OverviewRouteRow({
-  item,
-  highlightLabel,
-}: {
-  item: OverviewRouteItem
-  highlightLabel?: string
-}) {
-  const tone = getOverviewToneClasses(item.stateTone)
-
-  return (
-    <Link
-      href={`/campaigns/${item.entry.campaign.campaign_id}`}
-      className={`group block border-b border-[color:var(--dashboard-frame-border)]/75 py-4 last:border-b-0 ${
-        item.bounded ? 'opacity-90' : ''
-      }`}
-    >
-      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.7fr)_128px_128px_auto] xl:items-center xl:gap-5">
-        <div className="min-w-0">
-          <div className="flex flex-wrap items-center gap-2">
-            {highlightLabel ? (
-              <span className="inline-flex rounded-full border border-[color:var(--dashboard-accent-soft-border)] bg-[color:var(--dashboard-accent-soft)] px-2.5 py-1 text-[0.74rem] font-semibold text-[color:var(--dashboard-accent-strong)]">
-                {highlightLabel}
-              </span>
-            ) : null}
-            <span className="text-[0.78rem] font-semibold tracking-[0.04em] text-[color:var(--dashboard-muted)]">
-              {item.contextLabel}
-            </span>
-          </div>
-          <div className="mt-2 flex flex-wrap items-center gap-2.5">
-            <h3 className="text-[1.03rem] font-semibold tracking-[-0.03em] text-[color:var(--dashboard-ink)]">
-              {item.entry.campaign.campaign_name}
-            </h3>
-            <span className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-[0.78rem] font-semibold ${tone.chip}`}>
-              <span className={`inline-flex h-2 w-2 rounded-full ${tone.dot}`} />
-              {item.stateLabel}
-            </span>
-          </div>
-          <p className="mt-1.5 text-sm leading-6 text-[color:var(--dashboard-text)]">{item.summary}</p>
-        </div>
-
-        <OverviewInlineMetric label={item.metricLabel} value={item.metricValue} />
-        <OverviewInlineMetric
-          label={item.secondaryMetricLabel ?? 'Signaal'}
-          value={item.secondaryMetricValue ?? 'Nog niet vrij'}
-        />
-        <span className="justify-self-start text-sm font-semibold text-[color:var(--dashboard-accent-strong)] transition-colors group-hover:text-[color:var(--dashboard-ink)] xl:justify-self-end">
-          {item.ctaLabel}
-        </span>
-      </div>
-    </Link>
-  )
-}
-
-function OverviewInlineMetric({
-  label,
-  value,
-}: {
-  label: string
-  value: string
-}) {
-  return (
-    <div className="min-w-0">
-      <p className="text-[0.64rem] font-semibold uppercase tracking-[0.18em] text-[color:var(--dashboard-muted)]">
-        {label}
-      </p>
-      <p className="dash-number mt-1.5 text-[1.08rem] leading-none text-[color:var(--dashboard-ink)]">{value}</p>
-    </div>
-  )
-}
-
-function buildOverviewBlockerItems(entries: CampaignHomeEntry[]) {
-  return [...entries]
-    .filter((entry) => ['setup', 'ready_to_launch', 'running', 'sparse'].includes(entry.state))
-    .sort(compareOverviewEntries)
-    .map((entry) => ({
-      entry,
-      blocker: getOverviewBlockerCopy(entry),
-    }))
+  return meta[state]
 }
 
 function getOverviewBlockerCopy(entry: CampaignHomeEntry) {
   if (entry.state === 'setup') return 'Respondentimport ontbreekt nog.'
-  if (entry.state === 'ready_to_launch') return 'Uitnodigingen zijn nog niet live.'
-  if (entry.state === 'running') return 'Er is nog geen veilige responslaag.'
   return 'Meer respons nodig voor een eerste read.'
 }
 
@@ -672,27 +633,266 @@ function formatCampaignPeriod(campaign: CampaignStats) {
   }).format(new Date(campaign.created_at))
 }
 
+function getOverviewToneClasses(tone: OverviewRouteTone) {
+  if (tone === 'emerald') {
+    return {
+      border: 'border-[color:var(--dashboard-accent-soft-border)]',
+      accent: 'bg-[color:var(--dashboard-accent-strong)]',
+      chip:
+        'border-[color:var(--dashboard-accent-soft-border)] bg-[color:var(--dashboard-accent-soft)] text-[color:var(--dashboard-accent-strong)]',
+      button:
+        'bg-[color:var(--dashboard-accent-strong)] text-white hover:bg-[#00584f]',
+    }
+  }
+
+  if (tone === 'blue') {
+    return {
+      border: 'border-[#c7d0dc]',
+      accent: 'bg-[#8292a5]',
+      chip: 'border-[#d9e1ea] bg-[#f5f7fa] text-[#506071]',
+      button: 'bg-[#1B2B3A] text-white hover:bg-[#24384b]',
+    }
+  }
+
+  if (tone === 'amber') {
+    return {
+      border: 'border-[#e7d7af]',
+      accent: 'bg-[#C88C20]',
+      chip: 'border-[#E7D7AF] bg-[#FBF4DF] text-[#7A5B18]',
+      button: 'bg-[#1B2B3A] text-white hover:bg-[#24384b]',
+    }
+  }
+
+  return {
+    border: 'border-[color:var(--dashboard-frame-border)]',
+    accent: 'bg-slate-300',
+    chip:
+      'border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)] text-[color:var(--dashboard-text)]',
+    button:
+      'bg-transparent text-[color:var(--dashboard-accent-strong)] hover:text-[color:var(--dashboard-ink)]',
+  }
+}
+
+function FilterPill({
+  href,
+  active,
+  label,
+}: {
+  href: string
+  active: boolean
+  label: string
+}) {
+  return (
+    <Link
+      href={href}
+      className={`inline-flex rounded-full border px-3 py-1.5 text-xs font-semibold transition-colors ${
+        active
+          ? 'border-[color:var(--dashboard-accent-soft-border)] bg-[color:var(--dashboard-accent-soft)] text-[color:var(--dashboard-accent-strong)]'
+          : 'border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)] text-[color:var(--dashboard-text)] hover:border-[color:var(--dashboard-accent-soft-border)] hover:text-[color:var(--dashboard-ink)]'
+      }`}
+    >
+      {label}
+    </Link>
+  )
+}
+
+function StatusCounterCard({ counter }: { counter: CockpitCounter }) {
+  const tone = getOverviewToneClasses(counter.tone)
+
+  return (
+    <div className={`relative overflow-hidden rounded-[18px] border bg-[color:var(--dashboard-surface)] px-4 py-4 shadow-[0_1px_2px_rgba(15,23,42,0.03)] ${tone.border}`}>
+      <div className={`absolute left-0 top-0 h-full w-1 ${tone.accent}`} />
+      <p className="pl-2 text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-[color:var(--dashboard-muted)]">
+        {counter.label}
+      </p>
+      <div className="mt-3 pl-2">
+        <p className="dash-number text-[2rem] leading-none text-[color:var(--dashboard-ink)]">{counter.count}</p>
+        <p className="mt-3 text-sm leading-6 text-[color:var(--dashboard-text)]">{counter.body}</p>
+      </div>
+      {counter.key === 'blocked_not_started' ? (
+        <span className="absolute right-4 top-4 inline-flex h-2.5 w-2.5 rounded-full bg-[#C88C20]" />
+      ) : null}
+    </div>
+  )
+}
+
+function TriageRouteCard({
+  item,
+  highlightLabel,
+}: {
+  item: CockpitRouteItem
+  highlightLabel?: string
+}) {
+  const tone = getOverviewToneClasses(item.stateTone)
+
+  return (
+    <article className={`overflow-hidden rounded-[18px] border bg-[color:var(--dashboard-surface)] shadow-[0_2px_8px_rgba(17,24,39,0.035)] transition-shadow hover:shadow-[0_16px_32px_rgba(17,24,39,0.08)] ${tone.border}`}>
+      <div className={`h-full border-l-4 ${tone.accent}`}>
+        <div className="flex flex-col gap-5 px-5 py-5 xl:flex-row xl:items-center xl:justify-between">
+          <div className="min-w-0 flex-1 space-y-4">
+            <div className="space-y-2">
+              <div className="flex flex-wrap items-center gap-2">
+                {highlightLabel ? (
+                  <span className="inline-flex rounded-full border border-[color:var(--dashboard-accent-soft-border)] bg-[color:var(--dashboard-accent-soft)] px-2.5 py-1 text-[0.74rem] font-semibold text-[color:var(--dashboard-accent-strong)]">
+                    {highlightLabel}
+                  </span>
+                ) : null}
+                <span className="text-[0.72rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
+                  {item.contextLabel}
+                </span>
+              </div>
+              <div className="flex flex-wrap items-center gap-2.5">
+                <h3 className="text-[1.08rem] font-semibold tracking-[-0.03em] text-[color:var(--dashboard-ink)]">
+                  {item.entry.campaign.campaign_name}
+                </h3>
+                <span className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-[0.78rem] font-semibold ${tone.chip}`}>
+                  <span className={`inline-flex h-2 w-2 rounded-full ${tone.accent}`} />
+                  {item.stateLabel}
+                </span>
+              </div>
+              <p className="text-sm font-medium uppercase tracking-[0.16em] text-[color:var(--dashboard-muted)]">
+                Product: {item.productLabel}
+              </p>
+            </div>
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-[minmax(0,1.2fr),180px,140px] xl:items-start">
+              <MetricBlock label="WAAROM" value={item.why} />
+              <MetricBlock label="VOLGENDE STAP" value={item.nextStep} />
+              <MetricBlock label="RESPONS" value={item.responseValue} compact />
+            </div>
+          </div>
+          <div className="xl:pl-6">
+            <Link
+              href={item.ctaHref}
+              className={`inline-flex w-full items-center justify-center rounded-lg px-5 py-3 text-sm font-semibold transition-colors xl:min-w-[158px] ${tone.button}`}
+            >
+              {item.ctaLabel}
+            </Link>
+          </div>
+        </div>
+      </div>
+    </article>
+  )
+}
+
+function BlockerRouteRow({ item }: { item: CockpitRouteItem }) {
+  return (
+    <article className="rounded-[18px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)] px-4 py-4 shadow-[0_1px_3px_rgba(10,25,47,0.03)]">
+      <div className="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+        <div className="grid gap-4 md:grid-cols-[minmax(0,0.9fr),minmax(0,1.1fr),160px] xl:flex-1 xl:grid-cols-[minmax(0,0.8fr),minmax(0,1fr),160px]">
+          <div className="min-w-0">
+            <p className="text-sm font-semibold tracking-[-0.02em] text-[color:var(--dashboard-ink)]">
+              {item.entry.campaign.campaign_name}
+            </p>
+            <p className="mt-1 text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--dashboard-muted)]">
+              {item.productLabel}
+            </p>
+          </div>
+          <MetricBlock label="REDEN" value={item.why} />
+          <MetricBlock label="NEXT" value={item.nextStep} />
+        </div>
+        <Link
+          href={item.ctaHref}
+          className="text-sm font-semibold text-[color:var(--dashboard-accent-strong)] transition-colors hover:text-[color:var(--dashboard-ink)]"
+        >
+          {item.ctaLabel}
+        </Link>
+      </div>
+    </article>
+  )
+}
+
+function ClosedRouteRow({ item }: { item: CockpitRouteItem }) {
+  return (
+    <article className="rounded-[18px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)] px-4 py-4 opacity-70 transition-opacity hover:opacity-100">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          <p className="text-sm font-semibold tracking-[-0.02em] text-[color:var(--dashboard-ink)]">
+            {item.entry.campaign.campaign_name}
+          </p>
+          <p className="mt-1 text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--dashboard-muted)]">
+            {item.productLabel}
+          </p>
+        </div>
+        <Link
+          href={item.ctaHref}
+          className="text-sm font-semibold text-[color:var(--dashboard-accent-strong)] transition-colors hover:text-[color:var(--dashboard-ink)]"
+        >
+          {item.ctaLabel}
+        </Link>
+      </div>
+    </article>
+  )
+}
+
+function MetricBlock({
+  label,
+  value,
+  compact = false,
+}: {
+  label: string
+  value: string
+  compact?: boolean
+}) {
+  return (
+    <div className="min-w-0">
+      <p className="text-[0.64rem] font-semibold uppercase tracking-[0.18em] text-[color:var(--dashboard-muted)]">
+        {label}
+      </p>
+      <p
+        className={`mt-1.5 ${compact ? 'dash-number text-[1.02rem] leading-none' : 'text-sm leading-6'} text-[color:var(--dashboard-ink)]`}
+      >
+        {value}
+      </p>
+    </div>
+  )
+}
+
+function InlineEmptyState({ message }: { message: string }) {
+  return (
+    <div className="rounded-[18px] border border-dashed border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)] px-5 py-6 text-sm leading-6 text-[color:var(--dashboard-text)]">
+      {message}
+    </div>
+  )
+}
+
 function AdminEmptyState() {
   return (
     <DashboardSection
       eyebrow="Setup"
       title="Nog geen campagnes beschikbaar"
-            description="Dit overzicht wordt vanzelf gevuld zodra je een organisatie, campagne en respondentbestand hebt toegevoegd."
+      description="Dit overzicht wordt vanzelf gevuld zodra je een organisatie, campagne en respondentbestand hebt toegevoegd."
     >
       <div className="grid gap-3 md:grid-cols-3">
         {[
           { step: '1', title: 'Organisatie', body: 'Maak eerst de klantorganisatie aan en leg het contactpunt vast.' },
-              { step: '2', title: 'Campagne', body: 'Kies ExitScan of RetentieScan en zet de campagne op met de juiste metadata.' },
-          { step: '3', title: 'Respondenten', body: 'Importeer respondenten en stuur uitnodigingen, zodat dit overzicht vanzelf in monitoring overgaat.' },
+          {
+            step: '2',
+            title: 'Campagne',
+            body: 'Kies ExitScan of RetentieScan en zet de campagne op met de juiste metadata.',
+          },
+          {
+            step: '3',
+            title: 'Respondenten',
+            body: 'Importeer respondenten en stuur uitnodigingen, zodat dit overzicht vanzelf in monitoring overgaat.',
+          },
         ].map(({ step, title, body }) => (
           <div
             key={step}
             className="rounded-[var(--dashboard-radius-card)] px-4 py-4"
             style={{ background: 'var(--dashboard-surface)', border: '1px solid var(--dashboard-frame-border)' }}
           >
-            <p className="text-[0.65rem] font-medium uppercase" style={{ color: 'var(--dashboard-muted)', letterSpacing: '0.18em' }}>Stap {step}</p>
-            <p className="mt-2 text-sm font-semibold" style={{ color: 'var(--dashboard-ink)' }}>{title}</p>
-            <p className="mt-1.5 text-sm leading-[1.65]" style={{ color: 'var(--dashboard-text)' }}>{body}</p>
+            <p
+              className="text-[0.65rem] font-medium uppercase"
+              style={{ color: 'var(--dashboard-muted)', letterSpacing: '0.18em' }}
+            >
+              Stap {step}
+            </p>
+            <p className="mt-2 text-sm font-semibold" style={{ color: 'var(--dashboard-ink)' }}>
+              {title}
+            </p>
+            <p className="mt-1.5 text-sm leading-[1.65]" style={{ color: 'var(--dashboard-text)' }}>
+              {body}
+            </p>
           </div>
         ))}
       </div>
@@ -721,7 +921,7 @@ function ViewerEmptyState() {
         </div>
         <div className="grid gap-3 md:grid-cols-3">
           {[
-              'Verisight beheert organisatie, campagne en respondentimport.',
+            'Verisight beheert organisatie, campagne en respondentimport.',
             'Jij krijgt daarna toegang tot het juiste dashboard en rapport.',
             'De eerste managementwaarde zit in lezen, duiden en prioriteren, niet in technische setup.',
           ].map((item, index) => (
@@ -729,7 +929,9 @@ function ViewerEmptyState() {
               key={item}
               className="rounded-2xl border border-[color:var(--border)] bg-white px-4 py-4 text-sm leading-6 text-[color:var(--text)]"
             >
-              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">Stap {index + 1}</p>
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
+                Stap {index + 1}
+              </p>
               <p className="mt-2">{item}</p>
             </div>
           ))}


### PR DESCRIPTION
## Samenvatting
- bouwt de dashboard overview om naar een cockpit/triagepagina
- houdt de pagina bounded tot navigatie en route-orientatie
- verifieerd met slice-tests en lokale QA

## Scope
- dashboard overview route en bijbehorende test
- geen deploy in deze PR

## Verificatie
- vitest op `app/(dashboard)/dashboard/page.test.ts`
- eslint op de overview-slice