### PR TITLE
Fix Action Center overview production deploy

### DIFF
--- a/frontend/app/(dashboard)/action-center/page.overview-shell.test.ts
+++ b/frontend/app/(dashboard)/action-center/page.overview-shell.test.ts
@@ -15,5 +15,6 @@ describe('action center bounded overview shell', () => {
     expect(previewSource).toContain('Te bespreken / reviewbaar')
     expect(previewSource).toContain('Geblokkeerd')
     expect(previewSource).toContain('Afgerond')
+    expect(previewSource).not.toContain('accent="slate"')
   })
 })

--- a/frontend/components/dashboard/action-center-preview.tsx
+++ b/frontend/components/dashboard/action-center-preview.tsx
@@ -1570,7 +1570,7 @@ export function ActionCenterPreview({
                               label="Afgerond"
                               value={`${workspaceReadbackSummary.closedRouteCount}`}
                               detail={`${workspaceReadbackSummary.closedRouteCount} routes met vastgelegd resultaat`}
-                              accent="slate"
+                              accent="teal"
                             />
                           </>
                         ) : null}


### PR DESCRIPTION
## Summary
- replace the invalid bounded overview stat accent with a supported value
- add a bounded overview source guardrail so the invalid accent cannot return

## Verification
- `npx vitest run "app/(dashboard)/action-center/page.entry-shell.test.ts" "app/(dashboard)/action-center/page.overview-shell.test.ts"`
- `npx eslint "components/dashboard/action-center-preview.tsx" "app/(dashboard)/action-center/page.overview-shell.test.ts"`