### PR TITLE
Dashboard admin setup page

### DIFF
--- a/frontend/app/(dashboard)/beheer/get-beheer-page-data.test.ts
+++ b/frontend/app/(dashboard)/beheer/get-beheer-page-data.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getCampaignStatusLabel,
+  mapCheckpointToActionHref,
+  mapExceptionToCategory,
+  mapExceptionToImpactLabel,
+} from './get-beheer-page-data'
+
+describe('dashboard admin setup mappings', () => {
+  it('maps setup checkpoints to the approved admin categories only', () => {
+    expect(mapExceptionToCategory('implementation_intake')).toBe('CAMPAGNES')
+    expect(mapExceptionToCategory('invite_readiness')).toBe('CAMPAGNES')
+    expect(mapExceptionToCategory('import_qa')).toBe('DATA & IMPORT')
+    expect(mapExceptionToCategory('client_activation')).toBe('TOEGANG & ROLLEN')
+    expect(mapExceptionToCategory('first_value')).toBeNull()
+    expect(mapExceptionToCategory('report_delivery')).toBeNull()
+    expect(mapExceptionToCategory('first_management_use')).toBeNull()
+  })
+
+  it('maps setup checkpoints only to approved /beheer anchors', () => {
+    expect(mapCheckpointToActionHref('implementation_intake')).toBe('/beheer#campagnes')
+    expect(mapCheckpointToActionHref('invite_readiness')).toBe('/beheer#campagnes')
+    expect(mapCheckpointToActionHref('import_qa')).toBe('/beheer#data-import')
+    expect(mapCheckpointToActionHref('client_activation')).toBe('/beheer#toegang')
+    expect(mapCheckpointToActionHref('first_value')).toBeNull()
+  })
+
+  it('maps exception statuses to the approved impact labels', () => {
+    expect(mapExceptionToImpactLabel('blocked')).toBe('KAN NIET VERDER')
+    expect(mapExceptionToImpactLabel('needs_operator_recovery')).toBe('OPERATOR INGREEP NODIG')
+    expect(mapExceptionToImpactLabel('awaiting_client_input')).toBe('WACHT OP KLANTINPUT')
+    expect(mapExceptionToImpactLabel('awaiting_external_delivery')).toBe('WACHT OP EXTERNE STAP')
+    expect(mapExceptionToImpactLabel('none')).toBeNull()
+  })
+
+  it('uses the fixed three-state campaign status label', () => {
+    expect(getCampaignStatusLabel([])).toBe('Geen campaigns')
+    expect(getCampaignStatusLabel([{ is_active: false }, { is_active: false }])).toBe('Geen actieve campaigns')
+    expect(getCampaignStatusLabel([{ is_active: true }, { is_active: false }])).toBe('Actief')
+  })
+})

--- a/frontend/app/(dashboard)/beheer/get-beheer-page-data.ts
+++ b/frontend/app/(dashboard)/beheer/get-beheer-page-data.ts
@@ -1,109 +1,326 @@
-import type { Campaign, CampaignStats, OrgInvite, Organization } from '@/lib/types'
+import type { CampaignDeliveryCheckpoint, DeliveryCheckpointKey, DeliveryExceptionStatus } from '@/lib/ops-delivery'
+import { getDeliveryCheckpointTitle } from '@/lib/ops-delivery'
+import type { Campaign, OrgInvite, Organization } from '@/lib/types'
 
