### PR TITLE
Clarify insight publish PR permission errors

### DIFF
--- a/frontend/scripts/import-content-machine-post.mjs
+++ b/frontend/scripts/import-content-machine-post.mjs
@@ -221,6 +221,21 @@ export function parseGitHubRepo(remoteUrl) {
   throw new Error(`Unsupported GitHub origin URL: ${normalized}`)
 }
 
+async function formatPullRequestCreationError(response, owner, repo) {
+  const failureBody = await response.text()
+
+  if (response.status === 404) {
+    return [
+      `GitHub pull request creation failed (404) for ${owner}/${repo}.`,
+      'The token can likely read the repository, but it does not have permission to open pull requests.',
+      'Ensure GITHUB_TOKEN or GH_TOKEN has pull request write access for this repository.',
+      `GitHub response: ${failureBody}`,
+    ].join(' ')
+  }
+
+  return `GitHub pull request creation failed (${response.status}): ${failureBody}`
+}
+
 export async function createPullRequest(plan, options = {}) {
   const { exec = execFileSync, fetchImpl = fetch, env = process.env } = options
   const token = readGithubToken(env)
@@ -249,8 +264,7 @@ export async function createPullRequest(plan, options = {}) {
   })
 
   if (!response.ok) {
-    const failureBody = await response.text()
-    throw new Error(`GitHub pull request creation failed (${response.status}): ${failureBody}`)
+    throw new Error(await formatPullRequestCreationError(response, owner, repo))
   }
 
   return response.json()

--- a/frontend/scripts/import-content-machine-post.test.mjs
+++ b/frontend/scripts/import-content-machine-post.test.mjs
@@ -170,6 +170,36 @@ describe('content-machine insight importer', () => {
     })
   })
 
+  it('surfaces a clear permission hint when GitHub returns 404 for PR creation', async () => {
+    const plan = buildImportPlan({
+      packageDir: '/tmp/20260506-onboarding-retentie',
+      repoRoot: '/repo/frontend',
+      post: buildPost(),
+      bodyMarkdown: '## Intro',
+      publishedAt: '2026-05-06',
+    })
+    const exec = vi.fn((command, args) => {
+      if (command === 'git' && args[0] === 'remote') {
+        return 'https://github.com/verisight/verisight-saas.git\n'
+      }
+
+      return ''
+    })
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      status: 404,
+      text: async () => '{"message":"Not Found"}',
+    }))
+
+    await expect(
+      createPullRequest(plan, {
+        exec,
+        fetchImpl,
+        env: { GITHUB_TOKEN: 'github-token' },
+      }),
+    ).rejects.toThrow(/does not have permission to open pull requests/i)
+  })
+
   it('imports the package, writes the markdown file, and prepares git and GitHub API publication', async () => {
     const repoRoot = createTempDirectory()
     const packageDir = createTempDirectory()


### PR DESCRIPTION
## Summary
- clarify GitHub PR creation failures for blog publish imports
- surface a specific permission hint when the GitHub API returns 404 on pull request creation
- add a regression test for that permission path

## Why
The content-machine publish flow can already write, commit, and push a generated insight branch. When PR creation fails because the API token lacks write permission, the old error was too generic.

## Verification
- `vitest run scripts/import-content-machine-post.test.mjs`
- `eslint scripts/import-content-machine-post.mjs scripts/import-content-machine-post.test.mjs`