### PR TITLE
Fix production build blockers for homepage and insights

### DIFF
--- a/frontend/components/marketing/design-tokens.tsx
+++ b/frontend/components/marketing/design-tokens.tsx
@@ -65,7 +65,7 @@ export function useInView(threshold = 0.12) {
 export function Reveal({
   children, delay = 0, from = 'up' as 'up' | 'right' | 'none', threshold = 0.1,
 }: {
-  children: React.ReactNode; delay?: number; from?: 'up' | 'right' | 'none'; threshold?: number
+  children?: React.ReactNode; delay?: number; from?: 'up' | 'right' | 'none'; threshold?: number
 }) {
   const [ref, inView] = useInView(threshold)
   const tr = { up: 'translateY(22px)', right: 'translateX(24px)', none: 'none' }

--- a/frontend/lib/insights.test.ts
+++ b/frontend/lib/insights.test.ts
@@ -84,6 +84,14 @@ describe('insight content parsing', () => {
     expect(result.generatedAt).toBe('2026-05-06')
   })
 
+  it('accepts generatedAt timestamps with microseconds', () => {
+    const result = parseInsightDocument(
+      buildInsightSource({ generatedAt: '2026-05-08T09:43:38.085818' }),
+    )
+
+    expect(result.generatedAt).toBe('2026-05-08T09:43:38.085818')
+  })
+
   it('loads markdown insight files from a directory and sorts newest first', () => {
     const directory = createTempDirectory()
 

--- a/frontend/lib/insights.ts
+++ b/frontend/lib/insights.ts
@@ -50,7 +50,7 @@ function readOptionalString(data: Record<string, unknown>, key: keyof InsightFro
 }
 
 function validateDateString(key: 'generatedAt' | 'publishedAt', value: string) {
-  const match = /^(\d{4})-(\d{2})-(\d{2})(?:T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?(?:Z|[+\-]\d{2}:\d{2})?)?$/.exec(
+  const match = /^(\d{4})-(\d{2})-(\d{2})(?:T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,6})?)?(?:Z|[+\-]\d{2}:\d{2})?)?$/.exec(
     value,
   )
   if (!match) {


### PR DESCRIPTION
## Summary
- make `Reveal` tolerate empty children in the marketing surface
- accept insight `generatedAt` timestamps with microseconds
- add a regression test for microsecond insight timestamps

## Verification
- `npm test -- lib/insights.test.ts`
- `npm run build`
