### PR TITLE
Action Center Teams scope view

### DIFF
--- a/frontend/app/(dashboard)/action-center/action-center-teams-view.test.ts
+++ b/frontend/app/(dashboard)/action-center/action-center-teams-view.test.ts
@@ -1,0 +1,174 @@
+import { readFileSync } from 'node:fs'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import { ActionCenterTeamsView } from '@/components/dashboard/action-center-teams-view'
+import type { ActionCenterPreviewItem } from '@/lib/action-center-preview-model'
+
+type ButtonElement = React.ReactElement<{
+  children?: React.ReactNode
+  onClick?: () => void
+  'data-team-id'?: string
+}>
+
+function buildItem(overrides: Partial<ActionCenterPreviewItem> = {}): ActionCenterPreviewItem {
+  return {
+    id: 'item-1',
+    code: 'ACT-1001',
+    title: 'Exit follow-through voorjaar',
+    summary: 'Een eerste bounded opvolgroute staat open.',
+    reason: 'Waarom dit nu eerst aandacht vraagt.',
+    sourceLabel: 'ExitScan',
+    orgId: 'org-1',
+    scopeType: 'department',
+    teamId: 'operations',
+    teamLabel: 'Operations',
+    ownerId: 'manager-1',
+    ownerName: 'Manager Operations',
+    ownerRole: 'Manager',
+    ownerSubtitle: 'Operations',
+    reviewOwnerName: 'HR lead',
+    priority: 'hoog',
+    status: 'in-uitvoering',
+    reviewDate: '2026-05-05',
+    expectedEffect: 'Maak het eerste verbeterpunt expliciet.',
+    reviewReason: 'Toets of de bounded stap zichtbaar is.',
+    reviewOutcome: 'bijstellen',
+    reviewDateLabel: '5 mei',
+    reviewRhythm: 'Maandelijks',
+    signalLabel: 'ExitScan - Exit voorjaar',
+    signalBody: 'Deze route vraagt nu een eerste bounded reactie.',
+    nextStep: 'Plan de eerste managerstap.',
+    peopleCount: 38,
+    coreSemantics: {} as ActionCenterPreviewItem['coreSemantics'],
+    openSignals: [],
+    updates: [],
+    ...overrides,
+  }
+}
+
+function collectButtons(node: React.ReactNode): ButtonElement[] {
+  const found: ButtonElement[] = []
+
+  function visit(value: React.ReactNode) {
+    if (!value) return
+    if (Array.isArray(value)) {
+      value.forEach(visit)
+      return
+    }
+    if (React.isValidElement(value)) {
+      const element = value as ButtonElement
+      if (element.type === 'button') {
+        found.push(element)
+      }
+      visit(element.props.children)
+    }
+  }
+
+  visit(node)
+  return found
+}
+
+describe('action center teams view', () => {
+  it('keeps the source copy free from mojibake markers', () => {
+    const source = readFileSync(new URL('../../../components/dashboard/action-center-teams-view.tsx', import.meta.url), 'utf8')
+
+    expect(source).not.toMatch(/Ã|Â|â|�/)
+    expect(source).toContain("{' · '}")
+    expect(source).toContain('één open opvolgingsroute')
+    expect(source).toContain('Minstens één route vraagt deze week aandacht.')
+  })
+
+  it('renders an empty state without crashing when no items are visible', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(ActionCenterTeamsView, {
+        items: [],
+        selectedTeamId: null,
+        onSelectTeam: () => {},
+        onNavigateToActions: () => {},
+        canAssignManagers: false,
+      }),
+    )
+
+    expect(html).toContain('Nog geen teams zichtbaar')
+    expect(html).toContain('Zodra opvolgingsroutes aan teamscopes zijn gekoppeld, verschijnt hier het teamoverzicht.')
+  })
+
+  it('renders the agreed scope copy and hides a zero people label in detail', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(ActionCenterTeamsView, {
+        items: [
+          buildItem({
+            id: 'item-1',
+            ownerId: null,
+            ownerName: null,
+            peopleCount: 0,
+          }),
+          buildItem({
+            id: 'item-2',
+            title: 'Tweede bounded stap',
+            teamId: 'operations',
+            teamLabel: 'Operations',
+            ownerId: null,
+            ownerName: null,
+            peopleCount: 0,
+          }),
+        ],
+        selectedTeamId: 'operations',
+        onSelectTeam: () => {},
+        onNavigateToActions: () => {},
+        canAssignManagers: false,
+      }),
+    )
+
+    expect(html).toContain('Action Center / Teams in scope')
+    expect(html).toContain('ACTION CENTER')
+    expect(html).toContain('Teams in scope')
+    expect(html).toContain('Bekijk welke teams of afdelingen aan opvolging, managers en reviews zijn gekoppeld.')
+    expect(html).toContain('Niet gekoppeld')
+    expect(html).toContain('Review deze week')
+    expect(html).not.toContain('0 mensen')
+    expect(html).not.toMatch(/Ã|Â|â|�/)
+  })
+
+  it('calls the row select callback with the clicked team id', () => {
+    const onSelectTeam = vi.fn()
+    const tree = ActionCenterTeamsView({
+      items: [
+        buildItem(),
+        buildItem({ id: 'item-2', teamId: 'support', teamLabel: 'Support', ownerId: null, ownerName: null }),
+      ],
+      selectedTeamId: null,
+      onSelectTeam,
+      onNavigateToActions: () => {},
+      canAssignManagers: false,
+    })
+
+    const rowButtons = collectButtons(tree).filter((button) => button.props['data-team-id'])
+    expect(rowButtons).toHaveLength(2)
+    expect(typeof rowButtons[1]?.props.onClick).toBe('function')
+
+    rowButtons[1].props.onClick?.()
+    expect(onSelectTeam).toHaveBeenCalledWith('support')
+  })
+
+  it('calls the navigate callback when an open action is clicked in the detail panel', () => {
+    const onNavigateToActions = vi.fn()
+    const tree = ActionCenterTeamsView({
+      items: [buildItem()],
+      selectedTeamId: 'operations',
+      onSelectTeam: () => {},
+      onNavigateToActions,
+      canAssignManagers: false,
+    })
+
+    const detailButtons = collectButtons(tree).filter(
+      (button) => !button.props['data-team-id'] && typeof button.props.onClick === 'function',
+    )
+    expect(detailButtons.length).toBeGreaterThan(0)
+    expect(typeof detailButtons[0]?.props.onClick).toBe('function')
+
+    detailButtons[0].props.onClick?.()
+    expect(onNavigateToActions).toHaveBeenCalledWith('item-1')
+  })
+})

