### PR TITLE
Keep Routebeheer bridge visible for admins

### DIFF
--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.test.ts
@@ -86,6 +86,13 @@ describe('routebeheer source integration', () => {
     expect(source).toContain('/campaigns/${id}/beheer')
   })
 
+  it('keeps the routebeheer bridge visible in admin view instead of hiding it behind the non-admin execution flag', () => {
+    const source = readFileSync(new URL('../page.tsx', import.meta.url), 'utf8')
+
+    expect(source).toContain('const showClientExecutionFlow = compositionState !== "closed";')
+    expect(source).not.toContain('const showClientExecutionFlow =\n    !isVerisightAdmin && compositionState !== "closed";')
+  })
+
   it('does not silently coerce unknown import readiness into a false auto-signal', () => {
     const source = readFileSync(new URL('./beheer-data.ts', import.meta.url), 'utf8')
 

--- a/frontend/app/(dashboard)/campaigns/[id]/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.tsx
@@ -832,8 +832,7 @@ export default async function CampaignPage({ params }: Props) {
     hasEnoughData,
   });
   const activationState = buildResponseActivationState(stats.total_completed);
-  const showClientExecutionFlow =
-    !isVerisightAdmin && compositionState !== "closed";
+  const showClientExecutionFlow = compositionState !== "closed";
   const showManagementOutput = isManagementVisibleState(compositionState);
   const showDeeperInsights =
     compositionState === "full" || compositionState === "closed";


### PR DESCRIPTION
## Summary
- keep the campaign-detail Routebeheer bridge visible in admin view
- add a source guardrail so the bridge is no longer hidden behind the non-admin execution flag

## Verification
- `npx vitest run "app/(dashboard)/campaigns/[id]/beheer/beheer-data.test.ts"`
- `npx eslint "app/(dashboard)/campaigns/[id]/page.tsx" "app/(dashboard)/campaigns/[id]/beheer/beheer-data.test.ts"`