### PR TITLE
Keep Routebeheer bridge visible for admins

### DIFF
--- a/frontend/app/(dashboard)/action-center/page.overview-shell.test.ts
+++ b/frontend/app/(dashboard)/action-center/page.overview-shell.test.ts
@@ -15,5 +15,6 @@ describe('action center bounded overview shell', () => {
     expect(previewSource).toContain('Te bespreken / reviewbaar')
     expect(previewSource).toContain('Geblokkeerd')
     expect(previewSource).toContain('Afgerond')
+    expect(previewSource).not.toContain('accent="slate"')
   })
 })

--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.test.ts
@@ -86,6 +86,13 @@ describe('routebeheer source integration', () => {
     expect(source).toContain('/campaigns/${id}/beheer')
   })
 
+  it('keeps the routebeheer bridge visible in admin view instead of hiding it behind the non-admin execution flag', () => {
+    const source = readFileSync(new URL('../page.tsx', import.meta.url), 'utf8')
+
+    expect(source).toContain('const showClientExecutionFlow = compositionState !== "closed";')
+    expect(source).not.toContain('const showClientExecutionFlow =\n    !isVerisightAdmin && compositionState !== "closed";')
+  })
+
   it('does not silently coerce unknown import readiness into a false auto-signal', () => {
     const source = readFileSync(new URL('./beheer-data.ts', import.meta.url), 'utf8')
 

--- a/frontend/app/(dashboard)/campaigns/[id]/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.tsx
@@ -832,8 +832,7 @@ export default async function CampaignPage({ params }: Props) {
     hasEnoughData,
   });
   const activationState = buildResponseActivationState(stats.total_completed);
-  const showClientExecutionFlow =
-    !isVerisightAdmin && compositionState !== "closed";
+  const showClientExecutionFlow = compositionState !== "closed";
   const showManagementOutput = isManagementVisibleState(compositionState);
   const showDeeperInsights =
     compositionState === "full" || compositionState === "closed";

--- a/frontend/components/dashboard/action-center-preview.tsx
+++ b/frontend/components/dashboard/action-center-preview.tsx
@@ -1570,7 +1570,7 @@ export function ActionCenterPreview({
                               label="Afgerond"
                               value={`${workspaceReadbackSummary.closedRouteCount}`}
                               detail={`${workspaceReadbackSummary.closedRouteCount} routes met vastgelegd resultaat`}
-                              accent="slate"
+                              accent="teal"
                             />
                           </>
                         ) : null}


### PR DESCRIPTION
Superseded by #122, which carries only the Routebeheer admin-visibility fix without the earlier overview hotfix commit.