### PR TITLE
Action Center Managers assignment page

### DIFF
--- a/frontend/app/(dashboard)/beheer/managers/page.test.ts
+++ b/frontend/app/(dashboard)/beheer/managers/page.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('beheer managers route source', () => {
+  const fileUrl = new URL('./page.tsx', import.meta.url)
+
+  it('uses the agreed assignment-only route and page shell', () => {
+    const source = readFileSync(fileUrl, 'utf8')
+
+    expect(source).toContain('Managers')
+    expect(source).toContain('ManagersPageView')
+    expect(source).toContain('getManagersPageData')
+  })
+
+  it('guards the route with suite access instead of reusing ActionCenterPreview', () => {
+    const source = readFileSync(fileUrl, 'utf8')
+
+    expect(source).toContain('canManageActionCenterAssignments')
+    expect(source).toContain("redirect('/action-center')")
+    expect(source).not.toContain('ActionCenterPreview')
+    expect(source).not.toContain('org_invites')
+  })
+
+  it('does not introduce lifecycle semantics into the managers page copy', () => {
+    const source = readFileSync(fileUrl, 'utf8').toLowerCase()
+
+    for (const forbidden of [
+      'uitnodiging',
+      'activatie',
+      'pending',
+      'invited',
+      'activated',
+      'access requested',
+      'wacht op toegang',
+      'toegang aangevraagd',
+    ]) {
+      expect(source).not.toContain(forbidden)
+    }
+  })
+})

--- a/frontend/app/(dashboard)/beheer/managers/page.tsx
+++ b/frontend/app/(dashboard)/beheer/managers/page.tsx
@@ -1,0 +1,47 @@
+import { redirect } from 'next/navigation'
+import { ManagersPageView } from '@/components/dashboard/managers-page-view'
+import { getManagersPageData } from '@/lib/managers-page-data'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { createClient } from '@/lib/supabase/server'
+import { loadSuiteAccessContext } from '@/lib/suite-access-server'
+
+export default async function BeheerManagersPage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ manager?: string }>
+}) {
+  const params = (await searchParams) ?? {}
+  const selectedManagerId = typeof params.manager === 'string' ? params.manager : null
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/login')
+  }
+
+  const {
+    context,
+    orgMemberships,
+    workspaceMemberships,
+  } = await loadSuiteAccessContext(supabase, user.id)
+
+  if (!context.canManageActionCenterAssignments) {
+    redirect('/action-center')
+  }
+
+  const orgIds = [
+    ...new Set([
+      ...context.organizationIds,
+      ...context.workspaceOrgIds,
+      ...orgMemberships.map((membership) => membership.org_id),
+      ...workspaceMemberships.map((membership) => membership.org_id),
+    ]),
+  ]
+
+  const dataClient = createAdminClient()
+  const pageData = await getManagersPageData(dataClient, orgIds)
+
+  return <ManagersPageView data={pageData} selectedManagerId={selectedManagerId} />
+}

