### PR TITLE
Fix public access for insights blog

### DIFF
--- a/frontend/lib/public-route-access.test.ts
+++ b/frontend/lib/public-route-access.test.ts
@@ -17,6 +17,8 @@ describe('public route access', () => {
     expect(isPublicRoutePath('/examples')).toBe(true)
     expect(isPublicRoutePath('/examples/voorbeeldrapport_verisight.pdf')).toBe(true)
     expect(isPublicRoutePath('/oplossingen/verloop-analyse')).toBe(true)
+    expect(isPublicRoutePath('/inzichten')).toBe(true)
+    expect(isPublicRoutePath('/inzichten/effectief-luisteren-als-sleutel-tot-beter-leiderschap')).toBe(true)
     expect(isPublicApiRoutePath('/api/contact')).toBe(true)
     expect(isPublicApiRoutePath('/api/contact/submit')).toBe(true)
     expect(isPublicRoutePath('/dashboard')).toBe(false)

--- a/frontend/lib/public-route-access.ts
+++ b/frontend/lib/public-route-access.ts
@@ -17,6 +17,7 @@ export const PUBLIC_ROUTES = [
   '/aanpak',
   '/tarieven',
   '/oplossingen',
+  '/inzichten',
   '/examples',
 ] as const
 


### PR DESCRIPTION
## Summary
- keep `/inzichten` and nested insight article routes in the public-route allowlist
- add a regression test so the blog index and slug routes stay publicly accessible

## Verification
- `npm test -- lib/public-route-access.test.ts`
- `npx eslint "lib/public-route-access.ts" "lib/public-route-access.test.ts"`