### PR TITLE
Add GA4 and Search Console verification hooks

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -14,3 +14,8 @@ NEXT_PUBLIC_API_URL=http://localhost:8000
 
 # Optionele fallback voor server-side rapportproxy's als org-secrets niet uitleesbaar zijn.
 BACKEND_ADMIN_TOKEN=jouw-backend-admin-token
+
+# Gratis web analytics
+NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
+GOOGLE_SITE_VERIFICATION=jouw-google-site-verification-code
+NEXT_PUBLIC_CLOUDFLARE_BEACON_TOKEN=jouw-cloudflare-beacon-token

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -34,3 +34,19 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Gratis analytics voor verisight.nl
+
+De marketing-site ondersteunt drie gratis analytics-ingangen via `frontend/.env.local` of je productie-env:
+
+```bash
+NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
+GOOGLE_SITE_VERIFICATION=jouw-google-site-verification-code
+NEXT_PUBLIC_CLOUDFLARE_BEACON_TOKEN=jouw-cloudflare-beacon-token
+```
+
+- `NEXT_PUBLIC_GA_MEASUREMENT_ID`: zet GA4 aan op alle routes.
+- `GOOGLE_SITE_VERIFICATION`: voegt de Search Console verificatie-meta-tag toe.
+- `NEXT_PUBLIC_CLOUDFLARE_BEACON_TOKEN`: zet Cloudflare Web Analytics aan.
+
+Laat een variabele leeg of weg als je die dienst nog niet wilt activeren.

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { IBM_Plex_Sans, Fraunces, Newsreader } from 'next/font/google'
+import { SiteAnalytics } from '@/components/marketing/site-analytics'
 import './globals.css'
 
 const ibmPlexSans = IBM_Plex_Sans({
@@ -26,6 +27,8 @@ const newsreader = Newsreader({
   display: 'swap',
   variable: '--font-newsreader',
 })
+
+const googleSiteVerification = process.env.GOOGLE_SITE_VERIFICATION
 
 export const metadata: Metadata = {
   title: {
@@ -63,6 +66,11 @@ export const metadata: Metadata = {
     index: true,
     follow: true,
   },
+  verification: googleSiteVerification
+    ? {
+        google: googleSiteVerification,
+      }
+    : undefined,
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
@@ -96,6 +104,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationSchema) }}
         />
         {children}
+        <SiteAnalytics />
       </body>
     </html>
   )

--- a/frontend/components/marketing/site-analytics.tsx
+++ b/frontend/components/marketing/site-analytics.tsx
@@ -1,0 +1,41 @@
+import Script from 'next/script'
+
+const googleAnalyticsId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID
+const cloudflareBeaconToken = process.env.NEXT_PUBLIC_CLOUDFLARE_BEACON_TOKEN
+
+export function SiteAnalytics() {
+  if (!googleAnalyticsId && !cloudflareBeaconToken) {
+    return null
+  }
+
+  return (
+    <>
+      {googleAnalyticsId ? (
+        <>
+          <Script
+            id="google-analytics-src"
+            src={`https://www.googletagmanager.com/gtag/js?id=${googleAnalyticsId}`}
+            strategy="afterInteractive"
+          />
+          <Script id="google-analytics-config" strategy="afterInteractive">
+            {`
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+              gtag('config', '${googleAnalyticsId}');
+            `}
+          </Script>
+        </>
+      ) : null}
+
+      {cloudflareBeaconToken ? (
+        <Script
+          id="cloudflare-web-analytics"
+          src="https://static.cloudflareinsights.com/beacon.min.js"
+          strategy="afterInteractive"
+          data-cf-beacon={JSON.stringify({ token: cloudflareBeaconToken })}
+        />
+      ) : null}
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- add an opt-in analytics component for GA4 and Cloudflare Web Analytics
- add Google Search Console verification support through Next.js metadata
- document the required environment variables for local and production setup

## Verification
- `npx eslint app/layout.tsx components/marketing/site-analytics.tsx`
- `npm run build`