### PR TITLE
Fix dashboard setup card routebeheer destination

### DIFF
--- a/frontend/app/(dashboard)/dashboard/home-launcher.test.ts
+++ b/frontend/app/(dashboard)/dashboard/home-launcher.test.ts
@@ -171,6 +171,25 @@ describe('dashboard and pdf availability', () => {
     expect(setupCard?.primaryAction.reason).toContain('Nog niet leesbaar')
   })
 
+  it('sends admin setup campaigns directly to the campaign-specific routebeheer page', () => {
+    const setupCampaign = buildCampaign({
+      campaign_id: 'setup-1',
+      campaign_name: 'ExitScan nieuw',
+      total_invited: 0,
+      total_completed: 0,
+      completion_rate_pct: 0,
+      avg_risk_score: null,
+      avg_signal_score: null,
+    })
+
+    const model = buildDashboardHomeModel({ campaigns: [setupCampaign], isAdmin: true })
+    const setupCard = model.groups.flatMap((group) => group.campaigns).find((card) => card.campaign.campaign_id === 'setup-1')
+
+    expect(setupCard?.primaryAction.available).toBe(true)
+    expect(setupCard?.primaryAction.kind).toBe('setup')
+    expect(setupCard?.primaryAction.href).toBe('/campaigns/setup-1/beheer')
+  })
+
   it('keeps the dashboard-versus-pdf choice explicit but compact in the recommendation model', () => {
     const model = buildDashboardHomeModel({
       campaigns: [buildCampaign({ campaign_id: 'ready-1' })],

--- a/frontend/app/(dashboard)/dashboard/home-launcher.ts
+++ b/frontend/app/(dashboard)/dashboard/home-launcher.ts
@@ -243,7 +243,7 @@ function buildDashboardAction(
         label: 'Naar setup',
         description: 'Open beheer om respondentimport, launchcontrole en livegang af te ronden.',
         available: true,
-        href: '/beheer',
+        href: `/campaigns/${campaign.campaign_id}/beheer`,
       }
     }
 


### PR DESCRIPTION
## Summary
- route admin setup/building dashboard cards to the campaign-specific routebeheer page
- keep the existing launcher model and labels intact
- add a regression test for the setup-card destination

## Verification
- `npm test -- "app/(dashboard)/dashboard/home-launcher.test.ts"`
- `npx eslint "app/(dashboard)/dashboard/home-launcher.ts" "app/(dashboard)/dashboard/home-launcher.test.ts"`
