### PR TITLE
Restructure HR routebeheer into a compact phased worktable

### DIFF
--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.test.ts
@@ -289,6 +289,23 @@ describe('routebeheer source integration', () => {
     expect(source).not.toContain('importReady: importReady === true')
   })
 
+  it('keeps a visible routebeheer entrypoint in the dashboard launcher for setup-heavy campaigns', () => {
+    const launcherSource = readFileSync(
+      new URL('../../../dashboard/home-launcher.ts', import.meta.url),
+      'utf8',
+    )
+
+    expect(launcherSource).toContain('href: `/campaigns/${campaign.campaign_id}/beheer`')
+  })
+
+  it('keeps routebeheer restricted to HR-capable users instead of manager-only action center access', () => {
+    const pageSource = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+
+    expect(pageSource).toContain('if (!context.canViewInsights)')
+    expect(pageSource).toContain('SuiteAccessDenied')
+    expect(pageSource).toContain('Jouw login opent alleen Action Center voor toegewezen teams.')
+  })
+
   it('keeps the operational route free from analytical or action-center detail imports', () => {
     const source = readFileSync(new URL('./route-beheer-components.tsx', import.meta.url), 'utf8')
 

--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.test.ts
@@ -253,7 +253,7 @@ describe('routebeheer data helpers', () => {
     expect(mapGuidedPhaseToHrRoutePhase('import_validation_required')).toBe('doelgroep')
     expect(mapGuidedPhaseToHrRoutePhase('launch_date_required')).toBe('communicatie')
     expect(mapGuidedPhaseToHrRoutePhase('communication_ready')).toBe('communicatie')
-    expect(mapGuidedPhaseToHrRoutePhase('ready_to_invite')).toBe('communicatie')
+    expect(mapGuidedPhaseToHrRoutePhase('ready_to_invite')).toBe('live')
     expect(mapGuidedPhaseToHrRoutePhase('survey_running')).toBe('live')
     expect(mapGuidedPhaseToHrRoutePhase('dashboard_active')).toBe('output')
     expect(mapGuidedPhaseToHrRoutePhase('first_next_step_available')).toBe('output')
@@ -274,10 +274,12 @@ describe('routebeheer data helpers', () => {
       importReady: true,
     })
 
-    expect(buildHrRouteBeheerNowDoing(guidedState)).toEqual({
+    expect(buildHrRouteBeheerNowDoing({ guidedState, campaignId: 'campaign-1' })).toEqual({
+      label: 'Nu doen',
       phaseKey: 'communicatie',
       title: guidedState.nextAction.title,
       body: guidedState.nextAction.body,
+      href: '/campaigns/campaign-1/beheer?fase=communicatie#fase-detail',
     })
   })
 })
@@ -308,16 +310,17 @@ describe('routebeheer source integration', () => {
 
   it('keeps the operational route free from analytical or action-center detail imports', () => {
     const source = readFileSync(new URL('./route-beheer-components.tsx', import.meta.url), 'utf8')
+    const phaseSource = readFileSync(new URL('./route-beheer-phase-sections.tsx', import.meta.url), 'utf8')
+    const combined = `${source}\n${phaseSource}`
 
-    expect(source).toContain('Livegang')
-    expect(source).toContain('Respons')
-    expect(source).toContain('Dashboard leesbaarheid')
-    expect(source).toContain('Eerstvolgende stap')
-    expect(source).not.toContain('Frictiescore')
-    expect(source).not.toContain('SDT')
-    expect(source).not.toContain('buildExitNarratives')
-    expect(source).not.toContain('buildRetentionNarratives')
-    expect(source).not.toContain('ActionPlaybook')
+    expect(combined).toContain('Nu doen')
+    expect(combined).toContain('Output & afronding')
+    expect(combined).toContain('Logboek / controle')
+    expect(combined).not.toContain('Frictiescore')
+    expect(combined).not.toContain('SDT')
+    expect(combined).not.toContain('buildExitNarratives')
+    expect(combined).not.toContain('buildRetentionNarratives')
+    expect(combined).not.toContain('ActionPlaybook')
   })
 
   it('keeps output summary compact while output detail remains owned by the output phase', async () => {

--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.test.ts
@@ -279,7 +279,29 @@ describe('routebeheer data helpers', () => {
       phaseKey: 'communicatie',
       title: guidedState.nextAction.title,
       body: guidedState.nextAction.body,
-      href: '/campaigns/campaign-1/beheer?fase=communicatie#fase-detail',
+      href: '/campaigns/campaign-1/beheer?fase=communicatie#route-instellingen',
+    })
+  })
+
+  it('sends output-oriented now-doing links to the actual dashboard destination', () => {
+    const guidedState = buildGuidedSelfServeState({
+      isActive: true,
+      totalInvited: 12,
+      totalCompleted: 4,
+      invitesNotSent: 0,
+      hasMinDisplay: true,
+      hasEnoughData: false,
+      importQaConfirmed: true,
+      launchTimingConfirmed: true,
+      communicationReady: true,
+      importReady: true,
+    })
+
+    expect(buildHrRouteBeheerNowDoing({ guidedState, campaignId: 'campaign-1' })).toMatchObject({
+      phaseKey: 'output',
+      title: guidedState.nextAction.title,
+      body: guidedState.nextAction.body,
+      href: '/campaigns/campaign-1',
     })
   })
 })
@@ -335,18 +357,18 @@ describe('routebeheer source integration', () => {
       reportReady: true,
       dashboardHref: '/campaigns/campaign-1',
       reportHref: '/reports',
-      label: 'Dashboard leesbaar / Rapport beschikbaar',
+      label: 'Dashboard / rapportstatus',
     })
 
     expect(data?.phaseSummaries.find((phase) => phase.key === 'output')).toMatchObject({
       key: 'output',
       status: 'current',
-      body: 'Dashboard leesbaar / Rapport beschikbaar',
+      body: 'Dashboard / rapportstatus',
     })
     expect(data?.phaseDetails.find((phase) => phase.key === 'output')).toMatchObject({
       key: 'output',
       status: 'current',
-      body: data?.readabilityBody,
+      body: 'Dashboard / rapportstatus',
     })
   })
 
