### PR TITLE
Fix dashboard route CTA to open routebeheer

### DIFF
--- a/frontend/app/(dashboard)/dashboard/page.test.ts
+++ b/frontend/app/(dashboard)/dashboard/page.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 import { selectLeadOverviewCampaign, selectPrimaryOverviewCampaign } from '@/lib/dashboard/overview-focus'
 import type { CampaignStats } from '@/lib/types'
+import { getCtaHrefForState } from './page'
 
 const campaigns: CampaignStats[] = [
   {
@@ -91,6 +92,16 @@ describe('dashboard home UX guardrails', () => {
     expect(source).toContain('MetricBlock label="RESPONS" value={item.responseValue} compact')
     expect(source).not.toContain('MetricBlock label={item.signalLabel.toUpperCase()}')
     expect(source).not.toContain('signalValue:')
+  })
+
+  it('sends route-management states directly to the beheer route instead of the old campaign maze page', () => {
+    expect(getCtaHrefForState('setup', 'campaign-123')).toBe('/campaigns/campaign-123/beheer')
+    expect(getCtaHrefForState('ready_to_launch', 'campaign-123')).toBe('/campaigns/campaign-123/beheer')
+    expect(getCtaHrefForState('running', 'campaign-123')).toBe('/campaigns/campaign-123/beheer')
+    expect(getCtaHrefForState('sparse', 'campaign-123')).toBe('/campaigns/campaign-123/beheer')
+    expect(getCtaHrefForState('partial', 'campaign-123')).toBe('/campaigns/campaign-123')
+    expect(getCtaHrefForState('full', 'campaign-123')).toBe('/campaigns/campaign-123')
+    expect(getCtaHrefForState('closed', 'campaign-123')).toBe('/campaigns/campaign-123')
   })
 
   it('allows the seeded HR demo campaign to override the default overview focus route', () => {

--- a/frontend/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/page.tsx
@@ -490,9 +490,15 @@ function buildCockpitRouteItem(entry: CampaignHomeEntry): CockpitRouteItem {
     why: getWhyCopy(entry),
     nextStep: ctaLabel,
     ctaLabel,
-    ctaHref: `/campaigns/${entry.campaign.campaign_id}`,
+    ctaHref: getCtaHrefForState(entry.state, entry.campaign.campaign_id),
     responseValue: completionValue,
   }
+}
+
+export function getCtaHrefForState(state: CampaignCompositionState, campaignId: string) {
+  if (state === 'partial' || state === 'full') return `/campaigns/${campaignId}`
+  if (state === 'closed') return `/campaigns/${campaignId}`
+  return `/campaigns/${campaignId}/beheer`
 }
 
 function getToneForBucket(bucket: CockpitBucket): OverviewRouteTone {


### PR DESCRIPTION
## Summary
- send dashboard cards in setup/building states directly to `/campaigns/[id]/beheer`
- keep readable and closed routes on the existing campaign detail destination
- add a guardrail test for CTA destination mapping

## Verification
- `npm test -- "app/(dashboard)/dashboard/page.test.ts"`
- `npx eslint "app/(dashboard)/dashboard/page.tsx" "app/(dashboard)/dashboard/page.test.ts"`