-interface BeheerPageData {
+type SupabaseClientLike = Awaited<ReturnType<typeof import('@/lib/supabase/server').createClient>>
+
+type DeliveryRecordRow = {
+  id: string
+  campaign_id: string
+  lifecycle_stage: string
+  exception_status: DeliveryExceptionStatus | string
+  next_step: string | null
+  campaigns:
+    | { id: string; name: string; scan_type: Campaign['scan_type'] }
+    | Array<{ id: string; name: string; scan_type: Campaign['scan_type'] }>
+    | null
+}
+
+type DeliveryCheckpointRow = Pick<
+  CampaignDeliveryCheckpoint,
+  'id' | 'delivery_record_id' | 'checkpoint_key' | 'manual_state' | 'exception_status' | 'last_auto_summary'
+>
+
+export type SetupBlockerItem = {
+  id: string
+  category: string
+  impactLabel: string | null
+  title: string
+  description: string
+  actionHref: string | null
+}
+
+export interface BeheerPageData {
+  organizationsAvailable: boolean
+  campaignsAvailable: boolean
+  accessAvailable: boolean
+  deliveryAvailable: boolean
   orgs: Organization[]
   activeOrgs: Organization[]
   archivedOrgs: Organization[]
   campaigns: Campaign[]
+  topCampaigns: Campaign[]
+  remainingCampaignCount: number
   campaignCountByOrg: Record<string, number>
-  respondentCount: number
-  clientAccessCount: number
-  campaignStats: CampaignStats[]
+  respondentCount: number | null
+  clientAccessCount: number | null
   invites: OrgInvite[]
-  pendingInviteCount: number
-  step1Done: boolean
-  step2Done: boolean
-  step3Done: boolean
-  step4Done: boolean
+  pendingInviteCount: number | null
+  activeCampaignCount: number | null
+  blockedDeliveriesCount: number | null
+  setupBlockers: SetupBlockerItem[]
+  dataImportAlert: SetupBlockerItem | null
 }
 
-export async function getBeheerPageData(supabase: Awaited<ReturnType<typeof import('@/lib/supabase/server').createClient>>, userId: string): Promise<BeheerPageData> {
-  const { data: memberships } = await supabase
+export function mapExceptionToCategory(checkpointKey: DeliveryCheckpointKey): string | null {
+  switch (checkpointKey) {
+    case 'implementation_intake':
+    case 'invite_readiness':
+      return 'CAMPAGNES'
+    case 'import_qa':
+      return 'DATA & IMPORT'
+    case 'client_activation':
+      return 'TOEGANG & ROLLEN'
+    case 'first_value':
+    case 'report_delivery':
+    case 'first_management_use':
+      return null
+    default:
+      return null
+  }
+}
+
+export function mapCheckpointToActionHref(checkpointKey: DeliveryCheckpointKey): string | null {
+  switch (checkpointKey) {
+    case 'implementation_intake':
+    case 'invite_readiness':
+      return '/beheer#campagnes'
+    case 'import_qa':
+      return '/beheer#data-import'
+    case 'client_activation':
+      return '/beheer#toegang'
+    case 'first_value':
+    case 'report_delivery':
+    case 'first_management_use':
+      return null
+    default:
+      return null
+  }
+}
+
+export function mapExceptionToImpactLabel(
+  exceptionStatus: DeliveryExceptionStatus | null | undefined,
+): string | null {
+  switch (exceptionStatus) {
+    case 'blocked':
+      return 'KAN NIET VERDER'
+    case 'needs_operator_recovery':
+      return 'OPERATOR INGREEP NODIG'
+    case 'awaiting_client_input':
+      return 'WACHT OP KLANTINPUT'
+    case 'awaiting_external_delivery':
+      return 'WACHT OP EXTERNE STAP'
+    case 'none':
+    default:
+      return null
+  }
+}
+
+export function getCampaignStatusLabel(campaigns: Array<Pick<Campaign, 'is_active'>>) {
+  if (campaigns.length === 0) return 'Geen campaigns'
+  return campaigns.some((campaign) => campaign.is_active) ? 'Actief' : 'Geen actieve campaigns'
+}
+
+function normalizeInviteRows(invitesRaw: unknown) {
+  const rows = Array.isArray(invitesRaw) ? invitesRaw : []
+  return rows.map((invite) => {
+    const typedInvite = invite as OrgInvite
+    return {
+      ...typedInvite,
+      organizations: Array.isArray(typedInvite.organizations)
+        ? typedInvite.organizations[0]
+        : typedInvite.organizations,
+    }
+  }) as OrgInvite[]
+}
+
+function getCampaignFromDeliveryRecord(record: DeliveryRecordRow) {
+  return Array.isArray(record.campaigns) ? record.campaigns[0] ?? null : record.campaigns
+}
+
+function buildSetupBlockers(
+  deliveryRecords: DeliveryRecordRow[],
+  deliveryCheckpoints: DeliveryCheckpointRow[],
+) {
+  const recordById = Object.fromEntries(
+    deliveryRecords.map((record) => [record.id, record] as const),
+  )
+
+  return deliveryCheckpoints
+    .filter((checkpoint) => {
+      const key = checkpoint.checkpoint_key as DeliveryCheckpointKey
+      return (
+        mapExceptionToCategory(key) !== null &&
+        (checkpoint.exception_status !== 'none' || checkpoint.manual_state === 'pending')
+      )
+    })
+    .map((checkpoint) => {
+      const key = checkpoint.checkpoint_key as DeliveryCheckpointKey
+      const record = recordById[checkpoint.delivery_record_id]
+      const campaign = record ? getCampaignFromDeliveryRecord(record) : null
+      const titlePrefix = campaign?.name ? `${campaign.name} / ` : ''
+
+      return {
+        id: checkpoint.id,
+        category: mapExceptionToCategory(key) ?? 'Onbekend',
+        impactLabel: mapExceptionToImpactLabel(
+          checkpoint.exception_status as DeliveryExceptionStatus,
+        ),
+        title: `${titlePrefix}${getDeliveryCheckpointTitle(key)}`,
+        description:
+          record?.next_step?.trim() ||
+          checkpoint.last_auto_summary?.trim() ||
+          'Geen omschrijving beschikbaar',
+        actionHref: mapCheckpointToActionHref(key),
+      } satisfies SetupBlockerItem
+    })
+}
+
+export async function getBeheerPageData(
+  supabase: SupabaseClientLike,
+  userId: string,
+): Promise<BeheerPageData> {
+  const membershipsResult = await supabase
     .from('org_members')
     .select('organizations(*)')
     .eq('user_id', userId)
 
-  const orgs = (memberships?.flatMap(membership => membership.organizations).filter(Boolean) ?? []) as Organization[]
-  const activeOrgs = orgs.filter(org => org.is_active)
-  const archivedOrgs = orgs.filter(org => !org.is_active)
+  const organizationsAvailable = !membershipsResult.error
+  const orgs = organizationsAvailable
+    ? ((membershipsResult.data
+        ?.flatMap((membership) => membership.organizations)
+        .filter(Boolean) ?? []) as Organization[])
+    : []
+  const activeOrgs = orgs.filter((org) => org.is_active)
+  const archivedOrgs = orgs.filter((org) => !org.is_active)
+  const orgIds = orgs.map((org) => org.id)
 
-  const orgIds = orgs.map(org => org.id)
-  const { data: campaignsRaw } = orgIds.length
-    ? await supabase
-        .from('campaigns')
-        .select('*')
-        .in('organization_id', orgIds)
-        .order('created_at', { ascending: false })
-    : { data: [] }
-
-  const campaigns = (campaignsRaw ?? []) as Campaign[]
+  const campaignsResult =
+    organizationsAvailable && orgIds.length > 0
+      ? await supabase
+          .from('campaigns')
+          .select('*')
+          .in('organization_id', orgIds)
+          .order('created_at', { ascending: false })
+      : null
+  const campaignsAvailable = organizationsAvailable && (!campaignsResult || !campaignsResult.error)
+  const campaigns = campaignsAvailable
+    ? ((campaignsResult?.data ?? []) as Campaign[])
+    : []
+  const topCampaigns = campaigns.slice(0, 3)
+  const remainingCampaignCount = Math.max(0, campaigns.length - topCampaigns.length)
   const campaignCountByOrg = campaigns.reduce<Record<string, number>>((acc, campaign) => {
     acc[campaign.organization_id] = (acc[campaign.organization_id] ?? 0) + 1
     return acc
   }, {})
+  const activeCampaignCount = campaignsAvailable
+    ? campaigns.filter((campaign) => campaign.is_active).length
+    : null
 
-  const campaignIds = campaigns.map(campaign => campaign.id)
-  const { count: respondentCountRaw } = campaignIds.length
-    ? await supabase
-        .from('respondents')
-        .select('id', { count: 'exact', head: true })
-        .in('campaign_id', campaignIds)
-    : { count: 0 }
+  const campaignIds = campaigns.map((campaign) => campaign.id)
 
-  const { count: clientAccessCountRaw } = orgIds.length
-    ? await supabase
-        .from('org_members')
-        .select('id', { count: 'exact', head: true })
-        .in('org_id', orgIds)
-        .neq('user_id', userId)
-    : { count: 0 }
+  const respondentCountResult =
+    campaignsAvailable && campaignIds.length > 0
+      ? await supabase
+          .from('respondents')
+          .select('id', { count: 'exact', head: true })
+          .in('campaign_id', campaignIds)
+      : null
+  const respondentCount =
+    !campaignsAvailable
+      ? null
+      : campaignIds.length === 0
+        ? 0
+        : !respondentCountResult || respondentCountResult.error
+          ? null
+          : respondentCountResult.count ?? null
 
-  const { data: campaignStatsRaw } = orgIds.length
-    ? await supabase
-        .from('campaign_stats')
-        .select('*')
-        .in('organization_id', orgIds)
-        .order('created_at', { ascending: false })
-    : { data: [] }
+  const clientAccessCountResult =
+    organizationsAvailable && orgIds.length > 0
+      ? await supabase
+          .from('org_members')
+          .select('id', { count: 'exact', head: true })
+          .in('org_id', orgIds)
+          .neq('user_id', userId)
+      : null
 
-  const campaignStats = (campaignStatsRaw ?? []) as CampaignStats[]
+  const invitesResult =
+    organizationsAvailable && orgIds.length > 0
+      ? await supabase
+          .from('org_invites')
+          .select(
+            'id, org_id, email, full_name, role, invited_by, invited_at, accepted_at, organizations(id, name)',
+          )
+          .in('org_id', orgIds)
+          .order('accepted_at', { ascending: true, nullsFirst: true })
+          .order('invited_at', { ascending: false })
+      : null
 
-  const { data: invitesRaw } = orgIds.length
-    ? await supabase
-        .from('org_invites')
-        .select('id, org_id, email, full_name, role, invited_by, invited_at, accepted_at, organizations(id, name)')
-        .in('org_id', orgIds)
-        .order('accepted_at', { ascending: true, nullsFirst: true })
-        .order('invited_at', { ascending: false })
-    : { data: [] }
+  const accessAvailable =
+    organizationsAvailable &&
+    (!clientAccessCountResult || !clientAccessCountResult.error) &&
+    (!invitesResult || !invitesResult.error)
 
-  const invites = (invitesRaw ?? []).map(invite => ({
-    ...invite,
-    organizations: Array.isArray(invite.organizations) ? invite.organizations[0] : invite.organizations,
-  })) as OrgInvite[]
+  const clientAccessCount =
+    !accessAvailable
+      ? null
+      : orgIds.length === 0
+        ? 0
+        : clientAccessCountResult?.count ?? null
+  const invites = accessAvailable ? normalizeInviteRows(invitesResult?.data) : []
+  const pendingInviteCount = accessAvailable
+    ? invites.filter((invite) => !invite.accepted_at).length
+    : null
 
-  const respondentCount = respondentCountRaw ?? 0
-  const clientAccessCount = clientAccessCountRaw ?? 0
-  const pendingInviteCount = invites.filter(invite => !invite.accepted_at).length
-  const step1Done = activeOrgs.length > 0
-  const step2Done = campaigns.some(campaign => campaign.is_active)
-  const step3Done = respondentCount > 0
-  const step4Done = step2Done && (clientAccessCount > 0 || invites.length > 0)
+  const deliveryRecordsResult =
+    campaignsAvailable && campaignIds.length > 0
+      ? await supabase
+          .from('campaign_delivery_records')
+          .select('id, campaign_id, lifecycle_stage, exception_status, next_step, campaigns(id, name, scan_type)')
+          .in('campaign_id', campaignIds)
+          .order('updated_at', { ascending: false })
+      : null
+
+  const deliveryRecords =
+    campaignsAvailable && deliveryRecordsResult && !deliveryRecordsResult.error
+      ? ((deliveryRecordsResult.data ?? []) as DeliveryRecordRow[])
+      : []
+
+  const deliveryRecordIds = deliveryRecords.map((record) => record.id)
+  const deliveryCheckpointsResult =
+    campaignsAvailable && deliveryRecordIds.length > 0
+      ? await supabase
+          .from('campaign_delivery_checkpoints')
+          .select('id, delivery_record_id, checkpoint_key, manual_state, exception_status, last_auto_summary')
+          .in('delivery_record_id', deliveryRecordIds)
+      : null
+
+  const deliveryAvailable =
+    campaignsAvailable &&
+    (!deliveryRecordsResult || !deliveryRecordsResult.error) &&
+    (!deliveryCheckpointsResult || !deliveryCheckpointsResult.error)
+
+  const deliveryCheckpoints =
+    deliveryAvailable
+      ? ((deliveryCheckpointsResult?.data ?? []) as DeliveryCheckpointRow[])
+      : []
+
+  const blockedDeliveriesCount = deliveryAvailable
+    ? deliveryRecords.filter((record) => record.exception_status !== 'none').length
+    : null
+  const setupBlockers = deliveryAvailable ? buildSetupBlockers(deliveryRecords, deliveryCheckpoints) : []
+  const dataImportAlert =
+    setupBlockers.find((item) => item.category === 'DATA & IMPORT') ?? setupBlockers[0] ?? null
 
   return {
+    organizationsAvailable,
+    campaignsAvailable,
+    accessAvailable,
+    deliveryAvailable,
     orgs,
     activeOrgs,
     archivedOrgs,
     campaigns,
+    topCampaigns,
+    remainingCampaignCount,
     campaignCountByOrg,
     respondentCount,
     clientAccessCount,
-    campaignStats,
     invites,
     pendingInviteCount,
-    step1Done,
-    step2Done,
-    step3Done,
-    step4Done,
+    activeCampaignCount,
+    blockedDeliveriesCount,
+    setupBlockers,
+    dataImportAlert,
   }
 }

--- a/frontend/app/(dashboard)/beheer/page.test.ts
+++ b/frontend/app/(dashboard)/beheer/page.test.ts
@@ -1,23 +1,61 @@
 import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
-describe('beheer admin alignment', () => {
-  it('uses the shared dashboard family with a compact ops shell', () => {
+describe('dashboard admin setup page guardrails', () => {
+  it('keeps /beheer scoped to admin setup instead of routehub or analytics', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+    const helperSource = readFileSync(new URL('./get-beheer-page-data.ts', import.meta.url), 'utf8')
+    const combined = `${source}\n${helperSource}`
+
+    expect(combined).toContain('Dashboard admin setup')
+    expect(combined).toContain('Configureer organisaties, toegang, campagnes en data-readiness')
+    expect(combined).toContain('Open setupblokkades')
+    expect(combined).toContain('Secundaire adminmodules')
+
+    expect(combined).not.toContain('Operationele setup')
+    expect(combined).not.toContain('Werkvolgorde voor Verisight')
+    expect(combined).not.toContain('Open delivery- en activatiewerk')
+    expect(combined).not.toContain('Campagne-statusoverzicht')
+    expect(combined).not.toContain('Action Center')
+    expect(combined).not.toContain('avg_risk_score')
+    expect(combined).not.toContain('OperatorOnboardingBlueprint')
+  })
+
+  it('keeps the admin gate and setup-only navigation intact', () => {
     const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
 
-    expect(source).toContain('DashboardHero')
-    expect(source).toContain('DashboardSection')
-    expect(source).toContain('DashboardSummaryBar')
-    expect(source).toContain('surface="ops"')
-    expect(source).toContain('Operationele setup')
-    expect(source).toContain('Werkvolgorde voor Verisight')
-    expect(source).toContain('Open deliverylaag')
-    expect(source).toContain('Gebruik dit overzicht voor organisatie-setup, campaign-setup')
-    expect(source).toContain('Open billing registry')
-    expect(source).toContain('Billing default')
-    expect(source).toContain('Open health review')
-    expect(source).toContain('Health review default')
-    expect(source).toContain('Open case proof registry')
-    expect(source).toContain('Proof ladder default')
+    expect(source).toContain("redirect('/dashboard')")
+    expect(source).toContain('profile?.is_verisight_admin !== true')
+    expect(source).toContain('/beheer/billing')
+    expect(source).toContain('/beheer/health')
+    expect(source).toContain('/beheer/proof')
+    expect(source).toContain('/beheer/klantlearnings')
+    expect(source).toContain('/beheer/contact-aanvragen')
+    expect(source).not.toContain('/action-center')
+  })
+
+  it('keeps page and direct setup-flow copy free of mojibake markers', () => {
+    const pageSource = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+    const newOrgSource = readFileSync(
+      new URL('../../../components/dashboard/new-org-form.tsx', import.meta.url),
+      'utf8',
+    )
+    const addRespondentsSource = readFileSync(
+      new URL('../../../components/dashboard/add-respondents-form.tsx', import.meta.url),
+      'utf8',
+    )
+    const clientAccessSource = readFileSync(
+      new URL('../../../components/dashboard/client-access-list.tsx', import.meta.url),
+      'utf8',
+    )
+    const combined = `${pageSource}\n${newOrgSource}\n${addRespondentsSource}\n${clientAccessSource}`
+
+    expect(combined).not.toContain('Ã')
+    expect(combined).not.toContain('Â')
+    expect(combined).not.toContain('â')
+    expect(combined).not.toContain('�')
+    expect(combined).toContain('Organisatie aangemaakt.')
+    expect(combined).toContain('Voer minimaal één geldig e-mailadres in.')
+    expect(combined).toContain('Niet beschikbaar — data kon niet worden geladen')
   })
 })

--- a/frontend/app/(dashboard)/beheer/page.tsx
+++ b/frontend/app/(dashboard)/beheer/page.tsx
@@ -9,17 +9,14 @@ import {
   DashboardHero,
   DashboardPanel,
   DashboardSection,
-  DashboardSummaryBar,
 } from '@/components/dashboard/dashboard-primitives'
 import { DeleteOrgButton } from '@/components/dashboard/delete-org-button'
 import { InviteClientUserForm } from '@/components/dashboard/invite-client-user-form'
 import { NewCampaignForm } from '@/components/dashboard/new-campaign-form'
 import { NewOrgForm } from '@/components/dashboard/new-org-form'
-import { OperatorOnboardingBlueprint } from '@/components/dashboard/onboarding-panels'
-import { getDeliveryModeLabel } from '@/lib/implementation-readiness'
-import { getDeliveryCheckpointTitle, getDeliveryExceptionLabel, getDeliveryLifecycleLabel } from '@/lib/ops-delivery'
 import { createClient } from '@/lib/supabase/server'
-import { hasCampaignAddOn, REPORT_ADD_ON_LABELS, type Campaign, type CampaignStats, type Organization, type OrgInvite } from '@/lib/types'
+import { SCAN_TYPE_LABELS } from '@/lib/types'
+import { getBeheerPageData } from './get-beheer-page-data'
 
 export default async function BeheerPage() {
   const supabase = await createClient()
@@ -41,839 +38,482 @@ export default async function BeheerPage() {
     redirect('/dashboard')
   }
 
-  const { data: memberships } = await supabase
-    .from('org_members')
-    .select('organizations(*)')
-    .eq('user_id', user.id)
+  const {
+    organizationsAvailable,
+    campaignsAvailable,
+    accessAvailable,
+    deliveryAvailable,
+    orgs,
+    activeOrgs,
+    archivedOrgs,
+    campaigns,
+    topCampaigns,
+    remainingCampaignCount,
+    campaignCountByOrg,
+    respondentCount,
+    clientAccessCount,
+    invites,
+    pendingInviteCount,
+    activeCampaignCount,
+    blockedDeliveriesCount,
+    setupBlockers,
+    dataImportAlert,
+  } = await getBeheerPageData(supabase, user.id)
 
-  const orgs = (memberships?.flatMap((membership) => membership.organizations).filter(Boolean) ?? []) as Organization[]
-  const activeOrgs = orgs.filter((org) => org.is_active)
-  const archivedOrgs = orgs.filter((org) => !org.is_active)
-
-  const orgIds = orgs.map((org) => org.id)
-  const { data: campaignsRaw } = orgIds.length
-    ? await supabase
-        .from('campaigns')
-        .select('*')
-        .in('organization_id', orgIds)
-        .order('created_at', { ascending: false })
-    : { data: [] }
-
-  const campaigns = (campaignsRaw ?? []) as Campaign[]
-  const campaignCountByOrg = campaigns.reduce<Record<string, number>>((acc, campaign) => {
-    acc[campaign.organization_id] = (acc[campaign.organization_id] ?? 0) + 1
-    return acc
-  }, {})
-
-  const campaignIds = campaigns.map((campaign) => campaign.id)
-  const { count: respondentCount } = campaignIds.length
-    ? await supabase
-        .from('respondents')
-        .select('id', { count: 'exact', head: true })
-        .in('campaign_id', campaignIds)
-    : { count: 0 }
-
-  const { count: clientAccessCount } = orgIds.length
-    ? await supabase
-        .from('org_members')
-        .select('id', { count: 'exact', head: true })
-        .in('org_id', orgIds)
-        .neq('user_id', user.id)
-    : { count: 0 }
-
-  const { data: campaignStatsRaw } = orgIds.length
-    ? await supabase
-        .from('campaign_stats')
-        .select('*')
-        .in('organization_id', orgIds)
-        .order('created_at', { ascending: false })
-    : { data: [] }
-
-  const campaignStats = (campaignStatsRaw ?? []) as CampaignStats[]
-
-  const { data: invitesRaw } = orgIds.length
-    ? await supabase
-        .from('org_invites')
-        .select('id, org_id, email, full_name, role, invited_by, invited_at, accepted_at, organizations(id, name)')
-        .in('org_id', orgIds)
-        .order('accepted_at', { ascending: true, nullsFirst: true })
-        .order('invited_at', { ascending: false })
-    : { data: [] }
-
-  const invites = (invitesRaw ?? []).map((invite) => ({
-    ...invite,
-    organizations: Array.isArray(invite.organizations) ? invite.organizations[0] : invite.organizations,
-  })) as OrgInvite[]
-
-  const pendingInviteCount = invites.filter((invite) => !invite.accepted_at).length
-  const { data: deliveryRecordsRaw } = campaignIds.length
-    ? await supabase
-        .from('campaign_delivery_records')
-        .select('id, campaign_id, lifecycle_stage, exception_status, next_step, operator_owner, campaigns(id, name, scan_type)')
-        .in('campaign_id', campaignIds)
-        .order('updated_at', { ascending: false })
-    : { data: [] }
-
-  const deliveryRecords = (deliveryRecordsRaw ?? []) as Array<{
-    id: string
-    campaign_id: string
-    lifecycle_stage: string
-    exception_status: string
-    next_step: string | null
-    operator_owner: string | null
-    campaigns:
-      | { id: string; name: string; scan_type: 'exit' | 'retention' }
-      | { id: string; name: string; scan_type: 'exit' | 'retention' }[]
-      | null
-  }>
-  const blockedDeliveries = deliveryRecords.filter((record) => record.exception_status !== 'none')
-  const deliveryRecordIds = deliveryRecords.map((record) => record.id)
-  const { data: deliveryCheckpointsRaw } = deliveryRecordIds.length
-    ? await supabase
-        .from('campaign_delivery_checkpoints')
-        .select('id, delivery_record_id, checkpoint_key, manual_state, exception_status, last_auto_summary')
-        .in('delivery_record_id', deliveryRecordIds)
-    : { data: [] }
-  const deliveryCheckpoints = (deliveryCheckpointsRaw ?? []) as Array<{
-    id: string
-    delivery_record_id: string
-    checkpoint_key: string
-    manual_state: string
-    exception_status: string
-    last_auto_summary: string | null
-  }>
-
-  const firstValueReachedCount = deliveryRecords.filter((record) =>
-    ['first_value_reached', 'first_management_use', 'follow_up_decided', 'learning_closed'].includes(record.lifecycle_stage),
-  ).length
-  const openFollowUpCount = deliveryRecords.filter(
-    (record) => !['follow_up_decided', 'learning_closed'].includes(record.lifecycle_stage),
-  ).length
-  const deliveriesNeedingAttention = deliveryRecords
-    .filter(
-      (record) =>
-        record.exception_status !== 'none' ||
-        ['setup_in_progress', 'import_cleared', 'client_activation_pending'].includes(record.lifecycle_stage),
-    )
-    .slice(0, 4)
-  const pendingCheckpointConfirmations = deliveryCheckpoints.filter((checkpoint) => checkpoint.manual_state === 'pending')
-  const checkpointExceptions = deliveryCheckpoints.filter((checkpoint) => checkpoint.exception_status !== 'none')
-  const deliveryRecordById = Object.fromEntries(deliveryRecords.map((record) => [record.id, record]))
-  const reportDeliveryGaps = pendingCheckpointConfirmations.filter((checkpoint) => {
-    if (checkpoint.checkpoint_key !== 'report_delivery') return false
-    const record = deliveryRecordById[checkpoint.delivery_record_id]
-    return Boolean(
-      record &&
-        ['first_value_reached', 'first_management_use', 'follow_up_decided', 'learning_closed'].includes(record.lifecycle_stage),
-    )
-  })
-  const clientActivationGaps = pendingCheckpointConfirmations.filter((checkpoint) => {
-    if (checkpoint.checkpoint_key !== 'client_activation') return false
-    const record = deliveryRecordById[checkpoint.delivery_record_id]
-    return Boolean(
-      record &&
-        ['client_activation_pending', 'client_activation_confirmed', 'first_value_reached', 'first_management_use'].includes(
-          record.lifecycle_stage,
-        ),
-    )
-  })
-  const opsAttentionRows = pendingCheckpointConfirmations
-    .map((checkpoint) => {
-      const record = deliveryRecordById[checkpoint.delivery_record_id]
-      const campaign = record ? (Array.isArray(record.campaigns) ? record.campaigns[0] : record.campaigns) : null
-      if (!record || !campaign) return null
-      return {
-        checkpoint,
-        record,
-        campaign,
-      }
-    })
-    .filter(Boolean)
-    .slice(0, 6) as Array<{
-    checkpoint: {
-      id: string
-      checkpoint_key: string
-      manual_state: string
-      exception_status: string
-      last_auto_summary: string | null
-    }
-    record: (typeof deliveryRecords)[number]
-    campaign: { id: string; name: string; scan_type: 'exit' | 'retention' }
-  }>
-
-  const step1Done = activeOrgs.length > 0
-  const step2Done = campaigns.some((campaign) => campaign.is_active)
-  const step3Done = (respondentCount ?? 0) > 0
-  const step4Done = step2Done && (clientAccessCount ?? 0) > 0
-  const activeCampaignCount = campaigns.filter((campaign) => campaign.is_active).length
-  const liveRespondentCount = respondentCount ?? 0
-  const confirmedClientAccessCount = clientAccessCount ?? 0
-  const setupProgressCount = [step1Done, step2Done, step3Done, step4Done].filter(Boolean).length
+  const hasSetupBlockers = setupBlockers.length > 0
 
   return (
     <div className="space-y-6">
       <DashboardHero
         surface="ops"
         tone="slate"
-        eyebrow="Adminroute voor setup"
-        title="Operationele setup"
-        description="Gebruik dit overzicht voor organisatie-setup, campaign-setup, respondentimport en klantactivatie. Buyer-facing dashboards blijven apart; dit scherm houdt Verisight-werk, handoff en open operationele acties compact scanbaar."
+        eyebrow="Admin en configuratie"
+        title="Dashboard admin setup"
+        description="Configureer organisaties, toegang, campagnes en data-readiness."
         meta={
           <>
-            <DashboardChip surface="ops" label={`${activeOrgs.length} actieve organisatie${activeOrgs.length === 1 ? '' : 's'}`} />
-            <DashboardChip surface="ops" label={`${activeCampaignCount} actieve campaign${activeCampaignCount === 1 ? '' : 's'}`} tone="slate" />
             <DashboardChip
               surface="ops"
-              label={
-                pendingInviteCount === 0
-                  ? 'Geen open activaties'
-                  : `${pendingInviteCount} activatie${pendingInviteCount === 1 ? '' : 's'} wacht`
-              }
-              tone={pendingInviteCount > 0 ? 'amber' : 'emerald'}
+              tone={organizationsAvailable ? 'slate' : 'amber'}
+              label={organizationsAvailable ? `${orgs.length} organisaties` : 'Organisaties niet beschikbaar'}
+            />
+            <DashboardChip
+              surface="ops"
+              tone={campaignsAvailable ? 'slate' : 'amber'}
+              label={campaignsAvailable ? `${campaigns.length} campaigns` : 'Campaigns niet beschikbaar'}
             />
           </>
         }
-        actions={
-          <>
-            <Link
-              href="/beheer/contact-aanvragen"
-              className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
-            >
-              Open contactaanvragen
-            </Link>
-            <Link
-              href="/beheer/klantlearnings"
-              className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
-            >
-              Open klantlearnings
-            </Link>
-            <Link
-              href="/beheer/billing"
-              className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
-            >
-              Open billing registry
-            </Link>
-            <Link
-              href="/beheer/health"
-              className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
-            >
-              Open health review
-            </Link>
-            <Link
-              href="/beheer/proof"
-              className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
-            >
-              Open case proof registry
-            </Link>
-          </>
-        }
         aside={
-          <div className="space-y-3 text-sm text-slate-700">
-            <p className="font-semibold text-slate-950">Werkvolgorde voor Verisight</p>
-            <p>1. Organisatie, 2. campaign, 3. import en uitnodiging, 4. klanttoegang bevestigen.</p>
-            <p className="text-xs leading-5 text-slate-500">
-              Geen buyer-facing premiumlaag hier: dit scherm blijft utilitair en taakgericht, ook wanneer het dezelfde dashboardprimitives gebruikt.
-            </p>
-          </div>
+          hasSetupBlockers ? (
+            <div className="space-y-2">
+              <DashboardChip surface="ops" tone="amber" label="Setup aandacht nodig" />
+              <p className="text-sm font-semibold text-slate-950">
+                {setupBlockers.length} open blokkade{setupBlockers.length === 1 ? '' : 's'}
+              </p>
+              <p className="text-xs leading-5 text-slate-500">
+                Los eerst de open setupblokkades op voordat je verder gaat met toegang, campagnes of import.
+              </p>
+            </div>
+          ) : null
         }
       />
 
-      <DashboardSummaryBar
-        surface="ops"
-        items={[
-          {
-            label: 'Setupvoortgang',
-            value: `${setupProgressCount}/4 stappen actief`,
-            tone: setupProgressCount === 4 ? 'emerald' : 'amber',
-          },
-          {
-            label: 'Respondenten',
-            value: `${liveRespondentCount} gekoppeld`,
-            tone: liveRespondentCount > 0 ? 'emerald' : 'slate',
-          },
-          {
-            label: 'Klanttoegang',
-            value: `${confirmedClientAccessCount} bevestigd`,
-            tone: confirmedClientAccessCount > 0 ? 'emerald' : 'slate',
-          },
-          {
-            label: 'Open aandacht',
-            value: `${blockedDeliveries.length + pendingCheckpointConfirmations.length} items`,
-            tone: blockedDeliveries.length + pendingCheckpointConfirmations.length > 0 ? 'amber' : 'slate',
-          },
-        ]}
-        anchors={[
-          { id: 'cadence', label: 'Cadence' },
-          { id: 'werkvolgorde', label: 'Werkvolgorde' },
-          { id: 'setup', label: 'Setup' },
-          { id: 'campagnes', label: 'Campagnes' },
-        ]}
-      />
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <SetupStatusCard
+          label="ORGANISATIES"
+          metric={organizationsAvailable ? `${activeOrgs.length}` : '—'}
+          statusText={
+            !organizationsAvailable ? 'Niet beschikbaar' : activeOrgs.length > 0 ? 'Geconfigureerd' : 'Ontbreekt'
+          }
+          tone={!organizationsAvailable ? 'amber' : activeOrgs.length > 0 ? 'emerald' : 'amber'}
+        />
+        <SetupStatusCard
+          label="TOEGANG & ROLLEN"
+          metric={accessAvailable ? `${pendingInviteCount ?? 0}` : '—'}
+          statusText={
+            !accessAvailable
+              ? 'Niet beschikbaar'
+              : (pendingInviteCount ?? 0) > 0
+                ? 'Aandacht nodig'
+                : 'Geconfigureerd'
+          }
+          tone={!accessAvailable ? 'amber' : (pendingInviteCount ?? 0) > 0 ? 'amber' : 'emerald'}
+        />
+        <SetupStatusCard
+          label="CAMPAGNES"
+          metric={campaignsAvailable ? `${campaigns.length}` : '—'}
+          statusText={
+            !campaignsAvailable ? 'Niet beschikbaar' : getCampaignStatusText(campaigns.length, activeCampaignCount)
+          }
+          tone={!campaignsAvailable ? 'amber' : activeCampaignCount && activeCampaignCount > 0 ? 'emerald' : 'slate'}
+        />
+        <SetupStatusCard
+          label="DATA & IMPORT"
+          metric={deliveryAvailable ? `${blockedDeliveriesCount ?? 0}` : '—'}
+          statusText={
+            !deliveryAvailable
+              ? 'Niet beschikbaar'
+              : (blockedDeliveriesCount ?? 0) > 0
+                ? 'Blokkade'
+                : 'Geconfigureerd'
+          }
+          tone={!deliveryAvailable ? 'amber' : (blockedDeliveriesCount ?? 0) > 0 ? 'amber' : 'emerald'}
+        />
+      </div>
 
-      <DashboardSection
-        id="cadence"
-        surface="ops"
-        eyebrow="Cadence"
-        title="Open delivery- en activatiewerk"
-        description="Gebruik deze laag om open exceptions, pending checkpoints en klantactivatie compact te scannen. Dit is operationele besturing, niet de buyer-facing managementlaag."
-        aside={
-          <DashboardChip
-            surface="ops"
-            label={
-              deliveryRecords.length === 0
-                ? 'Nog geen deliveryrecords'
-                : `${deliveryRecords.length} deliveryrecord${deliveryRecords.length === 1 ? '' : 's'}`
-            }
-            tone="slate"
-          />
-        }
-      >
-        {deliveryRecords.length === 0 ? (
-          <DashboardPanel
-            surface="ops"
-            title="Nog geen deliveryrecords zichtbaar"
-            body="Zodra een campaign deliverytracking gebruikt, verschijnen hier open lifecycle- en checkpointsignalen. Tot die tijd blijft de beheerroute vooral gericht op setup."
-            tone="slate"
-          />
-        ) : (
-          <div className="space-y-4">
-            <div className="grid gap-4 xl:grid-cols-4">
-              <DashboardPanel
-                surface="ops"
-                eyebrow="Delivery"
-                title="Actieve deliveryrecords"
-                value={`${deliveryRecords.length}`}
-                body="Elke campaign bewaart lifecycle en exception-status in dezelfde adminlaag."
-                tone="slate"
-              />
-              <DashboardPanel
-                surface="ops"
-                eyebrow="Exceptions"
-                title="Open exceptions"
-                value={`${blockedDeliveries.length}`}
-                body="Blocked, recovery en wacht-op-klant blijven zichtbaar zonder losse notities."
-                tone={blockedDeliveries.length > 0 ? 'amber' : 'slate'}
-              />
-              <DashboardPanel
-                surface="ops"
-                eyebrow="Value"
-                title="First value bereikt"
-                value={`${firstValueReachedCount}`}
-                body="Campaigns die al voorbij setup zijn en managementwaarde hebben bereikt."
-                tone={firstValueReachedCount > 0 ? 'emerald' : 'slate'}
-              />
-              <DashboardPanel
-                surface="ops"
-                eyebrow="Follow-up"
-                title="Open follow-up"
-                value={`${openFollowUpCount}`}
-                body="Campaigns zonder expliciet gesloten learning- of follow-upbesluit."
-                tone={openFollowUpCount > 0 ? 'amber' : 'slate'}
-              />
-            </div>
-
-            <div className="grid gap-4 xl:grid-cols-4">
-              <DashboardPanel
-                surface="ops"
-                eyebrow="Checkpoints"
-                title="Pending confirmations"
-                value={`${pendingCheckpointConfirmations.length}`}
-                body="Handmatige bevestigingen op intake, import, activatie, report of management use."
-                tone={pendingCheckpointConfirmations.length > 0 ? 'amber' : 'slate'}
-              />
-              <DashboardPanel
-                surface="ops"
-                eyebrow="Checkpoints"
-                title="Checkpoint exceptions"
-                value={`${checkpointExceptions.length}`}
-                body="Exceptions op checkpointniveau die expliciete recovery vragen."
-                tone={checkpointExceptions.length > 0 ? 'amber' : 'slate'}
-              />
-              <DashboardPanel
-                surface="ops"
-                eyebrow="Activation"
-                title="Activation gaps"
-                value={`${clientActivationGaps.length}`}
-                body="Campaigns waar klantactivatie nog geen bevestigde afronding kent."
-                tone={clientActivationGaps.length > 0 ? 'amber' : 'slate'}
-              />
-              <DashboardPanel
-                surface="ops"
-                eyebrow="Reports"
-                title="Report gaps"
-                value={`${reportDeliveryGaps.length}`}
-                body="Campagnes die managementwaarde naderen zonder bevestigde report delivery."
-                tone={reportDeliveryGaps.length > 0 ? 'amber' : 'slate'}
-              />
-            </div>
-
-            {deliveriesNeedingAttention.length > 0 ? (
-              <div className="grid gap-3 lg:grid-cols-2">
-                {deliveriesNeedingAttention.map((record) => {
-                  const campaign = Array.isArray(record.campaigns) ? record.campaigns[0] : record.campaigns
-                  return (
-                    <div key={record.id} className="rounded-[20px] border border-slate-200 bg-white px-4 py-4 text-sm text-slate-700 shadow-[0_6px_18px_rgba(19,32,51,0.035)]">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <DashboardChip
-                          surface="ops"
-                          label={campaign?.scan_type === 'retention' ? 'RetentieScan' : 'ExitScan'}
-                          tone="slate"
-                        />
-                        <DashboardChip
-                          surface="ops"
-                          label={getDeliveryLifecycleLabel(record.lifecycle_stage as never)}
-                          tone="slate"
-                        />
-                        {record.exception_status !== 'none' ? (
-                          <DashboardChip
-                            surface="ops"
-                            label={getDeliveryExceptionLabel(record.exception_status as never)}
-                            tone="amber"
-                          />
-                        ) : null}
-                      </div>
-                      <p className="mt-3 text-sm font-semibold text-slate-950">{campaign?.name ?? 'Onbekende campaign'}</p>
-                      <p className="mt-2 leading-6 text-slate-600">
-                        {record.next_step ? `Volgende stap: ${record.next_step}` : 'Nog geen expliciete volgende stap opgeslagen.'}
-                      </p>
-                      {record.operator_owner ? (
-                        <p className="mt-2 text-xs text-slate-500">Eigenaar: {record.operator_owner}</p>
-                      ) : null}
-                      <a
-                        href={`/campaigns/${record.campaign_id}`}
-                        className="mt-3 inline-flex items-center rounded-full border border-slate-300 bg-slate-50 px-3 py-2 text-xs font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-100"
-                      >
-                        Open deliverylaag
-                      </a>
-                    </div>
-                  )
-                })}
-              </div>
-            ) : null}
-
-            {opsAttentionRows.length > 0 ? (
-              <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4">
-                <div className="flex flex-col gap-1 border-b border-slate-200 pb-3">
-                  <h3 className="text-sm font-semibold text-slate-900">Open ops loops</h3>
-                  <p className="text-sm leading-6 text-slate-500">
-                    Werk direct acceptance, escalatie en follow-through bij vanuit deze compacte lijst.
-                  </p>
+      {hasSetupBlockers ? (
+        <DashboardSection
+          surface="ops"
+          tone="amber"
+          title="Open setupblokkades"
+          description="Alleen blokkades binnen campagnes, toegang en data-import worden hier getoond."
+        >
+          <div className="grid gap-4 xl:grid-cols-2">
+            {setupBlockers.map((blocker) => (
+              <article
+                key={blocker.id}
+                className="rounded-[20px] border border-amber-200 bg-amber-50 px-5 py-5 shadow-[0_1px_4px_rgba(10,25,47,0.04)]"
+              >
+                <div className="flex flex-wrap gap-2">
+                  <DashboardChip surface="ops" tone="amber" label={blocker.category} />
+                  {blocker.impactLabel ? (
+                    <DashboardChip surface="ops" tone="amber" label={`Impact: ${blocker.impactLabel}`} />
+                  ) : null}
                 </div>
-                <div className="mt-3 space-y-3">
-                  {opsAttentionRows.map(({ checkpoint, record, campaign }) => (
-                    <div key={checkpoint.id} className="rounded-[18px] border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <DashboardChip surface="ops" label={campaign.scan_type === 'retention' ? 'RetentieScan' : 'ExitScan'} />
-                        <DashboardChip surface="ops" label={getDeliveryLifecycleLabel(record.lifecycle_stage as never)} />
-                        <DashboardChip
-                          surface="ops"
-                          label={getDeliveryCheckpointTitle(checkpoint.checkpoint_key as never)}
-                          tone="amber"
-                        />
-                      </div>
-                      <p className="mt-3 font-semibold text-slate-950">{campaign.name}</p>
-                      <p className="mt-1 leading-6 text-slate-600">
-                        {checkpoint.last_auto_summary ??
-                          'Nog geen autosamenvatting opgeslagen; open de deliverylaag om acceptance en recovery expliciet te bevestigen.'}
-                      </p>
-                      <div className="mt-3 flex flex-wrap items-center gap-3 text-xs text-slate-500">
-                        <span>Handmatige status: nog bevestigen</span>
-                        {record.operator_owner ? <span>Eigenaar: {record.operator_owner}</span> : null}
-                      </div>
-                      <a
-                        href={`/campaigns/${record.campaign_id}`}
-                        className="mt-3 inline-flex items-center rounded-full border border-slate-300 bg-slate-50 px-3 py-2 text-xs font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-100"
-                      >
-                        Open checkpoint
-                      </a>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            ) : null}
+                <h3 className="mt-4 text-base font-semibold text-slate-950">{blocker.title}</h3>
+                <p className="mt-2 text-sm leading-6 text-slate-700">{blocker.description}</p>
+                {blocker.actionHref ? (
+                  <Link
+                    href={blocker.actionHref}
+                    className="mt-4 inline-flex items-center rounded-full border border-emerald-300 bg-white px-4 py-2 text-sm font-semibold text-emerald-800 transition hover:border-emerald-400 hover:bg-emerald-50"
+                  >
+                    Open setupzone
+                  </Link>
+                ) : null}
+              </article>
+            ))}
           </div>
-        )}
-      </DashboardSection>
+        </DashboardSection>
+      ) : null}
 
       <DashboardSection
-        id="werkvolgorde"
         surface="ops"
-        eyebrow="Werkvolgorde"
-        title="Werkvolgorde voor Verisight"
-        description="Houd dezelfde assisted setupvolgorde aan over alle adminroutes heen. Dit maakt handoff, import-QA, activatie en learningregistratie sneller scanbaar zonder de buyer-facing shell te imiteren."
-        aside={<DashboardChip surface="ops" label={`${setupProgressCount}/4 setupstappen actief`} tone={step4Done ? 'emerald' : 'amber'} />}
-      >
-        <div className="space-y-5">
-          <div className="flex flex-wrap items-center gap-2">
-            <StepBadge n={1} label="Organisatie" done={step1Done} />
-            <div className="h-px w-6 bg-slate-200" />
-            <StepBadge n={2} label="Campaign" done={step2Done} />
-            <div className="h-px w-6 bg-slate-200" />
-            <StepBadge n={3} label="Import & uitnodigen" done={step3Done} />
-            <div className="h-px w-6 bg-slate-200" />
-            <StepBadge n={4} label="Klanttoegang" done={step4Done} />
-          </div>
-
-          <OperatorOnboardingBlueprint />
-
-          <div className="grid gap-3 lg:grid-cols-5">
-            <DashboardPanel
-              surface="ops"
-              eyebrow="Assets"
-              title="Interne handover-assets"
-              body="Gebruik voor assisted setup de repo-checklists docs/IMPLEMENTATION_OPERATOR_CHECKLIST.md en docs/CLIENT_ONBOARDING_CHECKLIST.md."
-              tone="slate"
-            />
-            <DashboardPanel
-              surface="ops"
-              eyebrow="Learning"
-              title="Learning default"
-              body="Leg pilots en vroege klantlessen vast in /beheer/klantlearnings, zodat buyer-signalen en implementationfrictie niet in losse notities verdwijnen."
-              tone="slate"
-            />
-            <DashboardPanel
-              surface="ops"
-              eyebrow="Billing"
-              title="Billing default"
-              body="Maak contract, betaalwijze en assisted launch readiness expliciet in /beheer/billing zonder seat-, plan- of checkoutfictie."
-              tone="slate"
-            />
-            <DashboardPanel
-              surface="ops"
-              eyebrow="Health"
-              title="Health review default"
-              body="Gebruik /beheer/health voor bounded activation-, denied-access- en follow-through signalen zonder brede analytics-stack."
-              tone="slate"
-            />
-            <DashboardPanel
-              surface="ops"
-              eyebrow="Proof"
-              title="Proof ladder default"
-              body="Beweeg cases via /beheer/proof bewust van lesson_only naar public_usable in plaats van sample-output direct als klantbewijs te gebruiken."
-              tone="slate"
-            />
-            <DashboardPanel
-              surface="ops"
-              eyebrow="Acceptatie"
-              title="Bevestig echte activatie"
-              body="Behandel klanttoegang pas als afgerond wanneer activatie echt bevestigd is. Een invite versturen is start, nog geen oplevering."
-              tone="amber"
-            />
-          </div>
-        </div>
-      </DashboardSection>
-
-      <DashboardSection
-        id="setup"
-        surface="ops"
-        eyebrow="Setup"
-        title="Organisatie, campaign, import en klanttoegang"
-        description="Werk direct de setup af in dezelfde adminlaag. Het ritme is compacter dan het buyer-dashboard: minder framing, meer taakuitvoering."
-        aside={<DashboardChip surface="ops" label={`${campaigns.length} campaign${campaigns.length === 1 ? '' : 's'} totaal`} />}
+        tone="slate"
+        title="Setupkern"
+        description="Gebruik deze vier zones alleen voor admin-configuratie en technische readiness."
       >
         <div className="grid gap-5 lg:grid-cols-2">
-          <StepCard done={step1Done} number={1} title="Organisatie aanmaken">
-            {orgs.length > 0 ? (
-              <div className="space-y-2">
-                {orgs.map((org) => (
-                  <div key={org.id} className="flex items-start justify-between gap-3 rounded-[18px] border border-slate-200 bg-slate-50 px-3 py-3 text-sm text-slate-700">
-                    <div className="min-w-0">
-                      <div className="flex items-center gap-2">
-                        <span className={org.is_active ? 'text-emerald-600' : 'text-slate-400'}>{org.is_active ? '✓' : '○'}</span>
-                        <span className="font-medium text-slate-900">{org.name}</span>
-                        <span className="truncate text-xs text-slate-400">({org.slug})</span>
-                        {!org.is_active ? (
-                          <span className="rounded-full bg-slate-200 px-2 py-0.5 text-[11px] font-medium text-slate-600">
-                            Gearchiveerd
-                          </span>
-                        ) : null}
-                      </div>
-                      <p className="mt-1 text-xs text-slate-500">{campaignCountByOrg[org.id] ?? 0} campaign(s) gekoppeld</p>
-                    </div>
-                    <div className="flex items-start gap-2">
-                      <ArchiveOrgButton orgId={org.id} orgName={org.name} isActive={org.is_active} />
-                      <DeleteOrgButton orgId={org.id} orgName={org.name} campaignCount={campaignCountByOrg[org.id] ?? 0} />
-                    </div>
-                  </div>
-                ))}
-
-                {archivedOrgs.length > 0 ? (
-                  <p className="text-xs text-slate-500">
-                    Gearchiveerde organisaties blijven beschikbaar voor historie, maar horen niet meer in nieuwe setupstappen.
-                  </p>
-                ) : null}
-
-                <div className="border-t border-slate-200 pt-3">
-                  <p className="mb-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Nieuwe organisatie</p>
-                  <NewOrgForm />
-                </div>
-              </div>
-            ) : (
-              <div className="space-y-3">
+          <SetupPanel
+            id="organisaties"
+            title="Organisaties"
+            summary={organizationsAvailable ? `${activeOrgs.length} actief · ${archivedOrgs.length} gearchiveerd` : 'Niet beschikbaar'}
+          >
+            {!organizationsAvailable ? (
+              <SectionFallback />
+            ) : orgs.length === 0 ? (
+              <div className="space-y-4">
                 <DashboardPanel
                   surface="ops"
-                  eyebrow="Start"
-                  title="Nog geen organisaties zichtbaar"
-                  body="Maak eerst de klantorganisatie aan. Daarna worden campaign- en activatiestappen automatisch bruikbaar."
-                  tone="slate"
+                  title="Nog geen organisaties. Maak hieronder de eerste organisatie aan."
+                  body="Zodra de eerste organisatie bestaat, worden campagnes, toegang en data-import beschikbaar."
+                  tone="amber"
                 />
                 <NewOrgForm />
               </div>
-            )}
-          </StepCard>
-
-          <StepCard done={step2Done} number={2} title="Campaign aanmaken">
-            {activeOrgs.length === 0 ? (
-              <LockedStep message="Maak eerst een actieve organisatie aan of heractiveer een gearchiveerde organisatie." />
             ) : (
-              <NewCampaignForm orgs={activeOrgs} />
-            )}
-          </StepCard>
-
-          <StepCard done={step3Done} number={3} title="Respondenten importeren en uitnodigen" span="full">
-            {campaigns.length === 0 ? (
-              <LockedStep message="Maak eerst een campaign aan." />
-            ) : (
-              <div className="space-y-5">
-                <DashboardPanel
-                  surface="ops"
-                  eyebrow="Input"
-                  title="Import blijft assisted"
-                  body="Gebruik een klantbestand met e-mailadressen en optionele segmentvelden. Verisight doet QA en verzending; de klant blijft verantwoordelijk voor correcte input en respons."
-                  tone="slate"
-                />
-
-                {campaigns.filter((campaign) => campaign.is_active).length === 0 ? (
-                  <div className="rounded-[18px] border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
-                    Geen actieve campaigns. Maak eerst een nieuwe campaign aan of gebruik archiefcampagnes alleen voor inzage.
-                  </div>
-                ) : null}
-
-                <AddRespondentsForm campaigns={campaigns} organizations={orgs} />
-
-                <div className="space-y-2 border-t border-slate-200 pt-3">
-                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Bestaande campaigns</p>
-                  {campaigns.map((campaign) => (
-                    <div key={campaign.id} className="flex items-center justify-between rounded-[18px] border border-slate-200 bg-slate-50 px-4 py-3">
-                      <div className="min-w-0 flex-1">
-                        <div className="mb-0.5 flex flex-wrap items-center gap-2">
-                          <DashboardChip surface="ops" label={campaign.scan_type === 'exit' ? 'ExitScan' : 'RetentieScan'} />
-                          <DashboardChip surface="ops" label={getDeliveryModeLabel(campaign.delivery_mode, campaign.scan_type)} />
-                          <span className={`text-xs font-medium ${campaign.is_active ? 'text-emerald-700' : 'text-slate-400'}`}>
-                            {campaign.is_active ? '● Actief' : '○ Gearchiveerd'}
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  {orgs.map((org) => (
+                    <div
+                      key={org.id}
+                      className="flex items-start justify-between gap-3 rounded-[18px] border border-slate-200 bg-slate-50 px-4 py-3"
+                    >
+                      <div className="min-w-0">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className={`text-sm ${org.is_active ? 'text-emerald-600' : 'text-slate-400'}`}>
+                            {org.is_active ? '●' : '○'}
                           </span>
+                          <p className="text-sm font-semibold text-slate-900">{org.name}</p>
+                          <span className="truncate text-xs text-slate-400">({org.slug})</span>
+                          {!org.is_active ? <DashboardChip surface="ops" label="Gearchiveerd" /> : null}
                         </div>
-                        <p className="truncate text-sm font-medium text-slate-900">{campaign.name}</p>
-                        {hasCampaignAddOn(campaign, 'segment_deep_dive') ? (
-                          <p className="mt-1 text-xs font-medium text-slate-700">
-                            Add-on actief: {REPORT_ADD_ON_LABELS.segment_deep_dive}
-                          </p>
-                        ) : null}
-                        <p className="text-xs text-slate-500">
-                          Aangemaakt{' '}
-                          {new Date(campaign.created_at).toLocaleDateString('nl-NL', {
-                            day: 'numeric',
-                            month: 'long',
-                            year: 'numeric',
-                          })}
+                        <p className="mt-1 text-xs text-slate-500">
+                          {campaignCountByOrg[org.id] ?? 0} campaign{campaignCountByOrg[org.id] === 1 ? '' : 's'} gekoppeld
                         </p>
                       </div>
-                      <a
-                        href={`/campaigns/${campaign.id}`}
-                        className="ml-4 flex-shrink-0 rounded-full border border-slate-300 bg-white px-3 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
-                      >
-                        {campaign.is_active ? 'Open campaign' : 'Bekijk archief'}
-                      </a>
+                      <div className="flex items-start gap-2">
+                        <ArchiveOrgButton orgId={org.id} orgName={org.name} isActive={org.is_active} />
+                        <DeleteOrgButton
+                          orgId={org.id}
+                          orgName={org.name}
+                          campaignCount={campaignCountByOrg[org.id] ?? 0}
+                        />
+                      </div>
                     </div>
                   ))}
                 </div>
+                <div className="border-t border-slate-200 pt-4">
+                  <p className="mb-3 text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                    Nieuwe organisatie
+                  </p>
+                  <NewOrgForm />
+                </div>
               </div>
             )}
-          </StepCard>
+          </SetupPanel>
 
-          <StepCard done={step4Done} number={4} title="Klantdashboard activeren" span="full">
-            {activeOrgs.length === 0 ? (
-              <LockedStep message="Maak eerst een actieve organisatie aan of heractiveer een gearchiveerde organisatie." />
-            ) : campaigns.filter((campaign) => campaign.is_active).length === 0 ? (
-              <LockedStep message="Maak eerst een actieve campaign aan voordat je klanttoegang activeert." />
+          <SetupPanel
+            id="toegang"
+            title="Toegang en rollen"
+            summary={
+              accessAvailable
+                ? `${clientAccessCount ?? 0} gekoppeld · ${pendingInviteCount ?? 0} open uitnodigingen`
+                : 'Niet beschikbaar'
+            }
+          >
+            {!accessAvailable ? (
+              <SectionFallback />
+            ) : activeOrgs.length === 0 ? (
+              <LockedState message="Maak eerst een actieve organisatie aan voordat je klanttoegang configureert." />
             ) : (
-              <div className="space-y-5">
-                <DashboardPanel
-                  surface="ops"
-                  eyebrow="Activatie"
-                  title="Bevestig dashboardtoegang pas na echte activatie"
-                  body="Nieuwe gebruikers ontvangen een activatiemail; bestaande accounts worden direct gekoppeld. Deze stap telt operationeel pas mee zodra toegang echt bevestigd is."
-                  tone="slate"
-                />
-                {pendingInviteCount > 0 && confirmedClientAccessCount === 0 ? (
-                  <div className="rounded-[18px] border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
-                    Er lopen al klantactivaties, maar er is nog geen bevestigde dashboardtoegang. Laat deze stap open staan tot echte activatie.
-                  </div>
-                ) : null}
+              <div className="space-y-4">
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <DashboardPanel
+                    surface="ops"
+                    title="Gekoppelde klantgebruikers"
+                    value={`${clientAccessCount ?? 0}`}
+                    body="Toegang blijft beperkt tot dashboardtoegang en activatiebeheer."
+                    tone="slate"
+                  />
+                  <DashboardPanel
+                    surface="ops"
+                    title="Open uitnodigingen"
+                    value={`${pendingInviteCount ?? 0}`}
+                    body={
+                      (pendingInviteCount ?? 0) === 0
+                        ? 'Geen openstaande uitnodigingen.'
+                        : 'Er lopen nog uitnodigingen die op activatie wachten.'
+                    }
+                    tone={(pendingInviteCount ?? 0) > 0 ? 'amber' : 'emerald'}
+                  />
+                </div>
                 <InviteClientUserForm orgs={activeOrgs} />
-                <div className="space-y-3 border-t border-slate-200 pt-4">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Klanttoegang en uitnodigingen</p>
-                    {pendingInviteCount > 0 ? (
-                      <DashboardChip surface="ops" label={`${pendingInviteCount} wacht op activatie`} tone="amber" />
-                    ) : null}
-                  </div>
+                <div className="border-t border-slate-200 pt-4">
+                  <p className="mb-3 text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                    Bestaande toegang
+                  </p>
                   <ClientAccessList invites={invites} />
                 </div>
               </div>
             )}
-          </StepCard>
-        </div>
-      </DashboardSection>
+          </SetupPanel>
 
-      {campaignStats.length > 0 ? (
-        <DashboardSection
-          id="campagnes"
-          surface="ops"
-          eyebrow="Campagnes"
-          title="Campagne-statusoverzicht"
-          description="Respons, risicosignaal en voortgang per campaign blijven hier compact uitleesbaar voor operators en beheerders."
-          aside={<DashboardChip surface="ops" label={`${campaignStats.length} campaignstats`} tone="slate" />}
-        >
-          <div className="overflow-x-auto rounded-[20px] border border-slate-200 bg-white">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b border-slate-200 bg-slate-50 text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
-                  <th className="px-5 py-3 text-left">Campaign</th>
-                  <th className="px-5 py-3 text-left">Organisatie</th>
-                  <th className="px-5 py-3 text-center">Status</th>
-                  <th className="px-5 py-3 text-right">Uitgenodigd</th>
-                  <th className="px-5 py-3 text-right">Ingevuld</th>
-                  <th className="px-5 py-3 text-right">Respons</th>
-                  <th className="px-5 py-3 text-right">Gem. risico</th>
-                  <th className="px-4 py-3" />
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-slate-100">
-                {campaignStats.map((stats) => {
-                  const pct = stats.completion_rate_pct ?? 0
-                  const org = orgs.find((item) => item.id === stats.organization_id)
-                  return (
-                    <tr key={stats.campaign_id} className="hover:bg-slate-50/70">
-                      <td className="px-5 py-3">
-                        <div className="font-medium text-slate-900">{stats.campaign_name}</div>
-                        <div className="mt-0.5 text-xs text-slate-500">
-                          {stats.scan_type === 'exit' ? 'ExitScan' : 'RetentieScan'}
-                        </div>
-                      </td>
-                      <td className="px-5 py-3 text-slate-600">{org?.name ?? '—'}</td>
-                      <td className="px-5 py-3 text-center">
-                        <span
-                          className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${
-                            stats.is_active ? 'bg-emerald-50 text-emerald-700' : 'bg-slate-100 text-slate-500'
-                          }`}
-                        >
-                          <span className={`h-1.5 w-1.5 rounded-full ${stats.is_active ? 'bg-emerald-600' : 'bg-slate-400'}`} />
-                          {stats.is_active ? 'Actief' : 'Gesloten'}
-                        </span>
-                      </td>
-                      <td className="px-5 py-3 text-right tabular-nums text-slate-700">{stats.total_invited ?? 0}</td>
-                      <td className="px-5 py-3 text-right tabular-nums text-slate-700">{stats.total_completed ?? 0}</td>
-                      <td className="px-5 py-3 text-right">
-                        <div className="flex items-center justify-end gap-2">
-                          <div className="h-1.5 w-16 overflow-hidden rounded-full bg-slate-100">
-                            <div
-                              className={`h-full rounded-full ${
-                                pct >= 60 ? 'bg-emerald-500' : pct >= 30 ? 'bg-amber-400' : 'bg-red-400'
-                              }`}
-                              style={{ width: `${Math.min(pct, 100)}%` }}
-                            />
+          <SetupPanel
+            id="campagnes"
+            title="Campagnes"
+            summary={campaignsAvailable ? `${campaigns.length} totaal` : 'Niet beschikbaar'}
+          >
+            {!campaignsAvailable ? (
+              <SectionFallback />
+            ) : (
+              <div className="space-y-4">
+                {topCampaigns.length === 0 ? (
+                  <DashboardPanel
+                    surface="ops"
+                    title="Geen campagnes gevonden."
+                    body="Maak hieronder de eerste campaign aan zodra er een actieve organisatie beschikbaar is."
+                    tone="amber"
+                  />
+                ) : (
+                  <div className="space-y-2">
+                    {topCampaigns.map((campaign) => (
+                      <div
+                        key={campaign.id}
+                        className="flex items-center justify-between gap-3 rounded-[18px] border border-slate-200 bg-slate-50 px-4 py-3"
+                      >
+                        <div className="min-w-0">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <span
+                              className={`text-sm ${campaign.is_active ? 'text-emerald-600' : 'text-slate-400'}`}
+                            >
+                              {campaign.is_active ? '●' : '○'}
+                            </span>
+                            <p className="truncate text-sm font-semibold text-slate-900">{campaign.name}</p>
                           </div>
-                          <span className="w-9 text-xs font-semibold tabular-nums text-slate-700">{pct}%</span>
+                          <p className="mt-1 text-xs text-slate-500">
+                            {SCAN_TYPE_LABELS[campaign.scan_type] ?? campaign.scan_type}
+                            {campaign.is_active ? ' · actief' : ' · gearchiveerd'}
+                          </p>
                         </div>
-                      </td>
-                      <td className="px-5 py-3 text-right tabular-nums text-slate-700">
-                        {stats.avg_risk_score ? (
-                          <span
-                            className={`font-semibold ${
-                              stats.avg_risk_score >= 7
-                                ? 'text-red-600'
-                                : stats.avg_risk_score >= 4.5
-                                  ? 'text-amber-600'
-                                  : 'text-emerald-700'
-                            }`}
-                          >
-                            {stats.avg_risk_score.toFixed(1)}
-                          </span>
-                        ) : (
-                          <span className="text-xs text-slate-300">—</span>
-                        )}
-                      </td>
-                      <td className="px-4 py-3">
-                        <a
-                          href={`/campaigns/${stats.campaign_id}`}
+                        <Link
+                          href={`/campaigns/${campaign.id}`}
                           className="rounded-full border border-slate-300 bg-white px-3 py-2 text-xs font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
                         >
                           Open campaign
-                        </a>
-                      </td>
-                    </tr>
-                  )
-                })}
-              </tbody>
-            </table>
-          </div>
-        </DashboardSection>
-      ) : null}
-    </div>
-  )
-}
+                        </Link>
+                      </div>
+                    ))}
+                    {remainingCampaignCount > 0 ? (
+                      <p className="text-xs text-slate-500">
+                        + {remainingCampaignCount} extra campaign{remainingCampaignCount === 1 ? '' : 's'}
+                      </p>
+                    ) : null}
+                  </div>
+                )}
 
-function StepBadge({ n, label, done }: { n: number; label: string; done: boolean }) {
-  return (
-    <div className="flex items-center gap-1.5">
-      <div
-        className={`flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full text-xs font-bold ${
-          done ? 'bg-emerald-600 text-white' : 'bg-slate-200 text-slate-600'
-        }`}
+                <div className="border-t border-slate-200 pt-4">
+                  <p className="mb-3 text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                    Nieuwe campaign
+                  </p>
+                  {activeOrgs.length === 0 ? (
+                    <LockedState message="Maak eerst een actieve organisatie aan voordat je een campaign configureert." />
+                  ) : (
+                    <NewCampaignForm orgs={activeOrgs} />
+                  )}
+                </div>
+              </div>
+            )}
+          </SetupPanel>
+
+          <SetupPanel
+            id="data-import"
+            title="Data en import"
+            summary={
+              campaignsAvailable
+                ? `${respondentCount === null ? '—' : respondentCount} respondent${respondentCount === 1 ? '' : 'en'}`
+                : 'Niet beschikbaar'
+            }
+          >
+            {!campaignsAvailable || !deliveryAvailable ? (
+              <SectionFallback />
+            ) : campaigns.length === 0 ? (
+              <LockedState message="Maak eerst een campaign aan voordat je data importeert." />
+            ) : (
+              <div className="space-y-4">
+                {dataImportAlert ? (
+                  <div className="rounded-[18px] border border-amber-200 bg-amber-50 px-4 py-4 text-sm text-amber-950">
+                    <div className="flex flex-wrap gap-2">
+                      <DashboardChip surface="ops" tone="amber" label={dataImportAlert.category} />
+                      {dataImportAlert.impactLabel ? (
+                        <DashboardChip surface="ops" tone="amber" label={`Impact: ${dataImportAlert.impactLabel}`} />
+                      ) : null}
+                    </div>
+                    <p className="mt-3 font-semibold">{dataImportAlert.title}</p>
+                    <p className="mt-2 leading-6">{dataImportAlert.description}</p>
+                  </div>
+                ) : (
+                  <DashboardPanel
+                    surface="ops"
+                    title="Geen importblokkades gevonden."
+                    body="Data-import kan hier verder worden voorbereid zonder open setupblokkade."
+                    tone="emerald"
+                  />
+                )}
+                <AddRespondentsForm campaigns={campaigns} organizations={orgs} />
+              </div>
+            )}
+          </SetupPanel>
+        </div>
+      </DashboardSection>
+
+      <DashboardSection
+        surface="ops"
+        tone="slate"
+        eyebrow="SECUNDAIRE ADMINMODULES"
+        title="Secundaire adminmodules"
+        description="Gebruik deze links alleen voor gespecialiseerde adminstromen buiten de setupkern."
       >
-        {done ? '✓' : n}
-      </div>
-      <span className={`hidden text-xs font-medium sm:block ${done ? 'text-emerald-700' : 'text-slate-600'}`}>{label}</span>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+          <AdminModuleLink href="/beheer/billing" label="Billing" subLabel="Naar billingmodule" />
+          <AdminModuleLink href="/beheer/health" label="Health" subLabel="Naar healthmodule" />
+          <AdminModuleLink href="/beheer/proof" label="Proof" subLabel="Naar proofmodule" />
+          <AdminModuleLink href="/beheer/klantlearnings" label="Klantlearnings" subLabel="Naar learnings" />
+          <AdminModuleLink href="/beheer/contact-aanvragen" label="Aanvragen" subLabel="Naar contact" />
+        </div>
+      </DashboardSection>
     </div>
   )
 }
 
-function StepCard({
-  done,
-  number,
-  title,
-  children,
-  span = 'half',
+function getCampaignStatusText(campaignCount: number, activeCampaignCount: number | null) {
+  if (campaignCount === 0) return 'Geen campaigns'
+  if ((activeCampaignCount ?? 0) > 0) return 'Actief'
+  return 'Geen actieve campaigns'
+}
+
+function SetupStatusCard({
+  label,
+  metric,
+  statusText,
+  tone,
 }: {
-  done: boolean
-  number: number
+  label: string
+  metric: string
+  statusText: string
+  tone: 'slate' | 'emerald' | 'amber'
+}) {
+  return (
+    <div className="rounded-[20px] border border-slate-200 bg-white px-5 py-4 shadow-[0_1px_4px_rgba(10,25,47,0.04)]">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">{label}</p>
+      <p className="mt-3 text-[1.7rem] font-bold tracking-tight text-slate-950">{metric}</p>
+      <div className="mt-3 flex items-center gap-2">
+        <span
+          className={`h-2.5 w-2.5 rounded-full ${
+            tone === 'emerald' ? 'bg-emerald-500' : tone === 'amber' ? 'bg-amber-500' : 'bg-slate-400'
+          }`}
+        />
+        <p
+          className={`text-sm font-medium ${
+            tone === 'emerald' ? 'text-emerald-700' : tone === 'amber' ? 'text-amber-800' : 'text-slate-600'
+          }`}
+        >
+          {statusText}
+        </p>
+      </div>
+    </div>
+  )
+}
+
+function SetupPanel({
+  id,
+  title,
+  summary,
+  children,
+}: {
+  id: string
   title: string
+  summary: string
   children: ReactNode
-  span?: 'half' | 'full'
 }) {
   return (
     <section
-      className={`rounded-[22px] border bg-white p-5 shadow-[0_8px_24px_rgba(19,32,51,0.04)] ${
-        span === 'full' ? 'lg:col-span-2' : ''
-      } ${done ? 'border-emerald-200' : 'border-slate-200'}`}
+      id={id}
+      className="rounded-[22px] border border-slate-200 bg-white p-5 shadow-[0_1px_4px_rgba(10,25,47,0.04)]"
     >
-      <div className="mb-4 flex items-center gap-2">
-        <div
-          className={`flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full text-xs font-bold ${
-            done ? 'bg-emerald-600 text-white' : 'bg-slate-900 text-white'
-          }`}
-        >
-          {done ? '✓' : number}
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-base font-semibold text-slate-950">{title}</h2>
+          <p className="mt-1 text-sm text-slate-500">{summary}</p>
         </div>
-        <h2 className="text-base font-semibold text-slate-900">{title}</h2>
       </div>
-      {children}
+      <div className="mt-5 border-t border-slate-200 pt-5">{children}</div>
     </section>
   )
 }
 
-function LockedStep({ message }: { message: string }) {
+function AdminModuleLink({
+  href,
+  label,
+  subLabel,
+}: {
+  href: string
+  label: string
+  subLabel: string
+}) {
+  return (
+    <Link
+      href={href}
+      className="rounded-[20px] border border-slate-200 bg-white px-4 py-4 text-left shadow-[0_1px_4px_rgba(10,25,47,0.04)] transition hover:border-emerald-300 hover:bg-emerald-50"
+    >
+      <p className="text-sm font-semibold text-slate-950">{label}</p>
+      <p className="mt-2 text-xs text-slate-500">{subLabel}</p>
+    </Link>
+  )
+}
+
+function SectionFallback() {
+  return (
+    <DashboardPanel
+      surface="ops"
+      title="Niet beschikbaar — data kon niet worden geladen"
+      body="Laad de pagina opnieuw of controleer of de admindata beschikbaar is voor deze gebruiker."
+      tone="amber"
+    />
+  )
+}
+
+function LockedState({ message }: { message: string }) {
   return (
     <div className="rounded-[18px] border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-500">
       {message}

--- a/frontend/components/dashboard/add-respondents-form.tsx
+++ b/frontend/components/dashboard/add-respondents-form.tsx
@@ -8,7 +8,13 @@ import {
   getInviteDefaultForDeliveryMode,
   normalizeDeliveryMode,
 } from '@/lib/implementation-readiness'
-import { hasCampaignAddOn, REPORT_ADD_ON_LABELS, SCAN_TYPE_LABELS, type Campaign, type Organization } from '@/lib/types'
+import {
+  hasCampaignAddOn,
+  REPORT_ADD_ON_LABELS,
+  SCAN_TYPE_LABELS,
+  type Campaign,
+  type Organization,
+} from '@/lib/types'
 import { CLIENT_FILE_SPEC } from '@/lib/client-onboarding'
 import {
   getDefaultCampaignId,
@@ -72,11 +78,11 @@ export function AddRespondentsForm({ campaigns, organizations }: Props) {
 
   const [campaignId, setCampaignId] = useState(getDefaultCampaignId(campaigns))
   const selectedCampaign = useMemo(
-    () => campaigns.find(campaign => campaign.id === campaignId) ?? null,
+    () => campaigns.find((campaign) => campaign.id === campaignId) ?? null,
     [campaignId, campaigns],
   )
   const organizationById = useMemo(
-    () => Object.fromEntries(organizations.map(organization => [organization.id, organization.name])),
+    () => Object.fromEntries(organizations.map((organization) => [organization.id, organization.name])),
     [organizations],
   )
   const selectedDeliveryMode = normalizeDeliveryMode(selectedCampaign?.delivery_mode)
@@ -131,31 +137,32 @@ export function AddRespondentsForm({ campaigns, organizations }: Props) {
       return
     }
 
-    const respondents = mode === 'emails'
-      ? emails.map(email => ({
-          email,
-          department: department || null,
-          role_level: roleLevel || null,
-          exit_month: exitMonth || null,
-          annual_salary_eur: salary ? parseFloat(salary) : null,
-        }))
-      : Array.from({ length: count }, () => ({
-          email: null,
-          department: department || null,
-          role_level: roleLevel || null,
-          exit_month: exitMonth || null,
-          annual_salary_eur: salary ? parseFloat(salary) : null,
-        }))
+    const respondents =
+      mode === 'emails'
+        ? emails.map((email) => ({
+            email,
+            department: department || null,
+            role_level: roleLevel || null,
+            exit_month: exitMonth || null,
+            annual_salary_eur: salary ? parseFloat(salary) : null,
+          }))
+        : Array.from({ length: count }, () => ({
+            email: null,
+            department: department || null,
+            role_level: roleLevel || null,
+            exit_month: exitMonth || null,
+            annual_salary_eur: salary ? parseFloat(salary) : null,
+          }))
 
     const { createClient } = await import('@/lib/supabase/client')
     const supabase = createClient()
-    const rows = respondents.map(r => ({
+    const rows = respondents.map((respondent) => ({
       campaign_id: campaignId,
-      department: r.department,
-      role_level: r.role_level,
-      exit_month: r.exit_month,
-      annual_salary_eur: r.annual_salary_eur,
-      email: r.email,
+      department: respondent.department,
+      role_level: respondent.role_level,
+      exit_month: respondent.exit_month,
+      annual_salary_eur: respondent.annual_salary_eur,
+      email: respondent.email,
     }))
 
     const { data, error: supabaseError } = await supabase
@@ -248,13 +255,15 @@ export function AddRespondentsForm({ campaigns, organizations }: Props) {
     !hasPreviewErrors &&
     previewResult.valid_rows > 0 &&
     previewResult.launch_blocked !== true
-  const previewMissingDepartmentCount = previewResult?.preview_rows.filter(row => !row.department?.trim()).length ?? 0
-  const previewMissingRoleLevelCount = previewResult?.preview_rows.filter(row => !row.role_level?.trim()).length ?? 0
+  const previewMissingDepartmentCount =
+    previewResult?.preview_rows.filter((row) => !row.department?.trim()).length ?? 0
+  const previewMissingRoleLevelCount =
+    previewResult?.preview_rows.filter((row) => !row.role_level?.trim()).length ?? 0
 
   return (
     <div className="space-y-5">
       <div className="rounded-xl border border-blue-100 bg-blue-50 px-4 py-3 text-sm text-blue-900">
-        <p className="font-semibold mb-1">Rol van Verisight en rol van de klant</p>
+        <p className="mb-1 font-semibold">Rol van Verisight en rol van de klant</p>
         <p className="text-blue-800">
           Deze setup is voor Verisight-beheerders. De klant levert een respondentbestand aan; Verisight zet de
           campagne op, controleert de import en verstuurt uitnodigingen. Daarna krijgt de organisatie toegang tot
@@ -292,21 +301,22 @@ export function AddRespondentsForm({ campaigns, organizations }: Props) {
 
       <form onSubmit={handleManualSubmit} className="space-y-4">
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
+          <label className="mb-1 block text-sm font-medium text-gray-700">
             Campaign <span className="text-red-500">*</span>
           </label>
           <select
             value={campaignId}
-            onChange={e => {
+            onChange={(e) => {
               setCampaignId(e.target.value)
               resetFeedback()
               resetUploadState()
             }}
             className={selectCls}
           >
-            {campaigns.map(campaign => (
+            {campaigns.map((campaign) => (
               <option key={campaign.id} value={campaign.id}>
-                {organizationById[campaign.organization_id] ?? 'Onbekende organisatie'} — {campaign.name} ({SCAN_TYPE_LABELS[campaign.scan_type]})
+                {organizationById[campaign.organization_id] ?? 'Onbekende organisatie'} — {campaign.name} (
+                {SCAN_TYPE_LABELS[campaign.scan_type]})
                 {campaign.is_active ? '' : ' — gearchiveerd'}
               </option>
             ))}
@@ -321,104 +331,116 @@ export function AddRespondentsForm({ campaigns, organizations }: Props) {
                 : 'border-amber-100 bg-amber-50 text-amber-950'
             }`}
           >
-            <p className="font-semibold mb-1">
-              {SCAN_TYPE_LABELS[selectedCampaign.scan_type]} {getDeliveryModeLabel(selectedDeliveryMode, selectedCampaign.scan_type)}
+            <p className="mb-1 font-semibold">
+              {SCAN_TYPE_LABELS[selectedCampaign.scan_type]}{' '}
+              {getDeliveryModeLabel(selectedDeliveryMode, selectedCampaign.scan_type)}
             </p>
             <p>{getDeliveryModeDescription(selectedDeliveryMode, selectedCampaign.scan_type)}</p>
             <p className="mt-2 text-xs">
-              Standaard invite-instelling voor deze route: {uploadSendInvites ? 'direct uitnodigen na gecontroleerde import' : 'eerst klaarzetten, daarna bewust uitnodigen'}.
+              Standaard invite-instelling voor deze route:{' '}
+              {uploadSendInvites
+                ? 'direct uitnodigen na gecontroleerde import'
+                : 'eerst klaarzetten, daarna bewust uitnodigen'}
+              .
             </p>
           </div>
         ) : null}
 
-        {hasSegmentDeepDive && (
+        {hasSegmentDeepDive ? (
           <div className="rounded-lg border border-blue-100 bg-blue-50 px-4 py-3 text-sm text-blue-900">
-            <p className="font-semibold mb-1">{REPORT_ADD_ON_LABELS.segment_deep_dive} staat aan voor deze campaign</p>
+            <p className="mb-1 font-semibold">{REPORT_ADD_ON_LABELS.segment_deep_dive} staat aan voor deze campaign</p>
             <p className="text-blue-800">
-              Voor deze rapportverdieping zijn <code className="font-mono">department</code> en <code className="font-mono">role_level</code>
-              {' '}sterk aanbevolen. Diensttijd wordt al uit de survey gehaald; de rest van de segmentanalyse valt of staat met nette metadata per respondent.
+              Voor deze rapportverdieping zijn <code className="font-mono">department</code> en{' '}
+              <code className="font-mono">role_level</code> sterk aanbevolen. Diensttijd wordt al uit de survey gehaald;
+              de rest van de segmentanalyse valt of staat met nette metadata per respondent.
             </p>
             <p className="mt-2 text-blue-800">
-              Aan te leveren Excel-kolommen: <code className="font-mono">email</code> (verplicht), <code className="font-mono">department</code> en <code className="font-mono">role_level</code> (sterk aanbevolen), <code className="font-mono">annual_salary_eur</code> (optioneel).
+              Aan te leveren Excel-kolommen: <code className="font-mono">email</code> (verplicht),{' '}
+              <code className="font-mono">department</code> en <code className="font-mono">role_level</code> (sterk
+              aanbevolen), <code className="font-mono">annual_salary_eur</code> (optioneel).
             </p>
             <p className="mt-2 text-blue-800">
-              Gebruik bij retrospectieve batches ook <code className="font-mono">exit_month</code> in formaat <code className="font-mono">YYYY-MM</code>, zodat recency en recall bias beter te duiden zijn in het rapport.
+              Gebruik bij retrospectieve batches ook <code className="font-mono">exit_month</code> in formaat{' '}
+              <code className="font-mono">YYYY-MM</code>, zodat recency en recall bias beter te duiden zijn in het
+              rapport.
             </p>
           </div>
-        )}
+        ) : null}
 
-        {selectedCampaign?.scan_type === 'retention' && (
+        {selectedCampaign?.scan_type === 'retention' ? (
           <div className="rounded-lg border border-emerald-100 bg-emerald-50 px-4 py-3 text-sm text-emerald-950">
-            <p className="font-semibold mb-1">RetentieScan: minimale datadiscipline voor v1.1</p>
+            <p className="mb-1 font-semibold">RetentieScan: minimale datadiscipline voor v1.1</p>
             <p className="text-emerald-900">
-              Lever voor RetentieScan bij voorkeur altijd <code className="font-mono">email</code>, <code className="font-mono">department</code> en <code className="font-mono">role_level</code> aan.
-              Zonder afdeling en functieniveau wordt niet alleen het dashboard beperkter, maar ook de latere validatie van segmentverschillen en pragmatische follow-up.
+              Lever voor RetentieScan bij voorkeur altijd <code className="font-mono">email</code>,{' '}
+              <code className="font-mono">department</code> en <code className="font-mono">role_level</code> aan.
+              Zonder afdeling en functieniveau wordt niet alleen het dashboard beperkter, maar ook de latere validatie
+              van segmentverschillen en pragmatische follow-up.
             </p>
             <p className="mt-2 text-emerald-900">
-              Zet na de baseline ook een follow-up bestand klaar met team- of segmentuitkomsten zoals uitstroom, verzuim of vervolgmeting. Gebruik hiervoor het template <code className="font-mono">data/templates/retentionscan_followup_outcomes_template.csv</code>.
+              Zet na de baseline ook een follow-up bestand klaar met team- of segmentuitkomsten zoals uitstroom,
+              verzuim of vervolgmeting. Gebruik hiervoor het template{' '}
+              <code className="font-mono">data/templates/retentionscan_followup_outcomes_template.csv</code>.
             </p>
           </div>
-        )}
+        ) : null}
 
-        {mode === 'emails' && (
+        {mode === 'emails' ? (
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label className="mb-1 block text-sm font-medium text-gray-700">
               E-mailadressen <span className="text-red-500">*</span>
               <span className="ml-1 text-xs font-normal text-gray-400">(één per regel of komma-gescheiden)</span>
             </label>
             <textarea
               value={emailInput}
-              onChange={e => setEmailInput(e.target.value)}
+              onChange={(e) => setEmailInput(e.target.value)}
               placeholder={'anne@bedrijf.nl\nkarim@bedrijf.nl\nsanne@bedrijf.nl'}
               rows={4}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+              className="w-full resize-none rounded-lg border border-gray-300 px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
-            {emailInput && (
-              <p className="text-xs text-gray-400 mt-1">
-                {parseEmails(emailInput).length} e-mailadres(sen) herkend
-              </p>
-            )}
+            {emailInput ? (
+              <p className="mt-1 text-xs text-gray-400">{parseEmails(emailInput).length} e-mailadres(sen) herkend</p>
+            ) : null}
           </div>
-        )}
+        ) : null}
 
-        {mode === 'bulk' && (
+        {mode === 'bulk' ? (
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Aantal links</label>
+            <label className="mb-1 block text-sm font-medium text-gray-700">Aantal links</label>
             <input
               type="number"
               min={1}
               max={200}
               value={count}
-              onChange={e => setCount(parseInt(e.target.value, 10))}
+              onChange={(e) => setCount(parseInt(e.target.value, 10))}
               className={inputCls}
             />
-            <p className="text-xs text-gray-400 mt-1">
+            <p className="mt-1 text-xs text-gray-400">
               Er worden {count} anonieme survey-links gegenereerd. De klant verstuurt deze dan zelf.
             </p>
           </div>
-        )}
+        ) : null}
 
-        {mode !== 'upload' && (
+        {mode !== 'upload' ? (
           <>
             <div className={`grid gap-3 pt-1 ${isExitCampaign ? 'sm:grid-cols-4' : 'sm:grid-cols-3'}`}>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Afdeling <span className="text-gray-400 text-xs font-normal">(optioneel)</span>
+                <label className="mb-1 block text-sm font-medium text-gray-700">
+                  Afdeling <span className="text-xs font-normal text-gray-400">(optioneel)</span>
                 </label>
                 <input
                   type="text"
                   value={department}
-                  onChange={e => setDepartment(e.target.value)}
+                  onChange={(e) => setDepartment(e.target.value)}
                   placeholder="Operations"
                   className={inputCls}
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Niveau <span className="text-gray-400 text-xs font-normal">(optioneel)</span>
+                <label className="mb-1 block text-sm font-medium text-gray-700">
+                  Niveau <span className="text-xs font-normal text-gray-400">(optioneel)</span>
                 </label>
-                <select value={roleLevel} onChange={e => setRoleLevel(e.target.value)} className={selectCls}>
-                  {ROLE_LEVELS.map(option => (
+                <select value={roleLevel} onChange={(e) => setRoleLevel(e.target.value)} className={selectCls}>
+                  {ROLE_LEVELS.map((option) => (
                     <option key={option.value} value={option.value}>
                       {option.label}
                     </option>
@@ -427,26 +449,26 @@ export function AddRespondentsForm({ campaigns, organizations }: Props) {
               </div>
               {isExitCampaign ? (
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
-                    Exitmaand <span className="text-gray-400 text-xs font-normal">(optioneel)</span>
+                  <label className="mb-1 block text-sm font-medium text-gray-700">
+                    Exitmaand <span className="text-xs font-normal text-gray-400">(optioneel)</span>
                   </label>
                   <input
                     type="month"
                     value={exitMonth}
-                    onChange={e => setExitMonth(e.target.value)}
+                    onChange={(e) => setExitMonth(e.target.value)}
                     className={inputCls}
                   />
                 </div>
               ) : null}
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Bruto jaarsalaris € <span className="text-gray-400 text-xs font-normal">(optioneel)</span>
+                <label className="mb-1 block text-sm font-medium text-gray-700">
+                  Bruto jaarsalaris € <span className="text-xs font-normal text-gray-400">(optioneel)</span>
                 </label>
                 <input
                   type="number"
                   min={0}
                   value={salary}
-                  onChange={e => setSalary(e.target.value)}
+                  onChange={(e) => setSalary(e.target.value)}
                   placeholder="55000"
                   className={inputCls}
                 />
@@ -455,40 +477,48 @@ export function AddRespondentsForm({ campaigns, organizations }: Props) {
 
             <button type="submit" disabled={loading !== null} className={btnCls}>
               {loading === 'submit'
-                ? 'Bezig…'
+                ? 'Bezig...'
                 : mode === 'emails'
                   ? `Uitnodigingen versturen (${parseEmails(emailInput).length || '?'})`
                   : `${count} links genereren`}
             </button>
           </>
-        )}
+        ) : null}
       </form>
 
-      {mode === 'upload' && (
-        <div className="rounded-xl border border-gray-200 p-4 space-y-4">
+      {mode === 'upload' ? (
+        <div className="space-y-4 rounded-xl border border-gray-200 p-4">
           <div>
-            <p className="text-sm font-semibold text-gray-800 mb-1">Upload respondentbestand</p>
-            <p className="text-xs text-gray-500 leading-relaxed">
+            <p className="mb-1 text-sm font-semibold text-gray-800">Upload respondentbestand</p>
+            <p className="text-xs leading-relaxed text-gray-500">
               Gebruik één rij per respondent met minimaal een kolom <code className="font-mono">email</code>. Optioneel
               kun je <code className="font-mono">department</code>, <code className="font-mono">role_level</code>
-              {isExitCampaign ? <>, <code className="font-mono">exit_month</code></> : null} en <code className="font-mono">annual_salary_eur</code> meesturen. Upload een <code className="font-mono">.csv</code>
-              {' '}of <code className="font-mono">.xlsx</code> bestand.
+              {isExitCampaign ? <>, <code className="font-mono">exit_month</code></> : null} en{' '}
+              <code className="font-mono">annual_salary_eur</code> meesturen. Upload een{' '}
+              <code className="font-mono">.csv</code> of <code className="font-mono">.xlsx</code> bestand.
             </p>
-            <p className="mt-2 text-xs text-gray-500 leading-relaxed">
-              Lever minimaal {CLIENT_FILE_SPEC.minimumParticipants} deelnemers aan en gebruik alleen herkenbare standaardkolommen.
+            <p className="mt-2 text-xs leading-relaxed text-gray-500">
+              Lever minimaal {CLIENT_FILE_SPEC.minimumParticipants} deelnemers aan en gebruik alleen herkenbare
+              standaardkolommen.
             </p>
-            {selectedCampaign?.scan_type === 'retention' && (
+            {selectedCampaign?.scan_type === 'retention' ? (
               <p className="mt-2 text-xs leading-relaxed text-emerald-800">
-                Voor RetentieScan v1.1-validatie zijn <code className="font-mono">department</code> en <code className="font-mono">role_level</code> de aanbevolen standaard. Daarmee kunnen we later betrouwbaarheid, segmentverschillen en pragmatische follow-up veel netter toetsen.
+                Voor RetentieScan v1.1-validatie zijn <code className="font-mono">department</code> en{' '}
+                <code className="font-mono">role_level</code> de aanbevolen standaard. Daarmee kunnen we later
+                betrouwbaarheid, segmentverschillen en pragmatische follow-up veel netter toetsen.
               </p>
-            )}
-            {hasSegmentDeepDive && (
+            ) : null}
+            {hasSegmentDeepDive ? (
               <p className="mt-2 text-xs leading-relaxed text-blue-800">
-                Voor {REPORT_ADD_ON_LABELS.segment_deep_dive.toLowerCase()} zijn ingevulde kolommen <code className="font-mono">department</code>
-                {' '}en <code className="font-mono">role_level</code> sterk aanbevolen. Zonder die velden blijft het rapport beperkter op subgroepniveau.
-                Gebruik bij voorkeur exact deze kolommen: <code className="font-mono">email</code>, <code className="font-mono">department</code>, <code className="font-mono">role_level</code>, <code className="font-mono">exit_month</code>, <code className="font-mono">annual_salary_eur</code>.
+                Voor {REPORT_ADD_ON_LABELS.segment_deep_dive.toLowerCase()} zijn ingevulde kolommen{' '}
+                <code className="font-mono">department</code> en <code className="font-mono">role_level</code> sterk
+                aanbevolen. Zonder die velden blijft het rapport beperkter op subgroepniveau. Gebruik bij voorkeur exact
+                deze kolommen: <code className="font-mono">email</code>,{' '}
+                <code className="font-mono">department</code>, <code className="font-mono">role_level</code>,{' '}
+                <code className="font-mono">exit_month</code>,{' '}
+                <code className="font-mono">annual_salary_eur</code>.
               </p>
-            )}
+            ) : null}
             <div className="mt-3 flex flex-wrap gap-3 text-xs font-medium">
               <a
                 href="/templates/verisight-respondenten-template.xlsx"
@@ -505,17 +535,18 @@ export function AddRespondentsForm({ campaigns, organizations }: Props) {
                 Download CSV-template
               </a>
             </div>
-            {selectedCampaign?.scan_type === 'retention' && (
+            {selectedCampaign?.scan_type === 'retention' ? (
               <p className="mt-2 text-xs text-gray-500">
-                Voor follow-up uitkomsten gebruik je daarna het CSV-template <code className="font-mono">retentionscan_followup_outcomes_template.csv</code> uit de repo.
+                Voor follow-up uitkomsten gebruik je daarna het CSV-template{' '}
+                <code className="font-mono">retentionscan_followup_outcomes_template.csv</code> uit de repo.
               </p>
-            )}
+            ) : null}
           </div>
 
           <input
             type="file"
             accept=".csv,.xlsx"
-            onChange={e => {
+            onChange={(e) => {
               const nextFile = e.target.files?.[0] ?? null
               setUploadFile(nextFile)
               resetFeedback()
@@ -528,7 +559,7 @@ export function AddRespondentsForm({ campaigns, organizations }: Props) {
             <input
               type="checkbox"
               checked={uploadSendInvites}
-              onChange={e => setUploadSendInvites(e.target.checked)}
+              onChange={(e) => setUploadSendInvites(e.target.checked)}
               className="mt-0.5 rounded"
             />
             <span>
@@ -548,23 +579,23 @@ export function AddRespondentsForm({ campaigns, organizations }: Props) {
               disabled={loading !== null || !uploadFile}
               className={btnCls}
             >
-              {loading === 'preview' ? 'Bestand controleren…' : 'Bestand controleren'}
+              {loading === 'preview' ? 'Bestand controleren...' : 'Bestand controleren'}
             </button>
-            {canImportPreview && (
+            {canImportPreview ? (
               <button
                 type="button"
                 onClick={() => void requestImport(false)}
                 disabled={loading !== null}
-                className="bg-gray-900 hover:bg-black disabled:opacity-50 text-white text-sm font-semibold py-2.5 px-5 rounded-lg transition-colors"
+                className="rounded-lg bg-gray-900 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-black disabled:opacity-50"
               >
-                {loading === 'import' ? 'Importeren…' : `Importeer ${previewResult.valid_rows} respondenten`}
+                {loading === 'import' ? 'Importeren...' : `Importeer ${previewResult.valid_rows} respondenten`}
               </button>
-            )}
+            ) : null}
           </div>
 
-          {previewResult && (
-            <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 space-y-3">
-              <div className="grid sm:grid-cols-4 gap-3 text-sm">
+          {previewResult ? (
+            <div className="space-y-3 rounded-lg border border-gray-200 bg-gray-50 p-4">
+              <div className="grid gap-3 text-sm sm:grid-cols-4">
                 <ImportMetric label="Rijen" value={previewResult.total_rows} />
                 <ImportMetric label="Geldig" value={previewResult.valid_rows} />
                 <ImportMetric label="Fouten" value={previewResult.invalid_rows} />
@@ -581,9 +612,7 @@ export function AddRespondentsForm({ campaigns, organizations }: Props) {
                 <p className="font-semibold">{previewResult.readiness_label}</p>
                 <p className="mt-1 leading-6">{previewResult.recovery_hint}</p>
                 {previewResult.ignored_columns.length > 0 ? (
-                  <p className="mt-2 text-xs leading-5">
-                    Niet herkend: {previewResult.ignored_columns.join(', ')}.
-                  </p>
+                  <p className="mt-2 text-xs leading-5">Niet herkend: {previewResult.ignored_columns.join(', ')}.</p>
                 ) : null}
               </div>
 
@@ -598,11 +627,11 @@ export function AddRespondentsForm({ campaigns, organizations }: Props) {
                 </div>
               ) : null}
 
-              {previewResult.preview_rows.length > 0 && (
+              {previewResult.preview_rows.length > 0 ? (
                 <div>
-                  <p className="text-xs font-semibold text-gray-600 mb-2">Preview van geldige rijen</p>
+                  <p className="mb-2 text-xs font-semibold text-gray-600">Preview van geldige rijen</p>
                   <div className="overflow-x-auto">
-                    <table className="min-w-full text-xs border border-gray-200 rounded-lg overflow-hidden">
+                    <table className="min-w-full overflow-hidden rounded-lg border border-gray-200 text-xs">
                       <thead className="bg-white text-gray-500">
                         <tr>
                           <th className="px-2 py-2 text-left">Rij</th>
@@ -613,7 +642,7 @@ export function AddRespondentsForm({ campaigns, organizations }: Props) {
                         </tr>
                       </thead>
                       <tbody>
-                        {previewResult.preview_rows.map(row => (
+                        {previewResult.preview_rows.map((row) => (
                           <tr key={`${row.row_number}-${row.email}`} className="border-t border-gray-200 bg-white">
                             <td className="px-2 py-2">{row.row_number}</td>
                             <td className="px-2 py-2 font-mono">{row.email}</td>
@@ -626,7 +655,7 @@ export function AddRespondentsForm({ campaigns, organizations }: Props) {
                     </table>
                   </div>
                 </div>
-              )}
+              ) : null}
 
               {!hasPreviewErrors && previewResult.preview_rows.length > 0 ? (
                 <div className="rounded-lg border border-slate-200 bg-white px-4 py-3 text-xs leading-6 text-slate-700">
@@ -638,42 +667,40 @@ export function AddRespondentsForm({ campaigns, organizations }: Props) {
                   </p>
                   {selectedCampaign?.scan_type === 'retention' || hasSegmentDeepDive ? (
                     <p className="mt-1">
-                      Metadata-alert: {previewMissingDepartmentCount} rij(en) zonder <code className="font-mono">department</code> en {previewMissingRoleLevelCount} rij(en) zonder <code className="font-mono">role_level</code>.
+                      Metadata-alert: {previewMissingDepartmentCount} rij(en) zonder{' '}
+                      <code className="font-mono">department</code> en {previewMissingRoleLevelCount} rij(en) zonder{' '}
+                      <code className="font-mono">role_level</code>.
                     </p>
                   ) : null}
                 </div>
               ) : null}
 
-              {previewResult.errors.length > 0 && (
+              {previewResult.errors.length > 0 ? (
                 <div>
-                  <p className="text-xs font-semibold text-red-700 mb-2">Fouten die je eerst moet oplossen</p>
+                  <p className="mb-2 text-xs font-semibold text-red-700">Fouten die je eerst moet oplossen</p>
                   <ul className="space-y-1 text-xs text-red-700">
-                    {previewResult.errors.slice(0, 12).map(issue => (
+                    {previewResult.errors.slice(0, 12).map((issue) => (
                       <li key={`${issue.row_number}-${issue.field}-${issue.message}`}>
                         Rij {issue.row_number} — {issue.field}: {issue.message}
                       </li>
                     ))}
                   </ul>
-                  {previewResult.errors.length > 12 && (
-                    <p className="text-xs text-red-600 mt-2">
-                      + {previewResult.errors.length - 12} extra fout(en)
-                    </p>
-                  )}
+                  {previewResult.errors.length > 12 ? (
+                    <p className="mt-2 text-xs text-red-600">+ {previewResult.errors.length - 12} extra fout(en)</p>
+                  ) : null}
                 </div>
-              )}
+              ) : null}
             </div>
-          )}
+          ) : null}
         </div>
-      )}
+      ) : null}
 
-      {error && <p className="text-sm text-red-600">{error}</p>}
+      {error ? <p className="text-sm text-red-600">{error}</p> : null}
 
-      {result && (
-        <div className="rounded-xl border border-green-200 bg-green-50 p-4 space-y-3">
+      {result ? (
+        <div className="space-y-3 rounded-xl border border-green-200 bg-green-50 p-4">
           <div>
-            <p className="text-sm font-semibold text-green-800 mb-1">
-              {result.tokens.length} respondenten aangemaakt
-            </p>
+            <p className="mb-1 text-sm font-semibold text-green-800">{result.tokens.length} respondenten aangemaakt</p>
             {mode === 'bulk' ? (
               <p className="text-sm text-green-700">
                 Anonieme survey-links zijn gegenereerd. Deel deze links rechtstreeks met de klant of intern team.
@@ -683,28 +710,28 @@ export function AddRespondentsForm({ campaigns, organizations }: Props) {
                 {result.emailsSent} uitnodigingsmail{result.emailsSent !== 1 ? 's' : ''} verstuurd
               </p>
             ) : (
-              <p className="text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-2 mt-2">
+              <p className="mt-2 rounded border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700">
                 E-mails konden niet worden verstuurd. Kopieer de links hieronder als alternatief.
               </p>
             )}
           </div>
 
-          {(mode === 'bulk' || result.emailsSent === 0) && (
+          {mode === 'bulk' || result.emailsSent === 0 ? (
             <div>
-              <p className="text-xs font-medium text-gray-500 mb-1">Survey-links:</p>
+              <p className="mb-1 text-xs font-medium text-gray-500">Survey-links:</p>
               <textarea
                 readOnly
-                className="w-full font-mono text-xs bg-white border border-gray-200 rounded-lg p-3 h-28 resize-none focus:outline-none"
-                value={result.tokens.map(token => `${API_BASE}/survey/${token}`).join('\n')}
+                className="h-28 w-full resize-none rounded-lg border border-gray-200 bg-white p-3 font-mono text-xs focus:outline-none"
+                value={result.tokens.map((token) => `${API_BASE}/survey/${token}`).join('\n')}
               />
             </div>
-          )}
+          ) : null}
         </div>
-      )}
+      ) : null}
 
-      {importSuccess && (
+      {importSuccess ? (
         <div className="rounded-xl border border-green-200 bg-green-50 p-4">
-          <p className="text-sm font-semibold text-green-800 mb-1">
+          <p className="mb-1 text-sm font-semibold text-green-800">
             {importSuccess.imported} respondenten geïmporteerd
           </p>
           <p className="text-sm text-green-700">
@@ -713,12 +740,15 @@ export function AddRespondentsForm({ campaigns, organizations }: Props) {
               : 'Respondenten zijn toegevoegd zonder directe uitnodiging.'}
           </p>
           <p className="mt-2 text-xs text-green-800">
-            Volgende stap: {uploadSendInvites ? 'controleer campagnestatus en klantactivatie.' : 'verstuur uitnodigingen pas nadat timing en contactmoment bevestigd zijn.'}
+            Volgende stap:{' '}
+            {uploadSendInvites
+              ? 'controleer campagnestatus en klantactivatie.'
+              : 'verstuur uitnodigingen pas nadat timing en contactmoment bevestigd zijn.'}
           </p>
         </div>
-      )}
+      ) : null}
 
-      <p className="text-xs text-gray-400 leading-relaxed">
+      <p className="text-xs leading-relaxed text-gray-400">
         E-mailadressen worden uitsluitend gebruikt voor uitnodiging en herinneringen. In het dashboard draait het om
         groepsinzichten; individuele e-mailadressen worden daar niet getoond.
       </p>
@@ -741,10 +771,8 @@ function ModeButton({
     <button
       type="button"
       onClick={() => onClick(value)}
-      className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
-        current === value
-          ? 'bg-blue-600 text-white'
-          : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+      className={`rounded-lg px-4 py-2 text-sm font-medium transition-colors ${
+        current === value ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
       }`}
     >
       {label}
@@ -761,6 +789,9 @@ function ImportMetric({ label, value }: { label: string; value: number }) {
   )
 }
 
-const inputCls = 'w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500'
-const selectCls = 'w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white'
-const btnCls = 'bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white text-sm font-semibold py-2.5 px-5 rounded-lg transition-colors'
+const inputCls =
+  'w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500'
+const selectCls =
+  'w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500'
+const btnCls =
+  'rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:opacity-50'

--- a/frontend/components/dashboard/client-access-list.tsx
+++ b/frontend/components/dashboard/client-access-list.tsx
@@ -20,9 +20,11 @@ export function ClientAccessList({ invites }: Props) {
     const cooldownMs = RESEND_COOLDOWN_MINUTES * 60 * 1000
     const sentAt = new Date(invitedAt).getTime()
     const elapsedMs = Date.now() - sentAt
+
     if (elapsedMs >= cooldownMs) {
       return 0
     }
+
     return Math.max(1, Math.ceil((cooldownMs - elapsedMs) / (60 * 1000)))
   }
 
@@ -62,31 +64,29 @@ export function ClientAccessList({ invites }: Props) {
 
   return (
     <div className="space-y-3">
-      {message && <p className="text-sm text-green-600">{message}</p>}
-      {error && <p className="text-sm text-red-600">{error}</p>}
+      {message ? <p className="text-sm text-green-600">{message}</p> : null}
+      {error ? <p className="text-sm text-red-600">{error}</p> : null}
 
       {invites.length === 0 ? (
         <div className="rounded-lg border border-dashed border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-500">
           Er zijn nog geen klantaccounts of uitnodigingen voor deze organisaties.
         </div>
       ) : (
-        invites.map(invite => {
+        invites.map((invite) => {
           const isActive = Boolean(invite.accepted_at)
           const cooldownMinutes = !isActive ? getRemainingCooldownMinutes(invite.invited_at) : 0
           const resendBlocked = cooldownMinutes > 0
           const statusLabel = isActive ? 'Actieve dashboardtoegang' : 'Wacht op accountactivatie'
           const statusCls = isActive
-            ? 'bg-green-50 text-green-700 border-green-100'
-            : 'bg-amber-50 text-amber-700 border-amber-100'
+            ? 'border-green-100 bg-green-50 text-green-700'
+            : 'border-amber-100 bg-amber-50 text-amber-700'
 
           return (
             <div key={invite.id} className="rounded-xl border border-gray-200 bg-white px-4 py-3">
               <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                 <div className="min-w-0">
                   <div className="flex flex-wrap items-center gap-2">
-                    <p className="text-sm font-semibold text-gray-900">
-                      {invite.full_name?.trim() || invite.email}
-                    </p>
+                    <p className="text-sm font-semibold text-gray-900">{invite.full_name?.trim() || invite.email}</p>
                     <span className={`rounded-full border px-2 py-0.5 text-xs font-medium ${statusCls}`}>
                       {statusLabel}
                     </span>
@@ -108,15 +108,16 @@ export function ClientAccessList({ invites }: Props) {
                       ? 'Dashboardtoegang is actief. Volgende stap: bevestig het eerste dashboard- of rapportgebruik.'
                       : 'Activatie loopt nog. Bevestig de activatiemail en plan daarna het eerste klantcontact rond dashboardtoegang.'}
                   </p>
-                  {!isActive && resendBlocked && (
+                  {!isActive && resendBlocked ? (
                     <p className="mt-1 text-xs text-amber-700">
-                      Activatiemail recent verstuurd. Opnieuw uitnodigen kan over ongeveer {cooldownMinutes} minuut{cooldownMinutes === 1 ? '' : 'en'}.
+                      Activatiemail recent verstuurd. Opnieuw uitnodigen kan over ongeveer {cooldownMinutes} minuut
+                      {cooldownMinutes === 1 ? '' : 'en'}.
                     </p>
-                  )}
+                  ) : null}
                 </div>
 
                 <div className="flex items-center gap-2 sm:flex-shrink-0">
-                  {!isActive && (
+                  {!isActive ? (
                     <button
                       type="button"
                       disabled={busyKey === invite.id || resendBlocked}
@@ -125,7 +126,7 @@ export function ClientAccessList({ invites }: Props) {
                     >
                       {busyKey === invite.id ? 'Bezig...' : resendBlocked ? 'Even wachten' : 'Opnieuw uitnodigen'}
                     </button>
-                  )}
+                  ) : null}
                 </div>
               </div>
             </div>

--- a/frontend/components/dashboard/new-org-form.tsx
+++ b/frontend/components/dashboard/new-org-form.tsx
@@ -1,12 +1,12 @@
 'use client'
 
+import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { createClient } from '@/lib/supabase/client'
-import { useRouter } from 'next/navigation'
 
 export function NewOrgForm() {
-  const [name,  setName]  = useState('')
-  const [slug,  setSlug]  = useState('')
+  const [name, setName] = useState('')
+  const [slug, setSlug] = useState('')
   const [email, setEmail] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
@@ -21,30 +21,34 @@ export function NewOrgForm() {
       .replace(/^-|-$/g, '')
   }
 
-  // Auto-genereer slug vanuit naam
-  function handleNameChange(v: string) {
-    setName(v)
-    setSlug(normalizeSlug(v))
+  function handleNameChange(value: string) {
+    setName(value)
+    setSlug(normalizeSlug(value))
   }
 
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault()
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault()
     setLoading(true)
     setError(null)
 
-    const { error } = await supabase
+    const { error: insertError } = await supabase
       .from('organizations')
       .insert({ name, slug: normalizeSlug(slug), contact_email: email })
 
-    if (error) {
-      setError(error.message.includes('unique') ? 'Slug is al in gebruik.' : error.message)
+    if (insertError) {
+      setError(insertError.message.includes('unique') ? 'Slug is al in gebruik.' : insertError.message)
       setLoading(false)
       return
     }
 
     setSuccess(true)
-    setName(''); setSlug(''); setEmail('')
-    setTimeout(() => { setSuccess(false); router.refresh() }, 1500)
+    setName('')
+    setSlug('')
+    setEmail('')
+    setTimeout(() => {
+      setSuccess(false)
+      router.refresh()
+    }, 1500)
     setLoading(false)
   }
 
@@ -52,18 +56,22 @@ export function NewOrgForm() {
     <form onSubmit={handleSubmit} className="space-y-3">
       <Field label="Naam organisatie" required>
         <input
-          type="text" required value={name}
-          onChange={e => handleNameChange(e.target.value)}
+          type="text"
+          required
+          value={name}
+          onChange={(event) => handleNameChange(event.target.value)}
           placeholder="Acme BV"
           className={inputCls}
         />
       </Field>
 
-      <Field label="Slug" required hint="Alleen a–z, 0–9, koppelstreep">
+      <Field label="Slug" required hint="Alleen a-z, 0-9, koppelstreep">
         <input
-          type="text" required value={slug}
-          onChange={e => setSlug(normalizeSlug(e.target.value))}
-          pattern="[a-z0-9\-]+"
+          type="text"
+          required
+          value={slug}
+          onChange={(event) => setSlug(normalizeSlug(event.target.value))}
+          pattern="[a-z0-9\\-]+"
           placeholder="acme-bv"
           className={inputCls}
         />
@@ -71,36 +79,49 @@ export function NewOrgForm() {
 
       <Field label="Contacte-mail" required>
         <input
-          type="email" required value={email}
-          onChange={e => setEmail(e.target.value)}
+          type="email"
+          required
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
           placeholder="hr@acme.nl"
           className={inputCls}
         />
       </Field>
 
-      {error && <p className="text-sm text-red-600">{error}</p>}
-      {success && <p className="text-sm text-green-600">✓ Organisatie aangemaakt!</p>}
+      {error ? <p className="text-sm text-red-600">{error}</p> : null}
+      {success ? <p className="text-sm text-green-600">Organisatie aangemaakt.</p> : null}
 
       <button type="submit" disabled={loading} className={btnCls}>
-        {loading ? 'Bezig…' : '+ Aanmaken'}
+        {loading ? 'Bezig...' : '+ Aanmaken'}
       </button>
     </form>
   )
 }
 
-function Field({ label, required, hint, children }: {
-  label: string; required?: boolean; hint?: string; children: React.ReactNode
+function Field({
+  label,
+  required,
+  hint,
+  children,
+}: {
+  label: string
+  required?: boolean
+  hint?: string
+  children: React.ReactNode
 }) {
   return (
     <div>
-      <label className="block text-sm font-medium text-gray-700 mb-1">
-        {label}{required && <span className="text-red-500 ml-0.5">*</span>}
-        {hint && <span className="ml-1 text-xs text-gray-400 font-normal">({hint})</span>}
+      <label className="mb-1 block text-sm font-medium text-gray-700">
+        {label}
+        {required ? <span className="ml-0.5 text-red-500">*</span> : null}
+        {hint ? <span className="ml-1 text-xs font-normal text-gray-400">({hint})</span> : null}
       </label>
       {children}
     </div>
   )
 }
 
-const inputCls = 'w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent'
-const btnCls   = 'w-full bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white text-sm font-semibold py-2 px-4 rounded-lg transition-colors'
+const inputCls =
+  'w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500'
+const btnCls =
+  'w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:opacity-50'


### PR DESCRIPTION
## Samenvatting
- bouwt de admin/configuratiepagina onder `/beheer` om naar een zuivere setup-laag
- verwijdert analytische en routehub-drift uit deze pagina
- voegt guardrails toe voor copy en datacontract

## Scope
- beheer pagina, data helper en directe setupflowcomponenten

## Verificatie
- vitest op `app/(dashboard)/beheer/page.test.ts`
- vitest op `app/(dashboard)/beheer/get-beheer-page-data.test.ts`
- eslint op de admin setup-slice