--- a/frontend/app/(dashboard)/layout.tsx
+++ b/frontend/app/(dashboard)/layout.tsx
@@ -41,6 +41,7 @@ export default async function DashboardLayout({
   return (
     <DashboardShellFrame
       isAdmin={context.isVerisightAdmin}
+      canManageActionCenterAssignments={context.canManageActionCenterAssignments}
       shellMode={context.managerOnly ? 'action_center_only' : 'full'}
       userEmail={user.email ?? ''}
       acceptedCount={acceptedCount}

--- a/frontend/components/dashboard/dashboard-shell.tsx
+++ b/frontend/components/dashboard/dashboard-shell.tsx
@@ -20,6 +20,7 @@ type PortfolioCounts = Record<DashboardPortfolioView, number>
 
 export function DashboardShellFrame({
   isAdmin,
+  canManageActionCenterAssignments,
   shellMode,
   userEmail,
   acceptedCount,
@@ -28,6 +29,7 @@ export function DashboardShellFrame({
   children,
 }: {
   isAdmin: boolean
+  canManageActionCenterAssignments: boolean
   shellMode: DashboardShellMode
   userEmail: string
   acceptedCount: number
@@ -44,12 +46,13 @@ export function DashboardShellFrame({
     () =>
       buildDashboardShellNavigation({
         isAdmin,
+        canManageActionCenterAssignments,
         shellMode,
         currentCampaignPath,
         campaigns,
         portfolioCounts,
       }),
-    [campaigns, currentCampaignPath, isAdmin, portfolioCounts, shellMode],
+    [campaigns, canManageActionCenterAssignments, currentCampaignPath, isAdmin, portfolioCounts, shellMode],
   )
   const isActionCenter = pathname.startsWith('/action-center')
   const accountLabel = userEmail.split('@')[1]?.split('.')[0] ?? 'Verisight'

--- a/frontend/components/dashboard/managers-page-view.test.tsx
+++ b/frontend/components/dashboard/managers-page-view.test.tsx
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('managers page view', () => {
+  it('keeps the agreed assignment-only labels and ctas in the view source', () => {
+    const source = readFileSync(new URL('./managers-page-view.tsx', import.meta.url), 'utf8')
+    const helperSource = readFileSync(new URL('../../lib/managers-page-data.ts', import.meta.url), 'utf8')
+
+    expect(source).toContain('Beheer welke managers aan welke scope zijn gekoppeld en welke Action Center-toegang daaruit volgt.')
+    expect(source).toContain('Deze pagina regelt manager assignment en toegang. Geen dashboard, rapport of opvolgingsdetail.')
+    expect(source).toContain('Scopes zonder manager')
+    expect(source).toContain('Nog niet gekoppeld')
+    expect(source).toContain('Bekijk scope en toegang')
+    expect(source).toContain('Koppel manager aan scope')
+    expect(source).toContain('Bekijk gekoppelde scopes')
+    expect(source).toContain("{' · '}")
+    expect(helperSource).toContain('Dashboardtoegang: Niet toegestaan')
+    expect(helperSource).toContain('Rapporttoegang: Niet toegestaan')
+  })
+
+  it('keeps lifecycle semantics out of the visible view source', () => {
+    const source = readFileSync(new URL('./managers-page-view.tsx', import.meta.url), 'utf8').toLowerCase()
+
+    for (const forbidden of [
+      'uitnodiging',
+      'activatie',
+      'pending',
+      'invited',
+      'activated',
+      'access requested',
+      'wacht op toegang',
+      'toegang aangevraagd',
+      'Ã',
+      'Â',
+      'â',
+      '�',
+    ]) {
+      expect(source).not.toContain(forbidden)
+    }
+  })
+})

--- a/frontend/components/dashboard/managers-page-view.tsx
+++ b/frontend/components/dashboard/managers-page-view.tsx
@@ -1,0 +1,378 @@
+'use client'
+
+import Link from 'next/link'
+import {
+  DashboardChip,
+  DashboardHero,
+  DashboardKeyValue,
+  DashboardPanel,
+  DashboardSection,
+  DashboardSummaryBar,
+} from '@/components/dashboard/dashboard-primitives'
+import type { ManagerRegistryRow, ManagersPageData } from '@/lib/managers-page-data'
+
+function formatDateLabel(value: string | null) {
+  if (!value) {
+    return 'Niet beschikbaar'
+  }
+
+  return new Date(value).toLocaleDateString('nl-NL', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  })
+}
+
+function getStatusTone(status: ManagerRegistryRow['status']) {
+  switch (status) {
+    case 'gekoppeld':
+      return 'emerald' as const
+    case 'scopeconflict':
+      return 'amber' as const
+    default:
+      return 'slate' as const
+  }
+}
+
+export function ManagersPageView({
+  data,
+  selectedManagerId,
+}: {
+  data: ManagersPageData
+  selectedManagerId: string | null
+}) {
+  const selectedManager =
+    data.managers.find((manager) => manager.userId === selectedManagerId) ?? data.managers[0] ?? null
+
+  return (
+    <div className="space-y-6">
+      <DashboardHero
+        surface="ops"
+        tone="slate"
+        eyebrow="Action Center beheer"
+        title="Managers"
+        description="Beheer welke managers aan welke scope zijn gekoppeld en welke Action Center-toegang daaruit volgt."
+        meta={
+          <>
+            <DashboardChip
+              surface="ops"
+              label={`${data.organizationCount} organisatie${data.organizationCount === 1 ? '' : 's'}`}
+            />
+            <DashboardChip
+              surface="ops"
+              label={
+                data.lastUpdatedAt
+                  ? `Laatst gewijzigd ${formatDateLabel(data.lastUpdatedAt)}`
+                  : 'Nog geen assignmentupdates'
+              }
+              tone="slate"
+            />
+          </>
+        }
+        aside={
+          <div className="space-y-3 text-sm text-slate-700">
+            <p className="font-semibold text-slate-950">Beheerkader</p>
+            <p>Deze pagina regelt manager assignment en toegang. Geen dashboard, rapport of opvolgingsdetail.</p>
+          </div>
+        }
+      />
+
+      <DashboardSummaryBar
+        surface="ops"
+        items={[
+          {
+            label: 'Managers gekoppeld',
+            value: `${data.managerCount}`,
+            tone: data.managerCount > 0 ? 'emerald' : 'slate',
+          },
+          {
+            label: 'Scopes zonder manager',
+            value: data.uncoveredScopeCount === null ? 'Niet beschikbaar' : `${data.uncoveredScopeCount}`,
+            tone: data.uncoveredScopeCount && data.uncoveredScopeCount > 0 ? 'amber' : 'slate',
+          },
+          {
+            label: 'Scopeconflicten',
+            value: `${data.scopeConflictCount}`,
+            tone: data.scopeConflictCount > 0 ? 'amber' : 'slate',
+          },
+          {
+            label: 'Managers met scopegebonden AC-toegang',
+            value: `${data.scopedAccessCount}`,
+            tone: data.scopedAccessCount > 0 ? 'emerald' : 'slate',
+          },
+        ]}
+        anchors={[
+          { id: 'manager-register', label: 'Managerregister' },
+          { id: 'manager-detail', label: 'Scope en toegang' },
+          { id: 'scopes-zonder-manager', label: 'Ongekoppelde scopes' },
+          { id: 'governance', label: 'Governance' },
+        ]}
+      />
+
+      <DashboardSection
+        id="manager-register"
+        surface="ops"
+        eyebrow="Register"
+        title="Managerregister"
+        description="Bekijk per manager welke scope is gekoppeld, welk type scope dat is en welke bounded Action Center-toegang daaruit volgt."
+        aside={
+          <DashboardChip
+            surface="ops"
+            label={`${data.managers.length} manager${data.managers.length === 1 ? '' : 's'}`}
+          />
+        }
+      >
+        {data.managers.length === 0 ? (
+          <DashboardPanel
+            surface="ops"
+            eyebrow="Leeg"
+            title="Geen managers gekoppeld"
+            body="Zodra manager-assignmentrecords bestaan, verschijnt hier het register met scope en toegang."
+            tone="slate"
+          />
+        ) : (
+          <div className="grid gap-5 xl:grid-cols-[minmax(0,1.35fr),minmax(320px,0.65fr)]">
+            <div className="overflow-x-auto rounded-[18px] border border-slate-200 bg-white">
+              <table className="min-w-[960px] w-full text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200 bg-slate-50 text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                    <th className="px-4 py-3 text-left">Manager</th>
+                    <th className="px-4 py-3 text-left">Scopes</th>
+                    <th className="px-4 py-3 text-left">Scope type</th>
+                    <th className="px-4 py-3 text-left">Toegang</th>
+                    <th className="px-4 py-3 text-left">Status</th>
+                    <th className="px-4 py-3 text-left">Actie</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100">
+                  {data.managers.map((manager) => (
+                    <tr key={manager.userId} className="align-top hover:bg-slate-50/70">
+                      <td className="px-4 py-4">
+                        <p className="font-semibold text-slate-950">{manager.displayName}</p>
+                        <p className="mt-1 text-xs text-slate-500">
+                          {manager.loginEmail ?? 'Geen e-mailadres bekend'}
+                        </p>
+                      </td>
+                      <td className="px-4 py-4 text-slate-700">
+                        <p>
+                          {manager.scopes.length === 0
+                            ? 'Nog geen scope gekoppeld'
+                            : `${manager.scopes.length} scope${manager.scopes.length === 1 ? '' : 's'}`}
+                        </p>
+                        {manager.scopes[0] ? (
+                          <p className="mt-1 text-xs text-slate-500">{manager.scopes[0].scopeLabel}</p>
+                        ) : null}
+                      </td>
+                      <td className="px-4 py-4 text-slate-700">{manager.scopeTypeLabel}</td>
+                      <td className="px-4 py-4 text-slate-700">{manager.accessLabel}</td>
+                      <td className="px-4 py-4">
+                        <DashboardChip
+                          surface="ops"
+                          tone={getStatusTone(manager.status)}
+                          label={manager.statusLabel}
+                        />
+                      </td>
+                      <td className="px-4 py-4">
+                        <div className="flex flex-wrap gap-2">
+                          <Link
+                            href={`/beheer/managers?manager=${manager.userId}`}
+                            className="rounded-full border border-slate-300 bg-white px-3 py-2 text-xs font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+                          >
+                            Open manager
+                          </Link>
+                          <a
+                            href="#manager-detail"
+                            className="rounded-full border border-slate-300 bg-slate-50 px-3 py-2 text-xs font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-100"
+                          >
+                            Bekijk scope en toegang
+                          </a>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <div id="manager-detail" className="xl:sticky xl:top-[8rem] xl:self-start">
+              {selectedManager ? (
+                <div className="space-y-4 rounded-[22px] border border-slate-200 bg-white p-5 shadow-[0_10px_24px_rgba(19,32,51,0.05)]">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <DashboardChip
+                      surface="ops"
+                      label={selectedManager.statusLabel}
+                      tone={getStatusTone(selectedManager.status)}
+                    />
+                    <DashboardChip surface="ops" label={selectedManager.scopeTypeLabel} tone="slate" />
+                  </div>
+                  <div>
+                    <p className="text-lg font-semibold text-slate-950">{selectedManager.displayName}</p>
+                    <p className="mt-1 text-sm text-slate-500">
+                      {selectedManager.loginEmail ?? 'Geen e-mailadres bekend'}
+                    </p>
+                  </div>
+
+                  <div className="flex flex-wrap gap-2">
+                    <a
+                      href="#manager-detail"
+                      className="rounded-full border border-slate-300 bg-white px-3 py-2 text-xs font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+                    >
+                      Bekijk gekoppelde scopes
+                    </a>
+                    <a
+                      href="#scopes-zonder-manager"
+                      className="rounded-full border border-slate-300 bg-slate-50 px-3 py-2 text-xs font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-100"
+                    >
+                      Koppel manager aan scope
+                    </a>
+                  </div>
+
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <DashboardKeyValue
+                      surface="ops"
+                      label="Aangemaakt"
+                      value={formatDateLabel(selectedManager.createdAt)}
+                    />
+                    <DashboardKeyValue
+                      surface="ops"
+                      label="Laatst gewijzigd"
+                      value={formatDateLabel(selectedManager.updatedAt)}
+                    />
+                  </div>
+
+                  <div className="space-y-2 rounded-[18px] border border-slate-200 bg-slate-50 px-4 py-4">
+                    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Toegang</p>
+                    <ul className="space-y-2 text-sm text-slate-700">
+                      {selectedManager.permissions.map((permission) => (
+                        <li key={permission}>{permission}</li>
+                      ))}
+                    </ul>
+                  </div>
+
+                  <div className="space-y-3">
+                    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                      Gekoppelde scopes
+                    </p>
+                    {selectedManager.scopes.length === 0 ? (
+                      <div className="rounded-[18px] border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
+                        Nog geen scope gekoppeld.
+                      </div>
+                    ) : (
+                      selectedManager.scopes.map((scope) => (
+                        <div
+                          key={`${scope.orgId}-${scope.scopeValue}`}
+                          className="rounded-[18px] border border-slate-200 bg-slate-50 px-4 py-4 text-sm text-slate-700"
+                        >
+                          <div className="flex flex-wrap items-center gap-2">
+                            <DashboardChip surface="ops" label={scope.scopeTypeLabel} tone="slate" />
+                            <span className="text-xs text-slate-500">{scope.orgName}</span>
+                          </div>
+                          <p className="mt-3 font-semibold text-slate-950">{scope.scopeLabel}</p>
+                          <p className="mt-1 text-xs text-slate-500">
+                            Aangemaakt {formatDateLabel(scope.createdAt)} {' · '}Gewijzigd{' '}
+                            {formatDateLabel(scope.updatedAt)}
+                          </p>
+                        </div>
+                      ))
+                    )}
+                  </div>
+                </div>
+              ) : (
+                <DashboardPanel
+                  surface="ops"
+                  eyebrow="Detail"
+                  title="Nog geen managerdetail"
+                  body="Zodra een managerrecord zichtbaar is, verschijnt hier de scope- en toegangsdetaillaag."
+                  tone="slate"
+                />
+              )}
+            </div>
+          </div>
+        )}
+      </DashboardSection>
+
+      <DashboardSection
+        id="scopes-zonder-manager"
+        surface="ops"
+        eyebrow="Scopebasis"
+        title="Scopes zonder manager"
+        description="Alleen scopes uit actieve campaigns en respondent-context tellen mee. Er wordt geen extra masterdata of lifecyclelaag verondersteld."
+        aside={
+          <DashboardChip
+            surface="ops"
+            label={data.uncoveredScopeCount === null ? 'Niet beschikbaar' : `${data.uncoveredScopeCount} open`}
+            tone={data.uncoveredScopeCount && data.uncoveredScopeCount > 0 ? 'amber' : 'slate'}
+          />
+        }
+      >
+        {!data.uncoveredScopesAvailable ? (
+          <DashboardPanel
+            surface="ops"
+            eyebrow="Databasis"
+            title="Niet beschikbaar"
+            body="Er is nog geen bruikbare departmentbasis uit actieve campaigns en respondenten om ongekoppelde scopes te tellen."
+            tone="slate"
+          />
+        ) : data.uncoveredScopes.length === 0 ? (
+          <DashboardPanel
+            surface="ops"
+            eyebrow="Dekking"
+            title="Alle zichtbare scopes zijn gekoppeld"
+            body="Voor de huidige actieve campaign- en respondentcontext is er geen open afdeling zonder managerassignment."
+            tone="emerald"
+          />
+        ) : (
+          <div className="grid gap-3 lg:grid-cols-2">
+            {data.uncoveredScopes.map((scope) => (
+              <div
+                key={`${scope.orgId}-${scope.scopeValue}`}
+                className="rounded-[18px] border border-amber-200 bg-amber-50 px-4 py-4 text-sm text-amber-950"
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  <DashboardChip surface="ops" label="Nog niet gekoppeld" tone="amber" />
+                  <span className="text-xs text-amber-800">{scope.orgName}</span>
+                </div>
+                <p className="mt-3 font-semibold">{scope.scopeLabel}</p>
+                <p className="mt-2 text-xs leading-5 text-amber-900">
+                  Gebruik deze scope als volgende assignmentkandidaat wanneer je een manager wilt koppelen.
+                </p>
+              </div>
+            ))}
+          </div>
+        )}
+      </DashboardSection>
+
+      <DashboardSection
+        id="governance"
+        surface="ops"
+        eyebrow="Governance"
+        title="Scope en toegang blijven bounded"
+        description="Deze beheerpagina blijft bewust beperkt tot assignment en scope. Managergebruikers krijgen hier geen dashboard-, rapport- of bredere gebruikersbeheerlaag."
+      >
+        <div className="grid gap-4 lg:grid-cols-3">
+          <DashboardPanel
+            surface="ops"
+            eyebrow="Assignment"
+            title="Statusmodel"
+            body="Gekoppeld, Nog niet gekoppeld en Scopeconflict zijn de enige toegestane assignmentstatussen in v1."
+            tone="slate"
+          />
+          <DashboardPanel
+            surface="ops"
+            eyebrow="Toegang"
+            title="Scopegebonden Action Center"
+            body="De permissiematrix blijft beperkt tot scope, opvolgen en review plannen. Dashboard en rapport blijven expliciet uit."
+            tone="slate"
+          />
+          <DashboardPanel
+            surface="ops"
+            eyebrow="Guardrail"
+            title="Geen lifecyclelaag"
+            body="De pagina blijft bij assignment en scope, zonder extra gebruikerslevenscyclus of onboardingstatus."
+            tone="slate"
+          />
+        </div>
+      </DashboardSection>
+    </div>
+  )
+}

--- a/frontend/lib/dashboard/shell-navigation.test.ts
+++ b/frontend/lib/dashboard/shell-navigation.test.ts
@@ -115,6 +115,7 @@ describe('dashboard shell navigation', () => {
   it('keeps admin links separate from buyer overview navigation', () => {
     const navigation = buildDashboardShellNavigation({
       isAdmin: true,
+      canManageActionCenterAssignments: true,
       shellMode: 'full',
       currentCampaignPath: null,
       campaigns: [...campaigns],
@@ -130,10 +131,32 @@ describe('dashboard shell navigation', () => {
       key: 'overview',
       href: '/dashboard',
     })
-    expect(navigation.admin.map((item) => item.label)).toEqual(['Setup', 'Leads', 'Action Center bron'])
+    expect(navigation.admin.map((item) => item.label)).toEqual(['Setup', 'Managers', 'Leads', 'Action Center bron'])
     expect(navigation.modules[3]).toMatchObject({
       key: 'onboarding',
       href: '/dashboard?module=onboarding',
+    })
+  })
+
+  it('shows the managers beheer entry for customer owners who may manage action center assignments', () => {
+    const navigation = buildDashboardShellNavigation({
+      isAdmin: false,
+      canManageActionCenterAssignments: true,
+      shellMode: 'full',
+      currentCampaignPath: null,
+      campaigns: [...campaigns],
+      portfolioCounts: {
+        ready: 3,
+        building: 1,
+        setup: 0,
+        closed: 2,
+      },
+    })
+
+    expect(navigation.admin.map((item) => item.label)).toEqual(['Managers'])
+    expect(navigation.admin[0]).toMatchObject({
+      label: 'Managers',
+      href: '/beheer/managers',
     })
   })
 

--- a/frontend/lib/dashboard/shell-navigation.ts
+++ b/frontend/lib/dashboard/shell-navigation.ts
@@ -153,12 +153,14 @@ export function getActiveModuleFromLocation(
 
 export function buildDashboardShellNavigation({
   isAdmin,
+  canManageActionCenterAssignments = false,
   shellMode = 'full',
   currentCampaignPath,
   campaigns,
   portfolioCounts,
 }: {
   isAdmin: boolean
+  canManageActionCenterAssignments?: boolean
   shellMode?: DashboardShellMode
   currentCampaignPath: string | null
   campaigns: DashboardShellCampaignRef[]
@@ -233,28 +235,44 @@ export function buildDashboardShellNavigation({
     ]
   })
 
-  const admin: DashboardShellNavItem[] = isAdmin
-    ? [
-        {
-          label: 'Setup',
-          detail: 'Organisaties, campaignsetup en launchdiscipline.',
-          href: '/beheer',
-          disabled: false,
-        },
-        {
-          label: 'Leads',
-          detail: 'Sales-to-delivery context en contactaanvragen.',
-          href: '/beheer/contact-aanvragen',
-          disabled: false,
-        },
-        {
-          label: 'Action Center bron',
-          detail: 'Broncampagnes en opvolging beheren.',
-          href: '/beheer/klantlearnings',
-          disabled: false,
-        },
-      ]
-    : []
+  const admin: DashboardShellNavItem[] = [
+    ...(isAdmin
+      ? [
+          {
+            label: 'Setup',
+            detail: 'Organisaties, campaignsetup en launchdiscipline.',
+            href: '/beheer',
+            disabled: false,
+          },
+        ]
+      : []),
+    ...(canManageActionCenterAssignments
+      ? [
+          {
+            label: 'Managers',
+            detail: 'Manager assignment en scopegebonden Action Center-toegang.',
+            href: '/beheer/managers',
+            disabled: false,
+          },
+        ]
+      : []),
+    ...(isAdmin
+      ? [
+          {
+            label: 'Leads',
+            detail: 'Sales-to-delivery context en contactaanvragen.',
+            href: '/beheer/contact-aanvragen',
+            disabled: false,
+          },
+          {
+            label: 'Action Center bron',
+            detail: 'Broncampagnes en opvolging beheren.',
+            href: '/beheer/klantlearnings',
+            disabled: false,
+          },
+        ]
+      : []),
+  ]
 
   return {
     modules,
@@ -276,6 +294,7 @@ export function getDashboardShellCurrentLabel(pathname: string) {
   if (pathname.startsWith('/reports')) return 'Rapporten'
   if (pathname.startsWith('/action-center')) return 'Action Center'
   if (pathname.startsWith('/campaigns/')) return 'Campagnedetail'
+  if (pathname.startsWith('/beheer/managers')) return 'Managers'
   if (pathname.startsWith('/beheer/contact-aanvragen')) return 'Leadcontext'
   if (pathname.startsWith('/beheer/klantlearnings')) return 'Action Center'
   if (pathname.startsWith('/beheer')) return 'Setup en beheer'

--- a/frontend/lib/managers-page-data.test.ts
+++ b/frontend/lib/managers-page-data.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildDepartmentScopeValue,
+  countUncoveredDepartments,
+  deriveManagerAssignmentStatus,
+  parseManagerScopeLabel,
+  summarizeManagerPermissions,
+  type ManagerAssignmentWorkspaceRow,
+} from './managers-page-data'
+
+function buildWorkspaceRow(
+  overrides: Partial<ManagerAssignmentWorkspaceRow> = {},
+): ManagerAssignmentWorkspaceRow {
+  return {
+    org_id: 'org-1',
+    user_id: 'manager-1',
+    display_name: 'Manager Operations',
+    login_email: 'manager@example.com',
+    access_role: 'manager_assignee',
+    scope_type: 'department',
+    scope_value: buildDepartmentScopeValue('org-1', 'Operations'),
+    can_view: true,
+    can_update: true,
+    can_assign: false,
+    can_schedule_review: true,
+    created_at: '2026-05-01T09:00:00.000Z',
+    updated_at: '2026-05-02T09:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('managers page data helpers', () => {
+  it('normalizes department scope values from active respondent context', () => {
+    expect(buildDepartmentScopeValue('org-1', 'Operations')).toBe('org-1::department::operations')
+    expect(buildDepartmentScopeValue('org-1', ' Customer Success ')).toBe('org-1::department::customer success')
+  })
+
+  it('parses scope labels from existing assignment scope values', () => {
+    expect(parseManagerScopeLabel('org-1::department::operations', 'department', 'Pulse Q2')).toBe('Operations')
+    expect(parseManagerScopeLabel('org-1::campaign::camp-1', 'item', 'Pulse Q2')).toBe('Pulse Q2')
+    expect(parseManagerScopeLabel('org-1', 'org', 'Pulse Q2')).toBe('Organisatie')
+  })
+
+  it('counts only uncovered departments that exist in active campaign respondent context', () => {
+    const uncovered = countUncoveredDepartments({
+      activeDepartments: [
+        buildDepartmentScopeValue('org-1', 'Operations'),
+        buildDepartmentScopeValue('org-1', 'People'),
+        buildDepartmentScopeValue('org-1', 'People'),
+      ],
+      managerScopeValues: [buildDepartmentScopeValue('org-1', 'Operations')],
+    })
+
+    expect(uncovered).toBe(1)
+  })
+
+  it('marks a manager with valid scopes as gekoppeld', () => {
+    expect(deriveManagerAssignmentStatus([buildWorkspaceRow()])).toBe('gekoppeld')
+  })
+
+  it('marks a manager without visible scopes as nog_niet_gekoppeld', () => {
+    expect(
+      deriveManagerAssignmentStatus([
+        buildWorkspaceRow({
+          scope_value: '',
+        }),
+      ]),
+    ).toBe('nog_niet_gekoppeld')
+  })
+
+  it('marks org plus department scope combinations in the same org as a scopeconflict', () => {
+    expect(
+      deriveManagerAssignmentStatus([
+        buildWorkspaceRow({
+          scope_type: 'org',
+          scope_value: 'org-1',
+        }),
+        buildWorkspaceRow(),
+      ]),
+    ).toBe('scopeconflict')
+  })
+
+  it('summarizes only bounded Action Center permissions without dashboard or rapport toegang', () => {
+    expect(summarizeManagerPermissions(buildWorkspaceRow())).toEqual([
+      'Dashboardtoegang: Niet toegestaan',
+      'Rapporttoegang: Niet toegestaan',
+      'Action Center: Beperkt tot scope',
+      'Kan opvolgen',
+      'Kan review plannen',
+    ])
+  })
+})

--- a/frontend/lib/managers-page-data.ts
+++ b/frontend/lib/managers-page-data.ts
@@ -1,0 +1,409 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Campaign, Organization, Respondent } from '@/lib/types'
+import type { ActionCenterWorkspaceMember, ActionCenterWorkspaceScopeType } from '@/lib/suite-access'
+
+export type ManagerAssignmentStatus = 'gekoppeld' | 'nog_niet_gekoppeld' | 'scopeconflict' | 'onbekend'
+
+export type ManagerAssignmentWorkspaceRow = Pick<
+  ActionCenterWorkspaceMember,
+  | 'org_id'
+  | 'user_id'
+  | 'display_name'
+  | 'login_email'
+  | 'access_role'
+  | 'scope_type'
+  | 'scope_value'
+  | 'can_view'
+  | 'can_update'
+  | 'can_assign'
+  | 'can_schedule_review'
+  | 'created_at'
+  | 'updated_at'
+>
+
+type ActiveCampaignRow = Pick<Campaign, 'id' | 'organization_id' | 'name' | 'is_active'>
+type RespondentDepartmentRow = Pick<Respondent, 'campaign_id' | 'department'>
+type OrganizationRow = Pick<Organization, 'id' | 'name' | 'slug' | 'contact_email' | 'is_active' | 'created_at'>
+
+export interface ManagerScopeSummary {
+  orgId: string
+  orgName: string
+  scopeType: ActionCenterWorkspaceScopeType
+  scopeTypeLabel: string
+  scopeValue: string
+  scopeLabel: string
+  createdAt: string | null
+  updatedAt: string | null
+}
+
+export interface ManagerRegistryRow {
+  userId: string
+  displayName: string
+  loginEmail: string | null
+  status: ManagerAssignmentStatus
+  statusLabel: string
+  scopeTypeLabel: string
+  accessLabel: string
+  permissions: string[]
+  scopes: ManagerScopeSummary[]
+  createdAt: string | null
+  updatedAt: string | null
+}
+
+export interface ManagersPageData {
+  managers: ManagerRegistryRow[]
+  uncoveredScopes: Array<{
+    orgId: string
+    orgName: string
+    scopeLabel: string
+    scopeValue: string
+  }>
+  uncoveredScopesAvailable: boolean
+  managerCount: number
+  uncoveredScopeCount: number | null
+  scopeConflictCount: number
+  scopedAccessCount: number
+  organizationCount: number
+  lastUpdatedAt: string | null
+}
+
+function titleCase(value: string) {
+  return value
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+function normalizeDepartmentLabel(value: string | null | undefined) {
+  const trimmed = value?.trim() ?? ''
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function isValidScopeValue(value: string | null | undefined) {
+  return (value?.trim().length ?? 0) > 0
+}
+
+export function buildDepartmentScopeValue(orgId: string, departmentLabel: string) {
+  return `${orgId}::department::${departmentLabel.trim().toLowerCase()}`
+}
+
+export function parseManagerScopeLabel(
+  scopeValue: string,
+  scopeType: ActionCenterWorkspaceScopeType,
+  fallbackItemLabel?: string | null,
+) {
+  if (scopeType === 'org') {
+    return 'Organisatie'
+  }
+
+  if (scopeType === 'department') {
+    const rawDepartment = scopeValue.split('::')[2] ?? scopeValue
+    return titleCase(rawDepartment)
+  }
+
+  return fallbackItemLabel?.trim() || 'Campagne'
+}
+
+export function countUncoveredDepartments(args: {
+  activeDepartments: string[]
+  managerScopeValues: string[]
+}) {
+  const activeDepartmentSet = new Set(args.activeDepartments.filter(isValidScopeValue))
+  const managerScopeSet = new Set(args.managerScopeValues.filter(isValidScopeValue))
+
+  return [...activeDepartmentSet].filter((scopeValue) => !managerScopeSet.has(scopeValue)).length
+}
+
+export function deriveManagerAssignmentStatus(rows: ManagerAssignmentWorkspaceRow[]): ManagerAssignmentStatus {
+  if (rows.length === 0) {
+    return 'onbekend'
+  }
+
+  const validScopeRows = rows.filter((row) => isValidScopeValue(row.scope_value))
+  if (validScopeRows.length === 0) {
+    return 'nog_niet_gekoppeld'
+  }
+
+  const orgScopeByOrgId = new Set(
+    validScopeRows.filter((row) => row.scope_type === 'org').map((row) => row.org_id),
+  )
+  const nestedScopeByOrgId = new Set(
+    validScopeRows
+      .filter((row) => row.scope_type === 'department' || row.scope_type === 'item')
+      .map((row) => row.org_id),
+  )
+
+  for (const orgId of orgScopeByOrgId) {
+    if (nestedScopeByOrgId.has(orgId)) {
+      return 'scopeconflict'
+    }
+  }
+
+  return 'gekoppeld'
+}
+
+export function summarizeManagerPermissions(row: Pick<
+  ManagerAssignmentWorkspaceRow,
+  'can_update' | 'can_schedule_review'
+>) {
+  const permissions = [
+    'Dashboardtoegang: Niet toegestaan',
+    'Rapporttoegang: Niet toegestaan',
+    'Action Center: Beperkt tot scope',
+  ]
+
+  if (row.can_update) {
+    permissions.push('Kan opvolgen')
+  }
+
+  if (row.can_schedule_review) {
+    permissions.push('Kan review plannen')
+  }
+
+  return permissions
+}
+
+function getStatusLabel(status: ManagerAssignmentStatus) {
+  switch (status) {
+    case 'gekoppeld':
+      return 'Gekoppeld'
+    case 'nog_niet_gekoppeld':
+      return 'Nog niet gekoppeld'
+    case 'scopeconflict':
+      return 'Scopeconflict'
+    default:
+      return 'Onbekend'
+  }
+}
+
+function getScopeTypeLabel(scopeType: ActionCenterWorkspaceScopeType) {
+  switch (scopeType) {
+    case 'org':
+      return 'Organisatie'
+    case 'department':
+      return 'Afdeling'
+    case 'item':
+    default:
+      return 'Itemscope'
+  }
+}
+
+function getScopeTypeSummary(scopes: ManagerScopeSummary[]) {
+  const uniqueLabels = [...new Set(scopes.map((scope) => scope.scopeTypeLabel))]
+  if (uniqueLabels.length === 0) {
+    return 'Niet beschikbaar'
+  }
+  if (uniqueLabels.length === 1) {
+    return uniqueLabels[0]
+  }
+  return 'Gemengd'
+}
+
+function getAccessLabel(row: Pick<ManagerAssignmentWorkspaceRow, 'can_view' | 'can_update' | 'can_schedule_review'>) {
+  if (!row.can_view) {
+    return 'Onbekend'
+  }
+  if (row.can_update && row.can_schedule_review) {
+    return 'Opvolgen + review plannen'
+  }
+  if (row.can_update) {
+    return 'Kan opvolgen'
+  }
+  if (row.can_schedule_review) {
+    return 'Kan review plannen'
+  }
+  return 'Alleen scoped lezen'
+}
+
+function getLatestTimestamp(values: Array<string | null | undefined>) {
+  const definedValues = values.filter((value): value is string => Boolean(value))
+  if (definedValues.length === 0) {
+    return null
+  }
+
+  return definedValues.sort((left, right) => right.localeCompare(left))[0] ?? null
+}
+
+function toManagerRegistryRows(args: {
+  workspaceRows: ManagerAssignmentWorkspaceRow[]
+  organizationsById: Map<string, OrganizationRow>
+  activeCampaignsById: Map<string, ActiveCampaignRow>
+}) {
+  const rowsByUserId = args.workspaceRows.reduce<Map<string, ManagerAssignmentWorkspaceRow[]>>((acc, row) => {
+    const existing = acc.get(row.user_id) ?? []
+    existing.push(row)
+    acc.set(row.user_id, existing)
+    return acc
+  }, new Map())
+
+  return [...rowsByUserId.entries()]
+    .map<ManagerRegistryRow>(([userId, rows]) => {
+      const primaryRow = rows[0]
+      const status = deriveManagerAssignmentStatus(rows)
+      const scopes = rows
+        .filter((row) => isValidScopeValue(row.scope_value))
+        .map<ManagerScopeSummary>((row) => {
+          const org = args.organizationsById.get(row.org_id)
+          const fallbackCampaignLabel =
+            row.scope_type === 'item'
+              ? args.activeCampaignsById.get(row.scope_value.split('::')[2] ?? '')?.name ?? null
+              : null
+
+          return {
+            orgId: row.org_id,
+            orgName: org?.name ?? 'Niet beschikbaar',
+            scopeType: row.scope_type,
+            scopeTypeLabel: getScopeTypeLabel(row.scope_type),
+            scopeValue: row.scope_value,
+            scopeLabel: parseManagerScopeLabel(row.scope_value, row.scope_type, fallbackCampaignLabel),
+            createdAt: row.created_at ?? null,
+            updatedAt: row.updated_at ?? null,
+          }
+        })
+
+      const permissionUnion = {
+        can_update: rows.some((row) => row.can_update),
+        can_schedule_review: rows.some((row) => row.can_schedule_review),
+      }
+
+      return {
+        userId,
+        displayName: primaryRow.display_name?.trim() || primaryRow.login_email || 'Onbekende manager',
+        loginEmail: primaryRow.login_email ?? null,
+        status,
+        statusLabel: getStatusLabel(status),
+        scopeTypeLabel: getScopeTypeSummary(scopes),
+        accessLabel: getAccessLabel({
+          can_view: rows.some((row) => row.can_view),
+          ...permissionUnion,
+        }),
+        permissions: summarizeManagerPermissions(permissionUnion),
+        scopes,
+        createdAt: getLatestTimestamp(rows.map((row) => row.created_at ?? null)),
+        updatedAt: getLatestTimestamp(rows.map((row) => row.updated_at ?? null)),
+      }
+    })
+    .sort((left, right) => left.displayName.localeCompare(right.displayName))
+}
+
+export async function getManagersPageData(
+  supabase: SupabaseClient,
+  orgIds: string[],
+): Promise<ManagersPageData> {
+  const visibleOrgIds = [...new Set(orgIds)]
+  if (visibleOrgIds.length === 0) {
+    return {
+      managers: [],
+      uncoveredScopes: [],
+      uncoveredScopesAvailable: false,
+      managerCount: 0,
+      uncoveredScopeCount: null,
+      scopeConflictCount: 0,
+      scopedAccessCount: 0,
+      organizationCount: 0,
+      lastUpdatedAt: null,
+    }
+  }
+
+  const [{ data: organizationsRaw }, { data: workspaceRowsRaw }, { data: activeCampaignsRaw }] =
+    await Promise.all([
+      supabase
+        .from('organizations')
+        .select('id, name, slug, contact_email, is_active, created_at')
+        .in('id', visibleOrgIds),
+      supabase
+        .from('action_center_workspace_members')
+        .select(
+          'org_id, user_id, display_name, login_email, access_role, scope_type, scope_value, can_view, can_update, can_assign, can_schedule_review, created_at, updated_at',
+        )
+        .in('org_id', visibleOrgIds)
+        .eq('access_role', 'manager_assignee'),
+      supabase
+        .from('campaigns')
+        .select('id, organization_id, name, is_active')
+        .in('organization_id', visibleOrgIds)
+        .eq('is_active', true),
+    ])
+
+  const organizations = (organizationsRaw ?? []) as OrganizationRow[]
+  const workspaceRows = (workspaceRowsRaw ?? []) as ManagerAssignmentWorkspaceRow[]
+  const activeCampaigns = (activeCampaignsRaw ?? []) as ActiveCampaignRow[]
+  const activeCampaignIds = activeCampaigns.map((campaign) => campaign.id)
+  const organizationsById = new Map(organizations.map((organization) => [organization.id, organization]))
+  const activeCampaignsById = new Map(activeCampaigns.map((campaign) => [campaign.id, campaign]))
+
+  const { data: departmentRowsRaw } =
+    activeCampaignIds.length > 0
+      ? await supabase
+          .from('respondents')
+          .select('campaign_id, department')
+          .in('campaign_id', activeCampaignIds)
+      : { data: [] }
+
+  const departmentRows = (departmentRowsRaw ?? []) as RespondentDepartmentRow[]
+  const activeDepartmentScopeValues = departmentRows
+    .map((row) => {
+      const departmentLabel = normalizeDepartmentLabel(row.department)
+      if (!departmentLabel) {
+        return null
+      }
+
+      const campaign = activeCampaignsById.get(row.campaign_id)
+      if (!campaign) {
+        return null
+      }
+
+      return {
+        orgId: campaign.organization_id,
+        orgName: organizationsById.get(campaign.organization_id)?.name ?? 'Niet beschikbaar',
+        scopeLabel: departmentLabel,
+        scopeValue: buildDepartmentScopeValue(campaign.organization_id, departmentLabel),
+      }
+    })
+    .filter(Boolean) as Array<{
+    orgId: string
+    orgName: string
+    scopeLabel: string
+    scopeValue: string
+  }>
+
+  const uncoveredScopesAvailable = activeDepartmentScopeValues.length > 0
+  const managerScopeValues = workspaceRows
+    .filter((row) => row.scope_type === 'department' && isValidScopeValue(row.scope_value))
+    .map((row) => row.scope_value)
+  const uncoveredScopeSet = new Set(
+    activeDepartmentScopeValues
+      .filter((scope) => !managerScopeValues.includes(scope.scopeValue))
+      .map((scope) => `${scope.orgId}::${scope.scopeValue}`),
+  )
+  const uncoveredScopes = activeDepartmentScopeValues.filter((scope) =>
+    uncoveredScopeSet.has(`${scope.orgId}::${scope.scopeValue}`),
+  )
+  const managers = toManagerRegistryRows({
+    workspaceRows,
+    organizationsById,
+    activeCampaignsById,
+  })
+
+  return {
+    managers,
+    uncoveredScopes,
+    uncoveredScopesAvailable,
+    managerCount: managers.filter((manager) => manager.status !== 'nog_niet_gekoppeld').length,
+    uncoveredScopeCount: uncoveredScopesAvailable
+      ? countUncoveredDepartments({
+          activeDepartments: activeDepartmentScopeValues.map((scope) => scope.scopeValue),
+          managerScopeValues,
+        })
+      : null,
+    scopeConflictCount: managers.filter((manager) => manager.status === 'scopeconflict').length,
+    scopedAccessCount: new Set(
+      workspaceRows
+        .filter((row) => row.can_view && isValidScopeValue(row.scope_value))
+        .map((row) => row.user_id),
+    ).size,
+    organizationCount: organizations.length,
+    lastUpdatedAt: getLatestTimestamp(workspaceRows.map((row) => row.updated_at ?? row.created_at ?? null)),
+  }
+}


### PR DESCRIPTION
## Samenvatting
- voegt de zelfstandige `/beheer/managers` beheerpagina toe
- houdt de pagina assignment-only en bounded tot scope, permissies en conflictsignalen
- vermijdt lifecycle-, dashboard- en rapportsemantiek

## Scope
- managers route
- managers data projection/helperlaag
- shell navigation voor owner/admin toegang

## Verificatie
- slice was lokaal groen op vitest, eslint en browser-QA vóór de cherry-pick
- deze branch bevat alleen de managers-commit op actuele `main`