@@ -366,6 +388,7 @@ describe('routebeheer source integration', () => {
     ])
     expect(data?.phaseDetails.find((phase) => phase.key === 'communicatie')).toMatchObject({
       key: 'communicatie',
+      body: 'Route en startdatum',
       items: [
         { label: 'Route', value: data?.routeSettingsLabel },
         { label: 'Startdatum', value: '10 mei 2026' },

--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.test.ts
@@ -253,7 +253,7 @@ describe('routebeheer data helpers', () => {
     expect(mapGuidedPhaseToHrRoutePhase('import_validation_required')).toBe('doelgroep')
     expect(mapGuidedPhaseToHrRoutePhase('launch_date_required')).toBe('communicatie')
     expect(mapGuidedPhaseToHrRoutePhase('communication_ready')).toBe('communicatie')
-    expect(mapGuidedPhaseToHrRoutePhase('ready_to_invite')).toBe('live')
+    expect(mapGuidedPhaseToHrRoutePhase('ready_to_invite')).toBe('communicatie')
     expect(mapGuidedPhaseToHrRoutePhase('survey_running')).toBe('live')
     expect(mapGuidedPhaseToHrRoutePhase('dashboard_active')).toBe('output')
     expect(mapGuidedPhaseToHrRoutePhase('first_next_step_available')).toBe('output')

--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.test.ts
@@ -1,12 +1,182 @@
 import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
+import { buildGuidedSelfServeState } from '@/lib/guided-self-serve'
 import { buildDeliveryAutoSignals } from '@/lib/ops-delivery'
 import {
+  buildHrRouteBeheerNowDoing,
   buildRouteBeheerLifecycleSteps,
+  fetchRouteBeheerData,
   formatLatestActivityLabel,
   formatRoutePeriodLabel,
   getLatestActivityTimestamp,
+  mapGuidedPhaseToHrRoutePhase,
 } from './beheer-data'
+
+function createSupabaseMock() {
+  const queryResults = new Map<string, unknown>([
+    [
+      'campaign_stats|*',
+      {
+        data: {
+          campaign_id: 'campaign-1',
+          organization_id: 'org-1',
+          campaign_name: 'Exit Q3 2026',
+          scan_type: 'exit',
+          is_active: true,
+          total_invited: 12,
+          total_completed: 6,
+          completion_rate_pct: 50,
+          created_at: '2026-05-01T08:00:00.000Z',
+        },
+      },
+    ],
+    ['profiles|is_verisight_admin', { data: { is_verisight_admin: false } }],
+    ['org_members|role', { data: { role: 'owner' } }],
+    ['organizations|name', { data: { name: 'Acme HR' } }],
+    ['campaigns|delivery_mode, created_at', { data: { delivery_mode: 'guided_self_serve', created_at: '2026-05-01T08:00:00.000Z' } }],
+    ['org_members|id', { count: 4 }],
+    ['org_invites|id', { count: 1 }],
+    [
+      'campaign_delivery_records|*',
+      {
+        data: {
+          id: 'delivery-1',
+          campaign_id: 'campaign-1',
+          lifecycle_stage: 'first_value_reached',
+          launch_date: '2026-05-10T08:00:00.000Z',
+          launch_confirmed_at: '2026-05-10T08:00:00.000Z',
+          updated_at: '2026-05-12T09:30:00.000Z',
+          contact_request_id: 'contact-1',
+        },
+      },
+    ],
+    [
+      'respondents|id, sent_at, completed, completed_at',
+      {
+        data: [
+          { id: 'r1', sent_at: '2026-05-10T10:00:00.000Z', completed: true, completed_at: '2026-05-11T10:00:00.000Z' },
+          { id: 'r2', sent_at: '2026-05-10T10:00:00.000Z', completed: true, completed_at: '2026-05-11T11:00:00.000Z' },
+          { id: 'r3', sent_at: '2026-05-10T10:00:00.000Z', completed: true, completed_at: '2026-05-11T12:00:00.000Z' },
+          { id: 'r4', sent_at: '2026-05-10T10:00:00.000Z', completed: true, completed_at: '2026-05-11T13:00:00.000Z' },
+          { id: 'r5', sent_at: '2026-05-10T10:00:00.000Z', completed: true, completed_at: '2026-05-11T14:00:00.000Z' },
+          { id: 'r6', sent_at: '2026-05-10T10:00:00.000Z', completed: true, completed_at: '2026-05-11T15:00:00.000Z' },
+          { id: 'r7', sent_at: '2026-05-10T10:00:00.000Z', completed: false, completed_at: null },
+          { id: 'r8', sent_at: '2026-05-10T10:00:00.000Z', completed: false, completed_at: null },
+          { id: 'r9', sent_at: '2026-05-10T10:00:00.000Z', completed: false, completed_at: null },
+          { id: 'r10', sent_at: '2026-05-10T10:00:00.000Z', completed: false, completed_at: null },
+          { id: 'r11', sent_at: '2026-05-10T10:00:00.000Z', completed: false, completed_at: null },
+          { id: 'r12', sent_at: '2026-05-10T10:00:00.000Z', completed: false, completed_at: null },
+        ],
+      },
+    ],
+    [
+      'survey_responses|id, org_scores, sdt_scores, respondents!inner(campaign_id)',
+      {
+        data: Array.from({ length: 6 }, (_, index) => ({
+          id: `response-${index + 1}`,
+          org_scores: { engagement: 7.2 },
+          sdt_scores: { autonomy: 6.9 },
+        })),
+      },
+    ],
+    [
+      'campaign_action_audit_events|id, action_key, outcome, action_label, owner_label, actor_role, actor_label, summary, metadata, created_at',
+      {
+        data: [
+          {
+            id: 'audit-1',
+            action_key: 'launch_invites',
+            outcome: 'completed',
+            action_label: 'Invites launched',
+            owner_label: 'HR',
+            actor_role: 'owner',
+            actor_label: 'Alex',
+            summary: 'Invites zijn verstuurd',
+            metadata: {},
+            created_at: '2026-05-12T08:00:00.000Z',
+          },
+        ],
+      },
+    ],
+    [
+      'campaign_delivery_checkpoints|*',
+      {
+        data: [
+          {
+            checkpoint_key: 'implementation_intake',
+            manual_state: 'confirmed',
+            auto_state: 'ready',
+            created_at: '2026-05-02T09:00:00.000Z',
+          },
+          {
+            checkpoint_key: 'import_qa',
+            manual_state: 'confirmed',
+            auto_state: 'ready',
+            created_at: '2026-05-03T09:00:00.000Z',
+          },
+          {
+            checkpoint_key: 'invite_readiness',
+            manual_state: 'confirmed',
+            auto_state: 'ready',
+            created_at: '2026-05-04T09:00:00.000Z',
+          },
+        ],
+      },
+    ],
+  ])
+
+  function createQuery(table: string) {
+    let selectClause = ''
+
+    const resolveResult = () => {
+      const key = `${table}|${selectClause}`
+      if (!queryResults.has(key)) {
+        throw new Error(`Missing mock result for ${key}`)
+      }
+
+      return queryResults.get(key)
+    }
+
+    const query = {
+      select(value: string) {
+        selectClause = value
+        return query
+      },
+      eq() {
+        return query
+      },
+      in() {
+        return query
+      },
+      is() {
+        return query
+      },
+      order() {
+        return query
+      },
+      limit() {
+        return query
+      },
+      maybeSingle() {
+        return Promise.resolve(resolveResult())
+      },
+      single() {
+        return Promise.resolve(resolveResult())
+      },
+      then(onFulfilled?: (value: unknown) => unknown, onRejected?: (reason: unknown) => unknown) {
+        return Promise.resolve(resolveResult()).then(onFulfilled, onRejected)
+      },
+    }
+
+    return query
+  }
+
+  return {
+    from(table: string) {
+      return createQuery(table)
+    },
+  }
+}
 
 describe('routebeheer data helpers', () => {
   it('copies the quarter label from the campaign name when available', () => {
@@ -77,22 +247,42 @@ describe('routebeheer data helpers', () => {
     expect(signals.import_qa.autoState).toBe('unknown')
     expect(signals.import_qa.summary).toContain('nog niet bekend')
   })
+
+  it('maps guided self-serve phases deterministically into the five hr routebeheer phases', () => {
+    expect(mapGuidedPhaseToHrRoutePhase('participant_data_required')).toBe('doelgroep')
+    expect(mapGuidedPhaseToHrRoutePhase('import_validation_required')).toBe('doelgroep')
+    expect(mapGuidedPhaseToHrRoutePhase('launch_date_required')).toBe('communicatie')
+    expect(mapGuidedPhaseToHrRoutePhase('communication_ready')).toBe('communicatie')
+    expect(mapGuidedPhaseToHrRoutePhase('ready_to_invite')).toBe('communicatie')
+    expect(mapGuidedPhaseToHrRoutePhase('survey_running')).toBe('live')
+    expect(mapGuidedPhaseToHrRoutePhase('dashboard_active')).toBe('output')
+    expect(mapGuidedPhaseToHrRoutePhase('first_next_step_available')).toBe('output')
+    expect(mapGuidedPhaseToHrRoutePhase('closed')).toBe('afronding')
+  })
+
+  it('keeps guided nextAction as the single source for the now-doing row', () => {
+    const guidedState = buildGuidedSelfServeState({
+      isActive: true,
+      totalInvited: 12,
+      totalCompleted: 0,
+      invitesNotSent: 12,
+      hasMinDisplay: false,
+      hasEnoughData: false,
+      importQaConfirmed: true,
+      launchTimingConfirmed: true,
+      communicationReady: false,
+      importReady: true,
+    })
+
+    expect(buildHrRouteBeheerNowDoing(guidedState)).toEqual({
+      phaseKey: 'communicatie',
+      title: guidedState.nextAction.title,
+      body: guidedState.nextAction.body,
+    })
+  })
 })
 
 describe('routebeheer source integration', () => {
-  it('adds the routebeheer bridge link to the existing campaign detail page', () => {
-    const source = readFileSync(new URL('../page.tsx', import.meta.url), 'utf8')
-    expect(source).toContain('Routebeheer openen')
-    expect(source).toContain('/campaigns/${id}/beheer')
-  })
-
-  it('keeps the routebeheer bridge visible in admin view instead of hiding it behind the non-admin execution flag', () => {
-    const source = readFileSync(new URL('../page.tsx', import.meta.url), 'utf8')
-
-    expect(source).toContain('const showClientExecutionFlow = compositionState !== "closed";')
-    expect(source).not.toContain('const showClientExecutionFlow =\n    !isVerisightAdmin && compositionState !== "closed";')
-  })
-
   it('does not silently coerce unknown import readiness into a false auto-signal', () => {
     const source = readFileSync(new URL('./beheer-data.ts', import.meta.url), 'utf8')
 
@@ -111,5 +301,55 @@ describe('routebeheer source integration', () => {
     expect(source).not.toContain('buildExitNarratives')
     expect(source).not.toContain('buildRetentionNarratives')
     expect(source).not.toContain('ActionPlaybook')
+  })
+
+  it('keeps output summary compact while output detail remains owned by the output phase', async () => {
+    const data = await fetchRouteBeheerData({
+      campaignId: 'campaign-1',
+      supabase: createSupabaseMock(),
+      userId: 'user-1',
+    })
+
+    expect(data?.outputSummary).toEqual({
+      dashboardReady: true,
+      reportReady: true,
+      dashboardHref: '/campaigns/campaign-1',
+      reportHref: '/reports',
+      label: 'Dashboard leesbaar / Rapport beschikbaar',
+    })
+
+    expect(data?.phaseSummaries.find((phase) => phase.key === 'output')).toMatchObject({
+      key: 'output',
+      status: 'current',
+      body: 'Dashboard leesbaar / Rapport beschikbaar',
+    })
+    expect(data?.phaseDetails.find((phase) => phase.key === 'output')).toMatchObject({
+      key: 'output',
+      status: 'current',
+      body: data?.readabilityBody,
+    })
+  })
+
+  it('keeps route settings inside the communicatie phase instead of as a top-level standalone block', async () => {
+    const data = await fetchRouteBeheerData({
+      campaignId: 'campaign-1',
+      supabase: createSupabaseMock(),
+      userId: 'user-1',
+    })
+
+    expect(data?.phaseDetails.map((phase) => phase.key)).toEqual([
+      'doelgroep',
+      'communicatie',
+      'live',
+      'output',
+      'afronding',
+    ])
+    expect(data?.phaseDetails.find((phase) => phase.key === 'communicatie')).toMatchObject({
+      key: 'communicatie',
+      items: [
+        { label: 'Route', value: data?.routeSettingsLabel },
+        { label: 'Startdatum', value: '10 mei 2026' },
+      ],
+    })
   })
 })

--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.ts
@@ -62,9 +62,11 @@ export interface HrRouteBeheerPhaseDetail {
 }
 
 export interface HrRouteBeheerNowDoing {
+  label: 'Nu doen'
   phaseKey: HrRouteBeheerPhaseKey
   title: string
   body: string
+  href: string
 }
 
 export interface RouteBeheerPageData {
@@ -144,11 +146,11 @@ const HR_ROUTE_PHASE_ORDER: HrRouteBeheerPhaseKey[] = [
 ]
 
 const HR_ROUTE_PHASE_LABELS: Record<HrRouteBeheerPhaseKey, string> = {
-  doelgroep: 'Doelgroep',
-  communicatie: 'Communicatie',
-  live: 'Live',
-  output: 'Output',
-  afronding: 'Afronding',
+  doelgroep: 'Doelgroep klaarzetten',
+  communicatie: 'Communicatie instellen',
+  live: 'Live zetten & volgen',
+  output: 'Output beoordelen',
+  afronding: 'Afronden & controleren',
 }
 
 export function formatRoutePeriodLabel(campaignName: string, createdAt: string) {
@@ -382,8 +384,8 @@ export function mapGuidedPhaseToHrRoutePhase(phase: GuidedSelfServePhase): HrRou
       return 'doelgroep'
     case 'launch_date_required':
     case 'communication_ready':
-    case 'ready_to_invite':
       return 'communicatie'
+    case 'ready_to_invite':
     case 'survey_running':
       return 'live'
     case 'dashboard_active':
@@ -408,13 +410,24 @@ function getHrRouteBeheerPhaseStatus(
   return 'open'
 }
 
+export function getRouteBeheerPhaseHref(campaignId: string, phaseKey: HrRouteBeheerPhaseKey) {
+  return `/campaigns/${campaignId}/beheer?fase=${phaseKey}#fase-detail`
+}
+
 export function buildHrRouteBeheerNowDoing(
-  guidedState: Pick<ReturnType<typeof buildGuidedSelfServeState>, 'phase' | 'nextAction'>,
+  args: {
+    guidedState: Pick<ReturnType<typeof buildGuidedSelfServeState>, 'phase' | 'nextAction'>
+    campaignId: string
+  },
 ): HrRouteBeheerNowDoing {
+  const phaseKey = mapGuidedPhaseToHrRoutePhase(args.guidedState.phase)
+
   return {
-    phaseKey: mapGuidedPhaseToHrRoutePhase(guidedState.phase),
-    title: guidedState.nextAction.title,
-    body: guidedState.nextAction.body,
+    label: 'Nu doen',
+    phaseKey,
+    title: args.guidedState.nextAction.title,
+    body: args.guidedState.nextAction.body,
+    href: getRouteBeheerPhaseHref(args.campaignId, phaseKey),
   }
 }
 
@@ -434,7 +447,10 @@ export function buildHrRouteBeheerPhaseSummary(args: {
         label: HR_ROUTE_PHASE_LABELS[args.key],
         status: args.status,
         body: `${args.respondentCount} deelnemers geimporteerd`,
-        link: { label: 'Open doelgroep', href: `/campaigns/${args.campaignId}#operatie` },
+        link: {
+          label: 'Bekijk fase',
+          href: getRouteBeheerPhaseHref(args.campaignId, args.key),
+        },
       } satisfies HrRouteBeheerPhaseSummary
     case 'communicatie':
       return {
@@ -442,7 +458,10 @@ export function buildHrRouteBeheerPhaseSummary(args: {
         label: HR_ROUTE_PHASE_LABELS[args.key],
         status: args.status,
         body: 'Route en launchafspraken staan in deze fase bij elkaar.',
-        link: { label: 'Bekijk communicatie', href: '#route-instellingen' },
+        link: {
+          label: 'Bekijk fase',
+          href: getRouteBeheerPhaseHref(args.campaignId, args.key),
+        },
       } satisfies HrRouteBeheerPhaseSummary
     case 'live':
       return {
@@ -450,7 +469,10 @@ export function buildHrRouteBeheerPhaseSummary(args: {
         label: HR_ROUTE_PHASE_LABELS[args.key],
         status: args.status,
         body: `${args.totalCompleted}/${args.totalInvited} ingevuld`,
-        link: { label: 'Open uitnodigingen', href: '#beheer-onderdelen' },
+        link: {
+          label: 'Bekijk fase',
+          href: getRouteBeheerPhaseHref(args.campaignId, args.key),
+        },
       } satisfies HrRouteBeheerPhaseSummary
     case 'output':
       return {
@@ -458,7 +480,10 @@ export function buildHrRouteBeheerPhaseSummary(args: {
         label: HR_ROUTE_PHASE_LABELS[args.key],
         status: args.status,
         body: args.outputSummary.label,
-        link: { label: 'Open dashboard', href: args.outputSummary.dashboardHref },
+        link: {
+          label: 'Bekijk fase',
+          href: getRouteBeheerPhaseHref(args.campaignId, args.key),
+        },
       } satisfies HrRouteBeheerPhaseSummary
     case 'afronding':
       return {
@@ -466,7 +491,10 @@ export function buildHrRouteBeheerPhaseSummary(args: {
         label: HR_ROUTE_PHASE_LABELS[args.key],
         status: args.status,
         body: args.status === 'current' ? 'Campagne gesloten' : 'Nog niet afgerond',
-        link: null,
+        link: {
+          label: 'Bekijk fase',
+          href: getRouteBeheerPhaseHref(args.campaignId, args.key),
+        },
       } satisfies HrRouteBeheerPhaseSummary
     default:
       return {
@@ -503,7 +531,9 @@ function buildHrRouteBeheerPhaseDetail(args: {
         status: args.status,
         body: 'Controleer hier of de doelgroep compleet en bruikbaar in de route staat.',
         items: [{ label: 'Geimporteerd', value: `${args.respondentCount} deelnemers` }],
-        links: [{ label: 'Open doelgroep', href: `/campaigns/${args.campaignId}#operatie` }],
+        links: [
+          { label: 'Open doelgroep', href: `/campaigns/${args.campaignId}#operatie` },
+        ],
       } satisfies HrRouteBeheerPhaseDetail
     case 'communicatie':
       return {
@@ -515,7 +545,9 @@ function buildHrRouteBeheerPhaseDetail(args: {
           { label: 'Route', value: args.routeSettingsLabel },
           { label: 'Startdatum', value: args.routeSettingsBody.replace('Startdatum: ', '') },
         ],
-        links: [{ label: 'Bekijk instellingen', href: '#route-meta' }],
+        links: [
+          { label: 'Bekijk instellingen', href: `/campaigns/${args.campaignId}/beheer#route-instellingen` },
+        ],
       } satisfies HrRouteBeheerPhaseDetail
     case 'live':
       return {
@@ -527,7 +559,9 @@ function buildHrRouteBeheerPhaseDetail(args: {
           { label: 'Respons', value: `${args.totalCompleted}/${args.totalInvited} ingevuld` },
           { label: 'Openstaand', value: `${args.pendingCount}` },
         ],
-        links: [{ label: 'Ga naar beheeronderdelen', href: '#beheer-onderdelen' }],
+        links: [
+          { label: 'Open uitnodigingen', href: getRouteBeheerPhaseHref(args.campaignId, args.key) },
+        ],
       } satisfies HrRouteBeheerPhaseDetail
     case 'output':
       return {
@@ -756,7 +790,7 @@ export async function fetchRouteBeheerData(args: {
     label: hasMinDisplay ? 'Dashboard leesbaar / Rapport beschikbaar' : 'Nog onvoldoende data',
   } satisfies RouteBeheerPageData['outputSummary']
   const currentHrPhase = mapGuidedPhaseToHrRoutePhase(guidedState.phase)
-  const nowDoing = buildHrRouteBeheerNowDoing(guidedState)
+  const nowDoing = buildHrRouteBeheerNowDoing({ guidedState, campaignId })
   const phaseSummaries = HR_ROUTE_PHASE_ORDER.map((key) =>
     buildHrRouteBeheerPhaseSummary({
       key,

--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.ts
@@ -384,8 +384,8 @@ export function mapGuidedPhaseToHrRoutePhase(phase: GuidedSelfServePhase): HrRou
       return 'doelgroep'
     case 'launch_date_required':
     case 'communication_ready':
-      return 'communicatie'
     case 'ready_to_invite':
+      return 'communicatie'
     case 'survey_running':
       return 'live'
     case 'dashboard_active':

--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.ts
@@ -21,12 +21,50 @@ import type { CampaignAuditEventRecord } from '@/lib/campaign-audit'
 import { getCustomerActionPermission } from '@/lib/customer-permissions'
 
 type SupabaseLike = Pick<SupabaseClient, 'from'>
+type GuidedSelfServePhase = ReturnType<typeof buildGuidedSelfServeState>['phase']
 
 export type RouteBeheerLifecycleStep = {
   key: 'setup' | 'doelgroep' | 'uitnodigingen' | 'respons' | 'output' | 'afgerond'
   label: string
   status: 'done' | 'current' | 'pending'
   sublabel: string
+}
+
+export type HrRouteBeheerPhaseKey =
+  | 'doelgroep'
+  | 'communicatie'
+  | 'live'
+  | 'output'
+  | 'afronding'
+
+export type HrRouteBeheerPhaseStatus = 'done' | 'current' | 'open'
+
+export interface HrRouteBeheerActionLink {
+  label: string
+  href: string
+}
+
+export interface HrRouteBeheerPhaseSummary {
+  key: HrRouteBeheerPhaseKey
+  label: string
+  status: HrRouteBeheerPhaseStatus
+  body: string
+  link: HrRouteBeheerActionLink | null
+}
+
+export interface HrRouteBeheerPhaseDetail {
+  key: HrRouteBeheerPhaseKey
+  label: string
+  status: HrRouteBeheerPhaseStatus
+  body: string
+  items: Array<{ label: string; value: string }>
+  links: HrRouteBeheerActionLink[]
+}
+
+export interface HrRouteBeheerNowDoing {
+  phaseKey: HrRouteBeheerPhaseKey
+  title: string
+  body: string
 }
 
 export interface RouteBeheerPageData {
@@ -56,6 +94,16 @@ export interface RouteBeheerPageData {
   blockers: string[]
   lifecycleStage: DeliveryLifecycleStage | null
   lifecycleSteps: RouteBeheerLifecycleStep[]
+  nowDoing: HrRouteBeheerNowDoing | null
+  phaseSummaries: HrRouteBeheerPhaseSummary[]
+  phaseDetails: HrRouteBeheerPhaseDetail[]
+  outputSummary: {
+    dashboardReady: boolean
+    reportReady: boolean
+    dashboardHref: string
+    reportHref: string | null
+    label: string
+  }
   respondentCount: number
   routeSettingsLabel: string
   routeSettingsBody: string
@@ -85,6 +133,22 @@ const LIFECYCLE_LABELS: Record<RouteBeheerLifecycleStep['key'], string> = {
   respons: 'Respons',
   output: 'Output',
   afgerond: 'Afgerond',
+}
+
+const HR_ROUTE_PHASE_ORDER: HrRouteBeheerPhaseKey[] = [
+  'doelgroep',
+  'communicatie',
+  'live',
+  'output',
+  'afronding',
+]
+
+const HR_ROUTE_PHASE_LABELS: Record<HrRouteBeheerPhaseKey, string> = {
+  doelgroep: 'Doelgroep',
+  communicatie: 'Communicatie',
+  live: 'Live',
+  output: 'Output',
+  afronding: 'Afronding',
 }
 
 export function formatRoutePeriodLabel(campaignName: string, createdAt: string) {
@@ -311,6 +375,201 @@ function filterOperationalBlockers(snapshot: ReturnType<typeof buildDeliveryGove
   ].filter((item, index, items) => item.trim().length > 0 && items.indexOf(item) === index)
 }
 
+export function mapGuidedPhaseToHrRoutePhase(phase: GuidedSelfServePhase): HrRouteBeheerPhaseKey {
+  switch (phase) {
+    case 'participant_data_required':
+    case 'import_validation_required':
+      return 'doelgroep'
+    case 'launch_date_required':
+    case 'communication_ready':
+    case 'ready_to_invite':
+      return 'communicatie'
+    case 'survey_running':
+      return 'live'
+    case 'dashboard_active':
+    case 'first_next_step_available':
+      return 'output'
+    case 'closed':
+      return 'afronding'
+    default:
+      return 'doelgroep'
+  }
+}
+
+function getHrRouteBeheerPhaseStatus(
+  key: HrRouteBeheerPhaseKey,
+  currentPhase: HrRouteBeheerPhaseKey,
+): HrRouteBeheerPhaseStatus {
+  const currentIndex = HR_ROUTE_PHASE_ORDER.indexOf(currentPhase)
+  const phaseIndex = HR_ROUTE_PHASE_ORDER.indexOf(key)
+
+  if (phaseIndex < currentIndex) return 'done'
+  if (phaseIndex === currentIndex) return 'current'
+  return 'open'
+}
+
+export function buildHrRouteBeheerNowDoing(
+  guidedState: Pick<ReturnType<typeof buildGuidedSelfServeState>, 'phase' | 'nextAction'>,
+): HrRouteBeheerNowDoing {
+  return {
+    phaseKey: mapGuidedPhaseToHrRoutePhase(guidedState.phase),
+    title: guidedState.nextAction.title,
+    body: guidedState.nextAction.body,
+  }
+}
+
+export function buildHrRouteBeheerPhaseSummary(args: {
+  key: HrRouteBeheerPhaseKey
+  status: HrRouteBeheerPhaseStatus
+  campaignId: string
+  respondentCount: number
+  totalCompleted: number
+  totalInvited: number
+  outputSummary: RouteBeheerPageData['outputSummary']
+}) {
+  switch (args.key) {
+    case 'doelgroep':
+      return {
+        key: args.key,
+        label: HR_ROUTE_PHASE_LABELS[args.key],
+        status: args.status,
+        body: `${args.respondentCount} deelnemers geimporteerd`,
+        link: { label: 'Open doelgroep', href: `/campaigns/${args.campaignId}#operatie` },
+      } satisfies HrRouteBeheerPhaseSummary
+    case 'communicatie':
+      return {
+        key: args.key,
+        label: HR_ROUTE_PHASE_LABELS[args.key],
+        status: args.status,
+        body: 'Route en launchafspraken staan in deze fase bij elkaar.',
+        link: { label: 'Bekijk communicatie', href: '#route-instellingen' },
+      } satisfies HrRouteBeheerPhaseSummary
+    case 'live':
+      return {
+        key: args.key,
+        label: HR_ROUTE_PHASE_LABELS[args.key],
+        status: args.status,
+        body: `${args.totalCompleted}/${args.totalInvited} ingevuld`,
+        link: { label: 'Open uitnodigingen', href: '#beheer-onderdelen' },
+      } satisfies HrRouteBeheerPhaseSummary
+    case 'output':
+      return {
+        key: args.key,
+        label: HR_ROUTE_PHASE_LABELS[args.key],
+        status: args.status,
+        body: args.outputSummary.label,
+        link: { label: 'Open dashboard', href: args.outputSummary.dashboardHref },
+      } satisfies HrRouteBeheerPhaseSummary
+    case 'afronding':
+      return {
+        key: args.key,
+        label: HR_ROUTE_PHASE_LABELS[args.key],
+        status: args.status,
+        body: args.status === 'current' ? 'Campagne gesloten' : 'Nog niet afgerond',
+        link: null,
+      } satisfies HrRouteBeheerPhaseSummary
+    default:
+      return {
+        key: args.key,
+        label: HR_ROUTE_PHASE_LABELS[args.key],
+        status: args.status,
+        body: '',
+        link: null,
+      } satisfies HrRouteBeheerPhaseSummary
+  }
+}
+
+function buildHrRouteBeheerPhaseDetail(args: {
+  key: HrRouteBeheerPhaseKey
+  status: HrRouteBeheerPhaseStatus
+  campaignId: string
+  routeSettingsLabel: string
+  routeSettingsBody: string
+  respondentCount: number
+  totalCompleted: number
+  totalInvited: number
+  pendingCount: number
+  outputSummary: RouteBeheerPageData['outputSummary']
+  outputStatusLabel: string
+  readabilityBody: string
+  isActive: boolean
+  latestAuditSummary: string | null
+}) {
+  switch (args.key) {
+    case 'doelgroep':
+      return {
+        key: args.key,
+        label: HR_ROUTE_PHASE_LABELS[args.key],
+        status: args.status,
+        body: 'Controleer hier of de doelgroep compleet en bruikbaar in de route staat.',
+        items: [{ label: 'Geimporteerd', value: `${args.respondentCount} deelnemers` }],
+        links: [{ label: 'Open doelgroep', href: `/campaigns/${args.campaignId}#operatie` }],
+      } satisfies HrRouteBeheerPhaseDetail
+    case 'communicatie':
+      return {
+        key: args.key,
+        label: HR_ROUTE_PHASE_LABELS[args.key],
+        status: args.status,
+        body: 'Route-instellingen en launchafspraken blijven in deze communicatie-fase gebundeld.',
+        items: [
+          { label: 'Route', value: args.routeSettingsLabel },
+          { label: 'Startdatum', value: args.routeSettingsBody.replace('Startdatum: ', '') },
+        ],
+        links: [{ label: 'Bekijk instellingen', href: '#route-meta' }],
+      } satisfies HrRouteBeheerPhaseDetail
+    case 'live':
+      return {
+        key: args.key,
+        label: HR_ROUTE_PHASE_LABELS[args.key],
+        status: args.status,
+        body: 'Volg hier uitnodigingen, openstaande respons en het actuele verloop van de route.',
+        items: [
+          { label: 'Respons', value: `${args.totalCompleted}/${args.totalInvited} ingevuld` },
+          { label: 'Openstaand', value: `${args.pendingCount}` },
+        ],
+        links: [{ label: 'Ga naar beheeronderdelen', href: '#beheer-onderdelen' }],
+      } satisfies HrRouteBeheerPhaseDetail
+    case 'output':
+      return {
+        key: args.key,
+        label: HR_ROUTE_PHASE_LABELS[args.key],
+        status: args.status,
+        body: args.readabilityBody,
+        items: [
+          { label: 'Status', value: args.outputStatusLabel },
+          { label: 'Dashboard', value: args.outputSummary.dashboardReady ? 'Beschikbaar' : 'Nog niet' },
+          { label: 'Rapport', value: args.outputSummary.reportReady ? 'Beschikbaar' : 'Nog niet' },
+        ],
+        links: [
+          { label: 'Open dashboard', href: args.outputSummary.dashboardHref },
+          ...(args.outputSummary.reportHref
+            ? [{ label: 'Open rapporten', href: args.outputSummary.reportHref }]
+            : []),
+        ],
+      } satisfies HrRouteBeheerPhaseDetail
+    case 'afronding':
+      return {
+        key: args.key,
+        label: HR_ROUTE_PHASE_LABELS[args.key],
+        status: args.status,
+        body: args.isActive
+          ? 'De route loopt nog; afronding volgt pas na sluiting en nette close-out.'
+          : 'De route is gesloten en kan alleen nog terugkijken op output en logboek.',
+        items: [{ label: 'Laatste logregel', value: args.latestAuditSummary ?? 'Geen activiteit' }],
+        links: [{ label: 'Bekijk logboek', href: `/campaigns/${args.campaignId}#operatie` }],
+      } satisfies HrRouteBeheerPhaseDetail
+    default:
+      return {
+        key: args.key,
+        label: HR_ROUTE_PHASE_LABELS[args.key],
+        status: args.status,
+        body: '',
+        items: [],
+        links: [],
+      } satisfies HrRouteBeheerPhaseDetail
+  }
+}
+
 export async function fetchRouteBeheerData(args: {
   campaignId: string
   supabase: SupabaseLike
@@ -485,6 +744,48 @@ export async function fetchRouteBeheerData(args: {
   ]
     .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
     .join(' / ')
+  const routeSettingsBody = getRouteSettingsBody({
+    launchDate: deliveryRecord?.launch_date ?? deliveryRecord?.launch_confirmed_at ?? null,
+    createdAt: campaign?.created_at ?? stats.created_at,
+  })
+  const outputSummary = {
+    dashboardReady: hasMinDisplay,
+    reportReady: hasMinDisplay,
+    dashboardHref: `/campaigns/${campaignId}`,
+    reportHref: hasMinDisplay ? '/reports' : null,
+    label: hasMinDisplay ? 'Dashboard leesbaar / Rapport beschikbaar' : 'Nog onvoldoende data',
+  } satisfies RouteBeheerPageData['outputSummary']
+  const currentHrPhase = mapGuidedPhaseToHrRoutePhase(guidedState.phase)
+  const nowDoing = buildHrRouteBeheerNowDoing(guidedState)
+  const phaseSummaries = HR_ROUTE_PHASE_ORDER.map((key) =>
+    buildHrRouteBeheerPhaseSummary({
+      key,
+      status: getHrRouteBeheerPhaseStatus(key, currentHrPhase),
+      campaignId,
+      respondentCount: respondents.length,
+      totalCompleted: stats.total_completed,
+      totalInvited: stats.total_invited,
+      outputSummary,
+    }),
+  )
+  const phaseDetails = HR_ROUTE_PHASE_ORDER.map((key) =>
+    buildHrRouteBeheerPhaseDetail({
+      key,
+      status: getHrRouteBeheerPhaseStatus(key, currentHrPhase),
+      campaignId,
+      routeSettingsLabel,
+      routeSettingsBody,
+      respondentCount: respondents.length,
+      totalCompleted: stats.total_completed,
+      totalInvited: stats.total_invited,
+      pendingCount,
+      outputSummary,
+      outputStatusLabel: outputSummary.label,
+      readabilityBody: readability.body,
+      isActive: stats.is_active,
+      latestAuditSummary: auditEvents[0]?.summary ?? null,
+    }),
+  )
 
   return {
     campaignId,
@@ -519,15 +820,15 @@ export async function fetchRouteBeheerData(args: {
       hasMinDisplay,
       hasEnoughData,
     }),
+    nowDoing,
+    phaseSummaries,
+    phaseDetails,
+    // Keep this compact and always visible. Richer output explanation stays owned by the output phase detail.
+    outputSummary,
     respondentCount: respondents.length,
     routeSettingsLabel,
-    routeSettingsBody: getRouteSettingsBody({
-      launchDate: deliveryRecord?.launch_date ?? deliveryRecord?.launch_confirmed_at ?? null,
-      createdAt: campaign?.created_at ?? stats.created_at,
-    }),
-    outputStatusLabel: hasMinDisplay
-      ? 'Dashboard leesbaar / Rapport beschikbaar'
-      : 'Nog onvoldoende data',
+    routeSettingsBody,
+    outputStatusLabel: outputSummary.label,
     latestAuditSummary: auditEvents[0]?.summary ?? null,
     reportAvailable: hasMinDisplay,
     canExecuteCampaign,

--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.ts
@@ -414,6 +414,21 @@ export function getRouteBeheerPhaseHref(campaignId: string, phaseKey: HrRouteBeh
   return `/campaigns/${campaignId}/beheer?fase=${phaseKey}#fase-detail`
 }
 
+export function getRouteBeheerPhaseDetailHref(
+  campaignId: string,
+  phaseKey: HrRouteBeheerPhaseKey,
+) {
+  const detailAnchorByPhase: Record<HrRouteBeheerPhaseKey, string> = {
+    doelgroep: 'deelnemers-en-importstatus',
+    communicatie: 'route-instellingen',
+    live: 'uitnodigingen-en-respons',
+    output: 'dashboard-rapportstatus',
+    afronding: 'status-en-logboek',
+  }
+
+  return `/campaigns/${campaignId}/beheer?fase=${phaseKey}#${detailAnchorByPhase[phaseKey]}`
+}
+
 export function buildHrRouteBeheerNowDoing(
   args: {
     guidedState: Pick<ReturnType<typeof buildGuidedSelfServeState>, 'phase' | 'nextAction'>
@@ -427,7 +442,12 @@ export function buildHrRouteBeheerNowDoing(
     phaseKey,
     title: args.guidedState.nextAction.title,
     body: args.guidedState.nextAction.body,
-    href: getRouteBeheerPhaseHref(args.campaignId, phaseKey),
+    href:
+      phaseKey === 'output'
+        ? `/campaigns/${args.campaignId}`
+        : phaseKey === 'afronding'
+          ? `/campaigns/${args.campaignId}#operatie`
+          : getRouteBeheerPhaseDetailHref(args.campaignId, phaseKey),
   }
 }
 
@@ -446,7 +466,7 @@ export function buildHrRouteBeheerPhaseSummary(args: {
         key: args.key,
         label: HR_ROUTE_PHASE_LABELS[args.key],
         status: args.status,
-        body: `${args.respondentCount} deelnemers geimporteerd`,
+        body: 'Deelnemers en importstatus',
         link: {
           label: 'Bekijk fase',
           href: getRouteBeheerPhaseHref(args.campaignId, args.key),
@@ -457,7 +477,7 @@ export function buildHrRouteBeheerPhaseSummary(args: {
         key: args.key,
         label: HR_ROUTE_PHASE_LABELS[args.key],
         status: args.status,
-        body: 'Route en launchafspraken staan in deze fase bij elkaar.',
+        body: 'Route en startdatum',
         link: {
           label: 'Bekijk fase',
           href: getRouteBeheerPhaseHref(args.campaignId, args.key),
@@ -468,7 +488,7 @@ export function buildHrRouteBeheerPhaseSummary(args: {
         key: args.key,
         label: HR_ROUTE_PHASE_LABELS[args.key],
         status: args.status,
-        body: `${args.totalCompleted}/${args.totalInvited} ingevuld`,
+        body: 'Uitnodigingen en respons',
         link: {
           label: 'Bekijk fase',
           href: getRouteBeheerPhaseHref(args.campaignId, args.key),
@@ -490,7 +510,7 @@ export function buildHrRouteBeheerPhaseSummary(args: {
         key: args.key,
         label: HR_ROUTE_PHASE_LABELS[args.key],
         status: args.status,
-        body: args.status === 'current' ? 'Campagne gesloten' : 'Nog niet afgerond',
+        body: 'Status en logboek',
         link: {
           label: 'Bekijk fase',
           href: getRouteBeheerPhaseHref(args.campaignId, args.key),
@@ -529,7 +549,7 @@ function buildHrRouteBeheerPhaseDetail(args: {
         key: args.key,
         label: HR_ROUTE_PHASE_LABELS[args.key],
         status: args.status,
-        body: 'Controleer hier of de doelgroep compleet en bruikbaar in de route staat.',
+        body: 'Deelnemers en importstatus',
         items: [{ label: 'Geimporteerd', value: `${args.respondentCount} deelnemers` }],
         links: [
           { label: 'Open doelgroep', href: `/campaigns/${args.campaignId}#operatie` },
@@ -540,13 +560,13 @@ function buildHrRouteBeheerPhaseDetail(args: {
         key: args.key,
         label: HR_ROUTE_PHASE_LABELS[args.key],
         status: args.status,
-        body: 'Route-instellingen en launchafspraken blijven in deze communicatie-fase gebundeld.',
+        body: 'Route en startdatum',
         items: [
           { label: 'Route', value: args.routeSettingsLabel },
           { label: 'Startdatum', value: args.routeSettingsBody.replace('Startdatum: ', '') },
         ],
         links: [
-          { label: 'Bekijk instellingen', href: `/campaigns/${args.campaignId}/beheer#route-instellingen` },
+          { label: 'Bekijk instellingen', href: getRouteBeheerPhaseDetailHref(args.campaignId, args.key) },
         ],
       } satisfies HrRouteBeheerPhaseDetail
     case 'live':
@@ -554,13 +574,13 @@ function buildHrRouteBeheerPhaseDetail(args: {
         key: args.key,
         label: HR_ROUTE_PHASE_LABELS[args.key],
         status: args.status,
-        body: 'Volg hier uitnodigingen, openstaande respons en het actuele verloop van de route.',
+        body: 'Uitnodigingen en respons',
         items: [
           { label: 'Respons', value: `${args.totalCompleted}/${args.totalInvited} ingevuld` },
           { label: 'Openstaand', value: `${args.pendingCount}` },
         ],
         links: [
-          { label: 'Open uitnodigingen', href: getRouteBeheerPhaseHref(args.campaignId, args.key) },
+          { label: 'Open uitnodigingen', href: getRouteBeheerPhaseDetailHref(args.campaignId, args.key) },
         ],
       } satisfies HrRouteBeheerPhaseDetail
     case 'output':
@@ -568,7 +588,7 @@ function buildHrRouteBeheerPhaseDetail(args: {
         key: args.key,
         label: HR_ROUTE_PHASE_LABELS[args.key],
         status: args.status,
-        body: args.readabilityBody,
+        body: 'Dashboard / rapportstatus',
         items: [
           { label: 'Status', value: args.outputStatusLabel },
           { label: 'Dashboard', value: args.outputSummary.dashboardReady ? 'Beschikbaar' : 'Nog niet' },
@@ -586,9 +606,7 @@ function buildHrRouteBeheerPhaseDetail(args: {
         key: args.key,
         label: HR_ROUTE_PHASE_LABELS[args.key],
         status: args.status,
-        body: args.isActive
-          ? 'De route loopt nog; afronding volgt pas na sluiting en nette close-out.'
-          : 'De route is gesloten en kan alleen nog terugkijken op output en logboek.',
+        body: 'Status en logboek',
         items: [{ label: 'Laatste logregel', value: args.latestAuditSummary ?? 'Geen activiteit' }],
         links: [{ label: 'Bekijk logboek', href: `/campaigns/${args.campaignId}#operatie` }],
       } satisfies HrRouteBeheerPhaseDetail
@@ -787,7 +805,7 @@ export async function fetchRouteBeheerData(args: {
     reportReady: hasMinDisplay,
     dashboardHref: `/campaigns/${campaignId}`,
     reportHref: hasMinDisplay ? '/reports' : null,
-    label: hasMinDisplay ? 'Dashboard leesbaar / Rapport beschikbaar' : 'Nog onvoldoende data',
+    label: 'Dashboard / rapportstatus',
   } satisfies RouteBeheerPageData['outputSummary']
   const currentHrPhase = mapGuidedPhaseToHrRoutePhase(guidedState.phase)
   const nowDoing = buildHrRouteBeheerNowDoing({ guidedState, campaignId })

--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/page.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/page.test.ts
@@ -2,13 +2,20 @@ import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
 describe('routebeheer page guardrails', () => {
-  it('keeps routebeheer as an operational hub and excludes analytical or action-center detail layers', () => {
+  it('keeps routebeheer as a compact worktable instead of a stack of interpretation-heavy status surfaces', () => {
     const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
     const componentSource = readFileSync(new URL('./route-beheer-components.tsx', import.meta.url), 'utf8')
-    const combined = `${source}\n${componentSource}`
+    const phaseSource = readFileSync(new URL('./route-beheer-phase-sections.tsx', import.meta.url), 'utf8')
+    const combined = `${source}\n${componentSource}\n${phaseSource}`
 
-    expect(combined).toContain('Routebeheer')
-    expect(combined).toContain('Open dashboard')
+    expect(combined).toContain('RouteBeheerStructuredBody')
+    expect(combined).toContain('RouteBeheerNowDoingRow')
+    expect(combined).toContain('RouteBeheerPhaseOverview')
+    expect(combined).toContain('RouteBeheerOutputSummary')
+    expect(combined).not.toContain('RouteBeheerStatusCards')
+    expect(combined).not.toContain('RouteBeheerBlockerPanel')
+    expect(combined).not.toContain('Beheer livegang, respons en output-readiness voor deze route.')
+    expect(combined).not.toContain('Route vraagt nu operationele aandacht')
     expect(combined).not.toContain('Frictiescore')
     expect(combined).not.toContain('factoren')
     expect(combined).not.toContain('SDT')
@@ -19,12 +26,12 @@ describe('routebeheer page guardrails', () => {
 
   it('keeps routebeheer labels clean and preserves the approved instellingen CTA', () => {
     const componentSource = readFileSync(new URL('./route-beheer-components.tsx', import.meta.url), 'utf8')
+    const phaseSource = readFileSync(new URL('./route-beheer-phase-sections.tsx', import.meta.url), 'utf8')
+    const combined = `${componentSource}\n${phaseSource}`
 
-    expect(componentSource).toContain('Bekijk instellingen')
-    expect(componentSource).not.toContain('Ã')
-    expect(componentSource).not.toContain('Â')
-    expect(componentSource).not.toContain('â€¢')
-    expect(componentSource).not.toContain('�')
+    expect(combined).toContain('Bekijk instellingen')
+    expect(combined).not.toContain('Ã')
+    expect(combined).not.toContain('ï¿½')
   })
 
   it('reuses the existing campaign access boundary instead of inventing a new route role model', () => {
@@ -34,5 +41,15 @@ describe('routebeheer page guardrails', () => {
     expect(source).toContain('context.canViewInsights')
     expect(source).toContain('SuiteAccessDenied')
     expect(source).not.toContain('managerOnly')
+  })
+
+  it('keeps the five-phase routebeheer model explicit in the source', () => {
+    const source = readFileSync(new URL('./route-beheer-phase-sections.tsx', import.meta.url), 'utf8')
+
+    expect(source).toContain('Doelgroep klaarzetten')
+    expect(source).toContain('Communicatie instellen')
+    expect(source).toContain('Live zetten & volgen')
+    expect(source).toContain('Output beoordelen')
+    expect(source).toContain('Afronden & controleren')
   })
 })

--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/page.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/page.test.ts
@@ -16,6 +16,8 @@ describe('routebeheer page guardrails', () => {
     expect(combined).not.toContain('RouteBeheerBlockerPanel')
     expect(combined).not.toContain('Beheer livegang, respons en output-readiness voor deze route.')
     expect(combined).not.toContain('Route vraagt nu operationele aandacht')
+    expect(combined).not.toContain('Bekijk per fase wat klaar is en wat nog aandacht vraagt.')
+    expect(combined).not.toContain('Open rapport zodra de eerste dashboardread beschikbaar is.')
     expect(combined).not.toContain('Frictiescore')
     expect(combined).not.toContain('factoren')
     expect(combined).not.toContain('SDT')
@@ -25,13 +27,18 @@ describe('routebeheer page guardrails', () => {
   })
 
   it('keeps routebeheer labels clean and preserves the approved instellingen CTA', () => {
+    const dataSource = readFileSync(new URL('./beheer-data.ts', import.meta.url), 'utf8')
     const componentSource = readFileSync(new URL('./route-beheer-components.tsx', import.meta.url), 'utf8')
     const phaseSource = readFileSync(new URL('./route-beheer-phase-sections.tsx', import.meta.url), 'utf8')
-    const combined = `${componentSource}\n${phaseSource}`
+    const combined = `${dataSource}\n${componentSource}\n${phaseSource}`
 
     expect(combined).toContain('Bekijk instellingen')
-    expect(combined).not.toContain('Ã')
-    expect(combined).not.toContain('ï¿½')
+    expect(combined).toContain('Route en startdatum')
+    expect(combined).toContain('Uitnodigingen en respons')
+    expect(combined).toContain('Dashboard / rapportstatus')
+    expect(combined).toContain('Status en logboek')
+    expect(combined).not.toContain('Ãƒ')
+    expect(combined).not.toContain('Ã¯Â¿Â½')
   })
 
   it('reuses the existing campaign access boundary instead of inventing a new route role model', () => {

--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/page.tsx
@@ -4,19 +4,34 @@ import { createClient } from '@/lib/supabase/server'
 import { loadSuiteAccessContext } from '@/lib/suite-access-server'
 import { fetchRouteBeheerData } from './beheer-data'
 import {
-  RouteBeheerBlockerPanel,
   RouteBeheerHeader,
-  RouteBeheerLifecycleSection,
-  RouteBeheerSectionsWrapper,
-  RouteBeheerStatusCards,
+  RouteBeheerStructuredBody,
 } from './route-beheer-components'
+import type { HrRouteBeheerPhaseKey } from './beheer-data'
 
 interface Props {
   params: Promise<{ id: string }>
+  searchParams?: Promise<Record<string, string | string[] | undefined>>
 }
 
-export default async function RouteBeheerPage({ params }: Props) {
+function normalizeSelectedPhase(value: string | string[] | undefined): HrRouteBeheerPhaseKey | null {
+  if (typeof value !== 'string') return null
+
+  switch (value) {
+    case 'doelgroep':
+    case 'communicatie':
+    case 'live':
+    case 'output':
+    case 'afronding':
+      return value
+    default:
+      return null
+  }
+}
+
+export default async function RouteBeheerPage({ params, searchParams }: Props) {
   const { id } = await params
+  const resolvedSearchParams = searchParams ? await searchParams : undefined
   const supabase = await createClient()
   const {
     data: { user },
@@ -50,10 +65,10 @@ export default async function RouteBeheerPage({ params }: Props) {
   return (
     <div className="space-y-6">
       <RouteBeheerHeader data={data} />
-      <RouteBeheerStatusCards data={data} />
-      <RouteBeheerBlockerPanel blockers={data.blockers} />
-      <RouteBeheerLifecycleSection data={data} />
-      <RouteBeheerSectionsWrapper data={data} />
+      <RouteBeheerStructuredBody
+        data={data}
+        initialSelectedPhaseKey={normalizeSelectedPhase(resolvedSearchParams?.fase)}
+      />
     </div>
   )
 }

--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/route-beheer-components.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/route-beheer-components.tsx
@@ -65,7 +65,7 @@ export function RouteBeheerStructuredBody(args: {
       <DashboardSection
         id="route-fasen"
         title="Routefasen"
-        description="Bekijk per fase wat klaar is en wat nog aandacht vraagt."
+        description="Kies een fase voor details."
         eyebrow="Fasen"
         surface="ops"
         tone="slate"

--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/route-beheer-components.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/route-beheer-components.tsx
@@ -1,33 +1,15 @@
 import Link from 'next/link'
-import { DashboardChip, DashboardPanel, DashboardSection } from '@/components/dashboard/dashboard-primitives'
-import { CampaignActions } from '../campaign-actions'
-import { PdfDownloadButton } from '../pdf-download-button'
+import { DashboardChip, DashboardSection } from '@/components/dashboard/dashboard-primitives'
+import { formatLatestActivityLabel, type HrRouteBeheerPhaseKey, type RouteBeheerPageData } from './beheer-data'
 import {
-  formatLatestActivityLabel,
-  getLaunchCardValue,
-  type RouteBeheerLifecycleStep,
-  type RouteBeheerPageData,
-} from './beheer-data'
+  RouteBeheerLogbookSummary,
+  RouteBeheerNowDoingRow,
+  RouteBeheerOutputSummary,
+  RouteBeheerPhaseWorkspace,
+} from './route-beheer-phase-sections'
 
-function joinClasses(...classes: Array<string | false | null | undefined>) {
-  return classes.filter(Boolean).join(' ')
-}
-
-function sectionButtonClass(kind: 'primary' | 'secondary') {
-  return kind === 'primary'
-    ? 'inline-flex items-center justify-center rounded-full bg-[color:var(--teal)] px-4 py-2 text-sm font-semibold text-white transition hover:brightness-95'
-    : 'inline-flex items-center justify-center rounded-full border border-[color:var(--border)] bg-white px-4 py-2 text-sm font-semibold text-[color:var(--text)] transition hover:border-[color:var(--teal)] hover:text-[color:var(--ink)]'
-}
-
-function MetricRow({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-[16px] border border-[color:var(--border)] bg-[color:var(--bg)] px-4 py-3">
-      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
-        {label}
-      </p>
-      <p className="mt-2 text-sm font-semibold text-[color:var(--ink)]">{value}</p>
-    </div>
-  )
+function sectionButtonClass() {
+  return 'inline-flex items-center justify-center rounded-full border border-[color:var(--border)] bg-white px-4 py-2 text-sm font-semibold text-[color:var(--text)] transition hover:border-[color:var(--teal)] hover:text-[color:var(--ink)]'
 }
 
 export function RouteBeheerHeader({ data }: { data: RouteBeheerPageData }) {
@@ -41,12 +23,9 @@ export function RouteBeheerHeader({ data }: { data: RouteBeheerPageData }) {
           <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[color:var(--muted)]">
             Routebeheer
           </p>
-          <h1 className="mt-3 text-[1.9rem] font-bold tracking-tight text-[color:var(--ink)] sm:text-[2.15rem]">
-            Routebeheer
+          <h1 className="mt-2 text-[1.8rem] font-bold tracking-tight text-[color:var(--ink)] sm:text-[2.05rem]">
+            {data.campaignName}
           </h1>
-          <p className="mt-3 max-w-3xl text-sm leading-6 text-[color:var(--text)]">
-            Beheer livegang, respons en output-readiness voor deze route.
-          </p>
           <div className="mt-4 flex flex-wrap items-center gap-2.5 text-sm text-[color:var(--text)]">
             <span>{data.organizationName ?? 'Niet beschikbaar'}</span>
             <span aria-hidden="true">&middot;</span>
@@ -63,16 +42,9 @@ export function RouteBeheerHeader({ data }: { data: RouteBeheerPageData }) {
           <DashboardChip label={data.statusBadgeLabel} tone={data.statusBadgeTone} surface="ops" />
           <p className="text-sm text-[color:var(--text)]">{formatLatestActivityLabel(data.lastActivityAt)}</p>
           <div className="flex flex-wrap gap-2">
-            <Link href={`/campaigns/${data.campaignId}`} className={sectionButtonClass('secondary')}>
+            <Link href={`/campaigns/${data.campaignId}`} className={sectionButtonClass()}>
               Open dashboard
             </Link>
-            {data.reportAvailable ? (
-              <PdfDownloadButton
-                campaignId={data.campaignId}
-                campaignName={data.campaignName}
-                scanType={data.scanType}
-              />
-            ) : null}
           </div>
         </div>
       </div>
@@ -80,273 +52,36 @@ export function RouteBeheerHeader({ data }: { data: RouteBeheerPageData }) {
   )
 }
 
-export function RouteBeheerStatusCards({ data }: { data: RouteBeheerPageData }) {
+export function RouteBeheerStructuredBody(args: {
+  data: RouteBeheerPageData
+  initialSelectedPhaseKey: HrRouteBeheerPhaseKey | null
+}) {
+  const { data, initialSelectedPhaseKey } = args
+
   return (
-    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-      <DashboardPanel
-        title="Livegang"
-        value={getLaunchCardValue(data)}
-        body={
-          data.isActive
-            ? 'Laat zien of de route live staat en welk operationeel startmoment nu geldt.'
-            : 'Deze route is gesloten; livegang is niet meer actief.'
-        }
-        tone={data.isActive ? 'emerald' : 'slate'}
+    <div className="space-y-5">
+      <RouteBeheerNowDoingRow nowDoing={data.nowDoing} />
+
+      <DashboardSection
+        id="route-fasen"
+        title="Routefasen"
+        description="Bekijk per fase wat klaar is en wat nog aandacht vraagt."
+        eyebrow="Fasen"
         surface="ops"
-      />
-      <DashboardPanel
-        title="Respons"
-        value={`${data.totalCompleted}/${data.totalInvited} ingevuld`}
-        body={
-          data.pendingCount > 0
-            ? `${data.pendingCount} openstaand / ${data.completionRatePct != null ? `${data.completionRatePct}% afgerond` : 'Niet beschikbaar'}`
-            : 'Alle uitgenodigde respondenten hebben afgerond.'
-        }
-        tone={data.totalCompleted > 0 ? 'blue' : 'slate'}
-        surface="ops"
-      />
-      <DashboardPanel
-        title="Dashboard leesbaarheid"
-        value={data.readabilityLabel}
-        body={data.readabilityBody}
-        tone={data.hasEnoughData ? 'emerald' : data.hasMinDisplay ? 'amber' : 'slate'}
-        surface="ops"
-      />
-      <div className="rounded-lg border border-[color:var(--border)] border-l-4 border-l-[color:var(--teal)] bg-white p-4 shadow-[0_1px_4px_rgba(10,25,47,0.04)] sm:p-5">
-        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
-          Eerstvolgende stap
-        </p>
-        <p className="mt-3 text-lg font-semibold text-[color:var(--ink)]">
-          {data.nextActionTitle ?? 'Niet beschikbaar'}
-        </p>
-        <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">
-          {data.nextActionBody ?? 'Niet beschikbaar'}
-        </p>
-        <div className="mt-4">
-          <a href="#beheer-onderdelen" className={sectionButtonClass('primary')}>
-            Ga naar beheeronderdelen
-          </a>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-export function RouteBeheerBlockerPanel({ blockers }: { blockers: string[] }) {
-  if (blockers.length === 0) {
-    return null
-  }
-
-  return (
-    <section className="rounded-lg border border-amber-200 bg-amber-50 p-5 shadow-[0_1px_4px_rgba(10,25,47,0.04)]">
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-        <div className="min-w-0">
-          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-amber-900">
-            Actie nodig
-          </p>
-          <h2 className="mt-2 text-lg font-semibold text-amber-950">Route vraagt nu operationele aandacht</h2>
-          <ul className="mt-3 space-y-2 text-sm leading-6 text-amber-900">
-            {blockers.map((blocker) => (
-              <li key={blocker} className="flex gap-2">
-                <span aria-hidden="true">&bull;</span>
-                <span>{blocker}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <a
-            href="#beheer-onderdelen"
-            className="inline-flex items-center justify-center rounded-full bg-amber-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-950"
-          >
-            Ga naar beheeronderdelen
-          </a>
-          <Link href="#route-meta" className="inline-flex items-center justify-center rounded-full px-3 py-2 text-sm font-semibold text-amber-900 underline underline-offset-4">
-            Bekijk routestatus
-          </Link>
-        </div>
-      </div>
-    </section>
-  )
-}
-
-export function RouteBeheerLifecycleBar({ steps }: { steps: RouteBeheerLifecycleStep[] }) {
-  return (
-    <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-6">
-      {steps.map((step, index) => {
-        const dotClass =
-          step.status === 'done'
-            ? 'border-[#3C8D8A] bg-[#3C8D8A] text-white'
-            : step.status === 'current'
-              ? 'border-[color:var(--teal)] bg-[color:var(--teal)] text-white'
-              : 'border-[color:var(--border)] bg-[color:var(--bg)] text-[color:var(--muted)]'
-
-        return (
-          <div
-            key={step.key}
-            className="rounded-[18px] border border-[color:var(--border)] bg-[color:var(--bg)] px-4 py-4"
-          >
-            <div className="flex items-center gap-3">
-              <span
-                className={joinClasses(
-                  'inline-flex h-9 w-9 items-center justify-center rounded-full border text-sm font-semibold',
-                  dotClass,
-                )}
-              >
-                {index + 1}
-              </span>
-              <div>
-                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
-                  {step.label}
-                </p>
-                <p className="mt-1 text-sm font-semibold text-[color:var(--ink)]">{step.sublabel}</p>
-              </div>
-            </div>
-          </div>
-        )
-      })}
-    </div>
-  )
-}
-
-export function RouteBeheerSectionCards({ data }: { data: RouteBeheerPageData }) {
-  return (
-    <div className="grid gap-4 lg:grid-cols-2">
-      <div className="rounded-lg border border-[color:var(--border)] bg-white p-5 shadow-[0_1px_4px_rgba(10,25,47,0.04)]">
-        <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[color:var(--muted)]">
-          Doelgroep controleren
-        </p>
-        <p className="mt-2 text-lg font-semibold text-[color:var(--ink)]">
-          Bekijk importstatus en geimporteerde deelnemers.
-        </p>
-        <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">
-          {data.respondentCount} deelnemers geimporteerd
-        </p>
-        <div className="mt-4">
-          <Link href={`/campaigns/${data.campaignId}#operatie`} className={sectionButtonClass('secondary')}>
-            Open doelgroep
-          </Link>
-        </div>
-      </div>
-
-      <div className="rounded-lg border border-[color:var(--border)] bg-white p-5 shadow-[0_1px_4px_rgba(10,25,47,0.04)]">
-        <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[color:var(--muted)]">
-          Uitnodigingen beheren
-        </p>
-        <p className="mt-2 text-lg font-semibold text-[color:var(--ink)]">Stuur uitnodigingen of herinnering naar deelnemers.</p>
-        <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">
-          {data.totalCompleted} ingevuld / {data.pendingCount} openstaand
-        </p>
-        <div className="mt-4">
-          {data.canManageCampaign || data.canExecuteCampaign ? (
-            <CampaignActions
-              campaignId={data.campaignId}
-              isActive={data.isActive}
-              pendingCount={data.pendingCount}
-              canResendInvites={data.canExecuteCampaign}
-              canArchiveCampaign={data.canManageCampaign}
-            />
-          ) : (
-            <p className="text-sm leading-6 text-[color:var(--text)]">
-              Alleen de klant owner of Loep kan uitnodigingen en herinneringen hier verder uitvoeren.
-            </p>
-          )}
-        </div>
-      </div>
-
-      <div
-        id="route-instellingen"
-        className="rounded-lg border border-[color:var(--border)] bg-white p-5 shadow-[0_1px_4px_rgba(10,25,47,0.04)]"
+        tone="slate"
       >
-        <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[color:var(--muted)]">
-          Route-instellingen
-        </p>
-        <p className="mt-2 text-lg font-semibold text-[color:var(--ink)]">Bekijk startdatum, scantype en uitvoermodus.</p>
-        <div className="mt-3 space-y-3">
-          <MetricRow label="Route" value={data.routeSettingsLabel} />
-          <MetricRow label="Startdatum" value={data.routeSettingsBody.replace('Startdatum: ', '')} />
-        </div>
-        <div className="mt-4">
-          <a href="#route-meta" className={sectionButtonClass('secondary')}>
-            Bekijk instellingen
-          </a>
-        </div>
-      </div>
+        <RouteBeheerPhaseWorkspace
+          data={data}
+          initialSelectedPhaseKey={initialSelectedPhaseKey}
+        />
+      </DashboardSection>
 
-      <div className="rounded-lg border border-[color:var(--border)] bg-white p-5 shadow-[0_1px_4px_rgba(10,25,47,0.04)]">
-        <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[color:var(--muted)]">
-          Output openen
-        </p>
-        <p className="mt-2 text-lg font-semibold text-[color:var(--ink)]">Ga naar dashboard of download het rapport.</p>
-        <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">{data.outputStatusLabel}</p>
-        <div className="mt-4 flex flex-wrap items-center gap-3">
-          <Link href={`/campaigns/${data.campaignId}`} className={sectionButtonClass('secondary')}>
-            Open dashboard
-          </Link>
-          {data.reportAvailable ? (
-            <PdfDownloadButton
-              campaignId={data.campaignId}
-              campaignName={data.campaignName}
-              scanType={data.scanType}
-            />
-          ) : (
-            <span className="text-sm text-[color:var(--text)]">Open rapport zodra de eerste dashboardread beschikbaar is.</span>
-          )}
-        </div>
-      </div>
+      <RouteBeheerOutputSummary summary={data.outputSummary} />
 
-      <div className="rounded-lg border border-[color:var(--border)] bg-white p-5 shadow-[0_1px_4px_rgba(10,25,47,0.04)] lg:col-span-2">
-        <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[color:var(--muted)]">
-          Logboek bekijken
-        </p>
-        <p className="mt-2 text-lg font-semibold text-[color:var(--ink)]">Bekijk imports, uitnodigingen en lifecycle-mutaties.</p>
-        <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">
-          {data.latestAuditSummary ?? 'Geen activiteit'}
-        </p>
-        <div className="mt-4">
-          <Link href={`/campaigns/${data.campaignId}#operatie`} className={sectionButtonClass('secondary')}>
-            Bekijk logboek
-          </Link>
-        </div>
-      </div>
+      <RouteBeheerLogbookSummary
+        href={`/campaigns/${data.campaignId}#operatie`}
+        latestAuditSummary={data.latestAuditSummary}
+      />
     </div>
-  )
-}
-
-export function RouteBeheerEmptyState({ title, body }: { title: string; body: string }) {
-  return (
-    <div className="rounded-lg border border-dashed border-[color:var(--border)] bg-[color:var(--bg)] px-5 py-5 text-sm leading-6 text-[color:var(--text)]">
-      <p className="font-semibold text-[color:var(--ink)]">{title}</p>
-      <p className="mt-2">{body}</p>
-    </div>
-  )
-}
-
-export function RouteBeheerLifecycleSection({ data }: { data: RouteBeheerPageData }) {
-  return (
-    <DashboardSection
-      title="Lifecycle voortgang"
-      description="Volg waar de route staat tussen setup, doelgroep, uitnodigingen, respons, output en afronding."
-      eyebrow="Lifecycle"
-      surface="ops"
-      tone="slate"
-    >
-      <RouteBeheerLifecycleBar steps={data.lifecycleSteps} />
-    </DashboardSection>
-  )
-}
-
-export function RouteBeheerSectionsWrapper({ data }: { data: RouteBeheerPageData }) {
-  return (
-    <DashboardSection
-      id="beheer-onderdelen"
-      title="Beheer onderdelen"
-      description="Gebruik deze laag voor doelgroep, uitnodigingen, route-instellingen, output en logboek."
-      eyebrow="Onderdelen"
-      surface="ops"
-      tone="slate"
-    >
-      <RouteBeheerSectionCards data={data} />
-    </DashboardSection>
   )
 }

--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/route-beheer-phase-sections.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/route-beheer-phase-sections.test.ts
@@ -30,7 +30,7 @@ const phases: HrRouteBeheerPhaseSummary[] = [
     key: 'communicatie',
     label: 'Communicatie instellen',
     status: 'open',
-    body: 'Uitnodiging ontbreekt, reminder niet ingesteld',
+    body: 'Route en startdatum',
     link: { label: 'Open communicatie', href: '/campaigns/cmp-1/beheer#route-instellingen' },
   },
 ]
@@ -40,7 +40,7 @@ const phaseDetails: HrRouteBeheerPhaseDetail[] = [
     key: 'communicatie',
     label: 'Communicatie instellen',
     status: 'open',
-    body: 'Route-instellingen en launchafspraken blijven in deze communicatie-fase gebundeld.',
+    body: 'Route en startdatum',
     items: [
       { label: 'Route', value: 'ExitScan / Baseline / Q3 2026' },
       { label: 'Startdatum', value: '10 mei 2026' },
@@ -98,6 +98,7 @@ describe('routebeheer phase sections', () => {
     expect(markup).toContain('Open uitnodiging')
     expect(markup).toContain('Bekijk instellingen')
     expect(markup).toContain('10 mei 2026')
+    expect(markup).not.toContain('launchafspraken')
   })
 
   it('keeps the always-visible output summary compact and action-only', () => {
@@ -108,12 +109,12 @@ describe('routebeheer phase sections', () => {
           reportReady: false,
           dashboardHref: '/campaigns/cmp-1',
           reportHref: null,
-          label: 'Dashboard beschikbaar, rapport nog niet beschikbaar',
+          label: 'Dashboard / rapportstatus',
         },
       }),
     )
 
-    expect(markup).toContain('Dashboard beschikbaar, rapport nog niet beschikbaar')
+    expect(markup).toContain('Dashboard / rapportstatus')
     expect(markup).toContain('href="/campaigns/cmp-1"')
     expect(markup).not.toContain('readiness')
   })

--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/route-beheer-phase-sections.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/route-beheer-phase-sections.test.ts
@@ -1,0 +1,120 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import type { HrRouteBeheerPhaseDetail, HrRouteBeheerPhaseSummary } from './beheer-data'
+
+vi.mock('../campaign-actions', () => ({
+  CampaignActions: () => createElement('div', null, 'CampaignActions'),
+}))
+
+vi.mock('../pdf-download-button', () => ({
+  PdfDownloadButton: () => createElement('div', null, 'PdfDownloadButton'),
+}))
+
+import {
+  RouteBeheerNowDoingRow,
+  RouteBeheerOutputSummary,
+  RouteBeheerPhaseDetailPanel,
+  RouteBeheerPhaseOverview,
+} from './route-beheer-phase-sections'
+
+const phases: HrRouteBeheerPhaseSummary[] = [
+  {
+    key: 'doelgroep',
+    label: 'Doelgroep klaarzetten',
+    status: 'current',
+    body: '124 deelnemers, 18 ontbreken',
+    link: { label: 'Open doelgroep', href: '/campaigns/cmp-1#operatie' },
+  },
+  {
+    key: 'communicatie',
+    label: 'Communicatie instellen',
+    status: 'open',
+    body: 'Uitnodiging ontbreekt, reminder niet ingesteld',
+    link: { label: 'Open communicatie', href: '/campaigns/cmp-1/beheer#route-instellingen' },
+  },
+]
+
+const phaseDetails: HrRouteBeheerPhaseDetail[] = [
+  {
+    key: 'communicatie',
+    label: 'Communicatie instellen',
+    status: 'open',
+    body: 'Route-instellingen en launchafspraken blijven in deze communicatie-fase gebundeld.',
+    items: [
+      { label: 'Route', value: 'ExitScan / Baseline / Q3 2026' },
+      { label: 'Startdatum', value: '10 mei 2026' },
+    ],
+    links: [
+      { label: 'Open uitnodiging', href: '/campaigns/cmp-1#uitnodigingen' },
+      { label: 'Bekijk instellingen', href: '/campaigns/cmp-1/beheer#route-instellingen' },
+    ],
+  },
+]
+
+describe('routebeheer phase sections', () => {
+  it('renders a subtle now-doing row as a direct action link', () => {
+    const markup = renderToStaticMarkup(
+      createElement(RouteBeheerNowDoingRow, {
+        nowDoing: {
+          phaseKey: 'live',
+          title: 'Verstuur uitnodigingen',
+          body: 'Uitnodiging staat klaar, nog niet verstuurd',
+          href: '/campaigns/cmp-1#uitnodigingen',
+          label: 'Nu doen',
+        },
+      }),
+    )
+
+    expect(markup).toContain('Verstuur uitnodigingen')
+    expect(markup).toContain('Uitnodiging staat klaar, nog niet verstuurd')
+    expect(markup).toContain('href="/campaigns/cmp-1#uitnodigingen"')
+  })
+
+  it('renders all phases collapsed by default and shows fact lines without dominant explanatory copy', () => {
+    const markup = renderToStaticMarkup(
+      createElement(RouteBeheerPhaseOverview, {
+        phases,
+        selectedPhaseKey: null,
+        onSelectPhase: () => undefined,
+      }),
+    )
+
+    expect(markup).toContain('Doelgroep klaarzetten')
+    expect(markup).toContain('124 deelnemers, 18 ontbreken')
+    expect(markup).not.toContain('waarom dit belangrijk is')
+    expect(markup).not.toContain('aria-expanded="true"')
+  })
+
+  it('renders only the selected phase detail surface on demand', () => {
+    const markup = renderToStaticMarkup(
+      createElement(RouteBeheerPhaseDetailPanel, {
+        phases: phaseDetails,
+        selectedPhaseKey: 'communicatie',
+      }),
+    )
+
+    expect(markup).toContain('Communicatie instellen')
+    expect(markup).toContain('Open uitnodiging')
+    expect(markup).toContain('Bekijk instellingen')
+    expect(markup).toContain('10 mei 2026')
+  })
+
+  it('keeps the always-visible output summary compact and action-only', () => {
+    const markup = renderToStaticMarkup(
+      createElement(RouteBeheerOutputSummary, {
+        summary: {
+          dashboardReady: true,
+          reportReady: false,
+          dashboardHref: '/campaigns/cmp-1',
+          reportHref: null,
+          label: 'Dashboard beschikbaar, rapport nog niet beschikbaar',
+        },
+      }),
+    )
+
+    expect(markup).toContain('Dashboard beschikbaar, rapport nog niet beschikbaar')
+    expect(markup).toContain('href="/campaigns/cmp-1"')
+    expect(markup).not.toContain('readiness')
+  })
+})

--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/route-beheer-phase-sections.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/route-beheer-phase-sections.tsx
@@ -19,6 +19,13 @@ const PHASE_TITLES: Record<HrRouteBeheerPhaseKey, string> = {
   output: 'Output beoordelen',
   afronding: 'Afronden & controleren',
 }
+const PHASE_DETAIL_IDS: Record<HrRouteBeheerPhaseKey, string> = {
+  doelgroep: 'deelnemers-en-importstatus',
+  communicatie: 'route-instellingen',
+  live: 'uitnodigingen-en-respons',
+  output: 'dashboard-rapportstatus',
+  afronding: 'status-en-logboek',
+}
 const NOW_DOING_LABEL = 'Nu doen'
 const ROUTE_SETTINGS_CTA_LABEL = 'Bekijk instellingen'
 
@@ -166,7 +173,7 @@ export function RouteBeheerPhaseWorkspace(args: {
 
 function RouteBeheerPhaseDetailContent({ data, detail }: { data: RouteBeheerPageData; detail: HrRouteBeheerPhaseDetail }) {
   return (
-    <div className="space-y-4">
+    <div id={PHASE_DETAIL_IDS[detail.key]} className="space-y-4">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="min-w-0">
           <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
@@ -227,7 +234,7 @@ function RouteBeheerPhaseDetailContent({ data, detail }: { data: RouteBeheerPage
             />
           ) : (
             <span className="text-sm text-[color:var(--text)]">
-              Open rapport zodra de eerste dashboardread beschikbaar is.
+              Rapport nog niet beschikbaar.
             </span>
           )}
         </div>

--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/route-beheer-phase-sections.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/route-beheer-phase-sections.tsx
@@ -1,0 +1,412 @@
+'use client'
+
+import Link from 'next/link'
+import React, { useState } from 'react'
+import { CampaignActions } from '../campaign-actions'
+import { PdfDownloadButton } from '../pdf-download-button'
+import type {
+  HrRouteBeheerNowDoing,
+  HrRouteBeheerPhaseDetail,
+  HrRouteBeheerPhaseKey,
+  HrRouteBeheerPhaseSummary,
+  RouteBeheerPageData,
+} from './beheer-data'
+
+const PHASE_TITLES: Record<HrRouteBeheerPhaseKey, string> = {
+  doelgroep: 'Doelgroep klaarzetten',
+  communicatie: 'Communicatie instellen',
+  live: 'Live zetten & volgen',
+  output: 'Output beoordelen',
+  afronding: 'Afronden & controleren',
+}
+const NOW_DOING_LABEL = 'Nu doen'
+const ROUTE_SETTINGS_CTA_LABEL = 'Bekijk instellingen'
+
+function joinClasses(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(' ')
+}
+
+function phaseStatusLabel(status: 'done' | 'current' | 'open') {
+  if (status === 'done') return 'Klaar'
+  if (status === 'current') return 'Open'
+  return 'Wacht'
+}
+
+function phaseStatusClass(status: 'done' | 'current' | 'open') {
+  if (status === 'done') {
+    return 'border-[#D7E6DF] bg-[#F6FAF8] text-[#3C8D8A]'
+  }
+
+  if (status === 'current') {
+    return 'border-[#D9E4E2] bg-[#F7FBFA] text-[color:var(--teal)]'
+  }
+
+  return 'border-[color:var(--border)] bg-[color:var(--bg)] text-[color:var(--muted)]'
+}
+
+function detailActionClass(kind: 'primary' | 'secondary') {
+  return kind === 'primary'
+    ? 'inline-flex items-center justify-center rounded-full bg-[color:var(--teal)] px-4 py-2 text-sm font-semibold text-white transition hover:brightness-95'
+    : 'inline-flex items-center justify-center rounded-full border border-[color:var(--border)] bg-white px-4 py-2 text-sm font-semibold text-[color:var(--text)] transition hover:border-[color:var(--teal)] hover:text-[color:var(--ink)]'
+}
+
+export function RouteBeheerNowDoingRow({ nowDoing }: { nowDoing: HrRouteBeheerNowDoing | null }) {
+  if (!nowDoing) return null
+
+  return (
+    <Link
+      href={nowDoing.href}
+      className="group flex items-center justify-between gap-4 rounded-[18px] border border-[color:var(--border)] bg-[color:var(--bg)] px-4 py-3 transition hover:border-[color:var(--teal)] hover:bg-white"
+    >
+      <div className="min-w-0">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
+          {nowDoing.label ?? NOW_DOING_LABEL}
+        </p>
+        <p className="mt-1 text-sm font-semibold text-[color:var(--ink)]">{nowDoing.title}</p>
+        <p className="mt-1 text-sm text-[color:var(--text)]">{nowDoing.body}</p>
+      </div>
+      <span className="shrink-0 text-sm font-semibold text-[color:var(--teal)] transition group-hover:translate-x-0.5">
+        Open
+      </span>
+    </Link>
+  )
+}
+
+function RouteBeheerPhaseOverviewList(args: {
+  phases: HrRouteBeheerPhaseSummary[]
+  selectedPhaseKey: HrRouteBeheerPhaseKey | null
+  onSelectPhase: (phaseKey: HrRouteBeheerPhaseKey) => void
+}) {
+  const { phases, selectedPhaseKey, onSelectPhase } = args
+
+  return (
+    <div className="space-y-2">
+      {phases.map((phase) => {
+        const active = phase.key === selectedPhaseKey
+
+        return (
+          <button
+            key={phase.key}
+            type="button"
+            onClick={() => onSelectPhase(phase.key)}
+            aria-expanded={active}
+            className={joinClasses(
+              'w-full rounded-[18px] border px-4 py-3 text-left transition',
+              active
+                ? 'border-[color:var(--teal)] bg-white shadow-[0_4px_16px_rgba(10,25,47,0.05)]'
+                : 'border-[color:var(--border)] bg-[color:var(--bg)] hover:border-[color:var(--teal)] hover:bg-white',
+            )}
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div className="min-w-0">
+                <p className="text-sm font-semibold text-[color:var(--ink)]">
+                  {PHASE_TITLES[phase.key] ?? phase.label}
+                </p>
+                <p className="mt-1 text-sm text-[color:var(--text)]">{phase.body}</p>
+              </div>
+              <span
+                className={joinClasses(
+                  'shrink-0 rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em]',
+                  phaseStatusClass(phase.status),
+                )}
+              >
+                {phaseStatusLabel(phase.status)}
+              </span>
+            </div>
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+export function RouteBeheerPhaseOverview(args: {
+  phases: HrRouteBeheerPhaseSummary[]
+  selectedPhaseKey?: HrRouteBeheerPhaseKey | null
+  onSelectPhase?: (phaseKey: HrRouteBeheerPhaseKey) => void
+}) {
+  const [internalSelectedPhaseKey, setInternalSelectedPhaseKey] = useState<HrRouteBeheerPhaseKey | null>(
+    args.selectedPhaseKey ?? null,
+  )
+  const selectedPhaseKey = args.onSelectPhase ? args.selectedPhaseKey ?? null : internalSelectedPhaseKey
+  const onSelectPhase = args.onSelectPhase ?? setInternalSelectedPhaseKey
+
+  return (
+    <RouteBeheerPhaseOverviewList
+      phases={args.phases}
+      selectedPhaseKey={selectedPhaseKey}
+      onSelectPhase={onSelectPhase}
+    />
+  )
+}
+
+export function RouteBeheerPhaseWorkspace(args: {
+  data: RouteBeheerPageData
+  initialSelectedPhaseKey: HrRouteBeheerPhaseKey | null
+}) {
+  const [selectedPhaseKey, setSelectedPhaseKey] = useState<HrRouteBeheerPhaseKey | null>(
+    args.initialSelectedPhaseKey,
+  )
+
+  return (
+    <div className="space-y-4">
+      <RouteBeheerPhaseOverviewList
+        phases={args.data.phaseSummaries}
+        selectedPhaseKey={selectedPhaseKey}
+        onSelectPhase={setSelectedPhaseKey}
+      />
+      <RouteBeheerPhaseDetailSurface
+        data={args.data}
+        phases={args.data.phaseDetails}
+        selectedPhaseKey={selectedPhaseKey}
+      />
+    </div>
+  )
+}
+
+function RouteBeheerPhaseDetailContent({ data, detail }: { data: RouteBeheerPageData; detail: HrRouteBeheerPhaseDetail }) {
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
+            {PHASE_TITLES[detail.key] ?? detail.label}
+          </p>
+          <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">{detail.body}</p>
+        </div>
+        <span
+          className={joinClasses(
+            'rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em]',
+            phaseStatusClass(detail.status),
+          )}
+        >
+          {phaseStatusLabel(detail.status)}
+        </span>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        {detail.items.map((item) => (
+          <div key={`${detail.key}-${item.label}`} className="rounded-[16px] border border-[color:var(--border)] bg-[color:var(--bg)] px-4 py-3">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
+              {item.label}
+            </p>
+            <p className="mt-2 text-sm font-semibold text-[color:var(--ink)]">{item.value}</p>
+          </div>
+        ))}
+      </div>
+
+      {detail.key === 'live' ? (
+        <div className="space-y-3">
+          <div className="flex flex-wrap gap-2">
+            {detail.links.map((link, index) => (
+              <Link key={link.href} href={link.href} className={detailActionClass(index === 0 ? 'primary' : 'secondary')}>
+                {link.label}
+              </Link>
+            ))}
+          </div>
+          {data.canManageCampaign || data.canExecuteCampaign ? (
+            <CampaignActions
+              campaignId={data.campaignId}
+              isActive={data.isActive}
+              pendingCount={data.pendingCount}
+              canResendInvites={data.canExecuteCampaign}
+              canArchiveCampaign={data.canManageCampaign}
+            />
+          ) : null}
+        </div>
+      ) : detail.key === 'output' ? (
+        <div className="flex flex-wrap items-center gap-3">
+          <Link href={data.outputSummary.dashboardHref} className={detailActionClass('primary')}>
+            Open dashboard
+          </Link>
+          {data.reportAvailable ? (
+            <PdfDownloadButton
+              campaignId={data.campaignId}
+              campaignName={data.campaignName}
+              scanType={data.scanType}
+            />
+          ) : (
+            <span className="text-sm text-[color:var(--text)]">
+              Open rapport zodra de eerste dashboardread beschikbaar is.
+            </span>
+          )}
+        </div>
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          {detail.links.map((link, index) => {
+            const label =
+              detail.key === 'communicatie' && index > 0
+                ? ROUTE_SETTINGS_CTA_LABEL
+                : link.label
+
+            return (
+              <Link key={link.href} href={link.href} className={detailActionClass(index === 0 ? 'primary' : 'secondary')}>
+                {label}
+              </Link>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function RouteBeheerPhaseDetailSurface(args: {
+  data: RouteBeheerPageData
+  phases: HrRouteBeheerPhaseDetail[]
+  selectedPhaseKey: HrRouteBeheerPhaseKey | null
+}) {
+  const detail = args.phases.find((phase) => phase.key === args.selectedPhaseKey) ?? null
+
+  if (!detail) {
+    return null
+  }
+
+  return (
+    <section
+      id="fase-detail"
+      className="rounded-[20px] border border-[color:var(--border)] bg-white p-5 shadow-[0_1px_4px_rgba(10,25,47,0.04)]"
+    >
+      <RouteBeheerPhaseDetailContent data={args.data} detail={detail} />
+    </section>
+  )
+}
+
+export function RouteBeheerPhaseDetailPanel(args: {
+  phases: HrRouteBeheerPhaseDetail[]
+  selectedPhaseKey?: HrRouteBeheerPhaseKey | null
+  data?: RouteBeheerPageData
+  initialSelectedPhaseKey?: HrRouteBeheerPhaseKey | null
+}) {
+  const [internalSelectedPhaseKey] = useState<HrRouteBeheerPhaseKey | null>(
+    args.selectedPhaseKey ?? args.initialSelectedPhaseKey ?? null,
+  )
+  const selectedPhaseKey = args.selectedPhaseKey ?? internalSelectedPhaseKey
+
+  if (!selectedPhaseKey) {
+    return null
+  }
+
+  if (!args.data) {
+    const detail = args.phases.find((phase) => phase.key === selectedPhaseKey) ?? null
+    if (!detail) return null
+
+    return (
+      <section
+        id="fase-detail"
+        className="rounded-[20px] border border-[color:var(--border)] bg-white p-5 shadow-[0_1px_4px_rgba(10,25,47,0.04)]"
+      >
+        <div className="space-y-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
+                {PHASE_TITLES[detail.key] ?? detail.label}
+              </p>
+              <p className="mt-2 text-sm leading-6 text-[color:var(--text)]">{detail.body}</p>
+            </div>
+            <span
+              className={joinClasses(
+                'rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em]',
+                phaseStatusClass(detail.status),
+              )}
+            >
+              {phaseStatusLabel(detail.status)}
+            </span>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {detail.items.map((item) => (
+              <div key={`${detail.key}-${item.label}`} className="rounded-[16px] border border-[color:var(--border)] bg-[color:var(--bg)] px-4 py-3">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
+                  {item.label}
+                </p>
+                <p className="mt-2 text-sm font-semibold text-[color:var(--ink)]">{item.value}</p>
+              </div>
+            ))}
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {detail.links.map((link, index) => {
+              const label =
+                detail.key === 'communicatie' && index > 0
+                  ? ROUTE_SETTINGS_CTA_LABEL
+                  : link.label
+
+              return (
+                <Link key={link.href} href={link.href} className={detailActionClass(index === 0 ? 'primary' : 'secondary')}>
+                  {label}
+                </Link>
+              )
+            })}
+          </div>
+        </div>
+      </section>
+    )
+  }
+
+  return (
+    <RouteBeheerPhaseDetailSurface
+      data={args.data}
+      phases={args.phases}
+      selectedPhaseKey={selectedPhaseKey}
+    />
+  )
+}
+
+export function RouteBeheerOutputSummary({
+  summary,
+}: {
+  summary: RouteBeheerPageData['outputSummary']
+}) {
+  return (
+    <section className="rounded-[18px] border border-[color:var(--border)] bg-white px-4 py-4 shadow-[0_1px_4px_rgba(10,25,47,0.04)]">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
+            Output & afronding
+          </p>
+          <p className="mt-2 text-sm text-[color:var(--text)]">{summary.label}</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <span className={joinClasses('rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em]', summary.dashboardReady ? 'border-[#D7E6DF] bg-[#F6FAF8] text-[#3C8D8A]' : 'border-[color:var(--border)] bg-[color:var(--bg)] text-[color:var(--muted)]')}>
+            Dashboard {summary.dashboardReady ? 'klaar' : 'wacht'}
+          </span>
+          <span className={joinClasses('rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em]', summary.reportReady ? 'border-[#D7E6DF] bg-[#F6FAF8] text-[#3C8D8A]' : 'border-[color:var(--border)] bg-[color:var(--bg)] text-[color:var(--muted)]')}>
+            Rapport {summary.reportReady ? 'klaar' : 'wacht'}
+          </span>
+        </div>
+      </div>
+      <div className="mt-3 flex flex-wrap gap-2">
+        <Link href={summary.dashboardHref} className={detailActionClass('secondary')}>
+          Open dashboard
+        </Link>
+        {summary.reportHref ? (
+          <Link href={summary.reportHref} className={detailActionClass('secondary')}>
+            Open rapport
+          </Link>
+        ) : null}
+      </div>
+    </section>
+  )
+}
+
+export function RouteBeheerLogbookSummary(args: {
+  href: string
+  latestAuditSummary: string | null
+}) {
+  return (
+    <section className="rounded-[18px] border border-[color:var(--border)] bg-[color:var(--bg)] px-4 py-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
+            Logboek / controle
+          </p>
+          <p className="mt-2 text-sm text-[color:var(--text)]">
+            {args.latestAuditSummary ?? 'Geen activiteit'}
+          </p>
+        </div>
+        <Link href={args.href} className={detailActionClass('secondary')}>
+          Bekijk logboek
+        </Link>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- restructure HR routebeheer into a compact 5-phase worktable with a subtle clickable `Nu doen` row
- replace the old status wall and large beheer cards with collapsed phase navigation, on-demand phase detail, and compact output/logbook sections
- keep the existing guided-self-serve logic canonical while tightening copy, preserving route-instellingen discoverability, and restoring routebeheer entrypoint guardrails

## Test Plan
- [x] `npm test -- "app/(dashboard)/campaigns/[id]/beheer/beheer-data.test.ts" "app/(dashboard)/campaigns/[id]/beheer/page.test.ts" "app/(dashboard)/campaigns/[id]/beheer/route-beheer-phase-sections.test.ts"`
- [x] `npx eslint "app/(dashboard)/campaigns/[id]/beheer/page.tsx" "app/(dashboard)/campaigns/[id]/beheer/beheer-data.ts" "app/(dashboard)/campaigns/[id]/beheer/route-beheer-components.tsx" "app/(dashboard)/campaigns/[id]/beheer/route-beheer-phase-sections.tsx" "app/(dashboard)/campaigns/[id]/beheer/page.test.ts" "app/(dashboard)/campaigns/[id]/beheer/beheer-data.test.ts" "app/(dashboard)/campaigns/[id]/beheer/route-beheer-phase-sections.test.ts"`
- [x] `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key npm run build`
- [x] local HR visual smoke test on `/campaigns/[id]/beheer` against a seeded pilot route
