### PR TITLE
Dashboard product page as pure analytics

### DIFF
--- a/frontend/app/(dashboard)/campaigns/[id]/page-helpers.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/page-helpers.test.ts
@@ -102,7 +102,7 @@ describe('dashboard page helpers field semantics', () => {
     expect(panels[2]?.body).toContain('aanvullende signalen')
   })
 
-  it('keeps exit helper openings centered on frictiescore with werkfrictie as duiding', () => {
+  it('keeps exit helper openings centered on average signal language with werkfrictie as duiding', () => {
     const hero = buildHeroDescription({
       scanType: 'exit',
       isActive: false,
@@ -121,9 +121,9 @@ describe('dashboard page helpers field semantics', () => {
       topFactor: 'Leiderschap',
     })
 
-    expect(hero).toContain('Frictiescore')
+    expect(hero).toContain('gemiddelde signaalscore')
     expect(hero).toContain('werkfrictie')
-    expect(nextStep).toContain('Frictiescore')
+    expect(nextStep).toContain('gemiddelde signaalscore')
     expect(nextStep).toContain('werkfrictie')
   })
 })

--- a/frontend/app/(dashboard)/campaigns/[id]/page-helpers.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page-helpers.tsx
@@ -134,6 +134,10 @@ export function buildHeroDescription({
     return `Bekijk eerst het retentiesignaal, de respons en de laagst scorende thema's.`
   }
 
+  if (scanType === 'exit') {
+    return `Bekijk eerst de gemiddelde signaalscore, de respons en de sterkste werkfrictie in dit vertrekbeeld.`
+  }
+
   if (scanType === 'pulse') {
     return `Deze Pulse laat een compacte managementread zien van werkbeleving en geselecteerde werkfactoren. Lees de uitkomst als bounded reviewlaag voor dit meetmoment, met alleen een beperkte vergelijking naar de vorige vergelijkbare Pulse. Huidig ${scanDefinition.signalLabelLower}: ${averageRiskScore?.toFixed(1) ?? '-'} /10.`
   }
@@ -360,8 +364,8 @@ export function buildNextStepBody({
   }
 
   return topFactor
-    ? `Gebruik Frictiescore als openingssignaal en ${topFactor.toLowerCase()} als eerste werkfrictiespoor om te bepalen waar management eerst moet doorvragen en welke verbeteractie binnen 30-90 dagen het meest logisch is.`
-    : 'Gebruik Frictiescore als openingssignaal en werkfrictie als verklarende laag om het eerstvolgende verbetergesprek te richten.'
+    ? `Gebruik de gemiddelde signaalscore als openingssignaal en ${topFactor.toLowerCase()} als eerste werkfrictiespoor om te bepalen waar management eerst moet doorvragen en welke verbeteractie binnen 30-90 dagen het meest logisch is.`
+    : 'Gebruik de gemiddelde signaalscore als openingssignaal en werkfrictie als verklarende laag om het eerstvolgende verbetergesprek te richten.'
 }
 
 export function getDisclosureDefaults({

--- a/frontend/app/(dashboard)/campaigns/[id]/page.route-shell.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.route-shell.test.ts
@@ -1,49 +1,31 @@
 import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
-describe('campaign detail first-next-step shell', () => {
-  it('keeps the rail semantics on module level and shows breadcrumb + module back link in content', () => {
+describe('campaign detail route shell', () => {
+  it('keeps the manager-only insight boundary intact', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+
+    expect(source).toContain('if (!context.canViewInsights)')
+    expect(source).toContain('SuiteAccessDenied')
+  })
+
+  it('wires ExitScan through a dedicated analytical component and preserves report + module navigation', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+
+    expect(source).toContain('ExitProductDashboard')
+    expect(source).toContain('averageSignalScoreLabel')
+    expect(source).toContain('PdfDownloadButton')
+    expect(source).toContain('moduleBackLinkLabel')
+    expect(source).toContain('if (stats.scan_type === "exit")')
+    expect(source).not.toContain('return stats.scan_type === "exit" ? (')
+  })
+
+  it('keeps existing module breadcrumbs instead of collapsing to a generic dashboard jump', () => {
     const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
 
     expect(source).toContain('getDashboardModuleHref')
     expect(source).toContain('getDashboardModuleKeyForScanType')
     expect(source).toContain('getDashboardModuleLabel')
-    expect(source).toContain('Overzicht')
-    expect(source).toContain('moduleBackLinkLabel')
-    expect(source).toContain('Terug naar alle RetentieScans')
     expect(source).toContain('Terug naar alle ExitScans')
-    expect(source).not.toContain('Terug naar dashboardoverzicht')
-  })
-
-  it('reuses shared first-next-step guidance inside the route section', () => {
-    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
-
-    expect(source).toContain('getFirstNextStepGuidance')
-    expect(source).toContain('firstNextStepGuidance.cards.map')
-    expect(source).toContain('Alleen als vervolg echt nodig is')
-    expect(source).toContain('Compacte vervolgroutes')
-    expect(source).toContain('Geen standaard vervolg')
-    expect(source).toContain('followOnSuggestions.map')
-  })
-
-  it('keeps the module preview layer anchored to real campaign evidence', () => {
-    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
-
-    expect(source).toContain('SignalStatCard')
-    expect(source).toContain('InsightStatCard')
-    expect(source).toContain('FocusPanel')
-    expect(source).toContain("label=\"Signaal-index\"")
-    expect(source).toContain("label=\"Respons\"")
-    expect(source).toContain("label=\"Risicoband\"")
-    expect(source).toContain("label=\"Sterkste factor\"")
-    expect(source).toContain('focusPanelItems')
-  })
-
-  it('keeps the campaign-to-action-center handoff explicit instead of a generic module jump', () => {
-    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
-
-    expect(source).toContain('buildActionCenterRouteOpenRedirect(id, "campaign-detail")')
-    expect(source).toContain('actionCenterBridge.presentation.ctaLabel')
-    expect(source).toContain('actionCenterBridge.presentation.body')
   })
 })

--- a/frontend/app/(dashboard)/campaigns/[id]/page.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.test.ts
@@ -1,67 +1,93 @@
 import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
-describe('campaign detail management-read guardrails', () => {
-  it('keeps campaign detail the only surface that can open a new action center route', () => {
-    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
-    const normalizedSource = source.replaceAll('"', "'")
+const componentSource = () =>
+  readFileSync(
+    new URL('../../../../components/dashboard/exit-product-dashboard.tsx', import.meta.url),
+    'utf8',
+  )
 
-    expect(source).toContain('Open in Action Center')
-    expect(source).toContain('canOpenActionCenterRoute(deliveryRecord)')
-    expect(source).toContain('first_management_use_confirmed_at')
-    expect(normalizedSource).toContain(".select('id, lifecycle_stage, first_management_use_confirmed_at')")
+describe('exit dashboard analytics guardrails', () => {
+  it('keeps the ExitScan dashboard free from owner, action, review, workflow and setup language', () => {
+    const source = componentSource().toLowerCase()
+    const forbiddenTerms = [
+      'eerste eigenaar',
+      'route-eigenaar',
+      'eigenaar',
+      'eerste actie',
+      'eerste stap',
+      'reviewmoment',
+      'review plannen',
+      'manager toegewezen',
+      'action center',
+      'workflow',
+      'opvolgactie',
+      'start actie',
+      'maak actie',
+      'follow-on',
+      'uitvoerflow',
+      'livegang',
+      'importeren',
+      'uitnodigingen beheren',
+      'reminderactie',
+      'setup',
+    ]
+
+    for (const term of forbiddenTerms) {
+      expect(source).not.toContain(term)
+    }
   })
 
-  it('builds dedicated report-faithful read layers for exit and retention instead of reusing generic dashboard detail structure', () => {
-    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+  it('renders the agreed ExitScan analytical IA in the expected order', () => {
+    const source = componentSource()
+    const orderedHeadings = [
+      'Sterkste signaal',
+      'Waarom dit telt',
+      'Hoofdreden van vertrekbeeld',
+      'Meespelende factoren',
+      'Responscontext',
+      'Topfactoren',
+      'Verdeling van het vertrekbeeld',
+      'Diepere driverlaag',
+      'SDT-laag',
+      'Uitgebreide factorlaag',
+      'Methodische leesgrenzen',
+    ]
 
-    expect(source).toContain('ManagementReadHeader')
-    expect(source).toContain('ManagementReadSection')
-    expect(source).toContain('ManagementReadFactorTable')
-    expect(source).toContain('ManagementReadBridge')
-    expect(source).toContain("stats.scan_type === \"exit\"")
-    expect(source).toContain("stats.scan_type === \"retention\"")
-    expect(source).toContain('buildExitPictureDistribution')
-    expect(source).toContain('buildRetentionSignalSegments')
+    let previousIndex = -1
+    for (const heading of orderedHeadings) {
+      const index = source.indexOf(heading)
+      expect(index, `${heading} ontbreekt`).toBeGreaterThan(-1)
+      expect(index, `${heading} staat buiten volgorde`).toBeGreaterThan(previousIndex)
+      previousIndex = index
+    }
   })
 
-  it('keeps route pages in a bestuurlijke read layer and does not default to owner-action-review commitment blocks', () => {
-    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+  it('does not rely on mockdata or silent 0-fallbacks for meaningful dashboard values', () => {
+    const source = componentSource()
 
-    expect(source).toContain('Kernbeeld nu')
-    expect(source).toContain('Frictiescore')
-    expect(source).toContain('Dit is het gemiddelde frictieniveau in de leesbare responses.')
-    expect(source).toContain('Werkfrictie laat de richting van het beeld zien.')
-    expect(source).toContain('hoort pas in Action Center thuis')
-    expect(source).not.toContain('wie wat moet doen')
-    expect(source).not.toContain('route-eigenaar standaard als inhoudsblok pushen')
+    expect(source).not.toContain('?? 0')
+    expect(source.toLowerCase()).not.toContain('mock')
+    expect(source.toLowerCase()).not.toContain('placeholder')
+    expect(source).toContain('Nog niet beschikbaar')
+    expect(source).toContain('Onvoldoende data')
   })
 
-  it('preserves report-truth layers such as response basis, factor signal values and SDT', () => {
-    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+  it('keeps the visible ExitScan shell free from mojibake and uses a neutral score label', () => {
+    const source = componentSource()
 
-    expect(source).toContain('Respons & leescontext')
-    expect(source).toContain('Frictiescore')
-    expect(source).toContain('Verdeling van vertrekbeeld')
-    expect(source).toContain('Survey-stemmen')
-    expect(source).toContain('buildExitSurveyVoices')
-    expect(source).toContain('signal: presentation.signalDisplay')
-    expect(source).toContain('ExitDriversPriorityChart')
+    expect(source).not.toContain('Ã')
+    expect(source).not.toContain('Â')
+    expect(source).not.toContain('â')
+    expect(source).not.toContain('�')
+    expect(source).toContain('Gemiddelde signaalscore')
+    expect(source).not.toContain('Frictiescore')
+  })
+
+  it('renders the SDT layer only when real rows are available', () => {
+    const source = componentSource()
+
+    expect(source).toContain('sdtRows.length > 0')
     expect(source).toContain('ExitSdtNeedsChart')
-    expect(source).toContain('ExitOrgFactorsChart')
-    expect(source).toContain('buildFactorPresentation')
-    expect(source).toContain('Verdiepingslagen')
-    expect(source).toContain('n = ${responses.length}')
-  })
-
-  it('keeps the deeper generic campaign shell available for bounded routes and utility layers', () => {
-    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
-    const normalizedSource = source.replaceAll('"', "'")
-
-    expect(source).toContain('showClientExecutionFlow')
-    expect(source).toContain('Operatie, respondenten en uitvoering')
-    expect(normalizedSource).toContain("familyRoleLabel: 'Kernroute'")
-    expect(normalizedSource).toContain("familyRoleLabel: 'Begrensde peer-route'")
-    expect(normalizedSource).toContain("familyRoleLabel: 'Begrensde support-route'")
   })
 })

--- a/frontend/app/(dashboard)/campaigns/[id]/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/lib/dashboard/open-action-center-route";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { createClient } from "@/lib/supabase/server";
+import { ExitProductDashboard } from "@/components/dashboard/exit-product-dashboard";
 import { CampaignActions } from "./campaign-actions";
 import { PdfDownloadButton } from "./pdf-download-button";
 import {
@@ -36,11 +37,6 @@ import {
   ManagementReadNarratives,
   ManagementReadSection,
 } from "@/components/dashboard/management-read-primitives";
-import {
-  ExitDriversPriorityChart,
-  ExitOrgFactorsChart,
-  ExitSdtNeedsChart,
-} from "@/components/dashboard/exit-dashboard-visuals";
 import { DashboardTabs } from "@/components/dashboard/dashboard-tabs";
 import { FactorTable } from "@/components/dashboard/factor-table";
 import { GuidedSelfServePanel } from "@/components/dashboard/guided-self-serve-panel";
@@ -298,32 +294,6 @@ function buildExitPictureDistribution(responses: SurveyResponse[]) {
       { label: "Situationele context zichtbaar", value: `${toPercent(counts.situational)}%`, percent: toPercent(counts.situational) },
     ],
   }
-}
-
-function buildExitSurveyVoices(responses: SurveyResponse[]) {
-  const sanitize = (value: string) =>
-    value
-      .replace(/\s+/g, " ")
-      .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, "[verwijderd]")
-      .replace(/https?:\/\/\S+/gi, "[link verwijderd]")
-      .replace(/\+?\d[\d\s().-]{7,}\d/g, "[verwijderd]")
-      .trim()
-
-  const seen = new Set<string>()
-
-  return responses
-    .map((response) =>
-      sanitize(response.open_text_raw?.trim() || response.open_text_analysis?.trim() || ""),
-    )
-    .filter((text) => text.length >= 24)
-    .filter((text) => {
-      const normalized = text.toLowerCase()
-      if (seen.has(normalized)) return false
-      seen.add(normalized)
-      return true
-    })
-    .slice(0, 2)
-    .map((text) => (text.length > 180 ? `${text.slice(0, 177).trimEnd()}...` : text))
 }
 
 function buildExitNarratives(args: {
@@ -2163,6 +2133,10 @@ export default async function CampaignPage({ params }: Props) {
   const moduleBackLinkLabel = getDashboardModuleBackLinkLabel(stats.scan_type)
   const factorPriorityRows = buildFactorPriorityRows(factorData.orgAverages)
   const sdtRows = buildSdtRows(factorData.sdtAverages)
+  const responseContextNote = buildResponseContextNote(
+    stats.total_completed,
+    stats.completion_rate_pct ?? 0,
+  )
 
   if (
     showManagementOutput &&
@@ -2188,458 +2162,99 @@ export default async function CampaignPage({ params }: Props) {
         strongWorkSignalRate,
         distribution: exitDistribution,
       })
-      const remainingFactorRows = factorPriorityRows.slice(2)
-      const contextualFactorRows =
-        remainingFactorRows.length > 0 ? remainingFactorRows : factorPriorityRows.slice(0, 4)
-      const strongWorkSignalLabel =
-        strongWorkSignalRate !== null ? `${strongWorkSignalRate}%` : "Nog niet vrij"
-      const responseContextNote = buildResponseContextNote(
-        stats.total_completed,
-        stats.completion_rate_pct ?? 0,
+      const distributionSegments = [
+        {
+          label: "Werkfrictie",
+          value: `${exitDistribution.workPercent}%`,
+          percent: exitDistribution.workPercent,
+        },
+        {
+          label: "Trekfactoren",
+          value: `${exitDistribution.pullPercent}%`,
+          percent: exitDistribution.pullPercent,
+        },
+        {
+          label: "Situationele context",
+          value: `${exitDistribution.situationalPercent}%`,
+          percent: exitDistribution.situationalPercent,
+        },
+      ].filter((segment) => segment.percent > 0)
+      const dominantCategory =
+        [...distributionSegments].sort(
+          (left, right) => right.percent - left.percent,
+        )[0] ?? null
+      const contributingItems = [
+        secondFactor
+          ? {
+              label: "Meespelende factor",
+              value: secondFactor,
+              body: `${secondFactor} kleurt het vertrekbeeld mee naast de sterkste factor en hoort daarom in dezelfde analytische lezing thuis.`,
+            }
+          : null,
+        topContributingReasonLabel
+          ? {
+              label: "Meelezende context",
+              value: topContributingReasonLabel,
+              body: `${topContributingReasonLabel} komt als contextlaag terug onder de hoofdreden en helpt de samenhang van het vertrekbeeld te begrijpen.`,
+            }
+          : null,
+      ].filter(
+        (
+          item,
+        ): item is { label: string; value: string; body: string } =>
+          Boolean(item),
       )
-      const synthesisCards = [
-        {
-          label: "Hoofdredenen",
-          title: topExitReasonLabel ?? "Dominante vertrekreden nog niet vrij",
-          body:
-            topExitReasonLabel !== null
-              ? "Deze reden geeft de bestuurlijke hoofdrichting van het vertrekbeeld."
-              : "De route heeft nog niet genoeg leesbasis om een dominante vertrekreden stevig vrij te geven.",
-        },
-        {
-          label: "Meespelende factoren",
-          title:
-            topContributingReasonLabel ??
-            secondFactor ??
-            "Meespelende factor nog niet scherp genoeg",
-          body:
-            topContributingReasonLabel || secondFactor
-              ? `${topContributingReasonLabel ?? secondFactor} kleurt mee onder de hoofdreden en hoort daarom in dezelfde managementlezing thuis.`
-              : "Gebruik deze laag pas zodra een tweede factor of contextsignaal zichtbaar genoeg terugkomt.",
-        },
-        {
-          label: "Survey-stemmen",
-          title: `${strongWorkSignalLabel} sterk werksignaal`,
-          body:
-            strongWorkSignalRate !== null
-              ? `In ${strongWorkSignalRate}% van de leesbare responses staat werkfrictie vooraan. Daardoor blijven survey-stemmen vooral relevant als intern werkbeeld, niet als losse casuistiek.`
-              : "Gebruik survey-stemmen hier nog voorzichtig. Het groepsbeeld is nog niet stevig genoeg voor een scherp patroon per stemlaag.",
-        },
-        {
-          label: "Context",
-          title: `${organizationName} · ${scopeLabel}`,
-          body:
-            exitDistribution.total > 0
-              ? `Werkfrictie, trekfactoren en situationele context blijven bestuurlijk los relevant binnen deze scope. Lees ze samen, niet als concurrerende verklaringen.`
-              : "De contextlaag blijft op groepsniveau. Lees het patroon pas steviger zodra voldoende vertrekbeeld zichtbaar is.",
-        },
-      ]
-      const exitSurveyVoices = buildExitSurveyVoices(responses)
-
       return (
-        <div className="space-y-10">
-          <div className="space-y-4 border-b border-slate-200/80 pb-5">
-            <p className="text-[0.78rem] font-medium tracking-[0.01em] text-slate-500">
-              <Link href="/dashboard" className="transition-colors hover:text-slate-700">
-                Overzicht
-              </Link>{" "}
-              /{" "}
-              <Link href={moduleHref} className="transition-colors hover:text-slate-700">
-                {moduleLabel}
-              </Link>{" "}
-              / <span className="text-slate-700">{stats.campaign_name}</span>
-            </p>
-            <Link
-              href={moduleHref}
-              className="inline-flex items-center gap-2 text-sm font-medium text-slate-500 transition-colors hover:text-slate-700"
-            >
-              ← {moduleBackLinkLabel}
-            </Link>
-            <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-              <div className="space-y-3">
-                <div className="flex flex-wrap items-center gap-2.5">
-                  <span className="inline-flex rounded-full border border-[#E7D3BF] bg-[#FBF3E7] px-3 py-1 text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-[#A96026]">
-                    ExitScan
-                  </span>
-                  <span className="inline-flex rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-slate-600">
-                    {compositionStateMeta.label}
-                  </span>
-                </div>
-                <h1 className="font-serif text-[2.6rem] leading-[0.96] tracking-[-0.055em] text-[color:var(--dashboard-ink)] sm:text-[3.15rem]">
-                  {stats.campaign_name}
-                </h1>
-                <p className="text-sm leading-6 text-slate-600">
-                  {organizationName} · {routePeriodLabel} · {scopeLabel}
-                </p>
-              </div>
-              <div className="flex flex-wrap items-center gap-3">{headerActions}</div>
-            </div>
-          </div>
-
-          <section className="space-y-4 border-t border-slate-200/80 pt-6">
-            <div className="space-y-2">
-              <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-[color:var(--dashboard-muted)]">
-                Respons
-              </p>
-              <h2 className="font-serif text-[1.95rem] leading-[1.02] tracking-[-0.045em] text-[color:var(--dashboard-ink)]">
-                Respons & leescontext
-              </h2>
-            </div>
-            <div className="grid gap-4 lg:grid-cols-[minmax(0,0.95fr),minmax(0,1.05fr)] lg:items-start">
-              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-                {[
-                  { label: "Respons", value: `${stats.completion_rate_pct ?? 0}%` },
-                  { label: "Uitgenodigd", value: `${stats.total_invited}` },
-                  { label: "Ingevuld", value: `${stats.total_completed}` },
-                ].map((item) => (
-                  <div key={item.label} className="rounded-[18px] bg-[color:var(--dashboard-soft)]/62 px-4 py-4">
-                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
-                      {item.label}
-                    </p>
-                    <p className="mt-3 text-base font-semibold tracking-[-0.02em] text-[color:var(--dashboard-ink)]">
-                      {item.value}
-                    </p>
-                  </div>
-                ))}
-              </div>
-              <div className="rounded-[20px] bg-[color:var(--dashboard-soft)]/62 px-5 py-4 text-sm leading-6 text-[color:var(--dashboard-text)]">
-                {responseContextNote}
-              </div>
-            </div>
-          </section>
-
-          <section className="rounded-[30px] bg-[linear-gradient(180deg,rgba(255,250,245,0.98),rgba(249,242,235,0.94))] px-6 py-6 shadow-[0_18px_40px_rgba(17,24,39,0.06)] sm:px-7 sm:py-7">
-            <div className="flex flex-col gap-6 xl:grid xl:grid-cols-[minmax(0,1.2fr),minmax(340px,0.8fr)]">
-              <div className="space-y-5">
-                <div className="space-y-1">
-                  <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-[#A96026]">
-                    Kernbeeld nu
-                  </p>
-                </div>
-                <div className="grid gap-3 lg:grid-cols-2">
-                  <div className="rounded-[22px] border border-[#E7D7C6] bg-white/84 px-4 py-4">
-                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
-                      Wat speelt nu
-                    </p>
-                    <p className="mt-3 text-lg font-semibold tracking-[-0.03em] text-[color:var(--dashboard-ink)]">
-                      {topFactor ?? "De scherpste factor is nog niet vrij"}
-                    </p>
-                    <p className="mt-2 text-sm leading-6 text-[color:var(--dashboard-text)]">
-                      {topFactor
-                        ? `${topFactor} drukt nu het sterkst op het vertrekbeeld en hoort daarom de eerste lezing te openen.`
-                        : "De route is nog niet vrij genoeg om al één dominante factor stevig naar voren te trekken."}
-                    </p>
-                  </div>
-                  <div className="rounded-[22px] border border-[#E7D7C6] bg-white/84 px-4 py-4">
-                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
-                      Scherpste factor(en)
-                    </p>
-                    <div className="mt-3 space-y-3">
-                      <div>
-                        <p className="text-sm font-semibold text-[color:var(--dashboard-ink)]">
-                          {factorPriorityRows[0]?.factor ?? "Nog niet vrij"}
-                        </p>
-                        <p className="mt-1 text-sm text-slate-600">
-                          {factorPriorityRows[0]
-                            ? `${factorPriorityRows[0].score} · ${factorPriorityRows[0].signal ?? "Geen signaal"}`
-                            : "Nog geen stabiel factorbeeld"}
-                        </p>
-                      </div>
-                      <div className="border-t border-[#EEE4D8] pt-3">
-                        <p className="text-sm font-semibold text-[color:var(--dashboard-ink)]">
-                          {factorPriorityRows[1]?.factor ?? topExitReasonLabel ?? "Tweede laag nog niet scherp genoeg"}
-                        </p>
-                        <p className="mt-1 text-sm text-slate-600">
-                          {factorPriorityRows[1]
-                            ? `${factorPriorityRows[1].score} · ${factorPriorityRows[1].signal ?? "Geen signaal"}`
-                            : topExitReasonLabel
-                              ? `Dominante vertrekreden: ${topExitReasonLabel}`
-                              : "Nog geen tweede dragende factor zichtbaar"}
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
-                <div className="rounded-[24px] border border-[#E7D7C6] bg-white/88 px-5 py-5">
-                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
-                    Frictiescore
-                  </p>
-                  <p className="dash-number mt-3 text-[2.3rem] leading-none text-[color:var(--dashboard-ink)]">
-                    {averageRiskScore !== null ? `${averageRiskScore.toFixed(1)}/10` : "Nog niet vrij"}
-                  </p>
-                  <p className="mt-3 text-sm leading-6 text-[color:var(--dashboard-text)]">
-                    Dit is het gemiddelde frictieniveau in de leesbare responses. Hoe hoger de score, hoe vaker antwoorden wijzen op spanning of frictie in het werk.
-                  </p>
-                  <div className="mt-3 space-y-2 text-sm leading-6 text-[color:var(--dashboard-text)]">
-                    <p>
-                      Zie dit als de sterkte van het beeld: niet waar het vandaan komt, maar hoe zwaar de frictie gemiddeld naar voren komt.
-                    </p>
-                    <p>
-                      De score is opgebouwd uit patronen in de antwoorden op groepsniveau, niet uit één losse reden of één individuele response.
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </section>
-
-          <section className="space-y-4 border-t border-slate-200/80 pt-6">
-            <div className="space-y-2">
-              <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-[#2E756E]">
-                Drivers
-              </p>
-              <h2 className="font-serif text-[1.95rem] leading-[1.02] tracking-[-0.045em] text-[color:var(--dashboard-ink)]">
-                Drivers & prioriteitenbeeld
-              </h2>
-              <p className="max-w-4xl text-[1rem] leading-7 text-[color:var(--dashboard-text)]">
-                Deze pagina bundelt SDT-gebaseerde en organisatorische factoren in één prioriteitenbeeld. Daardoor zie je sneller welke thema&apos;s als eerste aandacht vragen.
-              </p>
-            </div>
-            <div className="grid gap-5 xl:grid-cols-[minmax(0,1.08fr),minmax(320px,0.92fr)]">
-              <ExitDriversPriorityChart rows={factorPriorityRows} />
-              <div>
-                <ManagementReadDistribution
-                  tone="exit"
-                  label="Vertrekbeeld"
-                  value={`${exitDistribution.workPercent}% werkfrictie`}
-                  narrative="Werkfrictie laat de richting van het beeld zien. Dit percentage betekent dat de meeste leesbare responses vooral wijzen naar factoren in werk, rol of organisatie, niet naar een externe trekfactor of alleen situatie."
-                  segments={exitDistribution.segments}
-                />
-              </div>
-            </div>
-            <div className="overflow-hidden rounded-[20px] border border-[color:var(--dashboard-frame-border)] bg-white/78">
-              <div className="border-b border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)]/72 px-5 py-3">
-                <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
-                  Factoren
-                </p>
-                <p className="mt-1 text-sm leading-6 text-[color:var(--dashboard-text)]">
-                  Rangorde op basis van lagere beleving en hoger signaal.
-                </p>
-              </div>
-              <div className="divide-y divide-[color:var(--dashboard-frame-border)]/80">
-                {factorPriorityRows.map((row, index) => {
-                  const severityWidth = Math.max(12, Math.min(100, (row.signalValue / 10) * 100))
-                  const severityTone =
-                    index === 0
-                      ? "bg-[#C36A29]"
-                      : index === 1
-                        ? "bg-[#D19422]"
-                        : index === 2
-                          ? "bg-[#D8A96B]"
-                          : "bg-[#D8CBB8]"
-
-                  return (
-                    <div
-                      key={row.factor}
-                      className="grid gap-3 px-5 py-4 lg:grid-cols-[58px_minmax(0,1.15fr)_180px_180px] lg:items-center lg:gap-5"
-                    >
-                      <div className="flex items-center gap-3">
-                        <span className="text-[1.1rem] font-semibold tabular-nums text-[color:var(--dashboard-ink)]">
-                          {String(index + 1).padStart(2, "0")}
-                        </span>
-                        <div className="hidden h-10 w-1.5 overflow-hidden rounded-full bg-[color:var(--dashboard-soft)] lg:block">
-                          <div
-                            className={`w-full rounded-full ${severityTone}`}
-                            style={{ height: `${severityWidth}%`, marginTop: `${100 - severityWidth}%` }}
-                          />
-                        </div>
-                      </div>
-                      <div className="space-y-1.5">
-                        <p className="text-sm font-semibold tracking-[-0.02em] text-[color:var(--dashboard-ink)]">
-                          {row.factor}
-                        </p>
-                        <p className="text-sm leading-6 text-[color:var(--dashboard-text)]">
-                          {row.note}
-                        </p>
-                      </div>
-                      <div>
-                        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
-                          Beleving
-                        </p>
-                        <p className="mt-1 text-sm font-semibold tabular-nums text-[color:var(--dashboard-ink)]">
-                          {row.score}
-                        </p>
-                      </div>
-                      <div>
-                        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
-                          Signaal
-                        </p>
-                        <p className="mt-1 text-sm font-semibold tabular-nums text-[color:var(--dashboard-ink)]">
-                          {row.signal ?? "Nog niet vrij"}
-                        </p>
-                      </div>
-                    </div>
-                  )
-                })}
-              </div>
-            </div>
-          </section>
-
-          <section className="space-y-4 border-t border-slate-200/80 pt-6">
-            <div className="space-y-2">
-              <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-[color:var(--dashboard-muted)]">
-                Synthese
-              </p>
-              <h2 className="font-serif text-[1.95rem] leading-[1.02] tracking-[-0.045em] text-[color:var(--dashboard-ink)]">
-                Synthese van vertrekbeeld
-              </h2>
-            </div>
-            <div className="grid gap-4 xl:grid-cols-2">
-              {synthesisCards.map((card) => (
-                <div
-                  key={card.label}
-                  className="rounded-[20px] bg-[color:var(--dashboard-soft)]/52 px-5 py-5"
-                >
-                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
-                    {card.label}
-                  </p>
-                  <h3 className="mt-3 text-[1.08rem] font-semibold tracking-[-0.03em] text-[color:var(--dashboard-ink)]">
-                    {card.title}
-                  </h3>
-                  <p className="mt-3 text-sm leading-6 text-[color:var(--dashboard-text)]">
-                    {card.body}
-                  </p>
-                </div>
-              ))}
-            </div>
-            <div className="grid gap-4 xl:grid-cols-[minmax(0,0.95fr),minmax(0,1.05fr)]">
-              <div className="rounded-[20px] bg-[color:var(--dashboard-soft)]/52 px-5 py-5">
-                <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
-                  Verdeling van vertrekbeeld
-                </p>
-                <p className="mt-3 text-sm leading-6 text-[color:var(--dashboard-text)]">
-                  Zo zie je hoe het leesbare vertrekbeeld verdeeld is tussen werkfrictie, trekfactoren en situationele context.
-                </p>
-                <div className="mt-4 flex h-3 overflow-hidden rounded-full bg-white/85">
-                  {exitDistribution.segments.map((segment, index) => {
-                    const fillTone =
-                      index === 0 ? "bg-[#C36A29]" : index === 1 ? "bg-[#D7A16B]" : "bg-[#D9D3CA]"
-
-                    return (
-                      <div
-                        key={`stack-${segment.label}`}
-                        className={fillTone}
-                        style={{ width: `${Math.max(0, Math.min(100, segment.percent))}%` }}
-                      />
-                    )
-                  })}
-                </div>
-                <div className="mt-4 space-y-3">
-                  {exitDistribution.segments.map((segment, index) => {
-                    const fillTone =
-                      index === 0 ? "bg-[#C36A29]" : index === 1 ? "bg-[#D7A16B]" : "bg-[#D9D3CA]"
-
-                    return (
-                      <div key={segment.label} className="space-y-1.5">
-                        <div className="flex items-center justify-between gap-3 text-sm text-slate-700">
-                          <span>{segment.label}</span>
-                          <span className="font-semibold text-[color:var(--dashboard-ink)]">
-                            {segment.value}
-                          </span>
-                        </div>
-                        <div className="h-2.5 overflow-hidden rounded-full bg-white/85">
-                          <div
-                            className={`h-full rounded-full ${fillTone}`}
-                            style={{ width: `${Math.max(0, Math.min(100, segment.percent))}%` }}
-                          />
-                        </div>
-                      </div>
-                    )
-                  })}
-                </div>
-              </div>
-              <div className="rounded-[20px] bg-[color:var(--dashboard-soft)]/52 px-5 py-5">
-                <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
-                  Survey-stemmen
-                </p>
-                <p className="mt-3 text-sm leading-6 text-[color:var(--dashboard-text)]">
-                  Korte anonieme stemmen uit de open antwoorden, zodat zichtbaar blijft dat er echte signalen onder het beeld liggen.
-                </p>
-                <div className="mt-4 space-y-3">
-                  {exitSurveyVoices.length > 0 ? (
-                    exitSurveyVoices.map((voice, index) => (
-                      <div key={`${index}-${voice}`} className="rounded-[16px] bg-white/85 px-4 py-4">
-                        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
-                          Anonieme stem {index + 1}
-                        </p>
-                        <p className="mt-2 text-sm italic leading-6 text-[color:var(--dashboard-text)]">
-                          &quot;{voice}&quot;
-                        </p>
-                      </div>
-                    ))
-                  ) : (
-                    <div className="rounded-[16px] bg-white/85 px-4 py-4">
-                      <p className="text-sm leading-6 text-[color:var(--dashboard-text)]">
-                        Nog geen open antwoorden scherp genoeg vrijgegeven voor een compacte stemlaag.
-                      </p>
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div>
-            {exitNarratives.length > 0 ? (
-              <div className="border-t border-slate-200/80 pt-5">
-                <ManagementReadNarratives items={exitNarratives} />
-              </div>
-            ) : null}
-          </section>
-
-          <section className="space-y-4 border-t border-slate-200/80 pt-6">
-            <div className="space-y-2">
-              <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-[color:var(--dashboard-muted)]">
-                Verdieping
-              </p>
-              <h2 className="font-serif text-[1.95rem] leading-[1.02] tracking-[-0.045em] text-[color:var(--dashboard-ink)]">
-                Verdiepingslagen
-              </h2>
-              <p className="max-w-4xl text-[1rem] leading-7 text-[color:var(--dashboard-text)]">
-                SDT, organisatiefactoren en aanvullende context blijven bewust secundair. Ze zijn nuttig voor verdieping, niet voor de eerste lezing.
-              </p>
-            </div>
-            <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr),minmax(0,1fr),minmax(300px,0.82fr)]">
-              <ExitSdtNeedsChart rows={sdtRows} />
-              <ExitOrgFactorsChart rows={contextualFactorRows} />
-              <div className="rounded-[20px] bg-[color:var(--dashboard-soft)]/52 px-5 py-5">
-                <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-[color:var(--dashboard-muted)]">
-                  Aanvullende context
-                </p>
-                <div className="mt-4 space-y-4 text-sm leading-6 text-[color:var(--dashboard-text)]">
-                  <div>
-                    <p className="font-semibold text-[color:var(--dashboard-ink)]">
-                      Dominante vertrekreden
-                    </p>
-                    <p className="mt-1">
-                      {topExitReasonLabel ?? "Nog niet stevig genoeg zichtbaar"}
-                    </p>
-                  </div>
-                  <div className="border-t border-[color:var(--dashboard-frame-border)] pt-4">
-                    <p className="font-semibold text-[color:var(--dashboard-ink)]">
-                      Meelezende context
-                    </p>
-                    <p className="mt-1">
-                      {topContributingReasonLabel ??
-                        "Nog geen meelezende contextcode scherp genoeg vrijgegeven"}
-                    </p>
-                  </div>
-                  <div className="border-t border-[color:var(--dashboard-frame-border)] pt-4">
-                    <p className="font-semibold text-[color:var(--dashboard-ink)]">
-                      Signaalzichtbaarheid
-                    </p>
-                    <p className="mt-1">
-                      {signalVisibilityAverage !== null
-                        ? `${signalVisibilityAverage.toFixed(1)}/10 zichtbaar in deze wave.`
-                        : "Nog niet stevig genoeg om als extra zichtbaarheidssignaal te lezen."}
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </section>
-
-        </div>
+        <ExitProductDashboard
+          moduleHref={moduleHref}
+          moduleLabel={moduleLabel}
+          moduleBackLinkLabel={moduleBackLinkLabel}
+          campaignName={stats.campaign_name}
+          organizationName={organizationName}
+          routePeriodLabel={routePeriodLabel}
+          scopeLabel={scopeLabel}
+          statusLabel={compositionStateMeta.label}
+          headerActions={headerActions}
+          averageSignalScoreLabel={
+            averageRiskScore !== null
+              ? `${averageRiskScore.toFixed(1)}/10`
+              : "Nog niet beschikbaar"
+          }
+          strongestFactorLabel={topFactor ?? "Nog niet beschikbaar"}
+          strongWorkSignalLabel={
+            responses.some((response) => Boolean(response.preventability))
+              ? `${strongWorkSignalRate}%`
+              : "Nog niet beschikbaar"
+          }
+          primaryReasonTitle={
+            topExitReasonLabel ?? dominantCategory?.label ?? "Nog niet beschikbaar"
+          }
+          primaryReasonBody={
+            topExitReasonLabel !== null
+              ? "Deze hoofdreden komt het vaakst terug in de leesbare responses en opent daarom als eerste de analytische lezing van dit vertrekbeeld."
+              : dominantCategory !== null
+                ? `${dominantCategory.value} van het leesbare vertrekbeeld valt in ${dominantCategory.label.toLowerCase()}. Daarmee is dit nu de dominante categorie in deze wave.`
+                : "Onvoldoende data om een hoofdreden of dominante categorie eerlijk vrij te geven."
+          }
+          whyItMattersItems={exitNarratives}
+          contributingItems={contributingItems}
+          totalInvited={String(stats.total_invited)}
+          totalCompleted={String(stats.total_completed)}
+          responseRate={`${stats.completion_rate_pct}%`}
+          responseContextNote={responseContextNote}
+          topFactors={factorPriorityRows}
+          distributionSegments={distributionSegments}
+          factorRows={factorPriorityRows}
+          sdtRows={sdtRows}
+          methodologyContent={
+            <MethodologyCard
+              scanType={stats.scan_type}
+              hasSegmentDeepDive={hasSegmentDeepDive}
+              signalLabel={scanDefinition.signalLabel}
+              embedded
+            />
+          }
+        />
       )
     }
 
@@ -3850,4 +3465,5 @@ export default async function CampaignPage({ params }: Props) {
     </div>
   );
 }
+
 

--- a/frontend/components/dashboard/exit-product-dashboard.tsx
+++ b/frontend/components/dashboard/exit-product-dashboard.tsx
@@ -1,0 +1,445 @@
+import type { ReactNode } from 'react'
+import Link from 'next/link'
+import { DashboardChip } from '@/components/dashboard/dashboard-primitives'
+import { ManagementReadFactorTable } from '@/components/dashboard/management-read-primitives'
+import {
+  ExitDriversPriorityChart,
+  ExitOrgFactorsChart,
+  ExitSdtNeedsChart,
+} from '@/components/dashboard/exit-dashboard-visuals'
+
+type FactorRow = {
+  factor: string
+  score: string
+  scoreValue: number
+  signal?: string
+  signalValue: number
+  band: string
+  note: string
+}
+
+type SdtRow = {
+  factor: string
+  score: string
+  scoreValue: number
+  signal: string
+  band: string
+  note: string
+}
+
+type NarrativeItem = {
+  title: string
+  tag: string
+  body: string
+}
+
+type DistributionSegment = {
+  label: string
+  value: string
+  percent: number
+}
+
+type ContributingItem = {
+  label: string
+  value: string
+  body: string
+}
+
+interface ExitProductDashboardProps {
+  moduleHref: string
+  moduleLabel: string
+  moduleBackLinkLabel: string
+  campaignName: string
+  organizationName: string
+  routePeriodLabel: string
+  scopeLabel: string
+  statusLabel: string
+  headerActions: ReactNode
+  averageSignalScoreLabel: string
+  strongestFactorLabel: string
+  strongWorkSignalLabel: string
+  primaryReasonTitle: string
+  primaryReasonBody: string
+  whyItMattersItems: NarrativeItem[]
+  contributingItems: ContributingItem[]
+  totalInvited: string
+  totalCompleted: string
+  responseRate: string
+  responseContextNote: string
+  topFactors: FactorRow[]
+  distributionSegments: DistributionSegment[]
+  factorRows: FactorRow[]
+  sdtRows: SdtRow[]
+  methodologyContent: ReactNode
+}
+
+function SectionShell({
+  id,
+  eyebrow,
+  title,
+  children,
+}: {
+  id: string
+  eyebrow: string
+  title: string
+  children: ReactNode
+}) {
+  return (
+    <section id={id} className="space-y-4 border-t border-slate-200/80 pt-6">
+      <div className="space-y-2">
+        <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-[color:var(--dashboard-muted)]">
+          {eyebrow}
+        </p>
+        <h2 className="font-serif text-[1.95rem] leading-[1.02] tracking-[-0.045em] text-[color:var(--dashboard-ink)]">
+          {title}
+        </h2>
+      </div>
+      {children}
+    </section>
+  )
+}
+
+function DataGapCard({
+  title = 'Onvoldoende data',
+  body = 'Nog niet beschikbaar voor een eerlijke analytische weergave.',
+}: {
+  title?: string
+  body?: string
+}) {
+  return (
+    <div className="rounded-[20px] border border-dashed border-slate-200 bg-slate-50 px-5 py-5">
+      <p className="text-sm font-semibold text-[color:var(--dashboard-ink)]">{title}</p>
+      <p className="mt-2 text-sm leading-6 text-[color:var(--dashboard-text)]">{body}</p>
+    </div>
+  )
+}
+
+export function ExitProductDashboard({
+  moduleHref,
+  moduleLabel,
+  moduleBackLinkLabel,
+  campaignName,
+  organizationName,
+  routePeriodLabel,
+  scopeLabel,
+  statusLabel,
+  headerActions,
+  averageSignalScoreLabel,
+  strongestFactorLabel,
+  strongWorkSignalLabel,
+  primaryReasonTitle,
+  primaryReasonBody,
+  whyItMattersItems,
+  contributingItems,
+  totalInvited,
+  totalCompleted,
+  responseRate,
+  responseContextNote,
+  topFactors,
+  distributionSegments,
+  factorRows,
+  sdtRows,
+  methodologyContent,
+}: ExitProductDashboardProps) {
+  const topFactorCards = topFactors.slice(0, 4)
+
+  return (
+    <div className="space-y-10">
+      <div className="space-y-4 border-b border-slate-200/80 pb-5">
+        <p className="text-[0.78rem] font-medium tracking-[0.01em] text-slate-500">
+          <Link href="/dashboard" className="transition-colors hover:text-slate-700">
+            Overzicht
+          </Link>{' '}
+          /{' '}
+          <Link href={moduleHref} className="transition-colors hover:text-slate-700">
+            {moduleLabel}
+          </Link>{' '}
+          / <span className="text-slate-700">{campaignName}</span>
+        </p>
+        <Link
+          href={moduleHref}
+          className="inline-flex items-center gap-2 text-sm font-medium text-slate-500 transition-colors hover:text-slate-700"
+        >
+          <span aria-hidden="true">&larr;</span> {moduleBackLinkLabel}
+        </Link>
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div className="space-y-3">
+            <div className="flex flex-wrap items-center gap-2.5">
+              <DashboardChip label="ExitScan" tone="amber" />
+              <DashboardChip label={statusLabel} tone="slate" />
+            </div>
+            <h1 className="font-serif text-[2.6rem] leading-[0.96] tracking-[-0.055em] text-[color:var(--dashboard-ink)] sm:text-[3.15rem]">
+              {campaignName}
+            </h1>
+            <p className="text-sm leading-6 text-slate-600">
+              {organizationName} <span aria-hidden="true">&middot;</span> {routePeriodLabel}{' '}
+              <span aria-hidden="true">&middot;</span> {scopeLabel}
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-3">{headerActions}</div>
+        </div>
+      </div>
+
+      <SectionShell id="sterkste-signaal" eyebrow="1. Kernsignaal" title="Sterkste signaal">
+        <div className="grid gap-4 xl:grid-cols-[minmax(0,1.05fr),minmax(280px,0.95fr)]">
+          <div className="rounded-[30px] bg-[linear-gradient(180deg,rgba(255,250,245,0.98),rgba(249,242,235,0.94))] px-6 py-6 shadow-[0_18px_40px_rgba(17,24,39,0.06)] sm:px-7 sm:py-7">
+            <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[#A96026]">
+              Gemiddelde signaalscore
+            </p>
+            <p className="dash-number mt-3 text-[2.6rem] leading-none text-[color:var(--dashboard-ink)]">
+              {averageSignalScoreLabel}
+            </p>
+            <p className="mt-3 text-sm leading-6 text-[color:var(--dashboard-text)]">
+              Dit is het sterkste analytische openingssignaal van deze ExitScan. Het laat zien
+              hoe zwaar het gemeten signaal gemiddeld terugkomt in de leesbare responses.
+            </p>
+          </div>
+          <div className="grid gap-4">
+            <div className="rounded-[22px] border border-slate-200 bg-white/88 px-5 py-5">
+              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                Sterkste factor
+              </p>
+              <p className="mt-3 text-lg font-semibold tracking-[-0.03em] text-[color:var(--dashboard-ink)]">
+                {strongestFactorLabel}
+              </p>
+            </div>
+            <div className="rounded-[22px] border border-slate-200 bg-white/88 px-5 py-5">
+              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                Sterk werksignaal
+              </p>
+              <p className="mt-3 text-lg font-semibold tracking-[-0.03em] text-[color:var(--dashboard-ink)]">
+                {strongWorkSignalLabel}
+              </p>
+            </div>
+          </div>
+        </div>
+      </SectionShell>
+
+      <SectionShell id="waarom-dit-telt" eyebrow="2. Uitleg" title="Waarom dit telt">
+        {whyItMattersItems.length > 0 ? (
+          <div className="grid gap-4 xl:grid-cols-3">
+            {whyItMattersItems.map((item) => (
+              <div
+                key={`${item.tag}-${item.title}`}
+                className="rounded-[20px] bg-[color:var(--dashboard-soft)]/52 px-5 py-5"
+              >
+                <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
+                  {item.tag}
+                </p>
+                <h3 className="mt-3 text-[1.08rem] font-semibold tracking-[-0.03em] text-[color:var(--dashboard-ink)]">
+                  {item.title}
+                </h3>
+                <p className="mt-3 text-sm leading-6 text-[color:var(--dashboard-text)]">
+                  {item.body}
+                </p>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <DataGapCard />
+        )}
+      </SectionShell>
+
+      <SectionShell
+        id="hoofdreden-vertrekbeeld"
+        eyebrow="3. Hoofdreden"
+        title="Hoofdreden van vertrekbeeld"
+      >
+        <div className="rounded-[22px] border border-slate-200 bg-white px-5 py-5 shadow-[0_12px_28px_rgba(19,32,51,0.05)]">
+          <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Dominante lezing
+          </p>
+          <h3 className="mt-3 text-[1.3rem] font-semibold tracking-[-0.03em] text-[color:var(--dashboard-ink)]">
+            {primaryReasonTitle}
+          </h3>
+          <p className="mt-3 max-w-3xl text-sm leading-6 text-[color:var(--dashboard-text)]">
+            {primaryReasonBody}
+          </p>
+        </div>
+      </SectionShell>
+
+      <SectionShell
+        id="meespelende-factoren"
+        eyebrow="4. Samenhang"
+        title="Meespelende factoren"
+      >
+        {contributingItems.length > 0 ? (
+          <div className="grid gap-4 xl:grid-cols-2">
+            {contributingItems.map((item) => (
+              <div
+                key={item.label}
+                className="rounded-[20px] bg-[color:var(--dashboard-soft)]/52 px-5 py-5"
+              >
+                <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
+                  {item.label}
+                </p>
+                <h3 className="mt-3 text-[1.08rem] font-semibold tracking-[-0.03em] text-[color:var(--dashboard-ink)]">
+                  {item.value}
+                </h3>
+                <p className="mt-3 text-sm leading-6 text-[color:var(--dashboard-text)]">
+                  {item.body}
+                </p>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <DataGapCard body="Nog niet beschikbaar voor een tweede analytische laag." />
+        )}
+      </SectionShell>
+
+      <SectionShell id="responscontext" eyebrow="5. Respons" title="Responscontext">
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,0.95fr),minmax(0,1.05fr)] lg:items-start">
+          <div className="grid gap-3 sm:grid-cols-3">
+            {[
+              { label: 'Respons', value: responseRate },
+              { label: 'Uitgenodigd', value: totalInvited },
+              { label: 'Ingevuld', value: totalCompleted },
+            ].map((item) => (
+              <div
+                key={item.label}
+                className="rounded-[18px] bg-[color:var(--dashboard-soft)]/62 px-4 py-4"
+              >
+                <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
+                  {item.label}
+                </p>
+                <p className="mt-3 text-base font-semibold tracking-[-0.02em] text-[color:var(--dashboard-ink)]">
+                  {item.value}
+                </p>
+              </div>
+            ))}
+          </div>
+          <div className="rounded-[20px] bg-[color:var(--dashboard-soft)]/62 px-5 py-4 text-sm leading-6 text-[color:var(--dashboard-text)]">
+            {responseContextNote}
+          </div>
+        </div>
+      </SectionShell>
+
+      <SectionShell id="topfactoren" eyebrow="6. Factoren" title="Topfactoren">
+        {topFactorCards.length > 0 ? (
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+            {topFactorCards.map((row) => (
+              <div
+                key={row.factor}
+                className="rounded-[22px] border border-slate-200 bg-white px-5 py-5"
+              >
+                <p className="text-sm font-semibold text-[color:var(--dashboard-ink)]">
+                  {row.factor}
+                </p>
+                <div className="mt-4 space-y-3 text-sm text-[color:var(--dashboard-text)]">
+                  <div className="flex items-center justify-between gap-3">
+                    <span>Beleving</span>
+                    <span className="font-semibold text-[color:var(--dashboard-ink)]">
+                      {row.score}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between gap-3">
+                    <span>Signaalsterkte</span>
+                    <span className="font-semibold text-[color:var(--dashboard-ink)]">
+                      {row.signal ?? 'Nog niet beschikbaar'}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between gap-3">
+                    <span>Managementband</span>
+                    <span className="font-semibold text-[color:var(--dashboard-ink)]">
+                      {row.band}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <DataGapCard />
+        )}
+      </SectionShell>
+
+      <SectionShell
+        id="verdeling-vertrekbeeld"
+        eyebrow="7. Verdeling"
+        title="Verdeling van het vertrekbeeld"
+      >
+        {distributionSegments.length > 0 ? (
+          <div className="grid gap-4 xl:grid-cols-[minmax(0,0.92fr),minmax(0,1.08fr)]">
+            <div className="rounded-[20px] bg-[color:var(--dashboard-soft)]/52 px-5 py-5">
+              <p className="text-sm leading-6 text-[color:var(--dashboard-text)]">
+                Zo verdeelt het leesbare vertrekbeeld zich over werkfrictie, trekfactoren en
+                situationele context.
+              </p>
+              <div className="mt-4 flex h-3 overflow-hidden rounded-full bg-white/85">
+                {distributionSegments.map((segment, index) => {
+                  const fillTone =
+                    index === 0 ? 'bg-[#C36A29]' : index === 1 ? 'bg-[#D7A16B]' : 'bg-[#D9D3CA]'
+
+                  return (
+                    <div
+                      key={`stack-${segment.label}`}
+                      className={fillTone}
+                      style={{ width: `${Math.max(0, Math.min(100, segment.percent))}%` }}
+                    />
+                  )
+                })}
+              </div>
+            </div>
+            <div className="space-y-3">
+              {distributionSegments.map((segment, index) => {
+                const fillTone =
+                  index === 0 ? 'bg-[#C36A29]' : index === 1 ? 'bg-[#D7A16B]' : 'bg-[#D9D3CA]'
+
+                return (
+                  <div
+                    key={segment.label}
+                    className="rounded-[20px] bg-[color:var(--dashboard-soft)]/52 px-5 py-4"
+                  >
+                    <div className="flex items-center justify-between gap-3 text-sm text-slate-700">
+                      <span>{segment.label}</span>
+                      <span className="font-semibold text-[color:var(--dashboard-ink)]">
+                        {segment.value}
+                      </span>
+                    </div>
+                    <div className="mt-3 h-2.5 overflow-hidden rounded-full bg-white/85">
+                      <div
+                        className={`h-full rounded-full ${fillTone}`}
+                        style={{ width: `${Math.max(0, Math.min(100, segment.percent))}%` }}
+                      />
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        ) : (
+          <DataGapCard />
+        )}
+      </SectionShell>
+
+      <SectionShell id="driverlaag" eyebrow="8. Drivers" title="Diepere driverlaag">
+        {factorRows.length > 0 ? <ExitDriversPriorityChart rows={factorRows} /> : <DataGapCard />}
+      </SectionShell>
+
+      {sdtRows.length > 0 ? (
+        <SectionShell id="sdt-laag" eyebrow="9. SDT" title="SDT-laag">
+          <ExitSdtNeedsChart rows={sdtRows} />
+        </SectionShell>
+      ) : null}
+
+      <SectionShell id="factorlaag" eyebrow="10. Factoren" title="Uitgebreide factorlaag">
+        {factorRows.length > 0 ? (
+          <div className="space-y-5">
+            <ExitOrgFactorsChart rows={factorRows} />
+            <ManagementReadFactorTable rows={factorRows} />
+          </div>
+        ) : (
+          <DataGapCard />
+        )}
+      </SectionShell>
+
+      <SectionShell
+        id="methodische-leesgrenzen"
+        eyebrow="11. Methode"
+        title="Methodische leesgrenzen"
+      >
+        {methodologyContent}
+      </SectionShell>
+    </div>
+  )
+}


### PR DESCRIPTION
## Samenvatting
- herbouwt de productpagina als zuivere analytische dashboardlaag
- houdt ExitScan bounded tot signaal, context, drivers, SDT en leesgrenzen
- verwijdert routebeheer- en setupdrift uit de zichtbare productview

## Scope
- `campaigns/[id]` productweergave en helperlaag
- nieuwe `exit-product-dashboard` component

## Verificatie
- vitest op `page.test.ts`, `page.route-shell.test.ts` en `page-helpers.test.ts`
- eslint op de productdashboard-slice