--- a/frontend/app/(dashboard)/action-center/page.route-shell.test.ts
+++ b/frontend/app/(dashboard)/action-center/page.route-shell.test.ts
@@ -1140,7 +1140,7 @@ describe("action center landing shell", () => {
     expect((markup.match(/Vervolg op eerdere route/g) ?? []).length).toBe(1);
   });
 
-  it("shows team Review < 7 dagen for upcoming reviews within the next week", () => {
+  it("shows the agreed team review labels for upcoming reviews within the next week", () => {
     const context = buildLiveContext();
     const [item] = buildLiveActionCenterItems([
       {
@@ -1164,8 +1164,10 @@ describe("action center landing shell", () => {
       }),
     );
 
-    expect(markup).toContain("Review &lt; 7 dagen");
-    expect(markup).toMatch(/Review &lt; 7 dagen<\/p><\/div><p[^>]*>1<\/p>/);
+    expect(markup).toContain("Review eerstvolgt");
+    expect(markup).toContain("binnen 7 dagen");
+    expect(markup).toContain("Review deze week");
+    expect(markup).toContain(`Volgende bespreking ${item.reviewDateLabel}`);
   });
 
   it("requires preview items to carry canonical core semantics as one grouped field", () => {

--- a/frontend/components/dashboard/action-center-preview.tsx
+++ b/frontend/components/dashboard/action-center-preview.tsx
@@ -26,6 +26,7 @@ import {
   getLiveActionCenterSummary,
   type ActionCenterWorkspaceReadbackSummary,
 } from '@/lib/action-center-live'
+import { buildActionCenterTeamRows } from '@/lib/action-center-teams-view'
 import type {
   ActionCenterPreviewItem,
   ActionCenterPreviewManagerOption,
@@ -33,6 +34,7 @@ import type {
   ActionCenterPreviewStatus,
   ActionCenterPreviewView,
 } from '@/lib/action-center-preview-model'
+import { ActionCenterTeamsView } from '@/components/dashboard/action-center-teams-view'
 import type {
   ActionCenterManagerActionThemeKey,
   ActionCenterManagerResponse,
@@ -624,63 +626,6 @@ function getViewCopy(view: ActionCenterPreviewView, selectedTitle: string | null
   }
 }
 
-function buildTeamRows(items: ActionCenterPreviewItem[]) {
-  const now = new Date()
-  const rows = new Map<
-    string,
-    {
-      id: string
-      orgId: string | null
-      scopeType: 'department' | 'item' | 'org'
-      label: string
-      peopleCount: number
-      currentManagerId: string | null | undefined
-      currentManagerName: string | null
-      openActions: number
-      reviewSoonCount: number
-      hasOwnerGap: boolean
-    }
-  >()
-
-  for (const item of items) {
-    const current = rows.get(item.teamId) ?? {
-      id: item.teamId,
-      orgId: item.orgId ?? null,
-      scopeType: item.scopeType ?? 'department',
-      label: item.teamLabel,
-      peopleCount: item.peopleCount,
-      currentManagerId: item.ownerId,
-      currentManagerName: item.ownerName,
-      openActions: 0,
-      reviewSoonCount: 0,
-      hasOwnerGap: false,
-    }
-
-    current.peopleCount = Math.max(current.peopleCount, item.peopleCount)
-    if (!current.currentManagerId && item.ownerId) {
-      current.currentManagerId = item.ownerId
-    }
-    if (!current.currentManagerName && item.ownerName) {
-      current.currentManagerName = item.ownerName
-    }
-    if (item.status !== 'afgerond' && item.status !== 'gestopt') {
-      current.openActions += 1
-    }
-    if (getReviewBucket(item.reviewDate, now) === 'deze-week') {
-      current.reviewSoonCount += 1
-    }
-    if (!item.ownerName) {
-      current.hasOwnerGap = true
-    }
-    rows.set(item.teamId, current)
-  }
-
-  return [...rows.values()].sort((left, right) => {
-    if (right.openActions !== left.openActions) return right.openActions - left.openActions
-    return left.label.localeCompare(right.label)
-  })
-}
-
 function getInitialFollowUpFormState(args: {
   item: ActionCenterPreviewItem | null
   assignmentOptions: ActionCenterPreviewManagerOption[]
@@ -959,7 +904,7 @@ export function ActionCenterPreview({
     setFollowUpForm(getInitialFollowUpFormState({ item: selectedItem, assignmentOptions }))
     setFollowUpError(null)
   }, [assignmentOptions, selectedItem])
-  const teamRows = buildTeamRows(items)
+  const teamRows = buildActionCenterTeamRows(items)
   const selectedTeam = teamRows.find((team) => team.id === selectedTeamId) ?? teamRows[0] ?? null
   const allSources = [...new Set(items.map((item) => item.sourceLabel))]
   const workspaceReadbackSummary = useMemo(() => getLiveActionCenterSummary(items), [items])
@@ -982,10 +927,6 @@ export function ActionCenterPreview({
   const ownerCoverageCount = teamRows.length - missingManagerCount
   const selectedTeamItems = items.filter((item) => item.teamId === selectedTeam?.id)
   const teamOpenItems = selectedTeamItems.filter((item) => item.status !== 'afgerond' && item.status !== 'gestopt')
-  const teamReviewItems = selectedTeamItems
-    .filter((item) => item.reviewDate)
-    .sort((left, right) => compareReviewDate(left.reviewDate, right.reviewDate))
-    .slice(0, 3)
   const focusItem = visibleDueItems[0] ?? visibleItems[0] ?? null
   const viewCopy = getViewCopy(activeView, activeView === 'overview' && selectedItem ? null : activeView === 'overview' ? null : selectedItem?.title ?? null)
   const allowLocalDraftEditing = !readOnly && !managerResponseEndpoint
@@ -2956,127 +2897,16 @@ export function ActionCenterPreview({
             ) : null}
 
             {activeView === 'teams' ? (
-              selectedTeam ? (
-                <div className="space-y-8">
-                  <section className="rounded-[28px] border border-[#e4d9cb] bg-[#fcfaf7] px-7 py-7 shadow-[0_12px_36px_rgba(19,32,51,0.06)]">
-                    <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
-                      <div className="max-w-2xl">
-                        <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[#8d8377]">Teamcontext</p>
-                        <h2 className="mt-3 text-[1.9rem] font-semibold tracking-[-0.05em] text-[#132033]">{selectedTeam.label}</h2>
-                        <p className="mt-4 text-[1rem] leading-8 text-[#4f6175]">
-                          Deze teamread houdt de managementflow compact: wat staat nog open, welke reviews komen eraan en wie is hier de expliciete eigenaar?
-                        </p>
-                      </div>
-                      <div className="grid gap-3 sm:grid-cols-3">
-                        <OverviewStat label="Open acties" value={`${teamOpenItems.length}`} detail="zichtbaar in deze teamcontext" accent="amber" />
-                        <OverviewStat label="Review < 7 dagen" value={`${selectedTeam.reviewSoonCount}`} detail="vragen snel gesprek" accent="red" />
-                        <OverviewStat label="Mensen" value={`${selectedTeam.peopleCount}`} detail="in deze scope" accent="teal" />
-                      </div>
-                    </div>
-                  </section>
-
-                  <div className="grid gap-6 xl:grid-cols-[minmax(0,1.45fr),minmax(320px,0.78fr)]">
-                    <section className="rounded-[28px] border border-[#e4d9cb] bg-white px-7 py-7 shadow-[0_12px_36px_rgba(19,32,51,0.06)]">
-                      <div className="flex items-center justify-between gap-3 border-b border-[#ece4d8] pb-5">
-                        <div>
-                          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Open teamacties</p>
-                          <h3 className="mt-2 text-[1.4rem] font-semibold tracking-[-0.03em] text-[#132033]">Wat ligt nu nog op tafel?</h3>
-                        </div>
-                        <p className="text-sm text-[#736b60]">{teamOpenItems.length} actief</p>
-                      </div>
-                      <div className="mt-6 space-y-4">
-                        {teamOpenItems.length === 0 ? (
-                          <EmptyBlock text="Voor dit team staan nu geen open opvolgacties meer zichtbaar." />
-                        ) : (
-                          teamOpenItems.map((item) => (
-                            <button
-                              key={item.id}
-                              type="button"
-                              className="flex w-full items-start justify-between gap-4 rounded-[22px] border border-[#ebe1d5] bg-[#fcfaf7] px-5 py-5 text-left transition hover:border-[#d7cab9]"
-                              onClick={() => {
-                                setSelectedItemId(item.id)
-                                setActiveView('actions')
-                              }}
-                            >
-                              <div className="min-w-0">
-                                <div className="flex flex-wrap items-center gap-2 text-sm text-[#6d6458]">
-                                  <MiniTag>{item.sourceLabel}</MiniTag>
-                                  <span>{getPriorityMeta(item.priority).label}</span>
-                                  <span className="text-[#b2a496]">/</span>
-                                  <span>{getOwnerDisplayName(item.ownerName)}</span>
-                                </div>
-                                <p className="mt-3 text-[1.08rem] font-semibold tracking-[-0.02em] text-[#132033]">{item.title}</p>
-                                <p className="mt-2 text-sm text-[#5d6f84]">
-                                  Review {item.reviewDateLabel}, ritme {item.reviewRhythm}
-                                </p>
-                              </div>
-                              <StatusPill status={item.status} />
-                            </button>
-                          ))
-                        )}
-                      </div>
-                    </section>
-
-                    <section className="space-y-6">
-                      <div className="rounded-[30px] bg-[#182231] px-7 py-7 text-white shadow-[0_22px_56px_rgba(19,32,51,0.18)]">
-                        <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/45">Teamverantwoordelijke</p>
-                        <div className="mt-5 flex items-center gap-4">
-                          <div className="flex h-14 w-14 items-center justify-center rounded-full bg-white/8 text-xl font-semibold">
-                            {getInitials(getTeamManagerDisplayName(selectedTeam.currentManagerName))}
-                          </div>
-                          <div>
-                            <p className="text-[1.4rem] font-semibold tracking-[-0.03em]">
-                              {getTeamManagerDisplayName(selectedTeam.currentManagerName)}
-                            </p>
-                            <p className="mt-1 text-sm text-white/58">Manager - {selectedTeam.label}</p>
-                          </div>
-                        </div>
-                        <div className="mt-6 grid grid-cols-3 gap-4">
-                          <DarkMetric label="Open" value={`${teamOpenItems.length}`} accent="text-white" />
-                          <DarkMetric label="Review < 7d" value={`${selectedTeam.reviewSoonCount}`} accent="text-[#ffb16e]" />
-                          <DarkMetric
-                            label="Geblokkeerd"
-                            value={`${teamOpenItems.filter((item) => item.status === 'geblokkeerd').length}`}
-                            accent="text-white"
-                          />
-                        </div>
-                        <p className="mt-6 text-sm leading-7 text-white/72">
-                          Deze teamrail blijft onderdeel van dezelfde omgeving en leest dus altijd mee met eigenaarschap en reviewplanning.
-                        </p>
-                      </div>
-
-                      <div className="rounded-[24px] border border-[#e4d9cb] bg-white px-6 py-6 shadow-[0_12px_36px_rgba(19,32,51,0.06)]">
-                        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Te bespreken deze week</p>
-                        <div className="mt-4 space-y-4">
-                          {teamReviewItems.length === 0 ? (
-                            <EmptyBlock text="Geen reviews meer gepland voor dit team in de huidige selectie." />
-                          ) : (
-                            teamReviewItems.map((item) => (
-                              <button
-                                key={item.id}
-                                type="button"
-                                className="w-full rounded-[18px] border border-[#efe7dc] bg-[#fcfaf7] px-4 py-4 text-left transition hover:border-[#d7cab9]"
-                                onClick={() => {
-                                  setSelectedItemId(item.id)
-                                  setActiveView('actions')
-                                }}
-                              >
-                                <p className="font-semibold text-[#132033]">{item.title}</p>
-                                <p className="mt-1 text-sm text-[#5d6f84]">Volgende bespreking {item.reviewDateLabel}</p>
-                              </button>
-                            ))
-                          )}
-                        </div>
-                      </div>
-                    </section>
-                  </div>
-                </div>
-              ) : (
-                <EmptySection
-                  title="Nog geen teamcontext beschikbaar"
-                  body="Zodra ExitScan-dossiers aan een teamcontext zijn gekoppeld, verschijnt hier de compacte teamweergave."
-                />
-              )
+              <ActionCenterTeamsView
+                items={filteredItems}
+                selectedTeamId={selectedTeamId}
+                onSelectTeam={setSelectedTeamId}
+                onNavigateToActions={(itemId) => {
+                  setSelectedItemId(itemId)
+                  setActiveView('actions')
+                }}
+                canAssignManagers={canAssignManagers}
+              />
             ) : null}
           </div>
         </div>

--- a/frontend/components/dashboard/action-center-teams-view.tsx
+++ b/frontend/components/dashboard/action-center-teams-view.tsx
@@ -1,0 +1,288 @@
+'use client'
+
+import React from 'react'
+import type { ActionCenterPreviewItem } from '@/lib/action-center-preview-model'
+import {
+  buildActionCenterTeamRows,
+  buildTeamsSummaryStats,
+  deriveScopeStatusChip,
+  isActionCenterReviewSoon,
+} from '@/lib/action-center-teams-view'
+
+interface ActionCenterTeamsViewProps {
+  items: ActionCenterPreviewItem[]
+  selectedTeamId: string | null
+  onSelectTeam: (teamId: string) => void
+  onNavigateToActions: (itemId: string) => void
+  canAssignManagers: boolean
+}
+
+const UNASSIGNED_MANAGER_LABEL = 'Niet gekoppeld'
+
+function getInitials(name: string | null) {
+  if (!name) return 'VS'
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? '')
+    .join('')
+}
+
+function getManagerName(name: string | null) {
+  return name ?? UNASSIGNED_MANAGER_LABEL
+}
+
+function isClosedStatus(status: ActionCenterPreviewItem['status']) {
+  return status === 'afgerond' || status === 'gestopt'
+}
+
+function ScopeStatusChip({ status }: { status: ReturnType<typeof deriveScopeStatusChip> }) {
+  const copy =
+    status === 'actief'
+      ? {
+          label: 'Actief',
+          className: 'border-[#caece8] bg-[#dff7f4] text-[#0d6a7c]',
+        }
+      : status === 'zonder-manager'
+        ? {
+            label: 'Zonder manager',
+            className: 'border-[#ffd7d1] bg-[#fff1ef] text-[#d2574b]',
+          }
+        : {
+            label: 'Geen opvolging',
+            className: 'border-[#e6dfd3] bg-[#f7f2ea] text-[#6d6559]',
+          }
+
+  return (
+    <span className={`inline-flex items-center rounded-xl border px-3 py-1.5 text-sm font-semibold ${copy.className}`}>
+      {copy.label}
+    </span>
+  )
+}
+
+function SummaryStat({
+  label,
+  value,
+  detail,
+  accent,
+}: {
+  label: string
+  value: string
+  detail: string
+  accent: 'amber' | 'red' | 'teal'
+}) {
+  const accentClass =
+    accent === 'amber' ? 'bg-[#ff9b4a]' : accent === 'red' ? 'bg-[#ef6e64]' : 'bg-[#70b7aa]'
+
+  return (
+    <div className="rounded-[18px] border border-[#e6ddd2] bg-white px-4 py-3.5">
+      <div className="flex items-center gap-2">
+        <span className={`h-2.5 w-2.5 rounded-full ${accentClass}`} />
+        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#7d7368]">{label}</p>
+      </div>
+      <p className="dash-number mt-3 text-[1.95rem] font-semibold tracking-[-0.05em] text-[#132033]">{value}</p>
+      <p className="mt-1 text-sm text-[#6d6458]">{detail}</p>
+    </div>
+  )
+}
+
+function EmptyBlock({ text }: { text: string }) {
+  return (
+    <div className="rounded-[18px] border border-dashed border-[#ddd3c7] bg-[#fbf8f4] px-5 py-5 text-sm leading-7 text-[#5d6f84]">
+      {text}
+    </div>
+  )
+}
+
+function EmptySection({ title, body }: { title: string; body: string }) {
+  return (
+    <section className="rounded-[28px] border border-[#e4d9cb] bg-white px-6 py-10 text-center shadow-[0_12px_36px_rgba(19,32,51,0.06)]">
+      <h2 className="text-[1.45rem] font-semibold tracking-[-0.03em] text-[#132033]">{title}</h2>
+      <p className="mx-auto mt-3 max-w-2xl text-sm leading-7 text-[#5d6f84]">{body}</p>
+    </section>
+  )
+}
+
+export function ActionCenterTeamsView({
+  items,
+  selectedTeamId,
+  onSelectTeam,
+  onNavigateToActions,
+  canAssignManagers,
+}: ActionCenterTeamsViewProps) {
+  void canAssignManagers
+
+  const teamRows = buildActionCenterTeamRows(items)
+  const selectedTeam = teamRows.find((team) => team.id === selectedTeamId) ?? teamRows[0] ?? null
+  const summary = buildTeamsSummaryStats(teamRows)
+  const selectedTeamItems = selectedTeam ? items.filter((item) => item.teamId === selectedTeam.id) : []
+  const teamOpenItems = selectedTeamItems.filter((item) => !isClosedStatus(item.status))
+  const teamReviewItems = selectedTeamItems.filter((item) => isActionCenterReviewSoon(item.reviewDate))
+  const blockedCount = teamOpenItems.filter((item) => item.status === 'geblokkeerd').length
+
+  if (!selectedTeam) {
+    return (
+      <EmptySection
+        title="Nog geen teams zichtbaar"
+        body="Zodra opvolgingsroutes aan teamscopes zijn gekoppeld, verschijnt hier het teamoverzicht."
+      />
+    )
+  }
+
+  return (
+    <div className="space-y-8">
+      <section className="rounded-[28px] border border-[#e4d9cb] bg-[#fcfaf7] px-7 py-7 shadow-[0_12px_36px_rgba(19,32,51,0.06)]">
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+          <div className="max-w-2xl">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Action Center / Teams in scope</p>
+            <p className="mt-3 text-[11px] font-semibold uppercase tracking-[0.2em] text-[#8d8377]">ACTION CENTER</p>
+            <h2 className="mt-3 text-[1.9rem] font-semibold tracking-[-0.05em] text-[#132033]">Teams in scope</h2>
+            <p className="mt-4 text-[1rem] leading-8 text-[#4f6175]">
+              Bekijk welke teams of afdelingen aan opvolging, managers en reviews zijn gekoppeld.
+            </p>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            <SummaryStat label="Teams in scope" value={`${summary.teamsInScope}`} detail="zichtbaar voor jou" accent="teal" />
+            <SummaryStat label="Zonder manager" value={`${summary.withoutManager}`} detail="nog niet gekoppeld" accent="red" />
+            <SummaryStat label="Met open opvolging" value={`${summary.withOpenFollowThrough}`} detail="actieve routes" accent="amber" />
+            <SummaryStat label="Review eerstvolgt" value={`${summary.reviewFirstUp}`} detail="binnen 7 dagen" accent="teal" />
+          </div>
+        </div>
+      </section>
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.45fr),minmax(320px,0.78fr)]">
+        <section className="overflow-x-auto rounded-[28px] border border-[#e4d9cb] bg-white shadow-[0_12px_36px_rgba(19,32,51,0.06)]">
+          <div className="min-w-[860px]">
+            <div className="grid grid-cols-[minmax(0,1.9fr),minmax(0,1.2fr),minmax(0,1.35fr),116px,116px] gap-4 border-b border-[#ebe1d5] bg-[#faf6f0] px-6 py-3 text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">
+              <span>TEAM / AFDELING</span>
+              <span>STATUS</span>
+              <span>MANAGER</span>
+              <span>OPEN OPVOLGING</span>
+              <span>REVIEW &lt; 7D</span>
+            </div>
+            <div className="divide-y divide-[#ebe1d5]">
+              {teamRows.map((team) => (
+                <button
+                  key={team.id}
+                  type="button"
+                  data-team-id={team.id}
+                  className={`grid w-full grid-cols-[minmax(0,1.9fr),minmax(0,1.2fr),minmax(0,1.35fr),116px,116px] gap-4 px-6 py-4 text-left transition hover:bg-[#fcfaf7] ${
+                    selectedTeam.id === team.id ? 'bg-[#fcfaf7]' : 'bg-white'
+                  }`}
+                  onClick={() => onSelectTeam(team.id)}
+                >
+                  <div className="min-w-0">
+                    <p className="font-semibold text-[#132033]">{team.label}</p>
+                    <p className="mt-1 text-sm text-[#7c7368]">
+                      {team.scopeType === 'department' ? 'Afdeling' : team.scopeType === 'org' ? 'Organisatie' : 'Itemscope'}
+                    </p>
+                  </div>
+                  <div>
+                    <ScopeStatusChip status={deriveScopeStatusChip(team)} />
+                  </div>
+                  <div className="flex items-center gap-3 text-sm text-[#132033]">
+                    <span className="flex h-9 w-9 items-center justify-center rounded-full bg-[#f3ece3] text-xs font-semibold text-[#5f564a]">
+                      {getInitials(getManagerName(team.currentManagerName))}
+                    </span>
+                    <span className="font-semibold">{getManagerName(team.currentManagerName)}</span>
+                  </div>
+                  <div className="text-sm font-semibold text-[#132033]">{team.openActions}</div>
+                  <div className="text-sm font-semibold text-[#5a7088]">{team.reviewSoonCount}</div>
+                </button>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="space-y-6">
+          <div className="rounded-[30px] bg-[#182231] px-7 py-7 text-white shadow-[0_22px_56px_rgba(19,32,51,0.18)]">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/45">Teamcontext</p>
+            <div className="mt-5 flex items-center gap-4">
+              <div className="flex h-14 w-14 items-center justify-center rounded-full bg-white/8 text-xl font-semibold">
+                {getInitials(getManagerName(selectedTeam.currentManagerName))}
+              </div>
+              <div>
+                <p className="text-[1.4rem] font-semibold tracking-[-0.03em]">{selectedTeam.label}</p>
+                <p className="mt-1 text-sm text-white/58">{getManagerName(selectedTeam.currentManagerName)}</p>
+              </div>
+            </div>
+            <div className="mt-6 grid grid-cols-3 gap-4">
+              <div>
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/45">Open</p>
+                <p className="mt-2 text-[1.9rem] font-semibold tracking-[-0.04em] text-white">{teamOpenItems.length}</p>
+              </div>
+              <div>
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/45">Review &lt; 7D</p>
+                <p className="mt-2 text-[1.9rem] font-semibold tracking-[-0.04em] text-[#ffb16e]">{selectedTeam.reviewSoonCount}</p>
+              </div>
+              <div>
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/45">Geblokkeerd</p>
+                <p className="mt-2 text-[1.9rem] font-semibold tracking-[-0.04em] text-white">{blockedCount}</p>
+              </div>
+            </div>
+            {selectedTeam.peopleCount > 0 ? (
+              <p className="mt-6 text-sm leading-7 text-white/72">{selectedTeam.peopleCount} mensen in scope</p>
+            ) : null}
+          </div>
+
+          <div className="rounded-[24px] border border-[#e4d9cb] bg-white px-6 py-6 shadow-[0_12px_36px_rgba(19,32,51,0.06)]">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Open acties</p>
+            <div className="mt-4 space-y-4">
+              {teamOpenItems.length === 0 ? (
+                <EmptyBlock text="Geen open acties voor dit team." />
+              ) : (
+                teamOpenItems.map((item) => (
+                  <button
+                    key={item.id}
+                    type="button"
+                    className="w-full rounded-[18px] border border-[#efe7dc] bg-[#fcfaf7] px-4 py-4 text-left transition hover:border-[#d7cab9]"
+                    onClick={() => onNavigateToActions(item.id)}
+                  >
+                    <p className="font-semibold text-[#132033]">{item.title}</p>
+                    <p className="mt-1 text-sm text-[#5d6f84]">
+                      {item.sourceLabel}
+                      {' · '}
+                      {item.reviewDateLabel}
+                    </p>
+                  </button>
+                ))
+              )}
+            </div>
+          </div>
+
+          <div className="rounded-[24px] border border-[#e4d9cb] bg-white px-6 py-6 shadow-[0_12px_36px_rgba(19,32,51,0.06)]">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Review deze week</p>
+            <div className="mt-4 space-y-4">
+              {teamReviewItems.length === 0 ? (
+                <EmptyBlock text="Geen reviews gepland voor dit team in de komende 7 dagen." />
+              ) : (
+                teamReviewItems.map((item) => (
+                  <button
+                    key={item.id}
+                    type="button"
+                    className="w-full rounded-[18px] border border-[#efe7dc] bg-[#fcfaf7] px-4 py-4 text-left transition hover:border-[#d7cab9]"
+                    onClick={() => onNavigateToActions(item.id)}
+                  >
+                    <p className="font-semibold text-[#132033]">{item.title}</p>
+                    <p className="mt-1 text-sm text-[#5d6f84]">Volgende bespreking {item.reviewDateLabel}</p>
+                  </button>
+                ))
+              )}
+            </div>
+          </div>
+        </section>
+      </div>
+
+      <section className="rounded-[24px] border border-[#e4d9cb] bg-white px-6 py-6 shadow-[0_12px_36px_rgba(19,32,51,0.06)]">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Legenda</p>
+        <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+          <p className="text-sm leading-7 text-[#42556b]"><span className="font-semibold text-[#132033]">Actief:</span> Scope heeft ten minste één open opvolgingsroute.</p>
+          <p className="text-sm leading-7 text-[#42556b]"><span className="font-semibold text-[#132033]">Zonder manager:</span> Scope heeft een open route maar geen toegewezen manager.</p>
+          <p className="text-sm leading-7 text-[#42556b]"><span className="font-semibold text-[#132033]">Geen opvolging:</span> Alle routes zijn afgerond of gestopt.</p>
+          <p className="text-sm leading-7 text-[#42556b]"><span className="font-semibold text-[#132033]">Review &lt; 7 dagen:</span> Minstens één route vraagt deze week aandacht.</p>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/frontend/lib/action-center-teams-view.test.ts
+++ b/frontend/lib/action-center-teams-view.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildActionCenterTeamRows,
+  buildTeamsSummaryStats,
+  deriveScopeStatusChip,
+  type ActionCenterTeamRow,
+} from '@/lib/action-center-teams-view'
+import type { ActionCenterPreviewItem } from '@/lib/action-center-preview-model'
+
+function buildItem(overrides: Partial<ActionCenterPreviewItem> = {}): ActionCenterPreviewItem {
+  return {
+    id: 'item-1',
+    code: 'ACT-1001',
+    title: 'Exit follow-through voorjaar',
+    summary: 'Een eerste bounded opvolgroute staat open.',
+    reason: 'Waarom dit nu eerst aandacht vraagt.',
+    sourceLabel: 'ExitScan',
+    orgId: 'org-1',
+    scopeType: 'department',
+    teamId: 'operations',
+    teamLabel: 'Operations',
+    ownerId: 'manager-1',
+    ownerName: 'Manager Operations',
+    ownerRole: 'Manager',
+    ownerSubtitle: 'Operations',
+    reviewOwnerName: 'HR lead',
+    priority: 'hoog',
+    status: 'in-uitvoering',
+    reviewDate: '2026-05-12',
+    expectedEffect: 'Maak het eerste verbeterpunt expliciet.',
+    reviewReason: 'Toets of de bounded stap zichtbaar is.',
+    reviewOutcome: 'bijstellen',
+    reviewDateLabel: '12 mei',
+    reviewRhythm: 'Maandelijks',
+    signalLabel: 'ExitScan - Exit voorjaar',
+    signalBody: 'Deze route vraagt nu een eerste bounded reactie.',
+    nextStep: 'Plan de eerste managerstap.',
+    peopleCount: 38,
+    coreSemantics: {} as ActionCenterPreviewItem['coreSemantics'],
+    openSignals: [],
+    updates: [],
+    ...overrides,
+  }
+}
+
+function buildTeamRow(overrides: Partial<ActionCenterTeamRow> = {}): ActionCenterTeamRow {
+  return {
+    id: 'operations',
+    orgId: 'org-1',
+    scopeType: 'department',
+    label: 'Operations',
+    peopleCount: 38,
+    currentManagerId: 'manager-1',
+    currentManagerName: 'Manager Operations',
+    openActions: 2,
+    reviewSoonCount: 1,
+    hasOwnerGap: false,
+    ...overrides,
+  }
+}
+
+describe('action center teams helpers', () => {
+  it('derives the agreed scope status chip only from existing team-row fields', () => {
+    expect(deriveScopeStatusChip(buildTeamRow({ openActions: 2, hasOwnerGap: false }))).toBe('actief')
+    expect(deriveScopeStatusChip(buildTeamRow({ openActions: 2, hasOwnerGap: true }))).toBe('zonder-manager')
+    expect(deriveScopeStatusChip(buildTeamRow({ openActions: 0, hasOwnerGap: false }))).toBe('geen-opvolging')
+  })
+
+  it('builds team rows from preview items without inventing extra data', () => {
+    const rows = buildActionCenterTeamRows([
+      buildItem({ reviewDate: '2026-05-05', reviewDateLabel: '5 mei' }),
+      buildItem({
+        id: 'item-2',
+        ownerId: null,
+        ownerName: null,
+        reviewDate: '2026-06-02',
+        reviewDateLabel: '2 jun',
+      }),
+      buildItem({
+        id: 'item-3',
+        teamId: 'support',
+        teamLabel: 'Support',
+        ownerId: null,
+        ownerName: null,
+        peopleCount: 0,
+        status: 'afgerond',
+        reviewDate: null,
+        reviewDateLabel: 'Nog niet gepland',
+      }),
+    ])
+
+    expect(rows).toHaveLength(2)
+    expect(rows[0]).toMatchObject({
+      id: 'operations',
+      openActions: 2,
+      reviewSoonCount: 1,
+      hasOwnerGap: true,
+      peopleCount: 38,
+    })
+    expect(rows[1]).toMatchObject({
+      id: 'support',
+      openActions: 0,
+      reviewSoonCount: 0,
+      hasOwnerGap: true,
+      peopleCount: 0,
+    })
+  })
+
+  it('summarises the visible team scope for the summary bar', () => {
+    const stats = buildTeamsSummaryStats([
+      buildTeamRow({ id: 'operations', openActions: 2, currentManagerId: 'manager-1', reviewSoonCount: 1 }),
+      buildTeamRow({ id: 'support', openActions: 1, currentManagerId: null, currentManagerName: null, hasOwnerGap: true, reviewSoonCount: 0 }),
+      buildTeamRow({ id: 'finance', openActions: 0, currentManagerId: null, currentManagerName: null, hasOwnerGap: false, reviewSoonCount: 0 }),
+    ])
+
+    expect(stats).toEqual({
+      teamsInScope: 3,
+      withoutManager: 2,
+      withOpenFollowThrough: 2,
+      reviewFirstUp: 1,
+    })
+  })
+})

--- a/frontend/lib/action-center-teams-view.ts
+++ b/frontend/lib/action-center-teams-view.ts
@@ -1,0 +1,99 @@
+import type { ActionCenterPreviewItem } from '@/lib/action-center-preview-model'
+
+export type ActionCenterTeamRow = {
+  id: string
+  orgId: string | null
+  scopeType: 'department' | 'item' | 'org'
+  label: string
+  peopleCount: number
+  currentManagerId: string | null | undefined
+  currentManagerName: string | null
+  openActions: number
+  reviewSoonCount: number
+  hasOwnerGap: boolean
+}
+
+export type ActionCenterTeamScopeStatus = 'actief' | 'zonder-manager' | 'geen-opvolging'
+
+function isClosedStatus(status: ActionCenterPreviewItem['status']) {
+  return status === 'afgerond' || status === 'gestopt'
+}
+
+function isReviewSoon(reviewDate: string | null, now = new Date()) {
+  if (!reviewDate) return false
+  const parsed = new Date(reviewDate)
+  if (Number.isNaN(parsed.getTime())) return false
+
+  const start = new Date(now)
+  start.setHours(0, 0, 0, 0)
+  const end = new Date(start)
+  end.setDate(end.getDate() + 7)
+
+  return parsed >= start && parsed < end
+}
+
+export function buildActionCenterTeamRows(items: ActionCenterPreviewItem[]): ActionCenterTeamRow[] {
+  const now = new Date()
+  const rows = new Map<string, ActionCenterTeamRow>()
+
+  for (const item of items) {
+    const current = rows.get(item.teamId) ?? {
+      id: item.teamId,
+      orgId: item.orgId ?? null,
+      scopeType: item.scopeType ?? 'department',
+      label: item.teamLabel,
+      peopleCount: item.peopleCount,
+      currentManagerId: item.ownerId,
+      currentManagerName: item.ownerName,
+      openActions: 0,
+      reviewSoonCount: 0,
+      hasOwnerGap: false,
+    }
+
+    current.peopleCount = Math.max(current.peopleCount, item.peopleCount)
+    if (!current.currentManagerId && item.ownerId) {
+      current.currentManagerId = item.ownerId
+    }
+    if (!current.currentManagerName && item.ownerName) {
+      current.currentManagerName = item.ownerName
+    }
+    if (!isClosedStatus(item.status)) {
+      current.openActions += 1
+    }
+    if (isReviewSoon(item.reviewDate, now)) {
+      current.reviewSoonCount += 1
+    }
+    if (!item.ownerName) {
+      current.hasOwnerGap = true
+    }
+
+    rows.set(item.teamId, current)
+  }
+
+  return [...rows.values()].sort((left, right) => {
+    if (right.openActions !== left.openActions) {
+      return right.openActions - left.openActions
+    }
+
+    return left.label.localeCompare(right.label)
+  })
+}
+
+export function deriveScopeStatusChip(team: ActionCenterTeamRow): ActionCenterTeamScopeStatus {
+  if (team.hasOwnerGap && team.openActions > 0) return 'zonder-manager'
+  if (team.openActions > 0 && !team.hasOwnerGap) return 'actief'
+  return 'geen-opvolging'
+}
+
+export function buildTeamsSummaryStats(teamRows: ActionCenterTeamRow[]) {
+  return {
+    teamsInScope: teamRows.length,
+    withoutManager: teamRows.filter((team) => !team.currentManagerId).length,
+    withOpenFollowThrough: teamRows.filter((team) => team.openActions > 0).length,
+    reviewFirstUp: teamRows.filter((team) => team.reviewSoonCount > 0).length,
+  }
+}
+
+export function isActionCenterReviewSoon(reviewDate: string | null, now = new Date()) {
+  return isReviewSoon(reviewDate, now)
+}


### PR DESCRIPTION
## Samenvatting
- voegt een echte Teams-scopeview toe binnen Action Center
- toont teams, status, open opvolging en reviewdruk zonder analyse- of performance-drift
- houdt de teamslaag bounded tot scope- en opvolgingsstructuur

## Scope
- teams view component
- helperlaag voor teamscope projectie
- route-shell guardrails voor teamslabels

## Verificatie
- teams-specifieke vitest-slice groen
- eslint op teams-slice groen