### PR TITLE
Route dashboard setup entries to routebeheer

### DIFF
--- a/frontend/app/(dashboard)/dashboard/home-launcher.test.ts
+++ b/frontend/app/(dashboard)/dashboard/home-launcher.test.ts
@@ -187,6 +187,7 @@ describe('dashboard and pdf availability', () => {
 
     expect(setupCard?.primaryAction.available).toBe(true)
     expect(setupCard?.primaryAction.kind).toBe('setup')
+    expect(setupCard?.primaryAction.label).toBe('Beheer route')
     expect(setupCard?.primaryAction.href).toBe('/campaigns/setup-1/beheer')
   })
 

--- a/frontend/app/(dashboard)/dashboard/home-launcher.ts
+++ b/frontend/app/(dashboard)/dashboard/home-launcher.ts
@@ -240,8 +240,8 @@ function buildDashboardAction(
     if (isAdmin) {
       return {
         kind: 'setup',
-        label: 'Naar setup',
-        description: 'Open beheer om respondentimport, launchcontrole en livegang af te ronden.',
+        label: 'Beheer route',
+        description: 'Open de werktafel om doelgroep, communicatie en livegang af te ronden.',
         available: true,
         href: `/campaigns/${campaign.campaign_id}/beheer`,
       }

--- a/frontend/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/page.tsx
@@ -517,7 +517,10 @@ function buildCockpitRouteItem(entry: CampaignHomeEntry): CockpitRouteItem {
     why: getWhyCopy(entry),
     nextStep: ctaLabel,
     ctaLabel,
-    ctaHref: `/campaigns/${entry.campaign.campaign_id}`,
+    ctaHref:
+      entry.state === 'setup' || entry.state === 'ready_to_launch' || entry.state === 'running'
+        ? `/campaigns/${entry.campaign.campaign_id}/beheer`
+        : `/campaigns/${entry.campaign.campaign_id}`,
     responseValue: completionValue,
   }
 }


### PR DESCRIPTION
## Wat dit fixt
- cockpit-entrypoints voor setup-, ready_to_launch- en running-campagnes gaan nu direct naar `/campaigns/[id]/beheer`
- de admin home-launcher noemt deze actie nu ook expliciet `Beheer route`
- de setupbeschrijving verwijst nu naar de werktafel in plaats van de oude setup-/detailomgeving

## Waarom
Voor opbouwcampagnes moet `Beheer route` de nieuwe HR-werktafel openen, niet de oude campagnedetailpagina.

## Verificatie
- `npm test -- "app/(dashboard)/dashboard/page.test.ts" "app/(dashboard)/dashboard/home-launcher.test.ts"`
- `npx eslint "app/(dashboard)/dashboard/page.tsx" "app/(dashboard)/dashboard/page.test.ts" "app/(dashboard)/dashboard/home-launcher.ts" "app/(dashboard)/dashboard/home-launcher.test.ts"`