### PR TITLE
Apply editorial insights UI system

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -2,65 +2,71 @@
 
 :root {
   /* Brand tokens — Stitch-aligned palette */
-  --ink:        #132033;
-  --navy:       #132033;
-  --petrol:     #132033;
-  --bg:         #F7F5F1;
+  --ink:        #051625;
+  --navy:       #1B2B3A;
+  --petrol:     #1B2B3A;
+  --bg:         #FBF9FA;
+  --bg-alt:     #F5F3F4;
   --surface:    #FFFFFF;
-  --teal:       #C96A4B;
-  --teal-light: #F3E4DA;
-  --text:       #4A5563;
-  --muted:      #6B7280;
-  --border:     #E5E0D6;
+  --surface-low:#F5F3F4;
+  --surface-mid:#EFEDEE;
+  --teal:       #C05A44;
+  --teal-light: #F3E1DC;
+  --text:       #1B1C1D;
+  --muted:      #43474C;
+  --meta:       #5A6B7D;
+  --border:     #E5E1D8;
+  --border-strong:#CFC9BF;
 
   /* Legacy compat */
   --background: var(--surface);
   --foreground: var(--ink);
 
   /* Layout */
-  --marketing-shell: 84rem;
-  --marketing-section-space: clamp(4rem, 6vw, 6.5rem);
-  --marketing-hero-space: clamp(3.5rem, 5.5vw, 5.75rem);
+  --marketing-shell: 80rem;
+  --marketing-section-space: clamp(4rem, 7vw, 5.5rem);
+  --marketing-hero-space: clamp(4rem, 6vw, 6rem);
+  --marketing-page-padding-x: clamp(1rem, 3.5vw, 3rem);
 
   /* Shadows */
-  --marketing-shadow-soft: 0 14px 32px rgba(19, 32, 51, 0.04);
-  --marketing-shadow-strong: 0 22px 48px rgba(19, 32, 51, 0.08);
-  --dashboard-shadow-soft: 0 12px 30px rgba(19, 32, 51, 0.05);
-  --dashboard-shadow-strong: 0 18px 38px rgba(19, 32, 51, 0.08);
-  --dashboard-shadow-card: 0 1px 6px rgba(19, 32, 51, 0.04);
+  --marketing-shadow-soft: 0 16px 40px rgba(27, 43, 58, 0.04);
+  --marketing-shadow-strong: 0 24px 56px rgba(27, 43, 58, 0.06);
+  --dashboard-shadow-soft: 0 16px 40px rgba(27, 43, 58, 0.04);
+  --dashboard-shadow-strong: 0 24px 56px rgba(27, 43, 58, 0.06);
+  --dashboard-shadow-card: none;
 
   /* Brand accent — copper (Stitch-aligned) */
-  --brand-accent-deep:  #C96A4B;
-  --brand-accent-mid:   #B85D41;
-  --brand-accent-soft:  #F3E4DA;
+  --brand-accent-deep:  #C05A44;
+  --brand-accent-mid:   #A94D3B;
+  --brand-accent-soft:  #F3E1DC;
 
   /* Dashboard canvas & surfaces — Stitch-aligned */
-  --dashboard-canvas:        #F7F5F1;
+  --dashboard-canvas:        #FBF9FA;
   --dashboard-surface:       #FFFFFF;
-  --dashboard-soft:          #FAF8F4;
+  --dashboard-soft:          #F5F3F4;
   --dashboard-rail:          #0a192f;
-  --dashboard-frame-border:  rgba(19, 32, 51, 0.08);
-  --dashboard-ink:           #132033;
-  --dashboard-text:          #4A5563;
-  --dashboard-muted:         #6B7280;
-  --dashboard-accent-soft:   #F3E4DA;
-  --dashboard-accent-soft-border: #E8B7A6;
-  --dashboard-accent-strong: #C96A4B;
-  --dashboard-blue-soft:     #F4F8F7;
-  --dashboard-amber-soft:    #FAF1EC;
+  --dashboard-frame-border:  rgba(27, 43, 58, 0.08);
+  --dashboard-ink:           #051625;
+  --dashboard-text:          #1B1C1D;
+  --dashboard-muted:         #5A6B7D;
+  --dashboard-accent-soft:   #F3E1DC;
+  --dashboard-accent-soft-border: rgba(192, 90, 68, 0.18);
+  --dashboard-accent-strong: #C05A44;
+  --dashboard-blue-soft:     #F5F3F4;
+  --dashboard-amber-soft:    #F5F3F4;
   --dashboard-topbar-strong: rgba(255, 255, 255, 0.97);
 
   /* Dashboard layout — sharper radii (Stitch direction) */
   --dashboard-sidebar-width: 260px;
   --dashboard-radius-card: 0.5rem;
-  --dashboard-radius-hero: 0.5rem;
+  --dashboard-radius-hero: 0.75rem;
   --dashboard-radius-chip: 9999px;
 
   /* Risk band colors */
   --risk-high:     #C65B52;
-  --risk-mid:      #C88C20;
+  --risk-mid:      #D39A2F;
   --risk-low:      #2E7C6D;
-  --risk-neutral:  #8A7D6E;
+  --risk-neutral:  #5A6B7D;
 }
 
 @theme inline {
@@ -75,9 +81,9 @@
   --color-text-body: var(--text);
   --color-muted: var(--muted);
   --color-border-warm: var(--border);
-  --font-sans: var(--font-ibm-plex-sans), system-ui, sans-serif;
-  --font-body: var(--font-ibm-plex-sans), system-ui, sans-serif;
-  --font-display: var(--font-newsreader), Georgia, serif;
+  --font-sans: var(--font-plus-jakarta), system-ui, sans-serif;
+  --font-body: var(--font-plus-jakarta), system-ui, sans-serif;
+  --font-display: var(--font-playfair), Georgia, serif;
 }
 
 html {
@@ -94,7 +100,7 @@ body {
   margin: 0;
   background: var(--bg);
   color: var(--foreground);
-  font-family: var(--font-ibm-plex-sans), system-ui, sans-serif;
+  font-family: var(--font-plus-jakarta), system-ui, sans-serif;
   text-rendering: optimizeLegibility;
   overflow-x: clip;
 }
@@ -112,8 +118,9 @@ input:focus-visible,
 textarea:focus-visible,
 select:focus-visible,
 summary:focus-visible {
-  outline: 2px solid var(--teal);
-  outline-offset: 3px;
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(192, 90, 68, 0.18);
+  border-radius: 6px;
 }
 
 ::selection {
@@ -160,7 +167,7 @@ details > summary::-webkit-details-marker {
   .marketing-shell {
     margin-inline: auto;
     width: min(100%, var(--marketing-shell));
-    padding-inline: clamp(1.25rem, 3vw, 2.5rem);
+    padding-inline: var(--marketing-page-padding-x);
   }
 
   .marketing-section {
@@ -188,8 +195,8 @@ details > summary::-webkit-details-marker {
   .marketing-panel {
     border: 1px solid var(--border);
     background: var(--surface);
-    box-shadow: var(--marketing-shadow-soft);
-    border-radius: 0.875rem;
+    box-shadow: none;
+    border-radius: 0.5rem;
     width: 100%;
     min-width: 0;
     max-width: 100%;
@@ -197,9 +204,9 @@ details > summary::-webkit-details-marker {
 
   .marketing-panel-soft {
     border: 1px solid var(--border);
-    background: var(--bg);
-    box-shadow: var(--marketing-shadow-soft);
-    border-radius: 0.875rem;
+    background: var(--surface-low);
+    box-shadow: none;
+    border-radius: 0.5rem;
     width: 100%;
     min-width: 0;
     max-width: 100%;
@@ -209,7 +216,7 @@ details > summary::-webkit-details-marker {
     border: 1px solid rgba(255, 255, 255, 0.1);
     background: var(--navy);
     box-shadow: var(--marketing-shadow-strong);
-    border-radius: 0.875rem;
+    border-radius: 0.75rem;
     color: var(--bg);
     width: 100%;
     min-width: 0;
@@ -222,7 +229,7 @@ details > summary::-webkit-details-marker {
     border: 1px solid rgba(255, 255, 255, 0.08);
     background: var(--navy);
     box-shadow: var(--marketing-shadow-strong);
-    border-radius: 0.875rem;
+    border-radius: 0.75rem;
     color: var(--bg);
     width: 100%;
     min-width: 0;
@@ -234,7 +241,7 @@ details > summary::-webkit-details-marker {
     position: absolute;
     inset: 1px;
     border: 1px solid rgba(255, 255, 255, 0.05);
-    border-radius: calc(0.875rem - 1px);
+    border-radius: calc(0.75rem - 1px);
     pointer-events: none;
   }
 
@@ -305,7 +312,7 @@ details > summary::-webkit-details-marker {
   .marketing-hero-copy {
     max-width: 41rem;
     font-size: 1rem;
-    line-height: 1.9;
+    line-height: 1.75;
   }
 
   .marketing-hero-cta-row {
@@ -331,10 +338,10 @@ details > summary::-webkit-details-marker {
 
   .marketing-support-note {
     border: 1px solid var(--border);
-    background: var(--surface);
-    border-radius: 1rem;
+    background: var(--surface-low);
+    border-radius: 0.5rem;
     padding: 1rem 1.15rem;
-    box-shadow: var(--marketing-shadow-soft);
+    box-shadow: none;
     width: 100%;
     min-width: 0;
     max-width: 100%;
@@ -348,9 +355,9 @@ details > summary::-webkit-details-marker {
   .marketing-link-card {
     border: 1px solid var(--border);
     background: var(--surface);
-    border-radius: 1rem;
+    border-radius: 0.5rem;
     padding: 0.95rem 1rem;
-    box-shadow: var(--marketing-shadow-soft);
+    box-shadow: none;
     width: 100%;
     min-width: 0;
     max-width: 100%;
@@ -401,31 +408,31 @@ details > summary::-webkit-details-marker {
   .marketing-feature-card {
     border: 1px solid var(--border);
     background: var(--surface);
-    box-shadow: var(--marketing-shadow-soft);
-    border-radius: 1.35rem;
+    box-shadow: none;
+    border-radius: 0.5rem;
     padding: 1.35rem;
   }
 
   .marketing-stat-card {
     border: 1px solid rgba(255, 255, 255, 0.08);
     background: rgba(255, 255, 255, 0.05);
-    border-radius: 1.35rem;
+    border-radius: 0.5rem;
     padding: 1rem 1rem 1.1rem;
   }
 
   .marketing-route-card {
     border: 1px solid var(--border);
     background: var(--surface);
-    box-shadow: var(--marketing-shadow-soft);
-    border-radius: 1.5rem;
+    box-shadow: none;
+    border-radius: 0.5rem;
     padding: 1.5rem;
   }
 
   .marketing-route-card-dark {
     border: 1px solid rgba(255, 255, 255, 0.08);
-    background: linear-gradient(180deg, rgba(255, 255, 255, 0.06) 0%, rgba(255, 255, 255, 0.03) 100%);
+    background: var(--navy);
     box-shadow: var(--marketing-shadow-strong);
-    border-radius: 1.5rem;
+    border-radius: 0.75rem;
     padding: 1.5rem;
   }
 
@@ -466,8 +473,8 @@ details > summary::-webkit-details-marker {
     overflow: hidden;
     border: 1px solid var(--border);
     background: var(--surface);
-    box-shadow: var(--marketing-shadow-soft);
-    border-radius: 1.75rem;
+    box-shadow: none;
+    border-radius: 0.5rem;
   }
 
   .marketing-divider-title {
@@ -493,8 +500,8 @@ details > summary::-webkit-details-marker {
     position: relative;
     border: 1px solid var(--border);
     background: var(--surface);
-    box-shadow: var(--marketing-shadow-soft);
-    border-radius: 1.5rem;
+    box-shadow: none;
+    border-radius: 0.5rem;
     padding: 1.5rem;
   }
 
@@ -504,8 +511,8 @@ details > summary::-webkit-details-marker {
     inset: 0 auto auto 0;
     width: 100%;
     height: 4px;
-    background: linear-gradient(90deg, var(--teal) 0%, rgba(60, 141, 138, 0.16) 100%);
-    border-radius: 1.5rem 1.5rem 0 0;
+    background: var(--accent);
+    border-radius: 0.5rem 0.5rem 0 0;
   }
 
   .dashboard-shell {
@@ -601,7 +608,7 @@ details > summary::-webkit-details-marker {
   }
 
   .dash-number {
-    font-family: var(--font-ibm-plex-sans), system-ui, sans-serif;
+    font-family: var(--font-plus-jakarta), system-ui, sans-serif;
     font-weight: 600;
     letter-spacing: -0.04em;
   }
@@ -643,7 +650,7 @@ details > summary::-webkit-details-marker {
     font-weight: 700;
     letter-spacing: 0.18em;
     text-transform: uppercase;
-    color: var(--teal);
+    color: var(--accent);
   }
 
   .marketing-text-title-lg {
@@ -695,23 +702,23 @@ details > summary::-webkit-details-marker {
     align-items: center;
     justify-content: center;
     font-family: var(--font-body);
-    border-radius: 9999px;
+    border-radius: 0.375rem;
     background: var(--brand-accent-deep);
-    padding: 0.8rem 1.5rem;
+    padding: 0.875rem 1.375rem;
     font-size: 0.9rem;
     font-weight: 600;
     color: white;
-    box-shadow: 0 14px 30px rgba(201, 106, 75, 0.18);
     transition:
       transform 180ms ease,
       background-color 180ms ease,
-      box-shadow 180ms ease;
+      border-color 180ms ease;
+    border: 1px solid var(--brand-accent-deep);
   }
 
   .marketing-button-primary:hover {
-    transform: translateY(-1px);
+    transform: translateY(-2px);
     background: var(--brand-accent-mid);
-    box-shadow: 0 16px 36px rgba(201, 106, 75, 0.22);
+    border-color: var(--brand-accent-mid);
   }
 
   .marketing-button-primary-warm {
@@ -719,23 +726,23 @@ details > summary::-webkit-details-marker {
     align-items: center;
     justify-content: center;
     font-family: var(--font-body);
-    border-radius: 9999px;
+    border-radius: 0.375rem;
     background: var(--brand-accent-deep);
-    padding: 0.8rem 1.5rem;
+    padding: 0.875rem 1.375rem;
     font-size: 0.9rem;
     font-weight: 600;
     color: white;
-    box-shadow: 0 14px 30px rgba(201, 106, 75, 0.18);
     transition:
       transform 180ms ease,
       background-color 180ms ease,
-      box-shadow 180ms ease;
+      border-color 180ms ease;
+    border: 1px solid var(--brand-accent-deep);
   }
 
   .marketing-button-primary-warm:hover {
-    transform: translateY(-1px);
+    transform: translateY(-2px);
     background: var(--brand-accent-mid);
-    box-shadow: 0 16px 36px rgba(201, 106, 75, 0.22);
+    border-color: var(--brand-accent-mid);
   }
 
   .marketing-button-secondary {
@@ -743,10 +750,10 @@ details > summary::-webkit-details-marker {
     align-items: center;
     justify-content: center;
     font-family: var(--font-body);
-    border-radius: 9999px;
+    border-radius: 0.375rem;
     border: 1px solid var(--border);
     background: var(--surface);
-    padding: 0.8rem 1.5rem;
+    padding: 0.875rem 1.375rem;
     font-size: 0.9rem;
     font-weight: 600;
     color: var(--ink);
@@ -757,7 +764,7 @@ details > summary::-webkit-details-marker {
   }
 
   .marketing-button-secondary:hover {
-    transform: translateY(-1px);
+    transform: translateY(-2px);
     border-color: var(--ink);
     color: var(--ink);
   }
@@ -767,10 +774,10 @@ details > summary::-webkit-details-marker {
     align-items: center;
     justify-content: center;
     font-family: var(--font-body);
-    border-radius: 9999px;
+    border-radius: 0.375rem;
     border: 1px solid rgba(255, 255, 255, 0.12);
     background: rgba(255, 255, 255, 0.06);
-    padding: 0.8rem 1.5rem;
+    padding: 0.875rem 1.375rem;
     font-size: 0.9rem;
     font-weight: 600;
     color: rgba(247, 245, 241, 0.9);
@@ -782,7 +789,7 @@ details > summary::-webkit-details-marker {
   }
 
   .marketing-button-secondary-dark:hover {
-    transform: translateY(-1px);
+    transform: translateY(-2px);
     border-color: rgba(255, 255, 255, 0.18);
     background: rgba(255, 255, 255, 0.1);
     color: white;
@@ -804,7 +811,7 @@ details > summary::-webkit-details-marker {
 
   .marketing-nav-link {
     font-family: var(--font-body);
-    border-radius: 9999px;
+    border-radius: 0.375rem;
     padding: 0.5rem 0.75rem;
     font-size: 0.9rem;
     color: var(--text);
@@ -843,7 +850,7 @@ details > summary::-webkit-details-marker {
     align-items: center;
     justify-content: center;
     font-family: var(--font-body);
-    border-radius: 9999px;
+    border-radius: 0.375rem;
     border: 1px solid var(--border);
     background: var(--surface);
     color: var(--text);
@@ -856,11 +863,11 @@ details > summary::-webkit-details-marker {
 
   .marketing-mobile-menu {
     margin-top: 1rem;
-    border-radius: 1rem;
+    border-radius: 0.75rem;
     border: 1px solid var(--border);
     background: var(--surface);
     padding: 1rem;
-    box-shadow: 0 24px 60px rgba(19, 32, 51, 0.08);
+    box-shadow: var(--marketing-shadow-soft);
   }
 
   .marketing-mobile-nav-link {
@@ -888,7 +895,7 @@ details > summary::-webkit-details-marker {
 
   .marketing-detail-hero {
     border-bottom: 1px solid var(--border);
-    background: #FFFCF8;
+    background: var(--bg);
   }
 
   .marketing-detail-hero-shell {
@@ -900,7 +907,7 @@ details > summary::-webkit-details-marker {
     font-weight: 700;
     letter-spacing: 0.18em;
     text-transform: uppercase;
-    color: var(--teal);
+    color: var(--accent);
   }
 
   .marketing-detail-title {
@@ -943,22 +950,22 @@ details > summary::-webkit-details-marker {
   .marketing-detail-panel {
     border: 1px solid var(--border);
     background: var(--surface);
-    box-shadow: var(--marketing-shadow-soft);
-    border-radius: 1rem;
+    box-shadow: none;
+    border-radius: 0.5rem;
     padding: 1.25rem;
   }
 
   .marketing-detail-panel-soft {
     border: 1px solid var(--border);
-    background: var(--bg);
-    border-radius: 1rem;
+    background: var(--surface-low);
+    border-radius: 0.5rem;
     padding: 1.25rem;
   }
 
   .marketing-detail-dark-card {
     border: 1px solid rgba(255, 255, 255, 0.12);
     background: rgba(247, 245, 241, 0.06);
-    border-radius: 1rem;
+    border-radius: 0.75rem;
     padding: 1.25rem;
   }
 
@@ -984,7 +991,7 @@ details > summary::-webkit-details-marker {
     width: 0.38rem;
     flex-shrink: 0;
     border-radius: 9999px;
-    background: var(--teal);
+    background: var(--accent);
   }
 
   .marketing-detail-list-item-light {
@@ -992,7 +999,7 @@ details > summary::-webkit-details-marker {
   }
 
   .marketing-detail-list-item-light::before {
-    background: var(--teal);
+    background: var(--accent);
   }
 
   .marketing-detail-grid {

--- a/frontend/app/inzichten/[slug]/page.test.ts
+++ b/frontend/app/inzichten/[slug]/page.test.ts
@@ -112,7 +112,7 @@ describe('inzichten article route', () => {
 
     expect(metadata.alternates?.canonical).toBe('/inzichten/waarom-onboarding-retentie-vroeg-voorspelt')
     expect(metadata.openGraph?.type).toBe('article')
-    expect(metadata.title).toBe('Waarom onboarding retentie vroeg voorspelt | Inzichten | Verisight')
+    expect(metadata.title).toBe('Waarom onboarding retentie vroeg voorspelt | Inzichten')
   })
 
   it('renders the route shell with article context and excludes the current post from related insights', async () => {

--- a/frontend/app/inzichten/[slug]/page.tsx
+++ b/frontend/app/inzichten/[slug]/page.tsx
@@ -21,7 +21,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     return {}
   }
 
-  const title = `${post.title} | Inzichten | Verisight`
+  const title = `${post.title} | Inzichten`
   const description = post.metaDescription
   const canonical = `/inzichten/${post.slug}`
 
@@ -86,24 +86,24 @@ export default async function InsightArticlePage({ params }: Props) {
         ctaLabel={marketingPrimaryCta.label}
         heroIntro={
           <div>
-            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--muted)]">Inzichten</p>
-            <h1 className="mt-4 max-w-4xl text-[clamp(2.8rem,5vw,4.8rem)] leading-[0.95] text-[var(--ink)]">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--meta)]">Inzichten</p>
+            <h1 className="mt-4 max-w-[12ch] text-balance font-display text-[clamp(2.35rem,8.8vw,4.8rem)] leading-[1.03] text-[var(--ink)]">
               {post.title}
             </h1>
-            <p className="mt-6 max-w-3xl text-lg leading-8 text-[var(--text)]">{post.metaDescription}</p>
+            <p className="mt-6 max-w-3xl text-lg leading-[1.8] text-[var(--muted)]">{post.metaDescription}</p>
           </div>
         }
         heroSupport={
-          <div className="space-y-4 rounded-[28px] border border-[var(--border)] bg-white p-6">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--muted)]">Artikelcontext</p>
-            <div className="space-y-3 text-sm leading-7 text-[var(--text)]">
+          <div className="space-y-4 rounded-[8px] border border-[var(--border)] bg-[var(--surface-low)] p-6">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--meta)]">Artikelcontext</p>
+            <div className="space-y-3 text-sm leading-[1.75] text-[var(--muted)]">
               <p>{post.category}</p>
               <p>{publishedLabel}</p>
               <p>{post.readingMinutes} min leestijd</p>
             </div>
             <a
               href={post.ctaTarget}
-              className="inline-flex items-center rounded-full border border-[var(--border)] px-4 py-2 text-sm font-semibold text-[var(--ink)] transition-colors hover:border-[var(--ink)]"
+              className="marketing-button-secondary"
             >
               {post.ctaLabel}
             </a>

--- a/frontend/app/inzichten/page.tsx
+++ b/frontend/app/inzichten/page.tsx
@@ -7,7 +7,7 @@ import { marketingPrimaryCta } from '@/components/marketing/site-content'
 import { getAllInsights } from '@/lib/insights'
 
 export const metadata: Metadata = {
-  title: 'Inzichten | Verisight',
+  title: 'Inzichten',
   description: 'Verdiepende inzichten over vertrek, behoud, duiding en opvolging binnen dezelfde wereld als Verisight.',
   alternates: {
     canonical: '/inzichten',
@@ -37,11 +37,11 @@ export default function InsightsIndexPage() {
       ctaLabel={marketingPrimaryCta.label}
       heroIntro={
         <div>
-          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--muted)]">INZICHTEN</p>
-          <h1 className="mt-4 max-w-4xl text-[clamp(3rem,6vw,5.5rem)] leading-[0.94] text-[var(--ink)]">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--meta)]">INZICHTEN</p>
+          <h1 className="mt-4 max-w-[11ch] text-balance font-display text-[clamp(2.7rem,8vw,5.5rem)] leading-[1.01] text-[var(--ink)]">
             Scherpere duiding bij vertrek, behoud en opvolging
           </h1>
-          <p className="mt-6 max-w-3xl text-lg leading-8 text-[var(--text)]">
+          <p className="mt-6 max-w-3xl text-lg leading-[1.8] text-[var(--muted)]">
             Hier leest u verdiepende artikelen die helpen scherper te kijken naar vertrek, behoud, prioriteiten en
             eerste opvolging. Rustige duiding, compact gebracht en duidelijk verbonden aan dezelfde wereld als
             Verisight.
@@ -49,16 +49,16 @@ export default function InsightsIndexPage() {
         </div>
       }
       heroSupport={
-        <div className="rounded-[28px] border border-[var(--border)] bg-white p-6">
-          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--muted)]">Waarover u hier leest</p>
-          <div className="mt-4 space-y-3 text-sm leading-7 text-[var(--text)]">
+        <div className="rounded-[8px] border border-[var(--border)] bg-[var(--surface-low)] p-6">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--meta)]">Waarover u hier leest</p>
+          <div className="mt-4 space-y-3 text-sm leading-[1.75] text-[var(--muted)]">
             <p>Vertrek begrijpen voordat patronen zich blijven herhalen.</p>
             <p>Behoud eerder zien voordat signalen pas in uitstroom zichtbaar worden.</p>
             <p>Prioriteiten scherper maken en opvolging pas organiseren wanneer dat echt nodig is.</p>
           </div>
           <Link
             href="/aanpak"
-            className="mt-6 inline-flex items-center rounded-full border border-[var(--border)] px-4 py-2 text-sm font-semibold text-[var(--ink)] transition-colors hover:border-[var(--ink)]"
+            className="marketing-button-secondary mt-6"
           >
             Bekijk hoe Verisight werkt
           </Link>

--- a/frontend/app/kennismaking/page.tsx
+++ b/frontend/app/kennismaking/page.tsx
@@ -30,7 +30,7 @@ const shellStyle = {
   padding: '0 clamp(20px, 4vw, 48px)',
 } as const
 
-const displayFont = 'var(--font-fraunces), Georgia, serif'
+const displayFont = 'var(--font-playfair), Georgia, serif'
 
 export default function KennismakingPage() {
   return (

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,31 +1,21 @@
 import type { Metadata } from 'next'
-import { IBM_Plex_Sans, Fraunces, Newsreader } from 'next/font/google'
+import { Playfair_Display, Plus_Jakarta_Sans } from 'next/font/google'
 import { SiteAnalytics } from '@/components/marketing/site-analytics'
 import './globals.css'
 
-const ibmPlexSans = IBM_Plex_Sans({
+const plusJakartaSans = Plus_Jakarta_Sans({
   subsets: ['latin'],
-  weight: ['300', '400', '500', '600'],
+  weight: ['400', '500', '600', '700'],
   display: 'swap',
-  variable: '--font-ibm-plex-sans',
+  variable: '--font-plus-jakarta',
 })
 
-const fraunces = Fraunces({
+const playfairDisplay = Playfair_Display({
   subsets: ['latin'],
-  weight: 'variable',
+  weight: ['600', '700'],
   style: ['normal', 'italic'],
-  axes: ['opsz'],
   display: 'swap',
-  variable: '--font-fraunces',
-})
-
-const newsreader = Newsreader({
-  subsets: ['latin'],
-  weight: 'variable',
-  style: ['normal', 'italic'],
-  axes: ['opsz'],
-  display: 'swap',
-  variable: '--font-newsreader',
+  variable: '--font-playfair',
 })
 
 const googleSiteVerification = process.env.GOOGLE_SITE_VERIFICATION
@@ -98,7 +88,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
   return (
     <html lang="nl">
-      <body className={`${ibmPlexSans.variable} ${fraunces.variable} ${newsreader.variable} font-[family-name:var(--font-ibm-plex-sans)] bg-[--bg] antialiased`}>
+      <body className={`${plusJakartaSans.variable} ${playfairDisplay.variable} font-[family-name:var(--font-plus-jakarta)] bg-[--bg] antialiased`}>
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationSchema) }}

--- a/frontend/app/producten/[slug]/page.tsx
+++ b/frontend/app/producten/[slug]/page.tsx
@@ -177,7 +177,7 @@ function ExitScanPage() {
     ruleLight: 'oklch(0.918 0.008 62)',
   }
     const AC = { deep: 'oklch(0.45 0.18 50)', mid: 'oklch(0.76 0.14 53)', soft: 'oklch(0.95 0.045 50)' }
-    const FF = 'var(--font-fraunces), serif'
+const FF = 'var(--font-playfair), serif'
     const SH = { maxWidth: 1200, margin: '0 auto', padding: '0 clamp(20px,4vw,48px)' }
     const cardShadow = '0 10px 28px rgba(22, 34, 56, 0.06), 0 2px 6px rgba(22, 34, 56, 0.04)'
     const featureCardStyle = {
@@ -370,7 +370,7 @@ function RetentionScanPage() {
     ruleLight: 'oklch(0.918 0.008 62)',
     teal: 'oklch(0.50 0.12 188)', tealSoft: 'oklch(0.94 0.04 185)', tealFaint: 'oklch(0.972 0.018 185)',
   }
-    const FF = 'var(--font-fraunces), serif'
+const FF = 'var(--font-playfair), serif'
     const SH = { maxWidth: 1200, margin: '0 auto', padding: '0 clamp(20px,4vw,48px)' }
     const cardShadow = '0 10px 28px rgba(22, 34, 56, 0.06), 0 2px 6px rgba(22, 34, 56, 0.04)'
     const featureCardStyle = {

--- a/frontend/components/marketing/design-tokens.tsx
+++ b/frontend/components/marketing/design-tokens.tsx
@@ -4,33 +4,33 @@ import { useState, useEffect, useRef } from 'react'
 
 // ── Design tokens ─────────────────────────────────────────────────
 export const T = {
-  paper:      '#F7F5F1',
-  paperSoft:  '#FAF8F4',
-  paperBlush: '#F3E4DA',
+  paper:      '#FBF9FA',
+  paperSoft:  '#F5F3F4',
+  paperBlush: '#F3E1DC',
   white:      '#FFFFFF',
-  navy:       '#132033',
-  ink:        '#132033',
-  inkSoft:    '#4A5563',
-  inkMuted:   '#6B7280',
-  inkFaint:   '#9AA3AE',
-  rule:       '#E5E0D6',
-  ruleLight:  '#F0EBE2',
-  teal:       '#7A908B',
-  tealMid:    '#90A29F',
-  tealSoft:   '#E8F0EE',
-  tealFaint:  '#F4F8F7',
+  navy:       '#1B2B3A',
+  ink:        '#051625',
+  inkSoft:    '#1B1C1D',
+  inkMuted:   '#43474C',
+  inkFaint:   '#5A6B7D',
+  rule:       '#E5E1D8',
+  ruleLight:  '#EFEDEE',
+  teal:       '#C05A44',
+  tealMid:    '#A94D3B',
+  tealSoft:   '#F3E1DC',
+  tealFaint:  '#F5F3F4',
 } as const
 
 export const AC = {
-  deep:  '#C96A4B',
-  mid:   '#D9886E',
+  deep:  '#C05A44',
+  mid:   '#A94D3B',
   light: '#E8B7A6',
-  soft:  '#F3E4DA',
-  faint: '#FAF1EC',
+  soft:  '#F3E1DC',
+  faint: '#F5F3F4',
 } as const
 
-export const FF = 'var(--font-fraunces), serif'
-export const SHELL = { maxWidth: 1200, margin: '0 auto', padding: '0 clamp(20px,4vw,48px)' } as const
+export const FF = 'var(--font-playfair), serif'
+export const SHELL = { maxWidth: 1280, margin: '0 auto', padding: '0 clamp(16px,3.5vw,48px)' } as const
 
 // ── Hooks ─────────────────────────────────────────────────────────
 export function useInView(threshold = 0.12) {

--- a/frontend/components/marketing/follow-on-route-page.tsx
+++ b/frontend/components/marketing/follow-on-route-page.tsx
@@ -343,7 +343,7 @@ export function FollowOnRoutePage({ route }: FollowOnRoutePageProps) {
   )
 }
 
-const FF = 'var(--font-fraunces), serif'
+const FF = 'var(--font-playfair), serif'
 const SHELL = { maxWidth: 1200, margin: '0 auto', padding: '0 clamp(20px,4vw,48px)' }
 
 function getRoutePalette(slug: FollowOnRouteContent['slug']) {

--- a/frontend/components/marketing/home-insight-action-demo.tsx
+++ b/frontend/components/marketing/home-insight-action-demo.tsx
@@ -23,8 +23,8 @@ const C = {
   tealLine:  '#E8B7A6',
 } as const
 
-const FF  = 'var(--font-fraunces), Georgia, serif'
-const FN  = 'var(--font-ibm-plex-sans), system-ui, sans-serif'
+const FF  = 'var(--font-playfair), Georgia, serif'
+const FN  = 'var(--font-plus-jakarta), system-ui, sans-serif'
 const SH  = { margin: '0 auto', maxWidth: 1240, padding: '0 clamp(20px, 4vw, 48px)' } as const
 
 const CARD_RADIUS  = 20

--- a/frontend/components/marketing/home-page-content.tsx
+++ b/frontend/components/marketing/home-page-content.tsx
@@ -3,33 +3,33 @@ import { Reveal } from '@/components/marketing/design-tokens'
 import { buildContactHref } from '@/lib/contact-funnel'
 
 const SURFACE = {
-  paper: '#F7F5F1',
-  paperSoft: '#FAF8F4',
+  paper: '#FBF9FA',
+  paperSoft: '#F5F3F4',
   surface: '#FFFFFF',
-  surfaceSoft: '#F7F5F1',
-  border: '#E5E0D6',
-  borderSoft: '#F0EBE2',
-  ink: '#132033',
-  text: '#4A5563',
-  muted: '#6B7280',
-  subtle: '#9AA3AE',
-  teal: '#7A908B',
-  tealSoft: '#E8F0EE',
-  amber: '#C96A4B',
-  amberSoft: '#F3E4DA',
-  amberGlow: '#B85D41',
-  charcoal: '#132033',
-  charcoalSoft: '#1C2A3D',
+  surfaceSoft: '#F5F3F4',
+  border: '#E5E1D8',
+  borderSoft: '#EFEDEE',
+  ink: '#051625',
+  text: '#1B1C1D',
+  muted: '#43474C',
+  subtle: '#5A6B7D',
+  teal: '#C05A44',
+  tealSoft: '#F3E1DC',
+  amber: '#C05A44',
+  amberSoft: '#F3E1DC',
+  amberGlow: '#A94D3B',
+  charcoal: '#051625',
+  charcoalSoft: '#1B2B3A',
 } as const
 
 const SHELL = {
   margin: '0 auto',
-  maxWidth: 1240,
+  maxWidth: 1280,
   padding: '0 clamp(20px, 4vw, 48px)',
 } as const
 
-const displayFont = 'var(--font-fraunces), Georgia, serif'
-const bodyFont = 'var(--font-ibm-plex-sans), system-ui, sans-serif'
+const displayFont = 'var(--font-playfair), Georgia, serif'
+const bodyFont = 'var(--font-plus-jakarta), system-ui, sans-serif'
 
 const heroTrustItems = [
   'Dashboard voor inzicht \u2022 Managementrapport voor duiding \u2022 Action Center voor opvolging',
@@ -517,8 +517,8 @@ function ManagementFlowSection() {
                   style={{
                     background: SURFACE.surface,
                     border: `1px solid ${SURFACE.borderSoft}`,
-                    borderRadius: 28,
-                    boxShadow: '0 10px 28px rgba(22, 34, 56, 0.06), 0 2px 6px rgba(22, 34, 56, 0.04)',
+                    borderRadius: 8,
+                    boxShadow: 'none',
                     minHeight: item.cardMinHeight ?? 408,
                     padding: '22px 24px 24px',
                     position: 'relative',
@@ -834,9 +834,9 @@ function HeroSection() {
               <p
                 className="marketing-home-hero-reveal-2"
                 style={{
-                  color: SURFACE.text,
-                  fontSize: 17,
-                  lineHeight: 1.6,
+                  color: SURFACE.muted,
+                  fontSize: 18,
+                  lineHeight: 1.72,
                   marginBottom: 28,
                   maxWidth: '32rem',
                 }}
@@ -852,7 +852,8 @@ function HeroSection() {
                 href={primaryHref}
                 style={{
                   background: SURFACE.amber,
-                  borderRadius: 2,
+                  border: `1px solid ${SURFACE.amber}`,
+                  borderRadius: 6,
                   color: '#fff',
                   display: 'inline-flex',
                   fontFamily: bodyFont,
@@ -869,7 +870,7 @@ function HeroSection() {
                 style={{
                   background: SURFACE.surface,
                   border: `1px solid ${SURFACE.border}`,
-                  borderRadius: 2,
+                  borderRadius: 6,
                   color: SURFACE.ink,
                   display: 'inline-flex',
                   fontFamily: bodyFont,
@@ -916,8 +917,8 @@ function HeroSection() {
                 style={{
                   background: SURFACE.paper,
                   border: `1px solid ${SURFACE.border}`,
-                  borderRadius: 18,
-                  boxShadow: '0 12px 28px rgba(22, 34, 56, 0.04)',
+                  borderRadius: 8,
+                  boxShadow: 'none',
                   height: 322,
                   overflow: 'hidden',
                   padding: '26px 28px 22px',
@@ -958,7 +959,7 @@ function HeroSection() {
                       style={{
                         background: 'rgba(255,255,255,0.48)',
                         border: `1px solid ${SURFACE.borderSoft}`,
-                        borderRadius: 12,
+                        borderRadius: 8,
                         padding: '8px 10px 7px',
                       }}
                     >
@@ -972,9 +973,9 @@ function HeroSection() {
 
                 <div
                   style={{
-                    background: `linear-gradient(180deg, rgba(255,255,255,0.42) 0%, ${SURFACE.paperSoft} 100%)`,
+                    background: SURFACE.surfaceSoft,
                     border: `1px solid ${SURFACE.border}`,
-                    borderRadius: 16,
+                    borderRadius: 8,
                     height: 186,
                     marginBottom: 16,
                     padding: '18px 18px 16px',
@@ -1016,7 +1017,7 @@ function HeroSection() {
                       style={{
                         background: 'rgba(255,255,255,0.56)',
                         border: `1px solid ${SURFACE.borderSoft}`,
-                        borderRadius: 13,
+                        borderRadius: 8,
                         padding: '10px 11px',
                       }}
                     >
@@ -1034,8 +1035,8 @@ function HeroSection() {
                 style={{
                   background: SURFACE.surface,
                   border: `1px solid ${SURFACE.border}`,
-                  borderRadius: 18,
-                  boxShadow: '0 16px 34px rgba(22, 34, 56, 0.08)',
+                  borderRadius: 8,
+                  boxShadow: '0 24px 56px rgba(27, 43, 58, 0.06)',
                   minHeight: 264,
                   overflow: 'hidden',
                   padding: '24px 24px 22px',
@@ -1099,8 +1100,8 @@ function HeroSection() {
                 style={{
                   background: SURFACE.charcoal,
                   border: '1px solid rgba(255,255,255,0.08)',
-                  borderRadius: 24,
-                  boxShadow: '0 24px 48px rgba(13, 17, 24, 0.24)',
+                  borderRadius: 12,
+                  boxShadow: '0 24px 56px rgba(5, 22, 37, 0.22)',
                   color: '#fff',
                   padding: '18px 19px 14px',
                   position: 'absolute',
@@ -1116,8 +1117,8 @@ function HeroSection() {
                       style={{
                         alignItems: 'center',
                         background: SURFACE.amber,
-                        borderRadius: 12,
-                        boxShadow: '0 12px 24px rgba(185, 87, 31, 0.2)',
+                        borderRadius: 8,
+                        boxShadow: 'none',
                         display: 'flex',
                         flexShrink: 0,
                         height: 42,
@@ -2103,8 +2104,8 @@ function FirstDeliverySection() {
                   style={{
                     background: SURFACE.surface,
                     border: `1px solid ${SURFACE.borderSoft}`,
-                    borderRadius: 28,
-                    boxShadow: '0 10px 24px rgba(22, 34, 56, 0.06), 0 2px 5px rgba(22, 34, 56, 0.04)',
+                    borderRadius: 8,
+                    boxShadow: 'none',
                     minHeight: item.minHeight ?? 132,
                     padding: '28px 28px 26px',
                   }}
@@ -2149,7 +2150,7 @@ function FirstDeliverySection() {
                 style={{
                   background: 'transparent',
                   border: `1.5px dashed ${SURFACE.border}`,
-                  borderRadius: 28,
+                  borderRadius: 8,
                   maxWidth: 760,
                   minHeight: 132,
                   padding: '28px 28px 26px',
@@ -2212,10 +2213,10 @@ function ContactSection() {
         <Reveal>
           <div
             style={{
-              background:
-                'radial-gradient(circle at left bottom, rgba(21, 101, 88, 0.34) 0%, rgba(21, 101, 88, 0) 28%), linear-gradient(135deg, #0d1724 0%, #122133 56%, #162634 100%)',
-              borderRadius: 38,
-              boxShadow: '0 22px 48px rgba(13, 23, 36, 0.16)',
+              background: SURFACE.charcoal,
+              border: '1px solid rgba(255,255,255,0.08)',
+              borderRadius: 12,
+              boxShadow: '0 24px 56px rgba(5, 22, 37, 0.22)',
               margin: '0 auto',
               maxWidth: 1200,
               padding: 'clamp(40px, 6vw, 72px) clamp(26px, 5vw, 64px)',
@@ -2260,7 +2261,7 @@ function ContactSection() {
                 style={{
                   alignItems: 'center',
                   background: SURFACE.amber,
-                  borderRadius: 999,
+                  borderRadius: 6,
                   color: '#fff',
                   display: 'inline-flex',
                   fontFamily: bodyFont,
@@ -2280,7 +2281,7 @@ function ContactSection() {
                   alignItems: 'center',
                   background: 'transparent',
                   border: '1px solid rgba(255, 250, 242, 0.22)',
-                  borderRadius: 999,
+                  borderRadius: 6,
                   color: '#fffdf8',
                   display: 'inline-flex',
                   fontFamily: bodyFont,

--- a/frontend/components/marketing/insight-article-content.tsx
+++ b/frontend/components/marketing/insight-article-content.tsx
@@ -16,33 +16,33 @@ export function InsightArticleContent({ post, relatedPosts }: InsightArticleCont
     <>
       <section className="border-b border-[var(--border)] bg-white">
         <div className="marketing-shell py-16 md:py-20">
-          <div className="grid gap-10 xl:grid-cols-[minmax(0,1fr)_320px] xl:items-start">
-            <article className="min-w-0 rounded-[32px] border border-[var(--border)] bg-[#fffdf9] p-7 md:p-10">
-              <div className="max-w-none">
+          <div className="grid gap-10 xl:grid-cols-[minmax(0,1fr)_300px] xl:items-start">
+            <article className="min-w-0 rounded-[8px] border border-[var(--border)] bg-white p-7 md:p-10">
+              <div className="mx-auto max-w-[42rem]">
                 <ReactMarkdown
                   remarkPlugins={[remarkGfm]}
                   components={{
                     h1: ({ ...props }) => (
-                      <h1 className="mt-10 text-[clamp(2.2rem,4vw,3.5rem)] leading-[0.98] text-[var(--ink)] first:mt-0" {...props} />
+                      <h1 className="mt-10 font-display text-[clamp(2.2rem,4vw,3.5rem)] leading-[1.02] text-[var(--ink)] first:mt-0" {...props} />
                     ),
                     h2: ({ ...props }) => (
-                      <h2 className="mt-10 text-[clamp(1.9rem,3vw,2.7rem)] leading-[1.02] text-[var(--ink)]" {...props} />
+                      <h2 className="mt-12 font-display text-[clamp(1.9rem,3vw,2.7rem)] leading-[1.08] text-[var(--ink)]" {...props} />
                     ),
                     h3: ({ ...props }) => (
-                      <h3 className="mt-8 text-[clamp(1.45rem,2.2vw,1.9rem)] leading-[1.08] text-[var(--ink)]" {...props} />
+                      <h3 className="mt-8 font-display text-[clamp(1.4rem,2.1vw,1.85rem)] leading-[1.12] text-[var(--ink)]" {...props} />
                     ),
-                    p: ({ ...props }) => <p className="mt-5 text-base leading-8 text-[var(--text)]" {...props} />,
-                    ul: ({ ...props }) => <ul className="mt-5 space-y-3 pl-5 text-base leading-8 text-[var(--text)]" {...props} />,
-                    ol: ({ ...props }) => <ol className="mt-5 space-y-3 pl-5 text-base leading-8 text-[var(--text)]" {...props} />,
+                    p: ({ ...props }) => <p className="mt-5 text-[1.02rem] leading-[1.85] text-[var(--text)]" {...props} />,
+                    ul: ({ ...props }) => <ul className="mt-5 space-y-3 pl-5 text-[1.02rem] leading-[1.85] text-[var(--text)]" {...props} />,
+                    ol: ({ ...props }) => <ol className="mt-5 space-y-3 pl-5 text-[1.02rem] leading-[1.85] text-[var(--text)]" {...props} />,
                     li: ({ ...props }) => <li className="pl-1" {...props} />,
                     blockquote: ({ ...props }) => (
                       <blockquote
-                        className="mt-6 border-l-2 border-[var(--border)] pl-5 text-base italic leading-8 text-[var(--text)]"
+                        className="mt-8 border-l-2 border-[var(--accent)] pl-5 font-display text-[1.18rem] italic leading-[1.65] text-[var(--ink)]"
                         {...props}
                       />
                     ),
                     a: ({ ...props }) => (
-                      <a className="font-semibold text-[var(--ink)] underline decoration-[var(--border)] underline-offset-4" {...props} />
+                      <a className="font-semibold text-[var(--ink)] underline decoration-[var(--border)] underline-offset-4 transition-colors hover:text-[var(--accent)]" {...props} />
                     ),
                     strong: ({ ...props }) => <strong className="font-semibold text-[var(--ink)]" {...props} />,
                   }}
@@ -53,46 +53,46 @@ export function InsightArticleContent({ post, relatedPosts }: InsightArticleCont
             </article>
 
             <aside className="space-y-5 xl:sticky xl:top-8">
-              <div className="rounded-[30px] border border-[var(--border)] bg-[#F7F5F1] p-6">
-                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--muted)]">
+              <div className="rounded-[8px] border border-[var(--border)] bg-[var(--surface-low)] p-6">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--meta)]">
                   Vervolgroute
                 </p>
-                <p className="mt-4 text-base leading-8 text-[var(--text)]">
+                <p className="mt-4 text-base leading-[1.75] text-[var(--muted)]">
                   {post.ctaType === 'knowledge'
                     ? 'Lees verder in de bredere route die bij dit onderwerp past.'
                     : 'Gebruik dit inzicht als startpunt voor een concreet vervolggesprek.'}
                 </p>
                 <Link
                   href={post.ctaTarget}
-                  className="mt-6 inline-flex items-center rounded-full bg-[#132033] px-5 py-3 text-sm font-semibold text-white transition-colors hover:bg-[#1c2a3d]"
+                  className="marketing-button-primary mt-6"
                 >
                   {post.ctaLabel}
                 </Link>
               </div>
 
-              <div className="rounded-[30px] border border-[var(--border)] bg-white p-6">
-                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--muted)]">
+              <div className="rounded-[8px] border border-[var(--border)] bg-white p-6">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--meta)]">
                   Gerelateerde oplossingspagina
                 </p>
-                <p className="mt-4 text-base leading-8 text-[var(--text)]">
+                <p className="mt-4 text-base leading-[1.75] text-[var(--muted)]">
                   Wilt u dit onderwerp vertalen naar een concretere managementvraag? Bekijk dan de bijpassende
                   oplossingsroute.
                 </p>
                 <Link
                   href={relatedSolutionHref}
-                  className="mt-6 inline-flex items-center rounded-full border border-[var(--border)] px-5 py-3 text-sm font-semibold text-[var(--ink)] transition-colors hover:border-[var(--ink)]"
+                  className="marketing-button-secondary mt-6"
                 >
                   Bekijk de oplossingsroute
                 </Link>
               </div>
 
-              <div className="rounded-[30px] border border-[var(--border)] bg-white p-6">
-                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--muted)]">
+              <div className="rounded-[8px] border border-[var(--border)] bg-white p-6">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--meta)]">
                   Terug naar overzicht
                 </p>
                 <Link
                   href="/inzichten"
-                  className="mt-4 inline-flex items-center rounded-full border border-[var(--border)] px-5 py-3 text-sm font-semibold text-[var(--ink)] transition-colors hover:border-[var(--ink)]"
+                  className="marketing-button-secondary mt-4"
                 >
                   Bekijk alle inzichten
                 </Link>

--- a/frontend/components/marketing/insight-card.tsx
+++ b/frontend/components/marketing/insight-card.tsx
@@ -25,23 +25,23 @@ export function InsightCard({ post }: { post: InsightPost }) {
   const publishedLabel = formatInsightDateLabel(post.publishedAt ?? post.generatedAt)
 
   return (
-    <article className="flex h-full flex-col rounded-[28px] border border-[var(--border)] bg-white p-6 shadow-[0_18px_40px_rgba(19,32,51,0.05)]">
-      <div className="flex items-center justify-between gap-4 text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--muted)]">
+    <article className="flex h-full flex-col rounded-[8px] border border-[var(--border)] bg-white p-6 transition-[border-color,transform] duration-150 hover:-translate-y-[2px] hover:border-[var(--border-strong)]">
+      <div className="flex items-center justify-between gap-4 text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--meta)]">
         <span>{post.category}</span>
         <span>{post.readingMinutes} min leestijd</span>
       </div>
 
-      <h3 className="mt-5 text-[clamp(1.5rem,2vw,1.9rem)] leading-[1.05] text-[var(--ink)]">
+      <h3 className="mt-5 font-display text-[clamp(1.5rem,2vw,1.9rem)] leading-[1.08] text-[var(--ink)]">
         {post.title}
       </h3>
 
-      <p className="mt-4 flex-1 text-sm leading-7 text-[var(--text)]">{post.metaDescription}</p>
+      <p className="mt-4 flex-1 text-[0.95rem] leading-[1.75] text-[var(--muted)]">{post.metaDescription}</p>
 
       <div className="mt-6 flex items-center justify-between gap-4 border-t border-[var(--border)] pt-4">
-        <span className="text-sm text-[var(--muted)]">{publishedLabel}</span>
+        <span className="text-sm text-[var(--meta)]">{publishedLabel}</span>
         <Link
           href={`/inzichten/${post.slug}`}
-          className="inline-flex items-center rounded-full border border-[var(--border)] px-4 py-2 text-sm font-semibold text-[var(--ink)] transition-colors hover:border-[var(--ink)]"
+          className="marketing-button-secondary"
         >
           Lees inzicht
         </Link>

--- a/frontend/components/marketing/insight-rail.tsx
+++ b/frontend/components/marketing/insight-rail.tsx
@@ -25,19 +25,21 @@ export function InsightRail({
   }
 
   return (
-    <section className="border-y border-[var(--border)] bg-[#F7F5F1]">
+    <section className="border-y border-[var(--border)] bg-[var(--bg-alt)]">
       <div className="marketing-shell py-16 md:py-20">
         <div className="flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
           <div className="max-w-3xl">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--muted)]">{eyebrow}</p>
-            <h2 className="mt-4 text-[clamp(2.2rem,4vw,3.5rem)] leading-[0.98] text-[var(--ink)]">{title}</h2>
-            {intro ? <p className="mt-4 max-w-2xl text-base leading-8 text-[var(--text)]">{intro}</p> : null}
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--meta)]">{eyebrow}</p>
+            <h2 className="mt-4 font-display text-[clamp(2.15rem,3.8vw,3.4rem)] leading-[1.02] text-[var(--ink)]">
+              {title}
+            </h2>
+            {intro ? <p className="mt-4 max-w-2xl text-base leading-[1.75] text-[var(--muted)]">{intro}</p> : null}
           </div>
 
           {viewAllHref && viewAllLabel ? (
             <Link
               href={viewAllHref}
-              className="inline-flex items-center rounded-full border border-[var(--border)] bg-white px-5 py-3 text-sm font-semibold text-[var(--ink)] transition-colors hover:border-[var(--ink)]"
+              className="marketing-button-secondary"
             >
               {viewAllLabel}
             </Link>

--- a/frontend/components/marketing/insights-index-content.tsx
+++ b/frontend/components/marketing/insights-index-content.tsx
@@ -10,12 +10,12 @@ export function InsightsIndexContent({ posts }: { posts: InsightPost[] }) {
     return (
       <section className="border-b border-[var(--border)] bg-white">
         <div className="marketing-shell py-16 md:py-20">
-          <div className="max-w-3xl rounded-[32px] border border-[var(--border)] bg-[#F7F5F1] p-8 md:p-10">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--muted)]">Inzichten</p>
-            <h2 className="mt-4 text-[clamp(2.1rem,4vw,3.2rem)] leading-[0.98] text-[var(--ink)]">
+          <div className="max-w-3xl rounded-[8px] border border-[var(--border)] bg-[var(--surface-low)] p-8 md:p-10">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--meta)]">Inzichten</p>
+            <h2 className="mt-4 font-display text-[clamp(2.1rem,4vw,3.2rem)] leading-[1.02] text-[var(--ink)]">
               Nog geen inzichten gepubliceerd.
             </h2>
-            <p className="mt-5 max-w-2xl text-base leading-8 text-[var(--text)]">
+            <p className="mt-5 max-w-2xl text-base leading-[1.75] text-[var(--muted)]">
               Deze plek wordt de publieke hub voor praktische artikelen over onboarding, behoud, uitstroom en de
               managementvragen die daarachter zitten.
             </p>
@@ -32,15 +32,15 @@ export function InsightsIndexContent({ posts }: { posts: InsightPost[] }) {
       <section className="border-b border-[var(--border)] bg-white">
         <div className="marketing-shell py-16 md:py-20">
           <div className="grid gap-8 xl:grid-cols-[minmax(0,1.18fr)_minmax(0,0.82fr)] xl:items-start">
-            <article className="rounded-[36px] border border-[var(--border)] bg-[#F7F5F1] p-8 md:p-10">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--muted)]">
+            <article className="rounded-[8px] border border-[var(--border)] bg-[var(--surface-low)] p-8 md:p-10">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--meta)]">
                 Uitgelicht inzicht
               </p>
-              <h2 className="mt-5 max-w-4xl text-[clamp(2.4rem,4.2vw,4.25rem)] leading-[0.95] text-[var(--ink)]">
+              <h2 className="mt-5 max-w-4xl font-display text-[clamp(2.4rem,4.2vw,4.25rem)] leading-[0.98] text-[var(--ink)]">
                 {featured.title}
               </h2>
-              <p className="mt-5 max-w-2xl text-base leading-8 text-[var(--text)]">{featured.metaDescription}</p>
-              <div className="mt-8 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-[var(--muted)]">
+              <p className="mt-5 max-w-2xl text-base leading-[1.8] text-[var(--muted)]">{featured.metaDescription}</p>
+              <div className="mt-8 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-[var(--meta)]">
                 <span className="text-[11px] font-semibold uppercase tracking-[0.16em]">{featured.category}</span>
                 <span>{featuredDate}</span>
                 <span>{featured.readingMinutes} min leestijd</span>
@@ -48,24 +48,24 @@ export function InsightsIndexContent({ posts }: { posts: InsightPost[] }) {
               <div className="mt-8 flex flex-wrap gap-4">
                 <Link
                   href={`/inzichten/${featured.slug}`}
-                  className="inline-flex items-center rounded-full bg-[#C96A4B] px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-[#B85D41]"
+                  className="marketing-button-primary"
                 >
                   Lees artikel
                 </Link>
                 <Link
                   href={featured.ctaTarget}
-                  className="inline-flex items-center rounded-full border border-[var(--border)] bg-white px-6 py-3 text-sm font-semibold text-[var(--ink)] transition-colors hover:border-[var(--ink)]"
+                  className="marketing-button-secondary"
                 >
                   {featured.ctaLabel}
                 </Link>
               </div>
             </article>
 
-            <div className="rounded-[30px] border border-[var(--border)] bg-white p-7">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--muted)]">
+            <div className="rounded-[8px] border border-[var(--border)] bg-white p-7">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--meta)]">
                 Waarom deze pagina er is
               </p>
-              <div className="mt-4 space-y-4 text-sm leading-7 text-[var(--text)]">
+              <div className="mt-4 space-y-4 text-sm leading-[1.75] text-[var(--muted)]">
                 <p>
                   Deze inzichtenbibliotheek is bedoeld voor scherpere duiding, niet als los kenniscentrum met een eigen
                   stijl of agenda.
@@ -85,17 +85,17 @@ export function InsightsIndexContent({ posts }: { posts: InsightPost[] }) {
       </section>
 
       {rest.length > 0 ? (
-        <section className="border-b border-[var(--border)] bg-[#F7F5F1]">
+        <section className="border-b border-[var(--border)] bg-[var(--bg-alt)]">
           <div className="marketing-shell py-16 md:py-20">
             <div className="flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
               <div className="max-w-3xl">
-                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--muted)]">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--meta)]">
                   Meer inzichten
                 </p>
-                <h2 className="mt-4 text-[clamp(2.1rem,3.6vw,3.2rem)] leading-[0.98] text-[var(--ink)]">
+                <h2 className="mt-4 font-display text-[clamp(2.1rem,3.6vw,3.2rem)] leading-[1.02] text-[var(--ink)]">
                   Verdere duiding, rustiger geordend
                 </h2>
-                <p className="mt-4 max-w-2xl text-base leading-8 text-[var(--text)]">
+                <p className="mt-4 max-w-2xl text-base leading-[1.75] text-[var(--muted)]">
                   De overige artikelen volgen ondersteunend. Compact, inhoudelijk en duidelijk verbonden aan dezelfde
                   vragen rond vertrek, behoud, prioritering en eerste opvolging.
                 </p>
@@ -103,13 +103,13 @@ export function InsightsIndexContent({ posts }: { posts: InsightPost[] }) {
 
               <Link
                 href="/aanpak"
-                className="inline-flex items-center rounded-full border border-[var(--border)] bg-white px-5 py-3 text-sm font-semibold text-[var(--ink)] transition-colors hover:border-[var(--ink)]"
+                className="marketing-button-secondary"
               >
                 Bekijk hoe Verisight werkt
               </Link>
             </div>
 
-            <div className="mt-10 overflow-hidden rounded-[32px] border border-[var(--border)] bg-white">
+            <div className="mt-10 overflow-hidden rounded-[8px] border border-[var(--border)] bg-white">
               {rest.map((post, index) => {
                 const publishedLabel = formatInsightDateLabel(post.publishedAt ?? post.generatedAt)
 
@@ -121,23 +121,23 @@ export function InsightsIndexContent({ posts }: { posts: InsightPost[] }) {
                     }`}
                   >
                     <div className="min-w-0">
-                      <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--muted)]">
+                      <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--meta)]">
                         <span>{post.category}</span>
                         <span className="normal-case tracking-normal text-sm font-normal">{publishedLabel}</span>
                         <span className="normal-case tracking-normal text-sm font-normal">
                           {post.readingMinutes} min leestijd
                         </span>
                       </div>
-                      <h3 className="mt-3 text-[clamp(1.45rem,2vw,1.95rem)] leading-[1.08] text-[var(--ink)]">
+                      <h3 className="mt-3 font-display text-[clamp(1.45rem,2vw,1.95rem)] leading-[1.1] text-[var(--ink)]">
                         {post.title}
                       </h3>
-                      <p className="mt-3 max-w-3xl text-sm leading-7 text-[var(--text)]">{post.metaDescription}</p>
+                      <p className="mt-3 max-w-3xl text-sm leading-[1.75] text-[var(--muted)]">{post.metaDescription}</p>
                     </div>
 
                     <div className="flex flex-wrap gap-3 md:justify-end">
                       <Link
                         href={`/inzichten/${post.slug}`}
-                        className="inline-flex items-center rounded-full border border-[var(--border)] bg-[#F7F5F1] px-5 py-3 text-sm font-semibold text-[var(--ink)] transition-colors hover:border-[var(--ink)]"
+                        className="marketing-button-secondary"
                       >
                         Lees artikel
                       </Link>

--- a/frontend/components/marketing/public-header.tsx
+++ b/frontend/components/marketing/public-header.tsx
@@ -33,13 +33,13 @@ export function PublicHeader({
   }
 
   return (
-    <header className="sticky top-0 z-50 border-b border-[var(--border)] bg-white">
+    <header className="sticky top-0 z-50 border-b border-[var(--border)] bg-[var(--bg)]/95 backdrop-blur">
       <div className="marketing-shell py-4">
         <div className="flex items-center justify-between gap-4">
           <div className="flex items-center gap-4">
             <div className="flex flex-col gap-0.5">
               <Wordmark size="md" showTagline={false} />
-              <span className="pl-px text-[8px] font-bold tracking-[0.18em] uppercase text-[rgba(19,32,51,0.36)] [font-family:var(--font-ibm-plex-sans)]">
+              <span className="pl-px text-[8px] font-bold tracking-[0.18em] uppercase text-[rgba(27,43,58,0.42)] [font-family:var(--font-plus-jakarta)]">
                 People, Patterns, Priorities
               </span>
             </div>

--- a/frontend/components/marketing/section-heading.tsx
+++ b/frontend/components/marketing/section-heading.tsx
@@ -14,17 +14,17 @@ export function SectionHeading({
   light = false,
 }: SectionHeadingProps) {
   const wrapper = align === 'center' ? 'mx-auto max-w-4xl text-center' : 'max-w-[56rem] text-left'
-  const eyebrowColor = light ? 'text-[var(--teal-light)]' : 'text-[var(--teal)]'
+  const eyebrowColor = light ? 'text-[rgba(242,240,241,0.72)]' : 'text-[var(--meta)]'
   const titleColor = light ? 'text-[var(--bg)]' : 'text-[var(--ink)]'
-  const descriptionColor = light ? 'text-[rgba(247,245,241,0.72)]' : 'text-[var(--text)]'
+  const descriptionColor = light ? 'text-[rgba(242,240,241,0.72)]' : 'text-[var(--muted)]'
 
   return (
     <div className={wrapper}>
-      <p className={`text-[0.68rem] font-semibold uppercase tracking-[0.22em] ${eyebrowColor}`}>
+      <p className={`text-[0.7rem] font-semibold uppercase tracking-[0.18em] ${eyebrowColor}`}>
         {eyebrow}
       </p>
       <h2
-        className={`mt-4 max-w-[18ch] font-display text-[clamp(1.8rem,3.8vw,2.65rem)] font-light leading-[1.05] tracking-[-0.03em] ${
+        className={`mt-4 max-w-[18ch] font-display text-[clamp(1.9rem,3.6vw,2.65rem)] font-semibold leading-[1.08] tracking-[-0.03em] ${
           align === 'center' ? 'mx-auto' : ''
         } ${titleColor}`}
       >
@@ -32,7 +32,7 @@ export function SectionHeading({
       </h2>
       {description ? (
         <p
-          className={`mt-5 max-w-[58ch] text-[1.02rem] leading-8 ${
+          className={`mt-5 max-w-[58ch] text-[1.02rem] leading-[1.75] ${
             align === 'center' ? 'mx-auto' : ''
           } ${descriptionColor}`}
         >


### PR DESCRIPTION
## Summary
- translate the insights/blog experience to the new editorial Verisight UI system
- update shared typography, color, card, spacing, radius, and focus tokens first
- carry the calmer editorial treatment into the homepage proof sections without changing product logic or route hierarchy

## Kept
- Verisight product hierarchy and commercial framing
- homepage/dashboard/product logic and proof-first structure
- main route vs support route distinction
- warm-light base with dark structural contrast

## Changed
- Playfair Display for major editorial headlines and Plus Jakarta Sans for UI/body
- layered paper card treatment, smaller radii, calmer shadows, terracotta-only accent strategy
- stronger text rhythm and narrower editorial reading column on insights pages
- quieter homepage proof clusters and CTA surfaces

## Verification
- `npm test -- "app/inzichten/page.test.ts" "app/inzichten/[slug]/page.test.ts"`
- `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key npm run build`
- local visual QA on `/`, `/inzichten`, and `/inzichten/[slug]` desktop/mobile