### PR TITLE
Restructure HR campaign results into a dedicated results environment

### DIFF
--- a/frontend/app/(dashboard)/campaigns/[id]/dashboard-architecture.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/dashboard-architecture.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 import {
   buildDashboardArchitecture,
@@ -6,122 +7,77 @@ import {
 } from './dashboard-architecture'
 
 describe('dashboard architecture', () => {
-  it('uses a reduced primary navigation with management reading first', () => {
+  it('keeps one fixed HR results order across scans', () => {
+    const source = readFileSync(new URL('./dashboard-architecture.ts', import.meta.url), 'utf8')
+
+    expect(source).toContain("id: 'response'")
+    expect(source).toContain("id: 'score'")
+    expect(source).toContain("id: 'synthesis'")
+    expect(source).toContain("id: 'drivers'")
+    expect(source).toContain("id: 'depth'")
+    expect(source).toContain("id: 'voices'")
+    expect(source).not.toContain("id: 'methodology'")
+    expect(source).not.toContain("id: 'campaign'")
+  })
+
+  it('reduces the shared architecture to one results-first primary view', () => {
     const architecture = buildDashboardArchitecture({
       scanType: 'exit',
       canManageCampaign: true,
       hasSegmentDeepDive: true,
     })
 
-    expect(architecture.primaryViews.map((view) => view.label)).toEqual([
-      'Overzicht',
-      'Onderbouwing',
-      'Actie',
-      'Campagne',
-    ])
-    expect(architecture.primaryViews[0]?.kind).toBe('overview')
-    expect(architecture.primaryViews[3]?.kind).toBe('campaign')
+    expect(architecture.primaryViews).toEqual([{ id: 'results', label: 'Resultaten', kind: 'results' }])
   })
 
-  it('keeps response, handoff and score interpretation explicit in the overview order', () => {
+  it('keeps the fixed results section order with score as the hero layer', () => {
     const architecture = buildDashboardArchitecture({
-      scanType: 'exit',
+      scanType: 'retention',
       canManageCampaign: true,
       hasSegmentDeepDive: true,
     })
 
     expect(architecture.overviewSections.map((section) => section.id)).toEqual([
-      'cover',
       'response',
-      'handoff',
       'score',
       'synthesis',
       'drivers',
-      'action',
-      'methodology',
+      'depth',
+      'voices',
     ])
-    expect(architecture.overviewSections.find((section) => section.id === 'response')?.emphasis).toBe(
-      'secondary',
+    expect(architecture.overviewSections.find((section) => section.id === 'response')?.title).toBe(
+      'Responsbasis',
     )
-    expect(architecture.overviewSections.find((section) => section.id === 'handoff')?.emphasis).toBe(
-      'hero',
+    expect(architecture.overviewSections.find((section) => section.id === 'score')?.emphasis).toBe('hero')
+    expect(architecture.overviewSections.find((section) => section.id === 'drivers')?.interaction).toBe(
+      'drilldown',
     )
-    expect(architecture.overviewSections.find((section) => section.id === 'score')?.emphasis).toBe(
-      'primary',
+    expect(architecture.overviewSections.find((section) => section.id === 'depth')?.title).toBe(
+      'Verdiepingslagen',
     )
-  })
-
-  it('keeps methodology and segment analysis out of the primary navigation headline layer', () => {
-    const architecture = buildDashboardArchitecture({
-      scanType: 'retention',
-      canManageCampaign: true,
-      hasSegmentDeepDive: true,
-    })
-
-    expect(architecture.primaryViews.some((view) => view.label === 'Methodiek')).toBe(false)
-    expect(architecture.overviewSections.find((section) => section.id === 'methodology')?.emphasis).toBe(
-      'secondary',
-    )
-    expect(
-      architecture.evidenceSections.find((section) => section.id === 'segments')?.requiresSegmentDeepDive,
-    ).toBe(true)
-    expect(architecture.evidenceSections.find((section) => section.id === 'segments')?.emphasis).toBe(
-      'secondary',
+    expect(architecture.overviewSections.find((section) => section.id === 'voices')?.title).toBe(
+      'Survey-stemmen',
     )
   })
 
-  it('marks the drivers layer as top-2-first drilldown instead of a flat factor dump', () => {
-    const architecture = buildDashboardArchitecture({
-      scanType: 'retention',
-      canManageCampaign: true,
-      hasSegmentDeepDive: true,
-    })
-
-    const driversSection = architecture.overviewSections.find((section) => section.id === 'drivers')
-
-    expect(driversSection?.interaction).toBe('drilldown')
-    expect(driversSection?.highlightCount).toBe(2)
-  })
-
-  it('keeps campaign operations in a separate view and only when operational detail exists', () => {
+  it('drops the old hybrid evidence, action and campaign section arrays', () => {
     const architecture = buildDashboardArchitecture({
       scanType: 'exit',
       canManageCampaign: false,
       hasSegmentDeepDive: false,
     })
 
-    expect(architecture.campaignSections.map((section) => section.id)).toEqual([
-      'campaign-status',
-      'respondents',
-    ])
-  })
-
-  it('keeps bounded fallback guidance explicit for non-core routes', () => {
-    const teamArchitecture = buildDashboardArchitecture({
-      scanType: 'team',
-      canManageCampaign: true,
-      hasSegmentDeepDive: false,
-    })
-    const leadershipArchitecture = buildDashboardArchitecture({
-      scanType: 'leadership',
-      canManageCampaign: true,
-      hasSegmentDeepDive: false,
-    })
-
-    expect(teamArchitecture.actionSections.find((section) => section.id === 'bounded-fallback')?.title).toContain(
-      'bredere duiding',
-    )
-    expect(
-      leadershipArchitecture.actionSections.find((section) => section.id === 'bounded-fallback')?.title,
-    ).toContain('bredere duiding')
+    expect(architecture.evidenceSections).toEqual([])
+    expect(architecture.actionSections).toEqual([])
+    expect(architecture.campaignSections).toEqual([])
   })
 })
 
 describe('score interpretation titles', () => {
-  it('keeps frictiescore language only on ExitScan', () => {
+  it('keeps scan-specific score titles while staying inside the shared results shell', () => {
     expect(getScoreInterpretationTitle('exit')).toContain('Frictiescore')
-    expect(getScoreInterpretationTitle('retention')).not.toContain('Frictiescore')
     expect(getScoreInterpretationTitle('retention')).toContain('Retentiesignaal')
+    expect(getScoreInterpretationTitle('onboarding')).toContain('Onboardingsignaal')
   })
 })
 

--- a/frontend/app/(dashboard)/campaigns/[id]/dashboard-architecture.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/dashboard-architecture.ts
@@ -1,6 +1,6 @@
 import type { ScanType } from '@/lib/types'
 
-export type DashboardViewKind = 'overview' | 'evidence' | 'action' | 'campaign'
+export type DashboardViewKind = 'results'
 export type DashboardSectionEmphasis = 'hero' | 'primary' | 'secondary'
 
 export type DashboardViewDefinition = {
@@ -63,72 +63,23 @@ export function buildDashboardArchitecture(args: {
   hasSegmentDeepDive: boolean
 }): DashboardArchitecture {
   return {
-    primaryViews: [
-      { id: 'overview', label: 'Overzicht', kind: 'overview' },
-      { id: 'evidence', label: 'Onderbouwing', kind: 'evidence' },
-      { id: 'action', label: 'Actie', kind: 'action' },
-      { id: 'campaign', label: 'Campagne', kind: 'campaign' },
-    ],
+    primaryViews: [{ id: 'results', label: 'Resultaten', kind: 'results' }],
     overviewSections: [
-      { id: 'cover', title: 'Cover en context', emphasis: 'secondary' },
-      { id: 'response', title: 'Response interpretation', emphasis: 'secondary' },
-      { id: 'handoff', title: 'Bestuurlijke handoff', emphasis: 'hero' },
-      { id: 'score', title: getScoreInterpretationTitle(args.scanType), emphasis: 'primary' },
+      { id: 'response', title: 'Responsbasis', emphasis: 'secondary' },
+      { id: 'score', title: getScoreInterpretationTitle(args.scanType), emphasis: 'hero' },
       { id: 'synthesis', title: 'Signalen in samenhang', emphasis: 'primary' },
       {
         id: 'drivers',
-        title: 'Drivers en prioriteiten',
+        title: 'Drivers & prioriteiten',
         emphasis: 'primary',
         interaction: 'drilldown',
-        highlightCount: 2,
       },
-      { id: 'action', title: 'Eerste route en actie', emphasis: 'primary' },
-      {
-        id: 'methodology',
-        title: 'Compacte methodiek en leeswijzer',
-        emphasis: 'secondary',
-        interaction: 'disclosure',
-      },
+      { id: 'depth', title: 'Verdiepingslagen', emphasis: 'secondary' },
+      { id: 'voices', title: 'Survey-stemmen', emphasis: 'secondary' },
     ],
-    evidenceSections: [
-      { id: 'sdt', title: 'SDT basislaag', emphasis: 'secondary' },
-      { id: 'org-factors', title: 'Organisatiefactoren', emphasis: 'secondary' },
-      {
-        id: 'segments',
-        title: 'Conditionele segmentanalyse',
-        emphasis: 'secondary',
-        requiresSegmentDeepDive: true,
-      },
-      {
-        id: 'methodology',
-        title: 'Methodologie, privacy en drempels',
-        emphasis: 'secondary',
-        interaction: 'disclosure',
-      },
-      { id: 'technical', title: 'Technische verantwoording', emphasis: 'secondary' },
-      { id: 'report', title: 'Volledig rapport', emphasis: 'secondary' },
-    ],
-    actionSections: [
-      { id: 'route', title: 'Eerste route, eigenaar en review', emphasis: 'primary' },
-      { id: 'playbooks', title: 'Verificatievragen en playbooks', emphasis: 'primary' },
-      ...(args.scanType === 'team' || args.scanType === 'leadership'
-        ? [
-            {
-              id: 'bounded-fallback',
-              title: 'Terug naar bredere duiding wanneer deze bounded route te smal wordt',
-              emphasis: 'secondary' as const,
-            },
-          ]
-        : []),
-    ],
-    campaignSections: [
-      {
-        id: 'campaign-status',
-        title: args.canManageCampaign ? 'Campagnestatus en readiness' : 'Campagnestatus',
-        emphasis: 'secondary',
-      },
-      { id: 'respondents', title: 'Respondenten en uitnodigingen', emphasis: 'secondary' },
-    ],
+    evidenceSections: [],
+    actionSections: [],
+    campaignSections: [],
   }
 }
 

--- a/frontend/app/(dashboard)/campaigns/[id]/open-answers-view-model.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/open-answers-view-model.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { buildOpenAnswersViewModel } from './open-answers-view-model'
+
+describe('buildOpenAnswersViewModel', () => {
+  it('groups answers by theme for navigation but keeps raw answers intact', () => {
+    const model = buildOpenAnswersViewModel([
+      { id: '1', theme: 'Werkdruk', text: 'De werkdruk liep te ver op.' },
+      { id: '2', theme: 'Werkdruk', text: 'Te weinig herstelmomenten.' },
+      { id: '3', theme: 'Leiderschap', text: 'Feedback kwam te laat.' },
+    ])
+
+    expect(model.themes.map((theme) => theme.title)).toEqual(['Werkdruk', 'Leiderschap'])
+    expect(model.groups[0]?.answers).toHaveLength(2)
+  })
+
+  it('returns an empty state when no answers are released', () => {
+    const model = buildOpenAnswersViewModel([])
+
+    expect(model.themes).toEqual([])
+    expect(model.groups).toEqual([])
+    expect(model.isEmpty).toBe(true)
+  })
+})

--- a/frontend/app/(dashboard)/campaigns/[id]/open-answers-view-model.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/open-answers-view-model.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildOpenAnswersViewModel } from './open-answers-view-model'
+import { buildOpenAnswerItems, buildOpenAnswersViewModel } from './open-answers-view-model'
 
 describe('buildOpenAnswersViewModel', () => {
   it('groups answers by theme for navigation but keeps raw answers intact', () => {
@@ -19,5 +19,68 @@ describe('buildOpenAnswersViewModel', () => {
     expect(model.themes).toEqual([])
     expect(model.groups).toEqual([])
     expect(model.isEmpty).toBe(true)
+  })
+
+  it('builds released answers from responses by sanitizing text, inferring themes and removing duplicates', () => {
+    const items = buildOpenAnswerItems('retention', [
+      {
+        id: '1',
+        respondent_id: 'resp-1',
+        risk_score: 7.1,
+        exit_reason_code: null,
+        risk_band: 'HOOG',
+        preventability: null,
+        sdt_scores: {},
+        org_scores: {
+          workload: 2.9,
+          growth: 7.2,
+        },
+        open_text_raw: 'Werkdruk bleef te hoog. Mail mij via test@example.com',
+        open_text_analysis: null,
+        full_result: {},
+        submitted_at: '2026-05-01T08:00:00.000Z',
+      },
+      {
+        id: '2',
+        respondent_id: 'resp-2',
+        risk_score: 6.4,
+        exit_reason_code: null,
+        risk_band: 'MIDDEN',
+        preventability: null,
+        sdt_scores: {},
+        org_scores: {
+          workload: 3.1,
+        },
+        open_text_raw: 'Werkdruk bleef te hoog. Mail mij via second@example.com',
+        open_text_analysis: null,
+        full_result: {},
+        submitted_at: '2026-05-02T08:00:00.000Z',
+      },
+      {
+        id: '3',
+        respondent_id: 'resp-3',
+        risk_score: 5.8,
+        exit_reason_code: null,
+        risk_band: 'MIDDEN',
+        preventability: null,
+        sdt_scores: {},
+        org_scores: {
+          leadership: 3.4,
+        },
+        open_text_raw: 'Feedback kwam te laat en verwachtingen waren onduidelijk.',
+        open_text_analysis: null,
+        full_result: {},
+        submitted_at: '2026-05-03T08:00:00.000Z',
+      },
+    ])
+
+    expect(items).toHaveLength(2)
+    expect(items[0]).toMatchObject({
+      theme: 'Werkbelasting',
+      text: 'Werkdruk bleef te hoog. Mail mij via [verwijderd]',
+    })
+    expect(items[1]).toMatchObject({
+      theme: 'Leiderschap',
+    })
   })
 })

--- a/frontend/app/(dashboard)/campaigns/[id]/open-answers-view-model.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/open-answers-view-model.ts
@@ -1,7 +1,95 @@
+import {
+  EXIT_REASON_LABELS,
+  FACTOR_LABELS,
+  type ScanType,
+  type SurveyResponse,
+} from '@/lib/types'
+
 export type OpenAnswerItem = {
   id: string
   theme: string
   text: string
+  submittedAt?: string
+}
+
+export type OpenAnswerTheme = {
+  title: string
+  count: number
+  anchorId: string
+}
+
+export type OpenAnswerGroup = {
+  title: string
+  count: number
+  anchorId: string
+  answers: OpenAnswerItem[]
+}
+
+const MIN_OPEN_ANSWER_LENGTH = 24
+
+function sanitizeOpenAnswerText(value: string) {
+  return value
+    .replace(/\s+/g, ' ')
+    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, '[verwijderd]')
+    .replace(/https?:\/\/\S+/gi, '[link verwijderd]')
+    .replace(/\+?\d[\d\s().-]{7,}\d/g, '[verwijderd]')
+    .trim()
+}
+
+function inferExitTheme(code: string | null) {
+  if (!code) return null
+  return EXIT_REASON_LABELS[code] ?? null
+}
+
+function inferTopFactorTheme(orgScores: SurveyResponse['org_scores']) {
+  const topFactor = Object.entries(orgScores ?? {})
+    .filter((entry): entry is [string, number] => typeof entry[1] === 'number')
+    .sort((left, right) => left[1] - right[1])[0]
+
+  return topFactor ? (FACTOR_LABELS[topFactor[0]] ?? topFactor[0]) : null
+}
+
+function inferTheme(scanType: ScanType, response: SurveyResponse) {
+  if (scanType === 'exit') {
+    return inferExitTheme(response.exit_reason_code) ?? inferTopFactorTheme(response.org_scores) ?? 'Overig'
+  }
+
+  return inferTopFactorTheme(response.org_scores) ?? 'Overig'
+}
+
+function toAnchorId(value: string) {
+  const normalized = value
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
+  return normalized || 'overig'
+}
+
+export function buildOpenAnswerItems(scanType: ScanType, responses: SurveyResponse[]) {
+  const seen = new Set<string>()
+
+  return responses
+    .map((response) => {
+      const rawText = response.open_text_raw?.trim() || response.open_text_analysis?.trim() || ''
+      const text = sanitizeOpenAnswerText(rawText)
+
+      if (text.length < MIN_OPEN_ANSWER_LENGTH) return null
+
+      const normalized = text.toLowerCase()
+      if (seen.has(normalized)) return null
+      seen.add(normalized)
+
+      return {
+        id: response.id,
+        theme: inferTheme(scanType, response),
+        text,
+        submittedAt: response.submitted_at,
+      } satisfies OpenAnswerItem
+    })
+    .filter((item): item is OpenAnswerItem => Boolean(item))
 }
 
 export function buildOpenAnswersViewModel(items: OpenAnswerItem[]) {
@@ -14,14 +102,27 @@ export function buildOpenAnswersViewModel(items: OpenAnswerItem[]) {
     grouped.set(key, bucket)
   }
 
-  const groups = Array.from(grouped.entries()).map(([title, answers]) => ({
-    title,
-    answers,
-  }))
+  const groups = Array.from(grouped.entries())
+    .map(([title, answers]) => ({
+      title,
+      count: answers.length,
+      anchorId: toAnchorId(title),
+      answers: [...answers].sort((left, right) =>
+        (right.submittedAt ?? '').localeCompare(left.submittedAt ?? ''),
+      ),
+    }))
+    .sort((left, right) => right.count - left.count || left.title.localeCompare(right.title, 'nl'))
 
   return {
     isEmpty: groups.length === 0,
-    themes: groups.map((group) => ({ title: group.title, count: group.answers.length })),
-    groups,
+    themes: groups.map(
+      (group) =>
+        ({
+          title: group.title,
+          count: group.count,
+          anchorId: group.anchorId,
+        }) satisfies OpenAnswerTheme,
+    ),
+    groups: groups.map((group) => ({ ...group })) satisfies OpenAnswerGroup[],
   }
 }

--- a/frontend/app/(dashboard)/campaigns/[id]/open-answers-view-model.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/open-answers-view-model.ts
@@ -70,26 +70,27 @@ function toAnchorId(value: string) {
 
 export function buildOpenAnswerItems(scanType: ScanType, responses: SurveyResponse[]) {
   const seen = new Set<string>()
+  const items: OpenAnswerItem[] = []
 
-  return responses
-    .map((response) => {
-      const rawText = response.open_text_raw?.trim() || response.open_text_analysis?.trim() || ''
-      const text = sanitizeOpenAnswerText(rawText)
+  for (const response of responses) {
+    const rawText = response.open_text_raw?.trim() || response.open_text_analysis?.trim() || ''
+    const text = sanitizeOpenAnswerText(rawText)
 
-      if (text.length < MIN_OPEN_ANSWER_LENGTH) return null
+    if (text.length < MIN_OPEN_ANSWER_LENGTH) continue
 
-      const normalized = text.toLowerCase()
-      if (seen.has(normalized)) return null
-      seen.add(normalized)
+    const normalized = text.toLowerCase()
+    if (seen.has(normalized)) continue
+    seen.add(normalized)
 
-      return {
-        id: response.id,
-        theme: inferTheme(scanType, response),
-        text,
-        submittedAt: response.submitted_at,
-      } satisfies OpenAnswerItem
+    items.push({
+      id: response.id,
+      theme: inferTheme(scanType, response),
+      text,
+      submittedAt: response.submitted_at,
     })
-    .filter((item): item is OpenAnswerItem => Boolean(item))
+  }
+
+  return items
 }
 
 export function buildOpenAnswersViewModel(items: OpenAnswerItem[]) {

--- a/frontend/app/(dashboard)/campaigns/[id]/open-answers-view-model.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/open-answers-view-model.ts
@@ -1,0 +1,27 @@
+export type OpenAnswerItem = {
+  id: string
+  theme: string
+  text: string
+}
+
+export function buildOpenAnswersViewModel(items: OpenAnswerItem[]) {
+  const grouped = new Map<string, OpenAnswerItem[]>()
+
+  for (const item of items) {
+    const key = item.theme.trim() || 'Overig'
+    const bucket = grouped.get(key) ?? []
+    bucket.push(item)
+    grouped.set(key, bucket)
+  }
+
+  const groups = Array.from(grouped.entries()).map(([title, answers]) => ({
+    title,
+    answers,
+  }))
+
+  return {
+    isEmpty: groups.length === 0,
+    themes: groups.map((group) => ({ title: group.title, count: group.answers.length })),
+    groups,
+  }
+}

--- a/frontend/app/(dashboard)/campaigns/[id]/open-antwoorden/page.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/open-antwoorden/page.test.ts
@@ -8,5 +8,7 @@ describe('open answers page', () => {
     expect(source).toContain('Alle open antwoorden')
     expect(source).toContain('Thematische clusters')
     expect(source).not.toContain('Routebeheer')
+    expect(source).toContain('if (releasedItems.length === 0)')
+    expect(source).toContain('notFound()')
   })
 })

--- a/frontend/app/(dashboard)/campaigns/[id]/open-antwoorden/page.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/open-antwoorden/page.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('open answers page', () => {
+  it('keeps the page inside the results environment and not beheer', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+
+    expect(source).toContain('Alle open antwoorden')
+    expect(source).toContain('Thematische clusters')
+    expect(source).not.toContain('Routebeheer')
+  })
+})

--- a/frontend/app/(dashboard)/campaigns/[id]/open-antwoorden/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/open-antwoorden/page.tsx
@@ -1,20 +1,244 @@
-export default function OpenAnswersPage() {
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { SuiteAccessDenied } from '@/components/dashboard/suite-access-denied'
+import { getScanDefinition } from '@/lib/scan-definitions'
+import {
+  getDashboardModuleHref,
+  getDashboardModuleKeyForScanType,
+  getDashboardModuleLabel,
+} from '@/lib/dashboard/shell-navigation'
+import { loadSuiteAccessContext } from '@/lib/suite-access-server'
+import { createClient } from '@/lib/supabase/server'
+import type { CampaignStats, Respondent, SurveyResponse } from '@/lib/types'
+import {
+  buildOpenAnswerItems,
+  buildOpenAnswersViewModel,
+} from '../open-answers-view-model'
+import { MIN_N_DISPLAY, MIN_N_PATTERNS } from '../page-helpers'
+import { buildResultsViewModel } from '../results-view-model'
+
+interface Props {
+  params: Promise<{ id: string }>
+}
+
+function formatRoutePeriodLabel(campaignName: string, createdAt: string) {
+  const quarterMatch = campaignName.match(/Q[1-4]\s?\d{4}/i)
+  if (quarterMatch) return quarterMatch[0].replace(/\s+/, ' ')
+
+  return new Intl.DateTimeFormat('nl-NL', {
+    month: 'long',
+    year: 'numeric',
+  }).format(new Date(createdAt))
+}
+
+function deriveScopeLabel(respondents: Respondent[]) {
+  const departments = Array.from(
+    new Set(respondents.map((respondent) => respondent.department).filter(Boolean)),
+  ) as string[]
+
+  if (departments.length === 0) return 'Scope binnen deze route'
+  if (departments.length === 1) return departments[0]
+  if (departments.length === 2) return `${departments[0]} & ${departments[1]}`
+  return `${departments[0]}, ${departments[1]} + ${departments.length - 2} meer`
+}
+
+function getResultsStatusLabel(readState: ReturnType<typeof buildResultsViewModel>['readState']) {
+  if (readState === 'readable') return 'Leesbaar'
+  if (readState === 'early-read') return 'Eerste read'
+  return 'Nog aan het opbouwen'
+}
+
+export default async function OpenAnswersPage({ params }: Props) {
+  const { id } = await params
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    notFound()
+  }
+
+  const { context } = await loadSuiteAccessContext(supabase, user.id)
+
+  if (!context.canViewInsights) {
+    return (
+      <SuiteAccessDenied
+        title="Je ziet hier geen open antwoorden"
+        description="Jouw login opent alleen Action Center voor toegewezen teams. Surveyresultaten, campagnedetails en open antwoorden blijven zichtbaar voor HR en Loep."
+      />
+    )
+  }
+
+  const { data: statsRow } = await supabase
+    .from('campaign_stats')
+    .select('*')
+    .eq('campaign_id', id)
+    .single()
+
+  if (!statsRow) notFound()
+  const stats = statsRow as CampaignStats
+
+  const [{ data: organization }, { data: respondentsRaw }, { data: responsesRaw }] = await Promise.all([
+    supabase.from('organizations').select('name').eq('id', stats.organization_id).maybeSingle(),
+    supabase
+      .from('respondents')
+      .select('*')
+      .eq('campaign_id', id)
+      .order('completed_at', { ascending: false, nullsFirst: false }),
+    supabase
+      .from('survey_responses')
+      .select(
+        `
+        id,
+        respondent_id,
+        risk_score,
+        signal_score,
+        risk_band,
+        preventability,
+        stay_intent_score,
+        direction_signal_score,
+        uwes_score,
+        turnover_intention_score,
+        exit_reason_code,
+        sdt_scores,
+        org_scores,
+        open_text_raw,
+        open_text_analysis,
+        full_result,
+        submitted_at,
+        respondents!inner(id, campaign_id)
+      `,
+      )
+      .eq('respondents.campaign_id', id),
+  ])
+
+  const respondents = (respondentsRaw ?? []) as Respondent[]
+  const responses = (responsesRaw ?? []) as unknown as SurveyResponse[]
+  const hasMinDisplay = responses.length >= MIN_N_DISPLAY
+  const releasedItems = hasMinDisplay ? buildOpenAnswerItems(stats.scan_type, responses) : []
+  const viewModel = buildOpenAnswersViewModel(releasedItems)
+  const resultsViewModel = buildResultsViewModel({
+    scanType: stats.scan_type,
+    respondentsCount: respondents.length,
+    hasMinDisplay,
+    hasEnoughData: responses.length >= MIN_N_PATTERNS,
+    hasOpenAnswers: releasedItems.length > 0,
+  })
+
+  const scanDefinition = getScanDefinition(stats.scan_type)
+  const moduleKey =
+    stats.scan_type === 'team' ? null : getDashboardModuleKeyForScanType(stats.scan_type)
+  const moduleLabel = moduleKey ? getDashboardModuleLabel(moduleKey) : scanDefinition.productName
+  const moduleHref = moduleKey ? getDashboardModuleHref(moduleKey) : '/dashboard'
+  const organizationName = organization?.name ?? 'Organisatie'
+  const routePeriodLabel = formatRoutePeriodLabel(stats.campaign_name, stats.created_at)
+  const scopeLabel = deriveScopeLabel(respondents)
+
   return (
     <div className="space-y-8">
-      <section className="space-y-2">
-        <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-[color:var(--dashboard-muted)]">
-          Resultaten
+      <section className="space-y-4 border-b border-slate-200/80 pb-5">
+        <p className="text-[0.78rem] font-medium tracking-[0.01em] text-slate-500">
+          <Link href="/dashboard" className="transition-colors hover:text-slate-700">
+            Overzicht
+          </Link>{' '}
+          /{' '}
+          <Link href={moduleHref} className="transition-colors hover:text-slate-700">
+            {moduleLabel}
+          </Link>{' '}
+          /{' '}
+          <Link href={`/campaigns/${id}`} className="transition-colors hover:text-slate-700">
+            {stats.campaign_name}
+          </Link>{' '}
+          / <span className="text-slate-700">Open antwoorden</span>
         </p>
-        <h1 className="font-serif text-[2.2rem] leading-[1.02] tracking-[-0.045em] text-[color:var(--dashboard-ink)]">
-          Alle open antwoorden
-        </h1>
-        <p className="max-w-3xl text-sm leading-6 text-[color:var(--dashboard-text)]">
-          Geanonimiseerde open antwoorden, gegroepeerd per zichtbaar thema.
-        </p>
+        <Link
+          href={`/campaigns/${id}#survey-stemmen`}
+          className="inline-flex items-center gap-2 text-sm font-medium text-slate-500 transition-colors hover:text-slate-700"
+        >
+          <span aria-hidden="true">&larr;</span> Terug naar survey-stemmen
+        </Link>
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center gap-2.5">
+            <span className="inline-flex rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-slate-600">
+              {getResultsStatusLabel(resultsViewModel.readState)}
+            </span>
+          </div>
+          <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-[color:var(--dashboard-muted)]">
+            Resultaten
+          </p>
+          <h1 className="font-serif text-[2.2rem] leading-[1.02] tracking-[-0.045em] text-[color:var(--dashboard-ink)]">
+            Alle open antwoorden
+          </h1>
+          <p className="max-w-3xl text-sm leading-6 text-[color:var(--dashboard-text)]">
+            Geanonimiseerde open antwoorden, gegroepeerd per zichtbaar thema. Deze subpagina gebruikt dezelfde vrijgavegrens als de survey-stemmen op de hoofdpagina.
+          </p>
+          <p className="text-sm leading-6 text-slate-600">
+            {organizationName} <span aria-hidden="true">&middot;</span> {routePeriodLabel}{' '}
+            <span aria-hidden="true">&middot;</span> {scopeLabel}
+          </p>
+        </div>
       </section>
 
-      <section>
+      <section className="space-y-3">
         <h2 className="text-lg font-semibold text-[color:var(--dashboard-ink)]">Thematische clusters</h2>
+        {viewModel.isEmpty ? (
+          <div className="rounded-[24px] border border-dashed border-slate-200 bg-slate-50 px-5 py-5">
+            <p className="text-sm font-semibold text-[color:var(--dashboard-ink)]">
+              Nog geen vrijgegeven open antwoorden
+            </p>
+            <p className="mt-2 text-sm leading-6 text-[color:var(--dashboard-text)]">
+              {hasMinDisplay
+                ? 'Er zijn nog geen geanonimiseerde open antwoorden beschikbaar om te groeperen.'
+                : `Open antwoorden openen pas vanaf ${MIN_N_DISPLAY} leesbare responses.`}
+            </p>
+          </div>
+        ) : (
+          <>
+            <div className="flex flex-wrap gap-2">
+              {viewModel.themes.map((theme) => (
+                <a
+                  key={theme.anchorId}
+                  href={`#${theme.anchorId}`}
+                  className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-600 transition-colors hover:text-slate-950"
+                >
+                  {theme.title} · {theme.count}
+                </a>
+              ))}
+            </div>
+
+            <div className="space-y-6">
+              {viewModel.groups.map((group) => (
+                <section key={group.anchorId} id={group.anchorId} className="space-y-4">
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+                    <div>
+                      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
+                        Thema
+                      </p>
+                      <h3 className="mt-2 text-xl font-semibold tracking-[-0.03em] text-[color:var(--dashboard-ink)]">
+                        {group.title}
+                      </h3>
+                    </div>
+                    <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">
+                      {group.count} antwoord{group.count === 1 ? '' : 'en'}
+                    </span>
+                  </div>
+
+                  <div className="grid gap-4">
+                    {group.answers.map((answer) => (
+                      <article
+                        key={answer.id}
+                        className="rounded-[20px] bg-[color:var(--dashboard-soft)]/52 px-5 py-5"
+                      >
+                        <p className="text-sm leading-7 text-[color:var(--dashboard-text)]">{answer.text}</p>
+                      </article>
+                    ))}
+                  </div>
+                </section>
+              ))}
+            </div>
+          </>
+        )}
       </section>
     </div>
   )

--- a/frontend/app/(dashboard)/campaigns/[id]/open-antwoorden/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/open-antwoorden/page.tsx
@@ -117,6 +117,10 @@ export default async function OpenAnswersPage({ params }: Props) {
   const responses = (responsesRaw ?? []) as unknown as SurveyResponse[]
   const hasMinDisplay = responses.length >= MIN_N_DISPLAY
   const releasedItems = hasMinDisplay ? buildOpenAnswerItems(stats.scan_type, responses) : []
+  if (releasedItems.length === 0) {
+    notFound()
+  }
+
   const viewModel = buildOpenAnswersViewModel(releasedItems)
   const resultsViewModel = buildResultsViewModel({
     scanType: stats.scan_type,

--- a/frontend/app/(dashboard)/campaigns/[id]/open-antwoorden/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/open-antwoorden/page.tsx
@@ -1,0 +1,21 @@
+export default function OpenAnswersPage() {
+  return (
+    <div className="space-y-8">
+      <section className="space-y-2">
+        <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-[color:var(--dashboard-muted)]">
+          Resultaten
+        </p>
+        <h1 className="font-serif text-[2.2rem] leading-[1.02] tracking-[-0.045em] text-[color:var(--dashboard-ink)]">
+          Alle open antwoorden
+        </h1>
+        <p className="max-w-3xl text-sm leading-6 text-[color:var(--dashboard-text)]">
+          Geanonimiseerde open antwoorden, gegroepeerd per zichtbaar thema.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold text-[color:var(--dashboard-ink)]">Thematische clusters</h2>
+      </section>
+    </div>
+  )
+}

--- a/frontend/app/(dashboard)/campaigns/[id]/page-helpers.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/page-helpers.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest'
 import {
   buildDecisionPanels,
   buildHeroDescription,
+  clusterRetentionOpenSignals,
   buildNextStepBody,
   computeAverageRiskScore,
   computeRetentionSupplementalAverages,
+  getLargestDistributionSegment,
 } from './page-helpers'
 import { getScanDefinition } from '@/lib/scan-definitions'
 import type { SurveyResponse } from '@/lib/types'
@@ -125,5 +127,39 @@ describe('dashboard page helpers field semantics', () => {
     expect(hero).toContain('werkfrictie')
     expect(nextStep).toContain('gemiddelde signaalscore')
     expect(nextStep).toContain('werkfrictie')
+  })
+
+  it('sanitizes retention open-answer samples before they can surface in synthesis cards', () => {
+    const themes = clusterRetentionOpenSignals([
+      {
+        id: 'resp-1',
+        respondent_id: 'r-1',
+        risk_score: 5.2,
+        risk_band: 'MIDDEN',
+        preventability: null,
+        exit_reason_code: null,
+        sdt_scores: {},
+        org_scores: {},
+        open_text_raw:
+          'Mijn leidinggevende is slecht bereikbaar. Mail me op jane@example.com of bel +31 6 12345678.',
+        full_result: {},
+        submitted_at: '2026-04-18T10:00:00Z',
+      },
+    ] as SurveyResponse[])
+
+    expect(themes[0]?.sample).toContain('[verwijderd]')
+    expect(themes[0]?.sample).not.toContain('jane@example.com')
+    expect(themes[0]?.sample).not.toContain('+31 6 12345678')
+  })
+
+  it('picks the actual largest distribution segment instead of relying on fixed ordering', () => {
+    const largest = getLargestDistributionSegment([
+      { label: 'Werkgerelateerde redenen', value: '20%', percent: 20 },
+      { label: 'Trekfactoren elders', value: '55%', percent: 55 },
+      { label: 'Situationele redenen', value: '25%', percent: 25 },
+    ])
+
+    expect(largest?.label).toBe('Trekfactoren elders')
+    expect(largest?.percent).toBe(55)
   })
 })

--- a/frontend/app/(dashboard)/campaigns/[id]/page-helpers.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page-helpers.tsx
@@ -61,6 +61,25 @@ export type RetentionTheme = {
   sample: string
 }
 
+export function sanitizeOpenAnswerExcerpt(value: string) {
+  return value
+    .replace(/\s+/g, ' ')
+    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, '[verwijderd]')
+    .replace(/https?:\/\/\S+/gi, '[link verwijderd]')
+    .replace(/\+?\d[\d\s().-]{7,}\d/g, '[verwijderd]')
+    .trim()
+}
+
+export function getLargestDistributionSegment<T extends { percent: number }>(segments: T[]) {
+  return segments.reduce<T | null>((largest, segment) => {
+    if (!largest || segment.percent > largest.percent) {
+      return segment
+    }
+
+    return largest
+  }, null)
+}
+
 export type DecisionPanel = {
   eyebrow: string
   title: string
@@ -1093,7 +1112,7 @@ export function clusterRetentionOpenSignals(responses: SurveyResponse[]): Retent
   for (const definition of definitions) counts.set(definition.key, { definition, texts: [] })
 
   for (const response of responses) {
-    const text = response.open_text_raw?.trim()
+    const text = sanitizeOpenAnswerExcerpt(response.open_text_raw?.trim() ?? '')
     if (!text) continue
     const normalized = text.toLowerCase()
     for (const definition of definitions) {

--- a/frontend/app/(dashboard)/campaigns/[id]/page.route-shell.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.route-shell.test.ts
@@ -2,6 +2,12 @@ import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
 describe('campaign detail route shell', () => {
+  it('keeps open answers reachable from the results environment in one click', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+
+    expect(source).toContain('/open-antwoorden')
+  })
+
   it('keeps the manager-only insight boundary intact', () => {
     const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
 
@@ -12,8 +18,6 @@ describe('campaign detail route shell', () => {
   it('wires ExitScan through a dedicated analytical component and preserves report + module navigation', () => {
     const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
 
-    expect(source).toContain('ExitProductDashboard')
-    expect(source).toContain('averageSignalScoreLabel')
     expect(source).toContain('PdfDownloadButton')
     expect(source).toContain('moduleBackLinkLabel')
     expect(source).toContain('if (stats.scan_type === "exit")')

--- a/frontend/app/(dashboard)/campaigns/[id]/page.route-shell.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.route-shell.test.ts
@@ -6,6 +6,7 @@ describe('campaign detail route shell', () => {
     const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
 
     expect(source).toContain('/open-antwoorden')
+    expect(source).toContain("blockVisibility.voices === 'visible' && releasedOpenAnswerItems.length > 0")
   })
 
   it('keeps the manager-only insight boundary intact', () => {
@@ -31,5 +32,14 @@ describe('campaign detail route shell', () => {
     expect(source).toContain('getDashboardModuleKeyForScanType')
     expect(source).toContain('getDashboardModuleLabel')
     expect(source).toContain('Terug naar alle ExitScans')
+  })
+
+  it('preserves the campaign-detail bridge into Action Center for candidate and active routes', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+
+    expect(source).toContain('buildCampaignDetailActionCenterBridge')
+    expect(source).toContain('openActionCenterRoute')
+    expect(source).toContain("buildActionCenterRouteOpenRedirect(id, 'campaign-detail')")
+    expect(source).toContain('Vervolgroute')
   })
 })

--- a/frontend/app/(dashboard)/campaigns/[id]/page.route-shell.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.route-shell.test.ts
@@ -20,8 +20,8 @@ describe('campaign detail route shell', () => {
 
     expect(source).toContain('PdfDownloadButton')
     expect(source).toContain('moduleBackLinkLabel')
-    expect(source).toContain('if (stats.scan_type === "exit")')
-    expect(source).not.toContain('return stats.scan_type === "exit" ? (')
+    expect(source).not.toContain('ExitProductDashboard')
+    expect(source).not.toContain('if (stats.scan_type === "exit")')
   })
 
   it('keeps existing module breadcrumbs instead of collapsing to a generic dashboard jump', () => {

--- a/frontend/app/(dashboard)/campaigns/[id]/page.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.test.ts
@@ -8,6 +8,20 @@ const componentSource = () =>
   )
 
 describe('exit dashboard analytics guardrails', () => {
+  it('removes the old hybrid campaign tabs and keeps results-first blocks visible on the route page', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+
+    expect(source).toContain('Responsbasis')
+    expect(source).toContain('Kernsignaal')
+    expect(source).toContain('Signalen in samenhang')
+    expect(source).toContain('Drivers & prioriteiten')
+    expect(source).toContain('Verdiepingslagen')
+    expect(source).toContain('Survey-stemmen')
+    expect(source).not.toContain('Samenvatting')
+    expect(source).not.toContain('Methodiek')
+    expect(source).not.toContain('Uitvoering')
+  })
+
   it('keeps the ExitScan dashboard free from owner, action, review, workflow and setup language', () => {
     const source = componentSource().toLowerCase()
     const forbiddenTerms = [

--- a/frontend/app/(dashboard)/campaigns/[id]/page.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.test.ts
@@ -22,6 +22,16 @@ describe('exit dashboard analytics guardrails', () => {
     expect(source).not.toContain('Uitvoering')
   })
 
+  it('does not keep the old tabs as the primary HR results structure', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+
+    expect(source).not.toContain('DashboardTabs')
+    expect(source).not.toContain("label: 'Overzicht'")
+    expect(source).not.toContain("label: 'Onderbouwing'")
+    expect(source).not.toContain("label: 'Actie'")
+    expect(source).not.toContain("label: 'Campagne'")
+  })
+
   it('keeps the ExitScan dashboard free from owner, action, review, workflow and setup language', () => {
     const source = componentSource().toLowerCase()
     const forbiddenTerms = [

--- a/frontend/app/(dashboard)/campaigns/[id]/page.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.test.ts
@@ -8,6 +8,21 @@ const componentSource = () =>
   )
 
 describe('exit dashboard analytics guardrails', () => {
+  it('keeps the shared route shell factual and free from the old exit-only branch', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8').toLowerCase()
+    const forbiddenTerms = [
+      'exitproductdashboard',
+      'managementread',
+      'bestuurlijke',
+      'eerste actie',
+      'reviewmoment',
+    ]
+
+    for (const term of forbiddenTerms) {
+      expect(source).not.toContain(term)
+    }
+  })
+
   it('removes the old hybrid campaign tabs and keeps results-first blocks visible on the route page', () => {
     const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
 

--- a/frontend/app/(dashboard)/campaigns/[id]/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.tsx
@@ -1,34 +1,40 @@
-import Link from "next/link"
-import { notFound } from "next/navigation"
-import { ExitProductDashboard } from "@/components/dashboard/exit-product-dashboard"
-import { SuiteAccessDenied } from "@/components/dashboard/suite-access-denied"
-import { getManagementBandLabel } from "@/lib/management-language"
-import { getScanDefinition } from "@/lib/scan-definitions"
+import type { ReactNode } from 'react'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { SuiteAccessDenied } from '@/components/dashboard/suite-access-denied'
+import { getManagementBandLabel } from '@/lib/management-language'
+import { getScanDefinition } from '@/lib/scan-definitions'
 import {
   getDashboardModuleHref,
   getDashboardModuleKeyForScanType,
   getDashboardModuleLabel,
-} from "@/lib/dashboard/shell-navigation"
-import { loadSuiteAccessContext } from "@/lib/suite-access-server"
-import { createClient } from "@/lib/supabase/server"
-import { FACTOR_LABELS, hasCampaignAddOn } from "@/lib/types"
-import type { CampaignStats, Respondent, SurveyResponse } from "@/lib/types"
-import { PdfDownloadButton } from "./pdf-download-button"
+} from '@/lib/dashboard/shell-navigation'
+import { loadSuiteAccessContext } from '@/lib/suite-access-server'
+import { createClient } from '@/lib/supabase/server'
+import { FACTOR_LABELS, hasCampaignAddOn } from '@/lib/types'
+import type { CampaignStats, Respondent, ScanType, SurveyResponse } from '@/lib/types'
+import {
+  buildOpenAnswerItems,
+  buildOpenAnswersViewModel,
+} from './open-answers-view-model'
 import {
   MethodologyCard,
   MIN_N_DISPLAY,
   MIN_N_PATTERNS,
+  clusterRetentionOpenSignals,
   computeAverageSignalScore,
   computeFactorAverages,
+  computeRetentionSupplementalAverages,
   computeStrongWorkSignalRate,
   getTopContributingReasonLabel,
   getTopExitReasonLabel,
-} from "./page-helpers"
-import { ResultsLayout } from "./results-layout"
+} from './page-helpers'
+import { PdfDownloadButton } from './pdf-download-button'
+import { ResultsLayout } from './results-layout'
 import {
   buildResultsViewModel,
   type ResultsBlockVisibility,
-} from "./results-view-model"
+} from './results-view-model'
 
 interface Props {
   params: Promise<{ id: string }>
@@ -53,34 +59,34 @@ type SdtRow = {
   note: string
 }
 
-type NarrativeItem = {
-  title: string
-  tag: string
-  body: string
-}
-
-type ContributingItem = {
+type MetricItem = {
   label: string
   value: string
+  caption: string
+}
+
+type SummaryItem = {
+  label: string
+  title: string
   body: string
 }
 
 const PRIMARY_RESULTS_ORDER = {
-  response: "Responsbasis",
-  signal: "Kernsignaal",
-  synthesis: "Signalen in samenhang",
-  drivers: "Drivers & prioriteiten",
-  depth: "Verdiepingslagen",
-  voices: "Survey-stemmen",
+  response: 'Responsbasis',
+  signal: 'Kernsignaal',
+  synthesis: 'Signalen in samenhang',
+  drivers: 'Drivers & prioriteiten',
+  depth: 'Verdiepingslagen',
+  voices: 'Survey-stemmen',
 } as const
 
 function formatRoutePeriodLabel(campaignName: string, createdAt: string) {
   const quarterMatch = campaignName.match(/Q[1-4]\s?\d{4}/i)
-  if (quarterMatch) return quarterMatch[0].replace(/\s+/, " ")
+  if (quarterMatch) return quarterMatch[0].replace(/\s+/, ' ')
 
-  return new Intl.DateTimeFormat("nl-NL", {
-    month: "long",
-    year: "numeric",
+  return new Intl.DateTimeFormat('nl-NL', {
+    month: 'long',
+    year: 'numeric',
   }).format(new Date(createdAt))
 }
 
@@ -89,52 +95,43 @@ function deriveScopeLabel(respondents: Respondent[]) {
     new Set(respondents.map((respondent) => respondent.department).filter(Boolean)),
   ) as string[]
 
-  if (departments.length === 0) return "Scope binnen deze route"
+  if (departments.length === 0) return 'Scope binnen deze route'
   if (departments.length === 1) return departments[0]
   if (departments.length === 2) return `${departments[0]} & ${departments[1]}`
   return `${departments[0]}, ${departments[1]} + ${departments.length - 2} meer`
 }
 
-function getDashboardModuleBackLinkLabel(scanType: CampaignStats["scan_type"]) {
-  if (scanType === "exit") return "Terug naar alle ExitScans"
-  if (scanType === "retention") return "Terug naar alle RetentieScans"
-  if (scanType === "onboarding") return "Terug naar alle Onboarding 30-60-90-routes"
-  if (scanType === "pulse") return "Terug naar alle Pulse-routes"
-  if (scanType === "leadership") return "Terug naar alle Leadership Scans"
-  return "Terug naar overzicht"
+function getDashboardModuleBackLinkLabel(scanType: CampaignStats['scan_type']) {
+  if (scanType === 'exit') return 'Terug naar alle ExitScans'
+  if (scanType === 'retention') return 'Terug naar alle RetentieScans'
+  if (scanType === 'onboarding') return 'Terug naar alle Onboarding 30-60-90-routes'
+  if (scanType === 'pulse') return 'Terug naar alle Pulse-routes'
+  if (scanType === 'leadership') return 'Terug naar alle Leadership Scans'
+  return 'Terug naar overzicht'
+}
+
+function formatScore(value: number | null) {
+  return value === null ? 'Nog niet beschikbaar' : `${value.toFixed(1)}/10`
+}
+
+function formatPercent(value: number | null) {
+  return value === null ? 'Nog niet beschikbaar' : `${Math.round(value)}%`
+}
+
+function truncateText(value: string, limit = 140) {
+  return value.length > limit ? `${value.slice(0, limit - 3).trimEnd()}...` : value
 }
 
 function buildResponseContextNote(totalCompleted: number, completionRate: number) {
   if (totalCompleted >= MIN_N_PATTERNS) {
-    return `Responsbasis van ${completionRate}% is stevig genoeg voor een eerste lezing. Lees verschillen nog steeds in samenhang met scope en context.`
+    return `${completionRate}% respons en ${totalCompleted} ingevulde responses liggen boven de analysegrens van ${MIN_N_PATTERNS}.`
   }
 
-  return `Eerste read is zichtbaar, maar detail blijft nog begrensd. Gebruik de responsbasis van ${completionRate}% vooral om richting te bepalen, niet om al te ver te concluderen.`
-}
+  if (totalCompleted >= MIN_N_DISPLAY) {
+    return `${completionRate}% respons en ${totalCompleted} ingevulde responses liggen boven de weergavegrens van ${MIN_N_DISPLAY}, maar nog onder de analysegrens van ${MIN_N_PATTERNS}.`
+  }
 
-function buildVisibleVoices(responses: SurveyResponse[]) {
-  const sanitize = (value: string) =>
-    value
-      .replace(/\s+/g, " ")
-      .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, "[verwijderd]")
-      .replace(/https?:\/\/\S+/gi, "[link verwijderd]")
-      .replace(/\+?\d[\d\s().-]{7,}\d/g, "[verwijderd]")
-      .trim()
-
-  const seen = new Set<string>()
-
-  return responses
-    .map((response) =>
-      sanitize(response.open_text_raw?.trim() || response.open_text_analysis?.trim() || ""),
-    )
-    .filter((text) => text.length >= 24)
-    .filter((text) => {
-      const normalized = text.toLowerCase()
-      if (seen.has(normalized)) return false
-      seen.add(normalized)
-      return true
-    })
-    .slice(0, 2)
+  return `${totalCompleted} ingevulde responses. Detailweergave opent vanaf ${MIN_N_DISPLAY} responses.`
 }
 
 function buildExitPictureDistribution(responses: SurveyResponse[]) {
@@ -147,8 +144,8 @@ function buildExitPictureDistribution(responses: SurveyResponse[]) {
   for (const response of responses) {
     const code = response.exit_reason_code
     if (!code) continue
-    if (code.startsWith("PL")) counts.pull += 1
-    else if (code.startsWith("S")) counts.situational += 1
+    if (code.startsWith('PL')) counts.pull += 1
+    else if (code.startsWith('S')) counts.situational += 1
     else counts.work += 1
   }
 
@@ -159,75 +156,22 @@ function buildExitPictureDistribution(responses: SurveyResponse[]) {
     total,
     segments: [
       {
-        label: "Werkfrictie zichtbaar",
+        label: 'Werkgerelateerde redenen',
         value: `${toPercent(counts.work)}%`,
         percent: toPercent(counts.work),
       },
       {
-        label: "Andere trekfactoren zichtbaar",
+        label: 'Trekfactoren elders',
         value: `${toPercent(counts.pull)}%`,
         percent: toPercent(counts.pull),
       },
       {
-        label: "Situationele context zichtbaar",
+        label: 'Situationele redenen',
         value: `${toPercent(counts.situational)}%`,
         percent: toPercent(counts.situational),
       },
     ],
   }
-}
-
-function buildExitNarratives(args: {
-  topFactorLabel: string | null
-  secondFactorLabel: string | null
-  topExitReasonLabel: string | null
-  topContributingReasonLabel: string | null
-  strongWorkSignalRate: number | null
-  distribution: ReturnType<typeof buildExitPictureDistribution>
-}): NarrativeItem[] {
-  const items: NarrativeItem[] = []
-
-  if (args.topFactorLabel) {
-    items.push({
-      title: `${args.topFactorLabel} zet de eerste leesrichting`,
-      tag: "Primair signaal",
-      body: `${args.topFactorLabel} ligt het scherpst onder de organisatiefactoren en hoort daarom de eerste bestuurlijke leeslaag te openen.`,
-    })
-  }
-
-  if (args.secondFactorLabel) {
-    items.push({
-      title: `${args.secondFactorLabel} versterkt het vertrekbeeld`,
-      tag: "Samenhang",
-      body: `${args.secondFactorLabel} komt niet losstaand terug, maar kleurt het patroon mee naast de eerste driver.`,
-    })
-  }
-
-  if (args.topExitReasonLabel || args.topContributingReasonLabel) {
-    items.push({
-      title: "Vertrekredenen en context wijzen dezelfde kant op",
-      tag: "Rapportlezing",
-      body: `${args.topExitReasonLabel ?? "De dominante vertrekreden"} en ${args.topContributingReasonLabel ?? "de contextcodes"} versterken samen het beeld dat vooral intern werkgerelateerde frictie zichtbaar is.`,
-    })
-  }
-
-  if (items.length < 3) {
-    items.push({
-      title: "Werkfrictie blijft de dominante lezing",
-      tag: "Vertrekbeeld",
-      body: `${args.distribution.segments[0]?.value ?? "0%"} van het vertrekbeeld valt in werkfrictie. Andere trekfactoren en situationele context blijven zichtbaar, maar dragen minder hard de eerste managementread.`,
-    })
-  }
-
-  if (items.length < 3 && args.strongWorkSignalRate !== null) {
-    items.push({
-      title: "Beinvloedbare werkcontext blijft bestuurlijk relevant",
-      tag: "Werkbaarheid",
-      body: `${args.strongWorkSignalRate}% van de leesbare responses valt in sterk werksignaal. Daardoor blijft deze route bestuurlijk vooral een intern werkvraagstuk, niet alleen een marktvraagstuk.`,
-    })
-  }
-
-  return items.slice(0, 3)
 }
 
 function buildFactorPriorityRows(factorAverages: Record<string, number>) {
@@ -244,10 +188,10 @@ function buildFactorPriorityRows(factorAverages: Record<string, number>) {
         band: getManagementBandLabel(signalValue),
         note:
           signalValue >= 7
-            ? "Vraagt in dit beeld als eerste aandacht."
+            ? 'Laagste ervaren score in deze route.'
             : signalValue >= 4.5
-              ? "Eerst toetsen voordat deze factor zwaarder meeweegt."
-              : "Zichtbaar, maar niet de eerste factor om te openen.",
+              ? 'Zichtbaar in het huidige patroon.'
+              : 'Nu minder uitgesproken dan de bovenste factoren.',
       } satisfies FactorRow
     })
     .sort((left, right) => right.signalValue - left.signalValue)
@@ -259,11 +203,11 @@ function buildSdtRows(sdtAverages: {
   relatedness?: number
 }) {
   return [
-    { key: "autonomy", label: "Autonomie", value: sdtAverages.autonomy },
-    { key: "competence", label: "Competentie & groei", value: sdtAverages.competence },
-    { key: "relatedness", label: "Verbondenheid", value: sdtAverages.relatedness },
+    { label: 'Autonomie', value: sdtAverages.autonomy },
+    { label: 'Competentie & groei', value: sdtAverages.competence },
+    { label: 'Verbondenheid', value: sdtAverages.relatedness },
   ]
-    .filter((item) => typeof item.value === "number")
+    .filter((item) => typeof item.value === 'number')
     .map((item) => {
       const scoreValue = Number(item.value)
       const signalValue = 11 - scoreValue
@@ -276,64 +220,282 @@ function buildSdtRows(sdtAverages: {
         band: getManagementBandLabel(signalValue),
         note:
           signalValue >= 7
-            ? "Draagt duidelijk mee aan het vertrekbeeld."
+            ? 'Duidelijk zichtbaar in de verdiepingslaag.'
             : signalValue >= 4.5
-              ? "Relevant als verdiepingslaag naast de organisatiefactoren."
-              : "Ondersteunend, maar niet de eerste driver van dit beeld.",
+              ? 'Aanwezig als aanvullende context.'
+              : 'Nu minder uitgesproken dan de andere SDT-lagen.',
       } satisfies SdtRow
     })
 }
 
-function getResultsStatusLabel(readState: ReturnType<typeof buildResultsViewModel>["readState"]) {
-  if (readState === "readable") return "Leesbaar"
-  if (readState === "early-read") return "Eerste read"
-  return "Nog aan het opbouwen"
+function getResultsStatusLabel(readState: ReturnType<typeof buildResultsViewModel>['readState']) {
+  if (readState === 'readable') return 'Leesbaar'
+  if (readState === 'early-read') return 'Eerste read'
+  return 'Nog aan het opbouwen'
+}
+
+function buildSignalHighlights(args: {
+  scanType: ScanType
+  signalLabel: string
+  isVisible: boolean
+  averageSignalScore: number | null
+  topFactorLabel: string | null
+  strongWorkSignalRate: number | null
+  supplemental: ReturnType<typeof computeRetentionSupplementalAverages>
+}) {
+  const items: MetricItem[] = [
+    {
+      label: args.signalLabel,
+      value: args.isVisible ? formatScore(args.averageSignalScore) : 'Nog niet beschikbaar',
+      caption: args.isVisible
+        ? 'Gemiddelde score over de leesbare responses.'
+        : `Beschikbaar vanaf ${MIN_N_DISPLAY} responses.`,
+    },
+  ]
+
+  if (args.scanType === 'exit') {
+    items.push(
+      {
+        label: 'Sterkste factor',
+        value: args.isVisible ? args.topFactorLabel ?? 'Nog niet beschikbaar' : 'Nog niet beschikbaar',
+        caption: 'Factor met de laagste gemiddelde belevingsscore in deze route.',
+      },
+      {
+        label: 'Sterk werksignaal',
+        value: args.isVisible ? formatPercent(args.strongWorkSignalRate) : 'Nog niet beschikbaar',
+        caption: 'Aandeel responses met een sterk werkgerelateerd signaal.',
+      },
+    )
+
+    return items
+  }
+
+  if (args.scanType === 'retention') {
+    items.push(
+      {
+        label: 'Bevlogenheid',
+        value: args.isVisible ? formatScore(args.supplemental.engagement) : 'Nog niet beschikbaar',
+        caption: 'Gemiddelde UWES-score binnen de leesbare responses.',
+      },
+      {
+        label: 'Stay-intent',
+        value: args.isVisible ? formatScore(args.supplemental.stayIntent) : 'Nog niet beschikbaar',
+        caption: 'Gemiddelde richtingsscore op groepsniveau.',
+      },
+    )
+
+    return items
+  }
+
+  items.push(
+    {
+      label: 'Richtingsvraag',
+      value: args.isVisible ? formatScore(args.supplemental.stayIntent) : 'Nog niet beschikbaar',
+      caption: 'Gemiddelde richtingsscore op groepsniveau.',
+    },
+    {
+      label: 'Topfactor',
+      value: args.isVisible ? args.topFactorLabel ?? 'Nog niet beschikbaar' : 'Nog niet beschikbaar',
+      caption: 'Factor met de laagste gemiddelde belevingsscore in deze route.',
+    },
+  )
+
+  return items
+}
+
+function buildSynthesisItems(args: {
+  scanType: ScanType
+  topFactorLabel: string | null
+  secondFactorLabel: string | null
+  topExitReasonLabel: string | null
+  topContributingReasonLabel: string | null
+  retentionThemes: ReturnType<typeof clusterRetentionOpenSignals>
+  openAnswerThemes: ReturnType<typeof buildOpenAnswersViewModel>['themes']
+  exitDistribution: ReturnType<typeof buildExitPictureDistribution> | null
+}) {
+  const items: SummaryItem[] = []
+
+  if (args.scanType === 'exit') {
+    if (args.topExitReasonLabel) {
+      items.push({
+        label: 'Dominante reden',
+        title: args.topExitReasonLabel,
+        body: 'Meest voorkomende vertrekreden binnen de leesbare exitresponses.',
+      })
+    }
+
+    if (args.topContributingReasonLabel) {
+      items.push({
+        label: 'Meespelende code',
+        title: args.topContributingReasonLabel,
+        body: 'Tweede reden die in dezelfde response-set zichtbaar terugkomt.',
+      })
+    }
+
+    const topSegment = args.exitDistribution?.segments[0]
+    if (topSegment) {
+      items.push({
+        label: 'Verdeling',
+        title: `${topSegment.label} (${topSegment.value})`,
+        body: 'Grootste segment in de huidige verdeling van het vertrekbeeld.',
+      })
+    }
+
+    return items
+  }
+
+  if (args.scanType === 'retention') {
+    for (const theme of args.retentionThemes.slice(0, 2)) {
+      items.push({
+        label: 'Open antwoorden',
+        title: `${theme.title} (${theme.count})`,
+        body: truncateText(theme.sample, 150),
+      })
+    }
+  }
+
+  if (args.topFactorLabel) {
+    items.push({
+      label: 'Topfactor',
+      title: args.topFactorLabel,
+      body: 'Laagste gemiddelde belevingsscore in de huidige route.',
+    })
+  }
+
+  if (args.secondFactorLabel) {
+    items.push({
+      label: 'Tweede factor',
+      title: args.secondFactorLabel,
+      body: 'Volgende factor op basis van de huidige gemiddelde scores.',
+    })
+  }
+
+  if (items.length < 3 && args.openAnswerThemes[0]) {
+    items.push({
+      label: 'Thema in survey-stemmen',
+      title: `${args.openAnswerThemes[0].title} (${args.openAnswerThemes[0].count})`,
+      body: 'Meest voorkomende groep binnen de vrijgegeven open antwoorden.',
+    })
+  }
+
+  return items.slice(0, 3)
+}
+
+function buildDepthNotes(args: {
+  scanDefinition: ReturnType<typeof getScanDefinition>
+  responsesLength: number
+  hasMinDisplay: boolean
+  hasEnoughData: boolean
+}) {
+  const thresholdBody = args.hasEnoughData
+    ? `${args.responsesLength} responses voldoen aan de analysegrens van ${MIN_N_PATTERNS}.`
+    : args.hasMinDisplay
+      ? `${args.responsesLength} responses voldoen aan de weergavegrens van ${MIN_N_DISPLAY}, maar nog niet aan de analysegrens van ${MIN_N_PATTERNS}.`
+      : `${args.responsesLength} responses; detailweergave start bij ${MIN_N_DISPLAY}.`
+
+  return [
+    {
+      label: 'Wat deze route toont',
+      body: args.scanDefinition.whatItIsText,
+    },
+    {
+      label: 'Wat deze route niet toont',
+      body: args.scanDefinition.whatItIsNotText,
+    },
+    {
+      label: 'Privacygrens',
+      body: args.scanDefinition.privacyBoundaryText,
+    },
+    {
+      label: 'Leesgrens',
+      body: thresholdBody,
+    },
+  ]
 }
 
 function ResultsBlockCard({
   title,
   visibility,
-  value,
+  summary,
   body,
   href,
   linkLabel,
+  children,
 }: {
   title: string
   visibility: ResultsBlockVisibility
-  value?: string
+  summary?: string
   body: string
   href?: string
   linkLabel?: string
+  children?: ReactNode
 }) {
   const toneClasses =
-    visibility === "visible"
-      ? "border-slate-200 bg-white"
-      : "border-dashed border-slate-200 bg-slate-50"
+    visibility === 'visible'
+      ? 'border-slate-200 bg-white'
+      : 'border-dashed border-slate-200 bg-slate-50'
 
   return (
-    <div className={`rounded-[22px] px-5 py-5 shadow-sm ${toneClasses}`}>
+    <div className={`rounded-[24px] border px-5 py-5 shadow-sm ${toneClasses}`}>
       <div className="flex items-start justify-between gap-3">
         <h2 className="text-lg font-semibold tracking-[-0.02em] text-[color:var(--dashboard-ink)]">
           {title}
         </h2>
         <span className="rounded-full bg-slate-100 px-3 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-slate-600">
-          {visibility === "visible" ? "Vrij" : "Begrensd"}
+          {visibility === 'visible' ? 'Vrij' : 'Begrensd'}
         </span>
       </div>
-      {value ? (
+      {summary ? (
         <p className="mt-4 text-xl font-semibold tracking-[-0.03em] text-[color:var(--dashboard-ink)]">
-          {value}
+          {summary}
         </p>
       ) : null}
       <p className="mt-3 text-sm leading-6 text-[color:var(--dashboard-text)]">{body}</p>
+      {children ? <div className="mt-5">{children}</div> : null}
       {href && linkLabel ? (
         <Link
           href={href}
-          className="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-slate-700 transition-colors hover:text-slate-950"
+          className="mt-5 inline-flex items-center gap-2 text-sm font-semibold text-slate-700 transition-colors hover:text-slate-950"
         >
           {linkLabel}
         </Link>
       ) : null}
+    </div>
+  )
+}
+
+function MetricTile({ item }: { item: MetricItem }) {
+  return (
+    <div className="rounded-[20px] bg-[color:var(--dashboard-soft)]/55 px-4 py-4">
+      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
+        {item.label}
+      </p>
+      <p className="mt-3 text-lg font-semibold tracking-[-0.03em] text-[color:var(--dashboard-ink)]">
+        {item.value}
+      </p>
+      <p className="mt-2 text-sm leading-6 text-[color:var(--dashboard-text)]">{item.caption}</p>
+    </div>
+  )
+}
+
+function SummaryCard({ item }: { item: SummaryItem }) {
+  return (
+    <div className="rounded-[20px] bg-[color:var(--dashboard-soft)]/52 px-5 py-5">
+      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
+        {item.label}
+      </p>
+      <h3 className="mt-3 text-[1.08rem] font-semibold tracking-[-0.03em] text-[color:var(--dashboard-ink)]">
+        {item.title}
+      </h3>
+      <p className="mt-3 text-sm leading-6 text-[color:var(--dashboard-text)]">{item.body}</p>
+    </div>
+  )
+}
+
+function EmptyInlineState({ body }: { body: string }) {
+  return (
+    <div className="rounded-[20px] border border-dashed border-slate-200 bg-slate-50 px-5 py-5 text-sm leading-6 text-[color:var(--dashboard-text)]">
+      {body}
     </div>
   )
 }
@@ -366,11 +528,11 @@ function ResultsShellHeader({
       <p className="text-[0.78rem] font-medium tracking-[0.01em] text-slate-500">
         <Link href="/dashboard" className="transition-colors hover:text-slate-700">
           Overzicht
-        </Link>{" "}
-        /{" "}
+        </Link>{' '}
+        /{' '}
         <Link href={moduleHref} className="transition-colors hover:text-slate-700">
           {moduleLabel}
-        </Link>{" "}
+        </Link>{' '}
         / <span className="text-slate-700">{campaignName}</span>
       </p>
       <Link
@@ -390,7 +552,7 @@ function ResultsShellHeader({
             {campaignName}
           </h1>
           <p className="text-sm leading-6 text-slate-600">
-            {organizationName} <span aria-hidden="true">&middot;</span> {routePeriodLabel}{" "}
+            {organizationName} <span aria-hidden="true">&middot;</span> {routePeriodLabel}{' '}
             <span aria-hidden="true">&middot;</span> {scopeLabel}
           </p>
         </div>
@@ -423,9 +585,9 @@ export default async function CampaignPage({ params }: Props) {
   }
 
   const { data: statsRow } = await supabase
-    .from("campaign_stats")
-    .select("*")
-    .eq("campaign_id", id)
+    .from('campaign_stats')
+    .select('*')
+    .eq('campaign_id', id)
     .single()
 
   if (!statsRow) notFound()
@@ -433,10 +595,10 @@ export default async function CampaignPage({ params }: Props) {
 
   const [{ data: organization }, { data: campaignMeta }, { data: responsesRaw }, { data: respondentsRaw }] =
     await Promise.all([
-      supabase.from("organizations").select("name").eq("id", stats.organization_id).maybeSingle(),
-      supabase.from("campaigns").select("enabled_modules").eq("id", id).maybeSingle(),
+      supabase.from('organizations').select('name').eq('id', stats.organization_id).maybeSingle(),
+      supabase.from('campaigns').select('enabled_modules').eq('id', id).maybeSingle(),
       supabase
-        .from("survey_responses")
+        .from('survey_responses')
         .select(
           `
           id,
@@ -459,12 +621,12 @@ export default async function CampaignPage({ params }: Props) {
           respondents!inner(id, campaign_id, department, role_level, completed, completed_at, token)
         `,
         )
-        .eq("respondents.campaign_id", id),
+        .eq('respondents.campaign_id', id),
       supabase
-        .from("respondents")
-        .select("*")
-        .eq("campaign_id", id)
-        .order("completed_at", { ascending: false, nullsFirst: false }),
+        .from('respondents')
+        .select('*')
+        .eq('campaign_id', id)
+        .order('completed_at', { ascending: false, nullsFirst: false }),
     ])
 
   const responses = (responsesRaw ?? []) as unknown as (SurveyResponse & {
@@ -472,248 +634,310 @@ export default async function CampaignPage({ params }: Props) {
   })[]
   const respondents = (respondentsRaw ?? []) as Respondent[]
 
+  const hasMinDisplay = responses.length >= MIN_N_DISPLAY
+  const hasEnoughData = responses.length >= MIN_N_PATTERNS
   const factorData = computeFactorAverages(responses)
   const factorPriorityRows = buildFactorPriorityRows(factorData.orgAverages)
   const sdtRows = buildSdtRows(factorData.sdtAverages)
-  const averageRiskScore = computeAverageSignalScore(responses)
-  const hasMinDisplay = responses.length >= MIN_N_DISPLAY
-  const hasEnoughData = responses.length >= MIN_N_PATTERNS
-  const openAnswers = buildVisibleVoices(responses)
-  const openAnswersHref = `/campaigns/${id}/open-antwoorden`
+  const averageSignalScore = computeAverageSignalScore(responses)
+  const supplemental = computeRetentionSupplementalAverages(responses)
+  const releasedOpenAnswerItems = hasMinDisplay ? buildOpenAnswerItems(stats.scan_type, responses) : []
+  const openAnswersViewModel = buildOpenAnswersViewModel(releasedOpenAnswerItems)
+  const strongWorkSignalRate = hasMinDisplay ? computeStrongWorkSignalRate(responses) : null
+  const topExitReasonLabel = hasMinDisplay ? getTopExitReasonLabel(responses) : null
+  const topContributingReasonLabel = hasEnoughData ? getTopContributingReasonLabel(responses) : null
+  const exitDistribution = hasEnoughData ? buildExitPictureDistribution(responses) : null
+  const retentionThemes = stats.scan_type === 'retention' ? clusterRetentionOpenSignals(responses) : []
   const resultsViewModel = buildResultsViewModel({
     scanType: stats.scan_type,
     respondentsCount: respondents.length,
     hasMinDisplay,
     hasEnoughData,
-    hasOpenAnswers: openAnswers.length > 0,
+    hasOpenAnswers: releasedOpenAnswerItems.length > 0,
   })
+
   const blockVisibility = Object.fromEntries(
     resultsViewModel.blocks.map((block) => [block.key, block.visibility]),
-  ) as Record<"response" | "signal" | "synthesis" | "drivers" | "depth" | "voices", ResultsBlockVisibility>
+  ) as Record<
+    'response' | 'signal' | 'synthesis' | 'drivers' | 'depth' | 'voices',
+    ResultsBlockVisibility
+  >
 
   const scanDefinition = getScanDefinition(stats.scan_type)
-  const organizationName = organization?.name ?? "Organisatie"
+  const organizationName = organization?.name ?? 'Organisatie'
   const routePeriodLabel = formatRoutePeriodLabel(stats.campaign_name, stats.created_at)
   const scopeLabel = deriveScopeLabel(respondents)
   const moduleKey =
-    stats.scan_type === "team" ? null : getDashboardModuleKeyForScanType(stats.scan_type)
+    stats.scan_type === 'team' ? null : getDashboardModuleKeyForScanType(stats.scan_type)
   const moduleLabel = moduleKey ? getDashboardModuleLabel(moduleKey) : scanDefinition.productName
-  const moduleHref = moduleKey ? getDashboardModuleHref(moduleKey) : "/dashboard"
+  const moduleHref = moduleKey ? getDashboardModuleHref(moduleKey) : '/dashboard'
   const moduleBackLinkLabel = getDashboardModuleBackLinkLabel(stats.scan_type)
   const topFactorLabel = factorPriorityRows[0]?.factor ?? null
   const secondFactorLabel = factorPriorityRows[1]?.factor ?? null
+  const signalHighlights = buildSignalHighlights({
+    scanType: stats.scan_type,
+    signalLabel: scanDefinition.signalLabel,
+    isVisible: blockVisibility.signal === 'visible',
+    averageSignalScore,
+    topFactorLabel,
+    strongWorkSignalRate,
+    supplemental,
+  })
+  const synthesisItems = buildSynthesisItems({
+    scanType: stats.scan_type,
+    topFactorLabel,
+    secondFactorLabel,
+    topExitReasonLabel,
+    topContributingReasonLabel,
+    retentionThemes,
+    openAnswerThemes: openAnswersViewModel.themes,
+    exitDistribution,
+  })
+  const depthNotes = buildDepthNotes({
+    scanDefinition,
+    responsesLength: responses.length,
+    hasMinDisplay,
+    hasEnoughData,
+  })
+  const openAnswersHref = `/campaigns/${id}/open-antwoorden`
 
   const responseSection = (
     <ResultsBlockCard
       title={PRIMARY_RESULTS_ORDER.response}
       visibility={blockVisibility.response}
-      value={`${stats.total_completed}/${stats.total_invited} ingevuld · ${stats.completion_rate_pct ?? 0}%`}
+      summary={`${stats.total_completed}/${stats.total_invited} ingevuld · ${stats.completion_rate_pct ?? 0}%`}
       body={buildResponseContextNote(stats.total_completed, stats.completion_rate_pct ?? 0)}
-      href={stats.scan_type === "exit" ? "#responscontext" : undefined}
-      linkLabel={stats.scan_type === "exit" ? "Ga naar responscontext" : undefined}
-    />
+    >
+      <div className="grid gap-3 sm:grid-cols-3">
+        {[
+          { label: 'Uitgenodigd', value: String(stats.total_invited) },
+          { label: 'Ingevuld', value: String(stats.total_completed) },
+          { label: 'Status', value: getResultsStatusLabel(resultsViewModel.readState) },
+        ].map((item) => (
+          <div
+            key={item.label}
+            className="rounded-[18px] bg-[color:var(--dashboard-soft)]/62 px-4 py-4"
+          >
+            <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
+              {item.label}
+            </p>
+            <p className="mt-3 text-base font-semibold tracking-[-0.02em] text-[color:var(--dashboard-ink)]">
+              {item.value}
+            </p>
+          </div>
+        ))}
+      </div>
+    </ResultsBlockCard>
   )
 
   const signalSection = (
     <ResultsBlockCard
       title={PRIMARY_RESULTS_ORDER.signal}
       visibility={blockVisibility.signal}
-      value={averageRiskScore !== null && hasMinDisplay ? `${averageRiskScore.toFixed(1)}/10` : "Nog niet beschikbaar"}
+      summary={blockVisibility.signal === 'visible' ? formatScore(averageSignalScore) : 'Nog niet beschikbaar'}
       body={
-        topFactorLabel && hasMinDisplay
-          ? `${scanDefinition.signalLabel} blijft de opening, met ${topFactorLabel.toLowerCase()} als eerste zichtbare factor binnen deze route.`
-          : `Deze laag komt pas vrij vanaf ${MIN_N_DISPLAY} leesbare responses. Tot die tijd blijft het kernsignaal bewust begrensd.`
+        blockVisibility.signal === 'visible'
+          ? `${scanDefinition.signalLabel} is vrijgegeven voor deze route. De aanvullende metrics hieronder tonen de scan-specifieke context die samen met het hoofdsignaal is opgeslagen.`
+          : `Deze laag opent vanaf ${MIN_N_DISPLAY} leesbare responses.`
       }
-      href={stats.scan_type === "exit" ? "#sterkste-signaal" : undefined}
-      linkLabel={stats.scan_type === "exit" ? "Ga naar sterkste signaal" : undefined}
-    />
+    >
+      <div className="grid gap-4 md:grid-cols-3">
+        {signalHighlights.map((item) => (
+          <MetricTile key={item.label} item={item} />
+        ))}
+      </div>
+    </ResultsBlockCard>
   )
-
-  const synthesisTitle =
-    stats.scan_type === "exit"
-      ? getTopExitReasonLabel(responses) ?? topFactorLabel ?? "Nog niet beschikbaar"
-      : topFactorLabel ?? "Nog niet beschikbaar"
-  const synthesisBody =
-    stats.scan_type === "exit"
-      ? getTopContributingReasonLabel(responses)
-        ? `${getTopContributingReasonLabel(responses)} speelt zichtbaar mee naast de dominante vertrekreden en hoort in dezelfde managementlezing thuis.`
-        : `Deze laag blijft pas echt scherp zodra er naast de hoofdreden ook een tweede contextsignaal stevig terugkomt.`
-      : secondFactorLabel
-        ? `${secondFactorLabel} kleurt het primaire signaal mee en helpt om verschillen in samenhang te lezen, niet als los detail.`
-        : `Gebruik deze laag pas steviger vanaf voldoende respons en meer dan een enkel zichtbaar factorspoor.`
 
   const synthesisSection = (
     <ResultsBlockCard
       title={PRIMARY_RESULTS_ORDER.synthesis}
       visibility={blockVisibility.synthesis}
-      value={blockVisibility.synthesis === "visible" ? synthesisTitle : "Nog niet beschikbaar"}
-      body={synthesisBody}
-      href={stats.scan_type === "exit" ? "#hoofdreden-vertrekbeeld" : undefined}
-      linkLabel={stats.scan_type === "exit" ? "Ga naar samenhang" : undefined}
-    />
+      summary={blockVisibility.synthesis === 'visible' ? synthesisItems[0]?.title ?? 'Nog niet beschikbaar' : 'Nog niet beschikbaar'}
+      body={
+        blockVisibility.synthesis === 'visible'
+          ? 'Deze laag bundelt de eerste samenhang die op groepsniveau zichtbaar is.'
+          : `Deze laag opent samen met het kernsignaal vanaf ${MIN_N_DISPLAY} responses.`
+      }
+    >
+      {blockVisibility.synthesis === 'visible' && synthesisItems.length > 0 ? (
+        <div className="grid gap-4 xl:grid-cols-3">
+          {synthesisItems.map((item) => (
+            <SummaryCard key={`${item.label}-${item.title}`} item={item} />
+          ))}
+        </div>
+      ) : (
+        <EmptyInlineState body="Nog geen tweede laag beschikbaar binnen de huidige leesgrens." />
+      )}
+    </ResultsBlockCard>
   )
 
-  const driversValue =
-    factorPriorityRows.length > 0 && hasEnoughData
-      ? factorPriorityRows
-          .slice(0, 3)
-          .map((row) => row.factor)
-          .join(" · ")
-      : "Nog niet beschikbaar"
   const driversSection = (
     <ResultsBlockCard
       title={PRIMARY_RESULTS_ORDER.drivers}
       visibility={blockVisibility.drivers}
-      value={driversValue}
+      summary={
+        blockVisibility.drivers === 'visible'
+          ? factorPriorityRows
+              .slice(0, 3)
+              .map((row) => row.factor)
+              .join(' · ')
+          : 'Nog niet beschikbaar'
+      }
       body={
-        hasEnoughData
-          ? "Gebruik deze laag om te zien welke factoren het eerst bestuurlijke aandacht vragen. Prioriteiten blijven groepsmatig en feitelijk."
+        blockVisibility.drivers === 'visible'
+          ? 'Factoren zijn geordend op huidige signaalsterkte binnen deze route.'
           : `Deze laag blijft begrensd tot er minimaal ${MIN_N_PATTERNS} leesbare responses zijn.`
       }
-      href={stats.scan_type === "exit" ? "#driverlaag" : undefined}
-      linkLabel={stats.scan_type === "exit" ? "Ga naar drivers" : undefined}
-    />
+    >
+      {blockVisibility.drivers === 'visible' && factorPriorityRows.length > 0 ? (
+        <div className="space-y-4">
+          {factorPriorityRows.slice(0, 4).map((row) => (
+            <div key={row.factor} className="rounded-[20px] bg-[color:var(--dashboard-soft)]/52 px-5 py-4">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <p className="text-sm font-semibold text-[color:var(--dashboard-ink)]">{row.factor}</p>
+                  <p className="mt-2 text-sm leading-6 text-[color:var(--dashboard-text)]">{row.note}</p>
+                </div>
+                <div className="rounded-full bg-white px-3 py-1 text-xs font-semibold text-slate-600">
+                  {row.signal}
+                </div>
+              </div>
+              <div className="mt-3 h-2.5 overflow-hidden rounded-full bg-white/85">
+                <div
+                  className="h-full rounded-full bg-[#C36A29]"
+                  style={{ width: `${Math.max(12, Math.min(100, row.signalValue * 10))}%` }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <EmptyInlineState body={`Volledige factorprioritering opent vanaf ${MIN_N_PATTERNS} responses.`} />
+      )}
+    </ResultsBlockCard>
   )
 
-  const depthValue =
-    blockVisibility.depth === "visible"
-      ? sdtRows.length > 0
-        ? `${sdtRows.length} verdiepingslaag${sdtRows.length === 1 ? "" : "en"}`
-        : `${factorPriorityRows.length} factorlaag${factorPriorityRows.length === 1 ? "" : "en"}`
-      : "Nog niet beschikbaar"
   const depthSection = (
     <ResultsBlockCard
       title={PRIMARY_RESULTS_ORDER.depth}
       visibility={blockVisibility.depth}
-      value={depthValue}
-      body={
-        blockVisibility.depth === "visible"
-          ? "Verdiepingslagen blijven ondersteunend aan de hoofdlezing: extra factorcontext, SDT en methodische begrenzing."
-          : "Deze laag blijft bewust compact zolang de eerste veilige read nog niet volledig open ligt."
+      summary={
+        blockVisibility.depth === 'visible'
+          ? sdtRows.length > 0
+            ? `${sdtRows.length} SDT-lagen zichtbaar`
+            : `${factorPriorityRows.length} factoren berekend`
+          : 'Nog niet beschikbaar'
       }
-      href={stats.scan_type === "exit" ? "#factorlaag" : undefined}
-      linkLabel={stats.scan_type === "exit" ? "Ga naar verdieping" : undefined}
-    />
+      body={
+        blockVisibility.depth === 'visible'
+          ? 'Verdiepingslagen tonen extra context en methodische grenzen binnen dezelfde route.'
+          : `Deze laag opent vanaf ${MIN_N_DISPLAY} leesbare responses.`
+      }
+    >
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr),minmax(0,1fr)]">
+        <div className="space-y-4">
+          {blockVisibility.depth === 'visible' && sdtRows.length > 0 ? (
+            <div className="grid gap-3">
+              {sdtRows.map((row) => (
+                <div
+                  key={row.factor}
+                  className="rounded-[20px] bg-[color:var(--dashboard-soft)]/52 px-5 py-4"
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="text-sm font-semibold text-[color:var(--dashboard-ink)]">{row.factor}</p>
+                    <span className="rounded-full bg-white px-3 py-1 text-xs font-semibold text-slate-600">
+                      {row.score}
+                    </span>
+                  </div>
+                  <p className="mt-2 text-sm leading-6 text-[color:var(--dashboard-text)]">{row.note}</p>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <EmptyInlineState body="Nog geen extra verdiepingslaag zichtbaar binnen de huidige routegegevens." />
+          )}
+
+          <div className="grid gap-3 md:grid-cols-2">
+            {depthNotes.map((note) => (
+              <div
+                key={note.label}
+                className="rounded-[20px] border border-slate-200 bg-white px-4 py-4"
+              >
+                <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                  {note.label}
+                </p>
+                <p className="mt-3 text-sm leading-6 text-[color:var(--dashboard-text)]">{note.body}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <MethodologyCard
+          scanType={stats.scan_type}
+          hasSegmentDeepDive={hasCampaignAddOn(campaignMeta, 'segment_deep_dive')}
+          signalLabel={scanDefinition.signalLabel}
+          embedded
+        />
+      </div>
+    </ResultsBlockCard>
   )
 
-  const voicesPreview =
-    openAnswers[0] && blockVisibility.voices === "visible"
-      ? openAnswers[0].length > 120
-        ? `${openAnswers[0].slice(0, 117).trimEnd()}...`
-        : openAnswers[0]
-      : "Nog niet beschikbaar"
-  const voicesBody =
-    blockVisibility.voices === "visible"
-      ? "Survey-stemmen blijven geanonimiseerd en horen bij deze resultatenomgeving. Open antwoorden zijn in een klik bereikbaar."
-      : "Open antwoorden komen pas vrij zodra er daadwerkelijk leesbare survey-stemmen beschikbaar zijn."
   const voicesSection = (
     <ResultsBlockCard
       title={PRIMARY_RESULTS_ORDER.voices}
       visibility={blockVisibility.voices}
-      value={voicesPreview}
-      body={voicesBody}
+      summary={
+        blockVisibility.voices === 'visible'
+          ? `${releasedOpenAnswerItems.length} antwoorden vrijgegeven`
+          : 'Nog niet beschikbaar'
+      }
+      body={
+        blockVisibility.voices === 'visible'
+          ? 'Open antwoorden blijven geanonimiseerd en zijn gegroepeerd per zichtbaar thema.'
+          : hasMinDisplay
+            ? 'Er zijn nog geen vrijgegeven open antwoorden binnen deze route.'
+            : `Open antwoorden openen pas vanaf ${MIN_N_DISPLAY} leesbare responses.`
+      }
       href={openAnswersHref}
       linkLabel="Open alle open antwoorden"
-    />
+    >
+      {blockVisibility.voices === 'visible' && openAnswersViewModel.groups.length > 0 ? (
+        <div className="space-y-4">
+          <div className="flex flex-wrap gap-2">
+            {openAnswersViewModel.themes.slice(0, 3).map((theme) => (
+              <span
+                key={theme.title}
+                className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-600"
+              >
+                {theme.title} · {theme.count}
+              </span>
+            ))}
+          </div>
+          <div className="grid gap-4 xl:grid-cols-2">
+            {openAnswersViewModel.groups
+              .flatMap((group) => group.answers.slice(0, 1).map((answer) => ({ group, answer })))
+              .slice(0, 2)
+              .map(({ group, answer }) => (
+                <div
+                  key={answer.id}
+                  className="rounded-[20px] bg-[color:var(--dashboard-soft)]/52 px-5 py-5"
+                >
+                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
+                    {group.title}
+                  </p>
+                  <p className="mt-3 text-sm leading-6 text-[color:var(--dashboard-text)]">
+                    {truncateText(answer.text, 180)}
+                  </p>
+                </div>
+              ))}
+          </div>
+        </div>
+      ) : (
+        <EmptyInlineState body="Er zijn nog geen vrijgegeven open antwoorden om te groeperen." />
+      )}
+    </ResultsBlockCard>
   )
-
-  const summaryShell = (
-    <ResultsLayout
-      sections={{
-        response: responseSection,
-        signal: signalSection,
-        synthesis: synthesisSection,
-        drivers: driversSection,
-        depth: depthSection,
-        voices: voicesSection,
-      }}
-    />
-  )
-
-  if (stats.scan_type === "exit") {
-    const strongWorkSignalRate = hasMinDisplay ? computeStrongWorkSignalRate(responses) : null
-    const topExitReasonLabel = hasMinDisplay ? getTopExitReasonLabel(responses) : null
-    const topContributingReasonLabel = hasMinDisplay ? getTopContributingReasonLabel(responses) : null
-    const exitDistribution = hasMinDisplay ? buildExitPictureDistribution(responses) : { total: 0, segments: [] }
-    const exitNarratives =
-      hasMinDisplay
-        ? buildExitNarratives({
-            topFactorLabel,
-            secondFactorLabel,
-            topExitReasonLabel,
-            topContributingReasonLabel,
-            strongWorkSignalRate,
-            distribution: buildExitPictureDistribution(responses),
-          })
-        : []
-    const contributingItems: ContributingItem[] = []
-
-    if (topContributingReasonLabel) {
-      contributingItems.push({
-        label: "Contextcode",
-        value: topContributingReasonLabel,
-        body: "Deze meespelende reden ligt zichtbaar onder het vertrekbeeld en helpt om de hoofdrichting beter feitelijk te lezen.",
-      })
-    }
-
-    if (secondFactorLabel) {
-      contributingItems.push({
-        label: "Tweede factor",
-        value: secondFactorLabel,
-        body: "Deze factor kleurt mee naast het primaire signaal en hoort daarom in dezelfde analytische laag thuis.",
-      })
-    }
-
-    return (
-      <div className="space-y-10">
-        {summaryShell}
-        <ExitProductDashboard
-          moduleHref={moduleHref}
-          moduleLabel={moduleLabel}
-          moduleBackLinkLabel={moduleBackLinkLabel}
-          campaignName={stats.campaign_name}
-          organizationName={organizationName}
-          routePeriodLabel={routePeriodLabel}
-          scopeLabel={scopeLabel}
-          statusLabel={getResultsStatusLabel(resultsViewModel.readState)}
-          headerActions={
-            <PdfDownloadButton campaignId={id} campaignName={stats.campaign_name} scanType={stats.scan_type} />
-          }
-          averageSignalScoreLabel={
-            averageRiskScore !== null && hasMinDisplay ? `${averageRiskScore.toFixed(1)}/10` : "Nog niet beschikbaar"
-          }
-          strongestFactorLabel={topFactorLabel ?? "Nog niet beschikbaar"}
-          strongWorkSignalLabel={
-            strongWorkSignalRate !== null ? `${strongWorkSignalRate}%` : "Nog niet beschikbaar"
-          }
-          primaryReasonTitle={topExitReasonLabel ?? topFactorLabel ?? "Nog niet beschikbaar"}
-          primaryReasonBody={
-            topExitReasonLabel
-              ? `${topExitReasonLabel} geeft de bestuurlijke hoofdrichting van het vertrekbeeld binnen deze route.`
-              : "Nog niet beschikbaar voor een eerlijke analytische hoofdrichting."
-          }
-          whyItMattersItems={exitNarratives}
-          contributingItems={contributingItems}
-          totalInvited={String(stats.total_invited)}
-          totalCompleted={String(stats.total_completed)}
-          responseRate={`${stats.completion_rate_pct ?? 0}%`}
-          responseContextNote={buildResponseContextNote(stats.total_completed, stats.completion_rate_pct ?? 0)}
-          topFactors={blockVisibility.signal === "visible" ? factorPriorityRows : []}
-          distributionSegments={blockVisibility.synthesis === "visible" ? exitDistribution.segments : []}
-          factorRows={blockVisibility.drivers === "visible" ? factorPriorityRows : []}
-          sdtRows={blockVisibility.depth === "visible" ? sdtRows : []}
-          methodologyContent={
-            <MethodologyCard
-              scanType={stats.scan_type}
-              hasSegmentDeepDive={hasCampaignAddOn(campaignMeta, "segment_deep_dive")}
-              signalLabel={scanDefinition.signalLabel}
-              embedded
-            />
-          }
-        />
-      </div>
-    )
-  }
 
   return (
     <div className="space-y-10">
@@ -729,7 +953,17 @@ export default async function CampaignPage({ params }: Props) {
         campaignId={id}
         scanType={stats.scan_type}
       />
-      {summaryShell}
+
+      <ResultsLayout
+        sections={{
+          response: responseSection,
+          signal: signalSection,
+          synthesis: synthesisSection,
+          drivers: driversSection,
+          depth: depthSection,
+          voices: voicesSection,
+        }}
+      />
     </div>
   )
 }

--- a/frontend/app/(dashboard)/campaigns/[id]/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.tsx
@@ -1,244 +1,78 @@
-﻿import Link from "next/link";
-import { notFound, redirect } from "next/navigation";
-import { isLiveActionCenterScanType } from "@/lib/action-center-live";
-import {
-  buildActionCenterRouteOpenPatch,
-  buildActionCenterRouteOpenRedirect,
-  canOpenActionCenterRoute,
-  getActionCenterRouteOpenableStages,
-  hasOpenedActionCenterRoute,
-} from "@/lib/dashboard/open-action-center-route";
-import { createAdminClient } from "@/lib/supabase/admin";
-import { createClient } from "@/lib/supabase/server";
-import { CampaignActions } from "./campaign-actions";
-import { PdfDownloadButton } from "./pdf-download-button";
-import {
-  DashboardChartPanel,
-  DashboardChip,
-  DashboardDisclosure,
-  DashboardHero,
-  DashboardKeyValue,
-  DashboardPanel,
-  DashboardRecommendationRail,
-  DashboardSection,
-  DashboardSummaryBar,
-  DashboardTimeline,
-  FocusPanel,
-  InsightStatCard,
-  SignalStatCard,
-} from "@/components/dashboard/dashboard-primitives";
-import {
-  ManagementReadBridge,
-  ManagementReadDistribution,
-  ManagementReadFactorTable,
-  ManagementReadHeader,
-  ManagementReadInfoGrid,
-  ManagementReadNarratives,
-  ManagementReadSection,
-} from "@/components/dashboard/management-read-primitives";
-import {
-  ExitDriversPriorityChart,
-  ExitOrgFactorsChart,
-  ExitSdtNeedsChart,
-} from "@/components/dashboard/exit-dashboard-visuals";
-import { DashboardTabs } from "@/components/dashboard/dashboard-tabs";
-import { FactorTable } from "@/components/dashboard/factor-table";
-import { GuidedSelfServePanel } from "@/components/dashboard/guided-self-serve-panel";
-import { buildLaunchControlState } from "@/lib/launch-controls";
-import { ManagementReadGuide } from "@/components/dashboard/onboarding-panels";
-import {
-  OnboardingAdvancer,
-  OnboardingBalloon,
-} from "@/components/dashboard/onboarding-balloon";
-import { PreflightChecklist } from "@/components/dashboard/preflight-checklist";
-import { RespondentTable } from "@/components/dashboard/respondent-table";
-import { RiskCharts } from "@/components/dashboard/risk-charts";
-import { SuiteAccessDenied } from "@/components/dashboard/suite-access-denied";
-import { getContactRequestsForAdmin } from "@/lib/contact-requests";
-import { deriveGuidedSelfServeDiscipline } from "@/lib/guided-self-serve";
-import {
-  getCampaignCompositionState,
-  isManagementVisibleState,
-} from "@/lib/dashboard/dashboard-state-composition";
-import {
-  ActionPlaybookList,
-  buildCampaignDetailActionCenterBridge,
-  buildDecisionPanels,
-  buildHeroDescription,
-  buildInsightWarnings,
-  buildPulseComparisonState,
-  buildRetentionSegmentPlaybooks,
-  buildRetentionTrendCards,
-  buildRiskHistogram,
-  buildSafeTableResponses,
-  CampaignHealthIndicator,
-  clusterRetentionOpenSignals,
-  computeAverageSignalScore,
-  computePulseSignalAverages,
-  computeAverageSignalVisibility,
-  computeFactorAverages,
-  computeRetentionSignalAverages,
-  computeRetentionSupplementalAverages,
-  computeStrongWorkSignalRate,
-  getDisclosureDefaults,
-  getTopContributingReasonLabel,
-  getTopExitReasonLabel,
-  MethodologyCard,
-  MIN_N_DISPLAY,
-  MIN_N_PATTERNS,
-  PulseTrendSection,
-  RecommendationList,
-  RetentionTrendSection,
-  SegmentPlaybookList,
-  SdtGauge,
-} from "./page-helpers";
-import {
-  buildCampaignReadinessState,
-  getDeliveryModeLabel,
-} from "@/lib/implementation-readiness";
-import { getFirstNextStepGuidance } from "@/lib/client-onboarding";
-import { type CampaignAuditEventRecord } from "@/lib/campaign-audit";
-import { getCustomerActionPermission } from "@/lib/customer-permissions";
-import {
-  buildFactorPresentation,
-  getManagementBandLabel,
-  getRiskBandFromScore,
-} from "@/lib/management-language";
-import type {
-  CampaignDeliveryCheckpoint,
-  CampaignDeliveryRecord,
-} from "@/lib/ops-delivery";
-import {
-  buildTeamLocalReadState,
-  buildTeamPriorityReadState,
-} from "@/lib/products/team";
-import { getProductModule } from "@/lib/products/shared/registry";
-import { buildResponseActivationState } from "@/lib/response-activation";
-import { getScanDefinition } from "@/lib/scan-definitions";
+import Link from "next/link"
+import { notFound } from "next/navigation"
+import { ExitProductDashboard } from "@/components/dashboard/exit-product-dashboard"
+import { SuiteAccessDenied } from "@/components/dashboard/suite-access-denied"
+import { getManagementBandLabel } from "@/lib/management-language"
+import { getScanDefinition } from "@/lib/scan-definitions"
 import {
   getDashboardModuleHref,
   getDashboardModuleKeyForScanType,
   getDashboardModuleLabel,
-} from "@/lib/dashboard/shell-navigation";
-import { loadSuiteAccessContext } from "@/lib/suite-access-server";
-import { FACTOR_LABELS, hasCampaignAddOn } from "@/lib/types";
-import type { CampaignStats, Respondent, SurveyResponse } from "@/lib/types";
+} from "@/lib/dashboard/shell-navigation"
+import { loadSuiteAccessContext } from "@/lib/suite-access-server"
+import { createClient } from "@/lib/supabase/server"
+import { FACTOR_LABELS, hasCampaignAddOn } from "@/lib/types"
+import type { CampaignStats, Respondent, SurveyResponse } from "@/lib/types"
+import { PdfDownloadButton } from "./pdf-download-button"
+import {
+  MethodologyCard,
+  MIN_N_DISPLAY,
+  MIN_N_PATTERNS,
+  computeAverageSignalScore,
+  computeFactorAverages,
+  computeStrongWorkSignalRate,
+  getTopContributingReasonLabel,
+  getTopExitReasonLabel,
+} from "./page-helpers"
+import { ResultsLayout } from "./results-layout"
+import {
+  buildResultsViewModel,
+  type ResultsBlockVisibility,
+} from "./results-view-model"
 
 interface Props {
-  params: Promise<{ id: string }>;
+  params: Promise<{ id: string }>
 }
 
-type PresentationMetricKey =
-  | "signal"
-  | "owner"
-  | "next-step"
-  | "review"
-  | "response"
-  | "readiness";
-
-type PresentationMetric = {
-  label: string;
-  value: string;
-  tone: "slate" | "blue" | "emerald" | "amber";
-  accent?: string;
-  helpText?: string;
-};
-
-function buildPresentationMetrics({
-  productExperience,
-  scanDefinition,
-  dashboardViewModel,
-  averageRiskScore,
-  totalCompleted,
-  totalInvited,
-  compositionStateMeta,
-  hasEnoughData,
-}: {
-  productExperience: {
-    summarySignalLabel: string;
-    summaryFocusLabel: string;
-    reviewLabel: string;
-  };
-  scanDefinition: ReturnType<typeof getScanDefinition>;
-  dashboardViewModel: {
-    topSummaryCards: Array<{ title: string; value?: string }>;
-    nextStep: { title: string };
-  };
-  averageRiskScore: number | null;
-  totalCompleted: number;
-  totalInvited: number;
-  compositionStateMeta: {
-    label: string;
-    tone: "slate" | "blue" | "emerald" | "amber";
-  };
-  hasEnoughData: boolean;
-}): Record<PresentationMetricKey, PresentationMetric> {
-  const ownerValue =
-    findPresentationCardValue(dashboardViewModel.topSummaryCards, [
-      "Eerste eigenaar",
-    ]) ?? "Nog niet vrijgegeven";
-  const reviewValue =
-    findPresentationCardValue(dashboardViewModel.topSummaryCards, [
-      "Reviewmoment",
-      "Reviewgrens",
-      "Leesgrens",
-    ]) ?? "Nog indicatief";
-
-  return {
-    signal: {
-      label: productExperience.summarySignalLabel,
-      value:
-        averageRiskScore !== null
-          ? `${averageRiskScore.toFixed(1)}/10`
-          : "Nog geen veilig beeld",
-      tone: averageRiskScore !== null ? "slate" : "amber",
-      helpText: scanDefinition.signalHelp,
-    },
-    owner: {
-      label: "Eerste eigenaar",
-      value: ownerValue,
-      tone: "slate",
-    },
-    "next-step": {
-      label: productExperience.summaryFocusLabel,
-      value: dashboardViewModel.nextStep.title,
-      tone: hasEnoughData ? "slate" : "amber",
-    },
-    review: {
-      label: productExperience.reviewLabel,
-      value: reviewValue,
-      tone: "slate",
-    },
-    response: {
-      label: "Responsstatus",
-      value: `${totalCompleted}/${totalInvited || 0} ingevuld`,
-      tone: hasEnoughData ? "emerald" : "amber",
-    },
-    readiness: {
-      label: "Dashboardstatus",
-      value: compositionStateMeta.label,
-      tone: compositionStateMeta.tone,
-    },
-  };
+type FactorRow = {
+  factor: string
+  score: string
+  scoreValue: number
+  signal: string
+  signalValue: number
+  band: string
+  note: string
 }
 
-function findPresentationCardValue(
-  cards: Array<{ title: string; value?: string }>,
-  titles: string[],
-) {
-  for (const title of titles) {
-    const match = cards.find((card) => card.title === title && card.value);
-    if (match?.value) return match.value;
-  }
-
-  return null;
+type SdtRow = {
+  factor: string
+  score: string
+  scoreValue: number
+  signal: string
+  band: string
+  note: string
 }
 
-function normalizeInformationalTone(
-  tone: "slate" | "blue" | "emerald" | "amber",
-) {
-  return tone === "blue" ? "slate" : tone;
+type NarrativeItem = {
+  title: string
+  tag: string
+  body: string
 }
+
+type ContributingItem = {
+  label: string
+  value: string
+  body: string
+}
+
+const PRIMARY_RESULTS_ORDER = {
+  response: "Responsbasis",
+  signal: "Kernsignaal",
+  synthesis: "Signalen in samenhang",
+  drivers: "Drivers & prioriteiten",
+  depth: "Verdiepingslagen",
+  voices: "Survey-stemmen",
+} as const
 
 function formatRoutePeriodLabel(campaignName: string, createdAt: string) {
   const quarterMatch = campaignName.match(/Q[1-4]\s?\d{4}/i)
@@ -261,6 +95,15 @@ function deriveScopeLabel(respondents: Respondent[]) {
   return `${departments[0]}, ${departments[1]} + ${departments.length - 2} meer`
 }
 
+function getDashboardModuleBackLinkLabel(scanType: CampaignStats["scan_type"]) {
+  if (scanType === "exit") return "Terug naar alle ExitScans"
+  if (scanType === "retention") return "Terug naar alle RetentieScans"
+  if (scanType === "onboarding") return "Terug naar alle Onboarding 30-60-90-routes"
+  if (scanType === "pulse") return "Terug naar alle Pulse-routes"
+  if (scanType === "leadership") return "Terug naar alle Leadership Scans"
+  return "Terug naar overzicht"
+}
+
 function buildResponseContextNote(totalCompleted: number, completionRate: number) {
   if (totalCompleted >= MIN_N_PATTERNS) {
     return `Responsbasis van ${completionRate}% is stevig genoeg voor een eerste lezing. Lees verschillen nog steeds in samenhang met scope en context.`
@@ -269,38 +112,7 @@ function buildResponseContextNote(totalCompleted: number, completionRate: number
   return `Eerste read is zichtbaar, maar detail blijft nog begrensd. Gebruik de responsbasis van ${completionRate}% vooral om richting te bepalen, niet om al te ver te concluderen.`
 }
 
-function buildExitPictureDistribution(responses: SurveyResponse[]) {
-  const counts = {
-    work: 0,
-    pull: 0,
-    situational: 0,
-  }
-
-  for (const response of responses) {
-    const code = response.exit_reason_code
-    if (!code) continue
-    if (code.startsWith("PL")) counts.pull += 1
-    else if (code.startsWith("S")) counts.situational += 1
-    else counts.work += 1
-  }
-
-  const total = counts.work + counts.pull + counts.situational
-  const toPercent = (value: number) => (total > 0 ? Math.round((value / total) * 100) : 0)
-
-  return {
-    total,
-    workPercent: toPercent(counts.work),
-    pullPercent: toPercent(counts.pull),
-    situationalPercent: toPercent(counts.situational),
-    segments: [
-      { label: "Werkfrictie zichtbaar", value: `${toPercent(counts.work)}%`, percent: toPercent(counts.work) },
-      { label: "Andere trekfactoren zichtbaar", value: `${toPercent(counts.pull)}%`, percent: toPercent(counts.pull) },
-      { label: "Situationele context zichtbaar", value: `${toPercent(counts.situational)}%`, percent: toPercent(counts.situational) },
-    ],
-  }
-}
-
-function buildExitSurveyVoices(responses: SurveyResponse[]) {
+function buildVisibleVoices(responses: SurveyResponse[]) {
   const sanitize = (value: string) =>
     value
       .replace(/\s+/g, " ")
@@ -323,7 +135,46 @@ function buildExitSurveyVoices(responses: SurveyResponse[]) {
       return true
     })
     .slice(0, 2)
-    .map((text) => (text.length > 180 ? `${text.slice(0, 177).trimEnd()}...` : text))
+}
+
+function buildExitPictureDistribution(responses: SurveyResponse[]) {
+  const counts = {
+    work: 0,
+    pull: 0,
+    situational: 0,
+  }
+
+  for (const response of responses) {
+    const code = response.exit_reason_code
+    if (!code) continue
+    if (code.startsWith("PL")) counts.pull += 1
+    else if (code.startsWith("S")) counts.situational += 1
+    else counts.work += 1
+  }
+
+  const total = counts.work + counts.pull + counts.situational
+  const toPercent = (value: number) => (total > 0 ? Math.round((value / total) * 100) : 0)
+
+  return {
+    total,
+    segments: [
+      {
+        label: "Werkfrictie zichtbaar",
+        value: `${toPercent(counts.work)}%`,
+        percent: toPercent(counts.work),
+      },
+      {
+        label: "Andere trekfactoren zichtbaar",
+        value: `${toPercent(counts.pull)}%`,
+        percent: toPercent(counts.pull),
+      },
+      {
+        label: "Situationele context zichtbaar",
+        value: `${toPercent(counts.situational)}%`,
+        percent: toPercent(counts.situational),
+      },
+    ],
+  }
 }
 
 function buildExitNarratives(args: {
@@ -333,8 +184,8 @@ function buildExitNarratives(args: {
   topContributingReasonLabel: string | null
   strongWorkSignalRate: number | null
   distribution: ReturnType<typeof buildExitPictureDistribution>
-}) {
-  const items = []
+}): NarrativeItem[] {
+  const items: NarrativeItem[] = []
 
   if (args.topFactorLabel) {
     items.push({
@@ -360,104 +211,44 @@ function buildExitNarratives(args: {
     })
   }
 
-  if (args.strongWorkSignalRate !== null) {
+  if (items.length < 3) {
     items.push({
-      title: "Beïnvloedbare werkcontext blijft bestuurlijk relevant",
+      title: "Werkfrictie blijft de dominante lezing",
+      tag: "Vertrekbeeld",
+      body: `${args.distribution.segments[0]?.value ?? "0%"} van het vertrekbeeld valt in werkfrictie. Andere trekfactoren en situationele context blijven zichtbaar, maar dragen minder hard de eerste managementread.`,
+    })
+  }
+
+  if (items.length < 3 && args.strongWorkSignalRate !== null) {
+    items.push({
+      title: "Beinvloedbare werkcontext blijft bestuurlijk relevant",
       tag: "Werkbaarheid",
       body: `${args.strongWorkSignalRate}% van de leesbare responses valt in sterk werksignaal. Daardoor blijft deze route bestuurlijk vooral een intern werkvraagstuk, niet alleen een marktvraagstuk.`,
     })
   }
 
-  if (items.length < 3) {
-    items.push({
-      title: "Werkfrictie blijft de dominante lezing",
-      tag: "Vertrekbeeld",
-      body: `${args.distribution.workPercent}% van het vertrekbeeld valt in werkfrictie. Andere trekfactoren en situationele context blijven zichtbaar, maar dragen minder hard de eerste managementread.`,
-    })
-  }
-
   return items.slice(0, 3)
-}
-
-function buildRetentionNarratives(args: {
-  topFactorLabel: string | null
-  secondFactorLabel: string | null
-  retentionThemes: Array<{ title: string; implication: string; sample: string }>
-  averageRiskScore: number | null
-  turnoverIntention: number | null
-  engagement: number | null
-}) {
-  const items = []
-
-  if (args.topFactorLabel) {
-    items.push({
-      title: `${args.topFactorLabel} draagt de eerste behoudsdruk`,
-      tag: "Hoofdpatroon",
-      body: `${args.topFactorLabel} ligt het scherpst onder de organisatiefactoren en hoort daarom de eerste bestuurlijke leesrichting te bepalen.`,
-    })
-  }
-
-  if (args.secondFactorLabel) {
-    items.push({
-      title: `${args.secondFactorLabel} versterkt het risico`,
-      tag: "Samenhang",
-      body: `${args.secondFactorLabel} staat niet los, maar vergroot de kans dat behoudsdruk harder voelbaar wordt naast de eerste driver.`,
-    })
-  }
-
-  if (args.retentionThemes[0]) {
-    items.push({
-      title: args.retentionThemes[0].title,
-      tag: "Open signalen",
-      body: args.retentionThemes[0].implication,
-    })
-  }
-
-  if (items.length < 3 && args.averageRiskScore !== null && args.turnoverIntention !== null) {
-    items.push({
-      title: "Retentiesignaal, vertrekintentie en bevlogenheid moeten samen gelezen worden",
-      tag: "Leesdiscipline",
-      body: `Met een retentiesignaal van ${args.averageRiskScore.toFixed(1)}/10, vertrekintentie op ${args.turnoverIntention.toFixed(1)}/10 en bevlogenheid op ${args.engagement?.toFixed(1) ?? "-"}/10 ontstaat de bestuurlijke kern in de verhouding tussen blijven, twijfelen en actief willen vertrekken.`,
-    })
-  }
-
-  return items.slice(0, 3)
-}
-
-function getDashboardModuleBackLinkLabel(scanType: CampaignStats["scan_type"]) {
-  if (scanType === "exit") return "Terug naar alle ExitScans"
-  if (scanType === "retention") return "Terug naar alle RetentieScans"
-  if (scanType === "onboarding") return "Terug naar alle Onboarding 30-60-90-routes"
-  if (scanType === "pulse") return "Terug naar alle Pulse-routes"
-  if (scanType === "leadership") return "Terug naar alle Leadership Scans"
-  return "Terug naar overzicht"
 }
 
 function buildFactorPriorityRows(factorAverages: Record<string, number>) {
   return Object.entries(factorAverages)
     .map(([factor, score]) => {
-      const signalScore = 11 - score
-      const presentation = buildFactorPresentation({
-        score,
-        signalScore,
-        managementLabel: getManagementBandLabel(signalScore),
-        showSignal: true,
-      })
+      const signalValue = 11 - score
 
       return {
         factor: FACTOR_LABELS[factor] ?? factor,
-        score: presentation.scoreDisplay,
+        score: `${score.toFixed(1)}/10`,
         scoreValue: score,
-        signal: presentation.signalDisplay,
-        band: presentation.managementLabel,
+        signal: `${signalValue.toFixed(1)}/10`,
+        signalValue,
+        band: getManagementBandLabel(signalValue),
         note:
-          signalScore >= 7
+          signalValue >= 7
             ? "Vraagt in dit beeld als eerste aandacht."
-            : signalScore >= 4.5
+            : signalValue >= 4.5
               ? "Eerst toetsen voordat deze factor zwaarder meeweegt."
               : "Zichtbaar, maar niet de eerste factor om te openen.",
-        signalValue: signalScore,
-      }
+      } satisfies FactorRow
     })
     .sort((left, right) => right.signalValue - left.signalValue)
 }
@@ -474,71 +265,153 @@ function buildSdtRows(sdtAverages: {
   ]
     .filter((item) => typeof item.value === "number")
     .map((item) => {
-      const signalScore = 11 - Number(item.value)
+      const scoreValue = Number(item.value)
+      const signalValue = 11 - scoreValue
+
       return {
         factor: item.label,
-        score: `${Number(item.value).toFixed(1)}/10`,
-        scoreValue: Number(item.value),
-        signal: `${signalScore.toFixed(1)}/10`,
-        band: getManagementBandLabel(signalScore),
+        score: `${scoreValue.toFixed(1)}/10`,
+        scoreValue,
+        signal: `${signalValue.toFixed(1)}/10`,
+        band: getManagementBandLabel(signalValue),
         note:
-          signalScore >= 7
+          signalValue >= 7
             ? "Draagt duidelijk mee aan het vertrekbeeld."
-            : signalScore >= 4.5
+            : signalValue >= 4.5
               ? "Relevant als verdiepingslaag naast de organisatiefactoren."
               : "Ondersteunend, maar niet de eerste driver van dit beeld.",
-      }
+      } satisfies SdtRow
     })
 }
 
-function buildRetentionSignalSegments(riskDistribution: {
-  HOOG: number
-  MIDDEN: number
-  LAAG: number
-}) {
-  const total = riskDistribution.HOOG + riskDistribution.MIDDEN + riskDistribution.LAAG
-  const toPercent = (value: number) => (total > 0 ? Math.round((value / total) * 100) : 0)
-
-  return [
-    { label: "Actief vertrekdenkend", value: `${toPercent(riskDistribution.HOOG)}%`, percent: toPercent(riskDistribution.HOOG) },
-    { label: "Latent risico", value: `${toPercent(riskDistribution.MIDDEN)}%`, percent: toPercent(riskDistribution.MIDDEN) },
-    { label: "Stabiel", value: `${toPercent(riskDistribution.LAAG)}%`, percent: toPercent(riskDistribution.LAAG) },
-  ]
+function getResultsStatusLabel(readState: ReturnType<typeof buildResultsViewModel>["readState"]) {
+  if (readState === "readable") return "Leesbaar"
+  if (readState === "early-read") return "Eerste read"
+  return "Nog aan het opbouwen"
 }
 
-function buildEngagementSegments(responses: SurveyResponse[]) {
-  const counts = { high: 0, mid: 0, low: 0 }
+function ResultsBlockCard({
+  title,
+  visibility,
+  value,
+  body,
+  href,
+  linkLabel,
+}: {
+  title: string
+  visibility: ResultsBlockVisibility
+  value?: string
+  body: string
+  href?: string
+  linkLabel?: string
+}) {
+  const toneClasses =
+    visibility === "visible"
+      ? "border-slate-200 bg-white"
+      : "border-dashed border-slate-200 bg-slate-50"
 
-  for (const response of responses) {
-    const value = response.uwes_score
-    if (typeof value !== "number") continue
-    if (value >= 7) counts.high += 1
-    else if (value >= 5) counts.mid += 1
-    else counts.low += 1
-  }
+  return (
+    <div className={`rounded-[22px] px-5 py-5 shadow-sm ${toneClasses}`}>
+      <div className="flex items-start justify-between gap-3">
+        <h2 className="text-lg font-semibold tracking-[-0.02em] text-[color:var(--dashboard-ink)]">
+          {title}
+        </h2>
+        <span className="rounded-full bg-slate-100 px-3 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-slate-600">
+          {visibility === "visible" ? "Vrij" : "Begrensd"}
+        </span>
+      </div>
+      {value ? (
+        <p className="mt-4 text-xl font-semibold tracking-[-0.03em] text-[color:var(--dashboard-ink)]">
+          {value}
+        </p>
+      ) : null}
+      <p className="mt-3 text-sm leading-6 text-[color:var(--dashboard-text)]">{body}</p>
+      {href && linkLabel ? (
+        <Link
+          href={href}
+          className="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-slate-700 transition-colors hover:text-slate-950"
+        >
+          {linkLabel}
+        </Link>
+      ) : null}
+    </div>
+  )
+}
 
-  const total = counts.high + counts.mid + counts.low
-  const toPercent = (value: number) => (total > 0 ? Math.round((value / total) * 100) : 0)
-
-  return [
-    { label: "Bevlogen", value: `${toPercent(counts.high)}%`, percent: toPercent(counts.high) },
-    { label: "Wisselend", value: `${toPercent(counts.mid)}%`, percent: toPercent(counts.mid) },
-    { label: "Laag bevlogen", value: `${toPercent(counts.low)}%`, percent: toPercent(counts.low) },
-  ]
+function ResultsShellHeader({
+  moduleHref,
+  moduleLabel,
+  moduleBackLinkLabel,
+  campaignName,
+  organizationName,
+  routePeriodLabel,
+  scopeLabel,
+  statusLabel,
+  campaignId,
+  scanType,
+}: {
+  moduleHref: string
+  moduleLabel: string
+  moduleBackLinkLabel: string
+  campaignName: string
+  organizationName: string
+  routePeriodLabel: string
+  scopeLabel: string
+  statusLabel: string
+  campaignId: string
+  scanType: string
+}) {
+  return (
+    <div className="space-y-4 border-b border-slate-200/80 pb-5">
+      <p className="text-[0.78rem] font-medium tracking-[0.01em] text-slate-500">
+        <Link href="/dashboard" className="transition-colors hover:text-slate-700">
+          Overzicht
+        </Link>{" "}
+        /{" "}
+        <Link href={moduleHref} className="transition-colors hover:text-slate-700">
+          {moduleLabel}
+        </Link>{" "}
+        / <span className="text-slate-700">{campaignName}</span>
+      </p>
+      <Link
+        href={moduleHref}
+        className="inline-flex items-center gap-2 text-sm font-medium text-slate-500 transition-colors hover:text-slate-700"
+      >
+        <span aria-hidden="true">&larr;</span> {moduleBackLinkLabel}
+      </Link>
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center gap-2.5">
+            <span className="inline-flex rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-slate-600">
+              {statusLabel}
+            </span>
+          </div>
+          <h1 className="font-serif text-[2.6rem] leading-[0.96] tracking-[-0.055em] text-[color:var(--dashboard-ink)] sm:text-[3.15rem]">
+            {campaignName}
+          </h1>
+          <p className="text-sm leading-6 text-slate-600">
+            {organizationName} <span aria-hidden="true">&middot;</span> {routePeriodLabel}{" "}
+            <span aria-hidden="true">&middot;</span> {scopeLabel}
+          </p>
+        </div>
+        <PdfDownloadButton campaignId={campaignId} campaignName={campaignName} scanType={scanType} />
+      </div>
+    </div>
+  )
 }
 
 export default async function CampaignPage({ params }: Props) {
-  const { id } = await params;
-  const supabase = await createClient();
+  const { id } = await params
+  const supabase = await createClient()
   const {
     data: { user },
-  } = await supabase.auth.getUser();
+  } = await supabase.auth.getUser()
 
   if (!user) {
-    notFound();
+    notFound()
   }
 
-  const { context } = await loadSuiteAccessContext(supabase, user.id);
+  const { context } = await loadSuiteAccessContext(supabase, user.id)
 
   if (!context.canViewInsights) {
     return (
@@ -546,1617 +419,79 @@ export default async function CampaignPage({ params }: Props) {
         title="Je ziet hier geen campagnedetail"
         description="Jouw login opent alleen Action Center voor toegewezen teams. Surveyresultaten, campagnedetails en rapporten blijven zichtbaar voor HR en Loep."
       />
-    );
+    )
   }
 
   const { data: statsRow } = await supabase
     .from("campaign_stats")
     .select("*")
     .eq("campaign_id", id)
-    .single();
+    .single()
 
-  if (!statsRow) notFound();
-  const stats = statsRow as CampaignStats;
+  if (!statsRow) notFound()
+  const stats = statsRow as CampaignStats
 
-  const { data: previousStatsRows } = await supabase
-    .from("campaign_stats")
-    .select("*")
-    .eq("organization_id", stats.organization_id)
-    .eq("scan_type", stats.scan_type)
-    .lt("created_at", stats.created_at)
-    .order("created_at", { ascending: false })
-    .limit(1);
-  const previousStats =
-    (previousStatsRows?.[0] as CampaignStats | undefined) ?? null;
-
-  const [
-    { data: profile },
-    { data: membership },
-    { data: organization },
-    { data: campaignMeta },
-    { count: activeClientAccessCount },
-    { count: pendingClientInviteCount },
-  ] = await Promise.all([
-    user
-      ? supabase
-          .from("profiles")
-          .select("is_verisight_admin")
-          .eq("id", user.id)
-          .maybeSingle()
-      : Promise.resolve({ data: null }),
-    user
-      ? supabase
-          .from("org_members")
-          .select("role")
-          .eq("org_id", stats.organization_id)
-          .eq("user_id", user.id)
-          .maybeSingle()
-      : Promise.resolve({ data: null }),
-    supabase
-      .from("organizations")
-      .select("name")
-      .eq("id", stats.organization_id)
-      .maybeSingle(),
-    supabase
-      .from("campaigns")
-      .select("enabled_modules, delivery_mode")
-      .eq("id", id)
-      .maybeSingle(),
-    supabase
-      .from("org_members")
-      .select("id", { count: "exact", head: true })
-      .eq("org_id", stats.organization_id)
-      .in("role", ["viewer", "member"]),
-    supabase
-      .from("org_invites")
-      .select("id", { count: "exact", head: true })
-      .eq("org_id", stats.organization_id)
-      .is("accepted_at", null),
-  ]);
-
-  const canManageCampaign =
-    profile?.is_verisight_admin === true ||
-    getCustomerActionPermission(membership?.role ?? null, "review_launch");
-  const isVerisightAdmin = profile?.is_verisight_admin === true;
-  const canExecuteCampaign =
-    isVerisightAdmin ||
-    getCustomerActionPermission(
-      membership?.role ?? null,
-      "import_respondents",
-    ) ||
-    getCustomerActionPermission(membership?.role ?? null, "launch_invites") ||
-    getCustomerActionPermission(membership?.role ?? null, "send_reminders");
-  const hasSegmentDeepDive = hasCampaignAddOn(
-    campaignMeta,
-    "segment_deep_dive",
-  );
-  const deliveryAdminClient = canExecuteCampaign ? createAdminClient() : null;
-  const { data: deliveryVisibilityRecord } = deliveryAdminClient
-    ? await deliveryAdminClient
-        .from("campaign_delivery_records")
-        .select("id")
-        .eq("campaign_id", id)
-        .maybeSingle()
-    : { data: null };
-  const { data: importQaCheckpointRaw } =
-    deliveryAdminClient && deliveryVisibilityRecord?.id
-      ? await deliveryAdminClient
-          .from("campaign_delivery_checkpoints")
-          .select("auto_state")
-          .eq("delivery_record_id", deliveryVisibilityRecord.id)
-          .eq("checkpoint_key", "import_qa")
-          .maybeSingle()
-      : { data: null };
-  const importReady = importQaCheckpointRaw?.auto_state === "ready";
-  const { data: deliveryRecordRaw } = await supabase
-    .from("campaign_delivery_records")
-    .select("*")
-    .eq("campaign_id", id)
-    .maybeSingle();
-  const deliveryRecord = (deliveryRecordRaw ??
-    null) as CampaignDeliveryRecord | null;
-  const { data: deliveryCheckpointsRaw } = deliveryRecord
-    ? await supabase
-        .from("campaign_delivery_checkpoints")
+  const [{ data: organization }, { data: campaignMeta }, { data: responsesRaw }, { data: respondentsRaw }] =
+    await Promise.all([
+      supabase.from("organizations").select("name").eq("id", stats.organization_id).maybeSingle(),
+      supabase.from("campaigns").select("enabled_modules").eq("id", id).maybeSingle(),
+      supabase
+        .from("survey_responses")
+        .select(
+          `
+          id,
+          respondent_id,
+          risk_score,
+          signal_score,
+          risk_band,
+          preventability,
+          stay_intent_score,
+          direction_signal_score,
+          uwes_score,
+          turnover_intention_score,
+          exit_reason_code,
+          sdt_scores,
+          org_scores,
+          open_text_raw,
+          open_text_analysis,
+          full_result,
+          submitted_at,
+          respondents!inner(id, campaign_id, department, role_level, completed, completed_at, token)
+        `,
+        )
+        .eq("respondents.campaign_id", id),
+      supabase
+        .from("respondents")
         .select("*")
-        .eq("delivery_record_id", deliveryRecord.id)
-        .order("created_at", { ascending: true })
-    : { data: [] };
-  const deliveryCheckpoints = (deliveryCheckpointsRaw ??
-    []) as CampaignDeliveryCheckpoint[];
-  const guidedSetupDiscipline = deriveGuidedSelfServeDiscipline(
-    deliveryCheckpoints
-      .filter(
-        (
-          checkpoint,
-        ): checkpoint is CampaignDeliveryCheckpoint & {
-          checkpoint_key:
-            | "implementation_intake"
-            | "import_qa"
-            | "invite_readiness";
-        } =>
-          checkpoint.checkpoint_key === "implementation_intake" ||
-          checkpoint.checkpoint_key === "import_qa" ||
-          checkpoint.checkpoint_key === "invite_readiness",
-      )
-      .map((checkpoint) => ({
-        checkpointKey: checkpoint.checkpoint_key,
-        manualState: checkpoint.manual_state,
-      })),
-  );
-  const { data: auditEventsRaw } =
-    isVerisightAdmin || Boolean(membership?.role)
-      ? await supabase
-          .from("campaign_action_audit_events")
-          .select(
-            "id, action_key, outcome, action_label, owner_label, actor_role, actor_label, summary, metadata, created_at",
-          )
-          .eq("campaign_id", id)
-          .order("created_at", { ascending: false })
-          .limit(8)
-      : { data: [] };
-  const auditEvents = (auditEventsRaw ?? []) as CampaignAuditEventRecord[];
-  const {
-    rows: deliveryLeadOptions,
-    configError: deliveryLeadConfigError,
-    loadError: deliveryLeadLoadError,
-  } = isVerisightAdmin
-    ? await getContactRequestsForAdmin(100)
-    : { rows: [], configError: null, loadError: null };
-  const deliveryLeadError = deliveryLeadConfigError ?? deliveryLeadLoadError;
-
-  const { data: responsesRaw } = await supabase
-    .from("survey_responses")
-    .select(
-      `
-      id, respondent_id, risk_score, risk_band, preventability, stay_intent_score, uwes_score, turnover_intention_score,
-      exit_reason_code, sdt_scores, org_scores, open_text_raw, open_text_analysis, full_result,
-      submitted_at,
-      respondents!inner(id, campaign_id, department, role_level, completed, completed_at, token)
-    `,
-    )
-    .eq("respondents.campaign_id", id);
-  const responses = (responsesRaw ?? []) as unknown as (SurveyResponse & {
-    respondents: Respondent;
-  })[];
-
-  let previousResponses: (SurveyResponse & { respondents: Respondent })[] = [];
-  if (
-    (stats.scan_type === "retention" || stats.scan_type === "pulse") &&
-    previousStats
-  ) {
-    const { data: previousResponsesRaw } = await supabase
-      .from("survey_responses")
-      .select(
-        `
-        id, respondent_id, risk_score, risk_band, preventability, stay_intent_score, uwes_score, turnover_intention_score,
-        exit_reason_code, sdt_scores, org_scores, open_text_raw, open_text_analysis, full_result,
-        submitted_at,
-        respondents!inner(id, campaign_id, department, role_level, completed, completed_at, token)
-      `,
-      )
-      .eq("respondents.campaign_id", previousStats.campaign_id);
-
-    previousResponses = (previousResponsesRaw ??
-      []) as unknown as (SurveyResponse & {
-      respondents: Respondent;
-    })[];
-  }
-
-  const { data: allRespondents } = await supabase
-    .from("respondents")
-    .select("*")
-    .eq("campaign_id", id)
-    .order("completed_at", { ascending: false, nullsFirst: false });
-  const respondents = (allRespondents ?? []) as Respondent[];
-  const unsentRespondents = respondents
-    .filter((respondent) => !respondent.sent_at && !respondent.completed)
-    .map((respondent) => ({
-      token: respondent.token,
-      email: respondent.email ?? null,
-    }));
-  const remindableCount = respondents.filter(
-    (respondent) => Boolean(respondent.sent_at) && !respondent.completed,
-  ).length;
-
-  const factorData = computeFactorAverages(responses);
-  const averageRiskScore = computeAverageSignalScore(responses);
-  const strongWorkSignalRate =
-    stats.scan_type === "exit" ? computeStrongWorkSignalRate(responses) : null;
-  const topExitReasonLabel =
-    stats.scan_type === "exit" ? getTopExitReasonLabel(responses) : null;
-  const topContributingReasonLabel =
-    stats.scan_type === "exit"
-      ? getTopContributingReasonLabel(responses)
-      : null;
-  const signalVisibilityAverage =
-    stats.scan_type === "exit"
-      ? computeAverageSignalVisibility(responses)
-      : null;
-  const retentionSupplemental = computeRetentionSupplementalAverages(responses);
-  const currentRetentionSignals =
-    stats.scan_type === "retention"
-      ? { retentionSignal: averageRiskScore, ...retentionSupplemental }
-      : null;
-  const previousRetentionSignals =
-    stats.scan_type === "retention" && previousResponses.length > 0
-      ? computeRetentionSignalAverages(previousResponses)
-      : null;
-  const currentPulseSignals =
-    stats.scan_type === "pulse" ? computePulseSignalAverages(responses) : null;
-  const previousPulseSignals =
-    stats.scan_type === "pulse" && previousResponses.length > 0
-      ? computePulseSignalAverages(previousResponses)
-      : null;
-  const pulseComparison =
-    stats.scan_type === "pulse"
-      ? buildPulseComparisonState({
-          current: currentPulseSignals ?? computePulseSignalAverages([]),
-          previous: previousPulseSignals,
-          currentResponsesLength: responses.length,
-          previousResponsesLength: previousResponses.length,
-        })
-      : null;
-  const teamLocalRead =
-    stats.scan_type === "team" ? buildTeamLocalReadState(responses) : null;
-  const teamPriorityRead =
-    stats.scan_type === "team" && teamLocalRead
-      ? buildTeamPriorityReadState(teamLocalRead)
-      : null;
-
-  const hasEnoughData = responses.length >= MIN_N_PATTERNS;
-  const hasMinDisplay = responses.length >= MIN_N_DISPLAY;
-  const scanDefinition = getScanDefinition(stats.scan_type);
-  const productModule = getProductModule(stats.scan_type);
-  const teamPriorityBand = (signalValue: number) =>
-    signalValue >= 7 ? "HOOG" : signalValue >= 4.5 ? "MIDDEN" : "LAAG";
-  const pendingCount = stats.total_invited - stats.total_completed;
-  const dashboardViewModel = productModule.buildDashboardViewModel({
-    signalLabelLower: scanDefinition.signalLabelLower,
-    averageSignal: averageRiskScore,
-    strongWorkSignalRate,
-    engagement: retentionSupplemental.engagement,
-    turnoverIntention: retentionSupplemental.turnoverIntention,
-    stayIntent: retentionSupplemental.stayIntent,
-    hasEnoughData,
-    hasMinDisplay,
-    pendingCount,
-    factorAverages: factorData.orgAverages,
-    topExitReasonLabel,
-    topContributingReasonLabel,
-    signalVisibilityAverage,
-  });
-
-  const invitesNotSent = respondents.filter(
-    (respondent) => !respondent.sent_at && !respondent.completed,
-  ).length;
-  const incompleteScores = responses.filter(
-    (response) => !response.org_scores || !response.sdt_scores,
-  ).length;
-  const launchControlState = buildLaunchControlState({
-    launchDate: deliveryRecord?.launch_date ?? null,
-    participantCommsConfig: deliveryRecord?.participant_comms_config ?? null,
-    reminderConfig: deliveryRecord?.reminder_config ?? null,
-    launchConfirmedAt: deliveryRecord?.launch_confirmed_at ?? null,
-  });
-  const readinessState = buildCampaignReadinessState({
-    totalInvited: stats.total_invited,
-    totalCompleted: stats.total_completed,
-    invitesNotSent,
-    incompleteScores,
-    hasMinDisplay,
-    hasEnoughData,
-    activeClientAccessCount: activeClientAccessCount ?? 0,
-    pendingClientInviteCount: pendingClientInviteCount ?? 0,
-    importReady,
-    launchControlReady: launchControlState.ready,
-    launchControlBlockers: launchControlState.blockers,
-  });
-  const compositionState = getCampaignCompositionState({
-    isActive: stats.is_active,
-    totalInvited: stats.total_invited,
-    totalCompleted: stats.total_completed,
-    invitesNotSent,
-    incompleteScores,
-    hasMinDisplay,
-    hasEnoughData,
-  });
-  const activationState = buildResponseActivationState(stats.total_completed);
-  const showClientExecutionFlow =
-    !isVerisightAdmin && compositionState !== "closed";
-  const showManagementOutput = isManagementVisibleState(compositionState);
-  const showDeeperInsights =
-    compositionState === "full" || compositionState === "closed";
-  const showDetailedManagementOutput = showDeeperInsights;
-  const demoteFollowThroughLayers =
-    showDetailedManagementOutput &&
-    stats.scan_type !== "exit" &&
-    stats.scan_type !== "retention";
-  const showPartialManagementOutput = compositionState === "partial";
-  const prefersReportFirst = compositionState === "closed";
-  const canOpenActionCenterFromDeliveryRecord = deliveryRecord
-    ? canOpenActionCenterRoute(deliveryRecord)
-    : false;
-  const actionCenterBridge = buildCampaignDetailActionCenterBridge({
-    campaignId: id,
-    routeEntryStage:
-      deliveryRecord && hasOpenedActionCenterRoute(deliveryRecord)
-        ? "active"
-        : null,
-    canOpenRoute:
-      showManagementOutput &&
-      isLiveActionCenterScanType(stats.scan_type) &&
-      canOpenActionCenterFromDeliveryRecord,
-    assessedAt: deliveryRecord?.updated_at ?? stats.created_at,
-  });
-  const actionCenterRouteHref = buildActionCenterRouteOpenRedirect(id, "campaign-detail");
-  const compositionStateMeta = {
-    setup: {
-      label: "Nog niet live",
-      tone: "amber" as const,
-      trust:
-        "Deze campagne blijft in setup. Toon hier nog geen managementlaag of rapport-first gedrag.",
-    },
-    ready_to_launch: {
-      label: "Launch klaar",
-      tone: "amber" as const,
-      trust:
-        "Respondenten staan klaar, maar invites zijn nog niet volledig live. Dashboard en rapport blijven bewust secundair.",
-    },
-    running: {
-      label: "Invites live",
-      tone: "amber" as const,
-      trust:
-        "De inviteflow loopt, maar zonder eerste veilige responslaag hoort dit nog als uitvoerstatus te landen.",
-    },
-    sparse: {
-      label: "Indicatief, nog dun",
-      tone: "amber" as const,
-      trust:
-        "Er zijn eerste responses, maar het beeld is nog te dun voor een veilige dashboardread of aanbevelingslaag.",
-    },
-    partial: {
-      label: "Deels zichtbaar",
-      tone: "amber" as const,
-      trust:
-        "De eerste read is open, maar drivers, aanbevelingen en vervolgblokken blijven deels verborgen door thresholds of scorecompleetheid.",
-    },
-    full: {
-      label: "Duiding gereed",
-      tone: "emerald" as const,
-      trust:
-        "Drivers, aanbevelingen en routeblokken mogen nu zichtbaar worden binnen de bestaande productgrenzen.",
-    },
-    closed: {
-      label: "Rapport eerst",
-      tone: "slate" as const,
-      trust:
-      "Deze campagne is gesloten. Gebruik dashboard en rapport nu voor terugblik, context en bestuurlijke opvolging.",
-    },
-  }[compositionState];
-  const utilitySectionVisible =
-    canExecuteCampaign || respondents.length > 0 || isVerisightAdmin;
-  const riskDistribution = {
-    HOOG: stats.band_high,
-    MIDDEN: stats.band_medium,
-    LAAG: stats.band_low,
-  };
-  const riskHistogram = buildRiskHistogram(responses);
-  const safeTableResponses = buildSafeTableResponses(
-    stats.scan_type,
-    responses,
-  );
-  const retentionTrendCards =
-    stats.scan_type === "retention" &&
-    currentRetentionSignals &&
-    previousRetentionSignals
-      ? buildRetentionTrendCards({
-          current: currentRetentionSignals,
-          previous: previousRetentionSignals,
-        })
-      : [];
-  const retentionSegmentPlaybooks =
-    stats.scan_type === "retention" && hasEnoughData
-      ? buildRetentionSegmentPlaybooks({
-          responses,
-          orgAverageSignal: averageRiskScore,
-          playbooks: productModule.getActionPlaybooks(),
-        })
-      : [];
-  const retentionThemes =
-    stats.scan_type === "retention"
-      ? clusterRetentionOpenSignals(responses)
-      : [];
-  const playbookCalibrationNote =
-    stats.scan_type === "retention"
-      ? (productModule.getActionPlaybookCalibrationNote?.() ?? null)
-      : null;
-  const disclosureDefaults = getDisclosureDefaults({
-    scanType: stats.scan_type,
-    hasEnoughData,
-    hasMinDisplay,
-    respondentsLength: respondents.length,
-    canManageCampaign,
-  });
-  const { data: learningDossiersRaw } =
-    profile?.is_verisight_admin === true
-      ? await supabase
-          .from("pilot_learning_dossiers")
-          .select(
-            "id, title, triage_status, updated_at, review_moment, next_route, stop_reason, management_action_outcome, adoption_outcome",
-          )
-          .eq("campaign_id", id)
-          .order("updated_at", { ascending: false })
-          .limit(3)
-      : { data: [] };
-  const learningDossiers = (learningDossiersRaw ?? []) as Array<{
-    id: string;
-    title: string;
-    triage_status: string;
-    updated_at: string;
-    review_moment: string | null;
-    next_route: string | null;
-    stop_reason: string | null;
-    management_action_outcome: string | null;
-    adoption_outcome: string | null;
-  }>;
-  const learningCloseoutEvidenceCount = learningDossiers.filter((dossier) =>
-    Boolean(
-      dossier.review_moment ||
-      dossier.next_route ||
-      dossier.stop_reason ||
-      dossier.management_action_outcome ||
-      dossier.adoption_outcome,
-    ),
-  ).length;
-  const firstNextStepGuidance = getFirstNextStepGuidance(stats.scan_type);
-  const primaryTeamPriority =
-    stats.scan_type === "team" && teamPriorityRead?.status === "ready"
-      ? (teamPriorityRead.groups.find((group) => group.isPrimary) ?? null)
-      : null;
-  const primaryTeamQuestions =
-    stats.scan_type === "team" && primaryTeamPriority
-      ? (productModule.getFocusQuestions()[primaryTeamPriority.topFactorKey]?.[
-          teamPriorityBand(primaryTeamPriority.topFactorSignalValue)
-        ] ?? [])
-      : [];
-  const primaryTeamPlaybook =
-    stats.scan_type === "team" && primaryTeamPriority
-      ? (productModule.getActionPlaybooks()[primaryTeamPriority.topFactorKey]?.[
-          teamPriorityBand(primaryTeamPriority.topFactorSignalValue)
-        ] ?? null)
-      : null;
-  const handoffTitle =
-    stats.scan_type === "retention"
-      ? "Eerste vervolgstap"
-      : stats.scan_type === "pulse"
-        ? "Pulse duiding en eerste vervolgactie"
-        : stats.scan_type === "team"
-          ? "Lokale duiding en eerste verificatie"
-          : stats.scan_type === "onboarding"
-            ? "Vroege landingsduiding en eerste vervolgstap"
-            : stats.scan_type === "leadership"
-              ? "Managementcontext en eerste verificatie"
-              : "Vertrekduiding en managementgesprek";
-  const handoffDescription =
-    stats.scan_type === "retention"
-      ? "Deze laag volgt dezelfde lijn als het rapport: waar staat behoud onder druk, waarom telt dat bestuurlijk en wat moet eerst geverifieerd worden."
-      : stats.scan_type === "pulse"
-          ? "Deze laag vertaalt Pulse naar een compacte samenvatting: welke review- of herijkingsvraag vraagt nu direct aandacht, wat moet je als eerste bijsturen en wanneer kijk je opnieuw."
-        : stats.scan_type === "team"
-          ? "Deze laag vertaalt TeamScan naar een bestuurlijk leesbare lokale read: welke afdelingen vallen op, wat moet je eerst toetsen en welke lokale context vraagt nu als eerste aandacht."
-          : stats.scan_type === "onboarding"
-            ? "Deze laag vertaalt onboarding naar een bestuurlijk leesbare landingsduiding: waar stokt de vroege landing, wat telt nu bestuurlijk en welke beperkte correctie hoort hier direct achteraan."
-            : stats.scan_type === "leadership"
-              ? "Deze laag vertaalt Leadership Scan naar een leesbare samenvatting: welke context valt op, wat moet je eerst toetsen en welke managementstap hoort hier direct achteraan."
-              : "Deze laag opent met de Frictiescore als samenvatting: wat keert terug, waar lijkt werkfrictie beinvloedbaar en waar moet management eerst doorvragen.";
-  const readinessLabel = activationState.readinessLabel;
-  const focusBadgeLabel =
-    stats.scan_type === "pulse"
-      ? "Signaal -> bijsturen -> opnieuw meten"
-      : stats.scan_type === "team"
-        ? "Lokaliseren -> verifieren -> begrenzen"
-        : stats.scan_type === "onboarding"
-          ? "Vroege landing -> corrigeren -> opnieuw toetsen"
-          : stats.scan_type === "leadership"
-            ? "Duiden -> verifieren -> begrenzen"
-            : stats.scan_type === "retention"
-              ? "Signaleren -> valideren -> handelen"
-              : "Terugblik -> duiden -> verbeteren";
-  const methodologyBadgeLabel =
-    stats.scan_type === "pulse"
-      ? "Reviewcontext"
-      : stats.scan_type === "team"
-        ? "Lokale context"
-        : stats.scan_type === "onboarding"
-          ? "Vroege landing"
-          : stats.scan_type === "leadership"
-            ? "Managementcontext"
-            : stats.scan_type === "retention"
-              ? "Privacy-first"
-              : "Rapportcontext";
-  const productExperience =
-    stats.scan_type === "retention"
-      ? {
-          familyRoleLabel: "Kernroute",
-          familyRoleTone: "emerald" as const,
-          summaryBarOrder: [
-            "signal",
-            "next-step",
-            "response",
-            "readiness",
-          ] as const,
-          heroAsideOrder: ["signal", "owner", "response", "readiness"] as const,
-          summaryFocusLabel: "Eerste route",
-          reviewLabel: "Reviewmoment",
-          evidenceSectionOrder: "management-first" as const,
-          recommendationOrder: "questions-first" as const,
-          trustNotePlacement: "drivers" as const,
-          trustNoteTitle: "Methodische status",
-          trustNoteBody: scanDefinition.evidenceStatusText,
-          trustNoteTone: "emerald" as const,
-          summaryTone: "slate" as const,
-          summarySignalLabel: "Retentiesignaal",
-          summaryContextLabel: "Groepssignaal · eerst toetsen",
-          summaryContextTone: "slate" as const,
-          summaryLeadTitle: "Eerste bestuurlijke leesrichting",
-          summaryLeadDescription:
-            "Lees RetentieScan eerst als groepssignaal: waar staat behoud onder druk, wat vraagt eerst verificatie en welk managementspoor moet daarna in Wat nu als eerste route worden gekozen.",
-          summaryCardEyebrow: "Behoudsspoor",
-          promotedSummaryCards: 2,
-          driverTitle: "Signaalbeeld en behoudsdruk",
-          driverDescription:
-            "Start bij retentiesignaal, trend en aanvullende signalen. Gebruik factoren en segmenten daarna om te bepalen waarom dit beeld ontstaat en waar behoud eerst nadere toetsing vraagt.",
-          driverIntro:
-            "Begin met het groepssignaal en open pas daarna factoren, trend en aanvullende lagen. Zo blijft RetentieScan een eerst-toetsen managementinstrument in plaats van een losse analysetabel.",
-          driverAsideLabel: hasEnoughData
-            ? "Behoudsdrivers beschikbaar"
-            : "Wacht op meer data",
-          driverAsideTone: hasEnoughData
-            ? ("slate" as const)
-            : ("amber" as const),
-          driverTabOrder: ["signalen", "trend", "factoren", "aanvullend"],
-          signalTabLabel: "Retentiesignaal",
-          signalTabTitle: "Retentiesignaal op groepsniveau",
-          signalTabDescription:
-            "Laat zien hoe breed en hoe scherp behoudsdruk zich over de groep verdeelt, zonder dit als individuele voorspelling te lezen.",
-          factorTabLabel: "Behoudsdrivers",
-          factorTabTitle: "Werkfactoren achter behoudsdruk",
-          factorTabDescription:
-            "Gebruik de laagst scorende werkfactoren als eerste verklarende laag voor managementgesprekken en gerichte verificatie.",
-          supplementalTabLabel: "Aanvullende signalen",
-          supplementalTitle: "Aanvullende signalen en SDT-basis",
-          supplementalDescription:
-            "Deze laag voegt bevlogenheid, open signalen en basisbehoeften toe aan het retentiebeeld, zodat trend en werkbeleving samen gelezen worden.",
-          actionTitle: "Waar behoud eerst aandacht vraagt",
-          focusQuestionTitle: "Prioritaire verificatievragen",
-          focusQuestionDescription:
-            "Start met de factoren en signalen die het eerst verificatie vragen. Gebruik de vragen om te bepalen wat in Wat nu de eerste managementroute wordt.",
-          playbookTitle: "Behoudsplaybooks onder de gekozen route",
-          playbookDescription:
-            "Deze playbooks vormen de uitvoerlaag onder de gekozen managementroute. Ze helpen van verificatie naar uitvoering te gaan zonder nieuwe prioriteiten te openen.",
-          routeTitle: "Van retentiesignaal naar managementroute",
-          routeDescription:
-            "Deze laag bundelt de gekozen route, eerste eigenaar, eerste stap en het logische reviewmoment zonder de executive hoofdlijn te verstoren.",
-          routeBadgeLabel: "Kernroute",
-          afterSessionTitle: "Na de eerste managementsessie",
-          afterSessionDescription:
-            "Gebruik het eerste reviewmoment om bewust te kiezen: blijf je op hetzelfde behoudsspoor, is segmentverdieping logisch of vraagt de volgende stap vooral een gerichte interventie en vervolgmeting?",
-        }
-      : stats.scan_type === "team"
-        ? {
-            familyRoleLabel: "Specialistische vervolgstap",
-            familyRoleTone: "blue" as const,
-            summaryBarOrder: [
-              "signal",
-              "next-step",
-              "response",
-              "readiness",
-            ] as const,
-            heroAsideOrder: [
-              "signal",
-              "next-step",
-              "response",
-              "readiness",
-            ] as const,
-            summaryFocusLabel: "Eerste lokale route",
-            reviewLabel: "Reviewmoment",
-            evidenceSectionOrder: "profile-first" as const,
-            recommendationOrder: "playbooks-first" as const,
-            trustNotePlacement: "handoff" as const,
-            trustNoteTitle: "Leesgrens van deze route",
-            trustNoteBody: scanDefinition.segmentText,
-            trustNoteTone: "amber" as const,
-            summaryTone: "slate" as const,
-            summarySignalLabel: "Teamsignaal",
-            summaryContextLabel: "Lokale context · afdeling eerst",
-            summaryContextTone: "slate" as const,
-            summaryLeadTitle: "Eerste bestuurlijke leesrichting",
-            summaryLeadDescription:
-              "Lees TeamScan eerst als veilige lokale contextlaag: welke afdelingen vallen op, welke factor kleurt dat beeld en welke lokale verificatie hoort nu als eerste.",
-            summaryCardEyebrow: "Lokaal spoor",
-            promotedSummaryCards: 2,
-            driverTitle: "Teamsignaal en lokale context",
-            driverDescription:
-              "Gebruik deze laag om het actuele teamsignaal gecontroleerd te verdiepen zonder TeamScan te verwarren met segment deep dive of manager ranking.",
-            driverIntro:
-              "Start bij de lokale read en gebruik daarna pas factoren, signaalverdeling en basisbehoeften om te bepalen welke afdelingen eerst verificatie vragen.",
-            driverAsideLabel: hasEnoughData
-              ? "Lokale read beschikbaar"
-              : "Wacht op meer data",
-            driverAsideTone: hasEnoughData
-              ? ("slate" as const)
-              : ("amber" as const),
-            driverTabOrder: ["lokaal", "factoren", "signalen", "aanvullend"],
-            signalTabLabel: "Signaalverdeling",
-            signalTabTitle: "Teamsignaal op groepsniveau",
-            signalTabDescription:
-              "Laat zien hoe breed en hoe scherp het teamsignaal zich over de totale groep verdeelt voordat je naar afdelingen kijkt.",
-            factorTabLabel: "Lokale drivers",
-            factorTabTitle: "Werkfactoren achter lokale frictie",
-            factorTabDescription:
-              "Gebruik de scherpste werkfactoren als eerste verklarende laag om te bepalen welke afdelingen lokale verificatie verdienen.",
-            supplementalTabLabel: "SDT-basis",
-            supplementalTitle: "Werkbeleving en SDT-basis",
-            supplementalDescription:
-              "Deze laag laat zien hoe autonomie, competentie en verbondenheid onder het huidige teamsignaal liggen en welke lokale context daardoor meer spanning laat zien.",
-            actionTitle: "Waar eerst lokaal op handelen",
-            focusQuestionTitle: "Prioritaire lokale verificatievragen",
-            focusQuestionDescription:
-              "Start met de factoren die het teamsignaal het scherpst kleuren en gebruik de vragen om te bepalen wat lokaal eerst getoetst moet worden.",
-            playbookTitle: "Lokale playbooks en eerste verificatie",
-            playbookDescription:
-              "Deze playbooks vormen de uitvoerlaag onder de gekozen lokale route. Ze helpen van verificatie naar een begrensde vervolgstap te gaan zonder de vraag breder te maken dan nodig.",
-            routeTitle: "Van TeamScan naar lokale managementroute",
-            routeDescription:
-              "Deze laag bundelt de gekozen lokale route, eerste eigenaar, eerste stap en de bewuste begrenzing van TeamScan zonder de executive hoofdlijn te verstoren.",
-            routeBadgeLabel: "Kleine vervolgstap",
-            afterSessionTitle: "Na de eerste managementsessie",
-            afterSessionDescription:
-              "Gebruik het eerste reviewmoment om bewust te kiezen: blijft een lokale vervolgstap logisch, is bredere duiding weer nodig of vraagt dit signaal juist minder lokalisatie dan gedacht?",
-          }
-        : stats.scan_type === "onboarding"
-          ? {
-              familyRoleLabel: "Begrensde peer-route",
-              familyRoleTone: "blue" as const,
-              summaryBarOrder: [
-                "signal",
-                "owner",
-                "review",
-                "readiness",
-              ] as const,
-              heroAsideOrder: [
-                "signal",
-                "owner",
-                "review",
-                "response",
-              ] as const,
-              summaryFocusLabel: "Eerste checkpoint",
-              reviewLabel: "Reviewmoment",
-              evidenceSectionOrder: "profile-first" as const,
-              recommendationOrder: "playbooks-first" as const,
-              trustNotePlacement: "handoff" as const,
-              trustNoteTitle: "Leesgrens van deze route",
-              trustNoteBody: scanDefinition.evidenceStatusText,
-              trustNoteTone: "amber" as const,
-              summaryTone: "slate" as const,
-              summarySignalLabel: "Onboardingsignaal",
-              summaryContextLabel: "Vroege landing · compacte teamread",
-              summaryContextTone: "slate" as const,
-              summaryLeadTitle: "Eerste bestuurlijke leesrichting",
-              summaryLeadDescription:
-                "Lees onboarding eerst als compacte teamread: waar stokt de vroege landing in de eerste 30-60-90 dagen, welke frictie is nu zichtbaar en welke beperkte correctie hoort daar direct bij.",
-              summaryCardEyebrow: "Landingsspoor",
-              promotedSummaryCards: 1,
-              driverTitle: "Onboardingsignaal en vroege landing",
-              driverDescription:
-                "Gebruik deze laag om het actuele landingsbeeld gecontroleerd te verdiepen zonder onboarding te verwarren met client onboarding of een volledige 30-60-90-journey.",
-              driverIntro:
-                "Start bij de landingsduiding en gebruik daarna pas factoren, signaalverdeling en basisbehoeften om te bepalen welke vroege factor nu eerst aandacht vraagt.",
-              driverAsideLabel: hasEnoughData
-                ? "Landingsduiding beschikbaar"
-                : "Wacht op meer data",
-              driverAsideTone: hasEnoughData
-                ? ("slate" as const)
-                : ("amber" as const),
-              driverTabOrder: ["factoren", "signalen", "aanvullend", "trend"],
-              signalTabLabel: "Landingsbeeld",
-              signalTabTitle: "Onboardingsignaal op groepsniveau",
-              signalTabDescription:
-                "Laat zien hoe breed en hoe scherp het huidige onboardingsignaal zich over de groep verdeelt zonder dit als journey- of retentieclaim te lezen.",
-              factorTabLabel: "Landingsdrivers",
-              factorTabTitle: "Werkfactoren achter vroege frictie",
-              factorTabDescription:
-                "Gebruik de scherpste werkfactoren als eerste managementspoor om te bepalen waar nieuwe instroom nu meer steun, duidelijkheid of inbedding nodig heeft.",
-              supplementalTabLabel: "SDT-basis",
-              supplementalTitle: "Werkbeleving en SDT-basis",
-              supplementalDescription:
-                "Deze laag laat zien hoe autonomie, competentie en verbondenheid onder het huidige onboardingcheckpoint liggen en welke vroege context daardoor meer spanning laat zien.",
-              actionTitle: "Waar eerst op handelen",
-              focusQuestionTitle: "Prioritaire landingsvragen",
-              focusQuestionDescription:
-                "Start met de factoren die de vroege landing het scherpst kleuren en gebruik de vragen om te bepalen wat eerst getoetst moet worden voordat een correctieroute wordt gekozen.",
-              playbookTitle: "Eerste correctie en borging",
-              playbookDescription:
-                "Deze uitvoerlaag helpt van verificatie naar een beperkte eerste correctie en een logisch volgend checkpoint te gaan, zonder de managementhoofdlijn zwaarder te maken dan nodig.",
-              routeTitle: "Van landingsduiding naar eerste managementkeuze",
-              routeDescription:
-                "Deze laag brengt eerste managementgebruik, de gekozen correctie en het logische vervolgmoment samen zonder onboarding te verwarren met een brede lifecycle-suite.",
-              routeBadgeLabel: "Begrensde peer-route",
-              afterSessionTitle: "Na de eerste managementsessie",
-              afterSessionDescription:
-                "Gebruik het eerste reviewmoment om bewust te kiezen: blijft een later checkpoint logisch, vraagt deze instroomfrictie eerst extra verificatie of hoort de vraag thuis in een andere productvorm?",
-            }
-          : stats.scan_type === "leadership"
-            ? {
-                familyRoleLabel: "Begrensde support-route",
-                familyRoleTone: "blue" as const,
-                summaryBarOrder: [
-                  "signal",
-                  "next-step",
-                  "review",
-                  "readiness",
-                ] as const,
-                heroAsideOrder: [
-                  "signal",
-                  "next-step",
-                  "review",
-                  "response",
-                ] as const,
-                summaryFocusLabel: "Eerste check",
-                reviewLabel: "Reviewmoment",
-                evidenceSectionOrder: "profile-first" as const,
-                recommendationOrder: "playbooks-first" as const,
-                trustNotePlacement: "handoff" as const,
-                trustNoteTitle: "Leesgrens van deze route",
-                trustNoteBody: scanDefinition.evidenceStatusText,
-                trustNoteTone: "amber" as const,
-                summaryTone: "slate" as const,
-                summarySignalLabel: "Leadershipsignaal",
-                summaryContextLabel: "Compacte context · groepsniveau",
-                summaryContextTone: "slate" as const,
-                summaryLeadTitle: "Eerste bestuurlijke leesrichting",
-                summaryLeadDescription:
-                  "Lees Leadership Scan eerst als compacte contextread: welke managementcontext kleurt het bestaande people-signaal mee en welke kleine check hoort daar nu logisch bij.",
-                summaryCardEyebrow: "Managementspoor",
-                promotedSummaryCards: 1,
-                driverTitle: "Managementcontext in beeld",
-                driverDescription:
-                  "Gebruik deze laag om het actuele leadershipbeeld gecontroleerd te verdiepen zonder Leadership Scan te verwarren met TeamScan, segment deep dive of een named leader view.",
-                driverIntro:
-                  "Start bij de begrensde read en gebruik daarna pas factoren, signaalverdeling en basisbehoeften om te bepalen welke context eerst een kleine check verdient.",
-                driverAsideLabel: hasEnoughData
-                  ? "Duiding beschikbaar"
-                  : "Wacht op meer data",
-                driverAsideTone: hasEnoughData
-                  ? ("slate" as const)
-                  : ("amber" as const),
-                driverTabOrder: ["factoren", "signalen", "aanvullend", "trend"],
-                signalTabLabel: "Managementbeeld",
-                signalTabTitle: "Leadershipsignaal op groepsniveau",
-                signalTabDescription:
-                  "Laat zien hoe breed en hoe scherp het huidige managementcontextsignaal zich over de groep verdeelt zonder dit te lezen als named leader of performanceclaim.",
-                factorTabLabel: "Managementdrivers",
-                factorTabTitle: "Werkfactoren achter managementfrictie",
-                factorTabDescription:
-                  "Gebruik de scherpste werkfactoren als eerste managementspoor om te bepalen waar de huidige aansturing of prioritering eerst duiding vraagt.",
-                supplementalTabLabel: "SDT-basis",
-                supplementalTitle: "Werkbeleving en SDT-basis",
-                supplementalDescription:
-                  "Deze laag laat zien hoe autonomie, competentie en verbondenheid onder het huidige leadershipsignaal liggen en welke managementcontext daardoor meer spanning laat zien.",
-                actionTitle: "Waar eerst op handelen",
-                focusQuestionTitle: "Prioritaire managementvragen",
-                focusQuestionDescription:
-                  "Start met de factoren die het leadershipbeeld het scherpst kleuren en gebruik de vragen om te bepalen wat eerst getoetst moet worden voordat een begrensde vervolgstap wordt gekozen.",
-                playbookTitle: "Begrensde checks en eerste vervolgstap",
-                playbookDescription:
-                "Deze checks vormen de uitvoerlaag onder de gekozen route. Ze helpen van duiding naar een kleine vervolgstap te gaan zonder named leader output te openen.",
-                routeTitle: "Van leadershipread naar begrensde vervolgstap",
-                routeDescription:
-                  "Deze laag brengt de gekozen check, kleine vervolgstap en het reviewmoment samen zonder Leadership Scan te laten lezen als een quasi-peer route.",
-                routeBadgeLabel: "Kleine vervolgstap",
-                afterSessionTitle: "Na de eerste managementsessie",
-                afterSessionDescription:
-                  "Gebruik het eerste reviewmoment om bewust te kiezen: blijft een kleine check genoeg, vraagt de vraag toch bredere duiding of hoort Leadership Scan hier juist te stoppen?",
-              }
-            : stats.scan_type === "exit"
-              ? {
-                  familyRoleLabel: "Kernroute",
-                  familyRoleTone: "blue" as const,
-                  summaryBarOrder: [
-                    "signal",
-                    "owner",
-                    "response",
-                    "readiness",
-                  ] as const,
-                  heroAsideOrder: [
-                    "signal",
-                    "owner",
-                    "response",
-                    "readiness",
-                  ] as const,
-                  summaryFocusLabel: "Eerste route",
-                  reviewLabel: "Reviewmoment",
-                  evidenceSectionOrder: "management-first" as const,
-                  recommendationOrder: "questions-first" as const,
-                  trustNotePlacement: "drivers" as const,
-                  trustNoteTitle: "Methodische status",
-                  trustNoteBody: scanDefinition.evidenceStatusText,
-                  trustNoteTone: "blue" as const,
-                  summaryTone: "slate" as const,
-                  summarySignalLabel: "Frictiescore",
-                  summaryContextLabel: "Werkfrictie · verklarende laag",
-                  summaryContextTone: "slate" as const,
-                  summaryLeadTitle: "Eerste bestuurlijke leesrichting",
-                  summaryLeadDescription:
-                    "Lees ExitScan eerst via de Frictiescore: wat keert terug, waar lijkt werkfrictie beinvloedbaar en welk managementspoor moet nu als eerste gekozen worden.",
-                  summaryCardEyebrow: "Vertrekspoor",
-                  promotedSummaryCards: 2,
-                  driverTitle: "Kernsignalen en vertrekbeeld",
-                  driverDescription:
-                    "Start bij de scherpste werkfactoren en gebruik daarna pas signaalverdeling en aanvullende lagen om het vertrekbeeld verder te onderbouwen.",
-                  driverIntro:
-                    "Begin met de factoren die het vertrekverhaal het meest kleuren. Gebruik signaalverdeling en SDT daarna om het managementgesprek scherper en concreter te maken.",
-                  driverAsideLabel: hasEnoughData
-                    ? "Vertrekdrivers beschikbaar"
-                    : "Wacht op meer data",
-                  driverAsideTone: hasEnoughData
-                    ? ("slate" as const)
-                    : ("amber" as const),
-                  driverTabOrder: [
-                    "factoren",
-                    "signalen",
-                    "aanvullend",
-                    "trend",
-                  ],
-                  signalTabLabel: "Frictiescore",
-                  signalTabTitle: "Frictiescore op groepsniveau",
-                  signalTabDescription:
-                    "Laat zien hoe breed en hoe scherp de Frictiescore zich over de groep verdeelt, zodat je werkfrictie en vertrekduiding in context kunt lezen.",
-                  factorTabLabel: "Vertrekdrivers",
-                  factorTabTitle: "Laagste scores per werkfactor",
-                  factorTabDescription:
-                    "Deze lijst toont per werkfactor de score en relatieve zwaarte.",
-                  supplementalTabLabel: "SDT-basis",
-                  supplementalTitle: "Werkbeleving en SDT-basis",
-                  supplementalDescription:
-                    "Deze laag laat zien hoe autonomie, competentie en verbondenheid onder het vertrekbeeld liggen en waar vervolgvragen het meeste opleveren.",
-                  actionTitle: "Waar eerst op handelen",
-                  focusQuestionTitle: "Prioritaire focusvragen",
-                  focusQuestionDescription:
-                    "Start met de factoren die het vertrekbeeld het scherpst kleuren en gebruik de vragen om te bepalen wat eerst getoetst moet worden voordat de eerste route wordt gekozen.",
-                  playbookTitle: "Besluit- en eigenaarschapsroutes",
-                  playbookDescription:
-                    "Deze playbooks vormen de uitvoerlaag onder de gekozen managementroute. Ze helpen van vertrekduiding naar uitvoering te gaan zonder nieuwe prioriteiten buiten het gekozen spoor te openen.",
-                  routeTitle: "Van vertrekduiding naar managementroute",
-                  routeDescription:
-                    "Deze laag bundelt de gekozen managementroute, eerste eigenaar, eerste stap en het logische reviewmoment zonder de kernflow bovenin te verstoren.",
-                  routeBadgeLabel: "Kernroute",
-                  afterSessionTitle: "Na de eerste managementsessie",
-                  afterSessionDescription:
-                    "Gebruik het eerste reviewmoment om bewust te kiezen: blijf je op hetzelfde vertrekspoor, vraagt deze scan verdere verdieping of wordt een tweede product logisch op basis van de eerste managementwaarde?",
-                }
-              : {
-                  familyRoleLabel: "Begrensde support-route",
-                  familyRoleTone: "blue" as const,
-                  summaryBarOrder: [
-                    "signal",
-                    "next-step",
-                    "review",
-                    "readiness",
-                  ] as const,
-                  heroAsideOrder: [
-                    "signal",
-                    "next-step",
-                    "review",
-                    "response",
-                  ] as const,
-                  summaryFocusLabel: "Eerste herijking",
-                  reviewLabel: "Reviewmoment",
-                  evidenceSectionOrder: "profile-first" as const,
-                  recommendationOrder: "playbooks-first" as const,
-                  trustNotePlacement: "handoff" as const,
-                  trustNoteTitle: "Leesgrens van deze route",
-                  trustNoteBody: scanDefinition.evidenceStatusText,
-                  trustNoteTone: "amber" as const,
-                  summaryTone: "slate" as const,
-                  summarySignalLabel: "Pulsesignaal",
-                  summaryContextLabel: "Reviewlaag · herhaalritme",
-                  summaryContextTone: "slate" as const,
-                  summaryLeadTitle: "Eerste bestuurlijke leesrichting",
-                  summaryLeadDescription:
-                    "Gebruik deze eerste laag om het primaire managementsignaal en het eerste werkspoor snel scherp te krijgen, voordat een route, eigenaar en hercheckmoment worden gekozen.",
-                  summaryCardEyebrow: "Pulse vervolgstap",
-                  promotedSummaryCards: 2,
-                  driverTitle: "Pulse groepsread en vergelijking",
-                  driverDescription:
-                    "Gebruik deze laag om het actuele Pulse-beeld gecontroleerd te verdiepen zonder de managementhoofdlijn kwijt te raken.",
-                  driverIntro:
-                    "Gebruik de tabs hieronder om tussen groepsread, factoren, aanvullende lagen en vergelijking te wisselen zonder de hoofdlijn van de duiding kwijt te raken.",
-                  driverAsideLabel: hasEnoughData
-                    ? "Pulse read beschikbaar"
-                    : "Wacht op meer data",
-                  driverAsideTone: hasEnoughData
-                    ? ("slate" as const)
-                    : ("amber" as const),
-                  driverTabOrder: [
-                    "factoren",
-                    "trend",
-                    "signalen",
-                    "aanvullend",
-                  ],
-                  signalTabLabel: "Signaalverdeling",
-                  signalTabTitle: "Signaalverdeling",
-                  signalTabDescription:
-                    "Laat zien hoe breed en hoe scherp de signalen zich over de groep verdelen op dit meetmoment.",
-                  factorTabLabel: "Factoren",
-                  factorTabTitle: "Organisatiefactoren",
-                  factorTabDescription:
-                    "De factoren hieronder helpen bepalen waar managementgesprekken en kleine correcties nu het meeste opleveren.",
-                  supplementalTabLabel: "SDT-basis",
-                  supplementalTitle: "SDT basisbehoeften",
-                  supplementalDescription:
-                    "Deze laag laat zien hoe de fundamentele werkbeleving onder de actuele Pulse-signalen mee beweegt.",
-                  actionTitle: "Prioriteiten en route-uitvoer",
-                  focusQuestionTitle: "Prioritaire focusvragen",
-                  focusQuestionDescription:
-                  "Start met de factoren die het scherpst afwijken en gebruik de vragen om te bepalen wat eerst getoetst moet worden voordat een route wordt gekozen.",
-                  playbookTitle: "Pulse playbooks en eerstvolgende correctie",
-                  playbookDescription:
-                  "Deze playbooks vormen de uitvoerlaag onder de gekozen route. Ze helpen van verificatie naar correctie en een logisch hercheckmoment te gaan.",
-                routeTitle: "Van Pulse read naar herhaalritme",
-                  routeDescription:
-                    "Deze laag brengt eerste managementgebruik, de gekozen correctie en het logische volgende meetmoment samen zonder Pulse te verwarren met een bredere kernroute of hoofdrapport.",
-                routeBadgeLabel: "Kleine vervolgstap",
-                  afterSessionTitle: "Na de eerste managementsessie",
-                  afterSessionDescription:
-                  "Gebruik het eerste reviewmoment om bewust te kiezen: doe je nog een compacte Pulse-check, verdiep je eerst de vraag verder of vraagt het thema nu een andere productvorm?",
-                };
-  const presentationMetrics = buildPresentationMetrics({
-    productExperience,
-    scanDefinition,
-    dashboardViewModel,
-    averageRiskScore,
-    totalCompleted: stats.total_completed,
-    totalInvited: stats.total_invited,
-    compositionStateMeta,
-    hasEnoughData,
-  });
-  const summaryItems = productExperience.summaryBarOrder.map(
-    (key) => presentationMetrics[key],
-  );
-  const heroAsideItems = productExperience.heroAsideOrder.map(
-    (key) => presentationMetrics[key],
-  );
-  const sectionAnchors = [
-    { id: "samenvatting", label: "Samenvatting" },
-    ...(showManagementOutput
-      ? [
-          {
-            id: "handoff",
-            label: showPartialManagementOutput
-              ? "Compacte read"
-              : stats.scan_type === "retention"
-                ? "Vervolg"
-                : stats.scan_type === "team"
-                  ? "Lokale read"
-                  : "Vervolg",
-          },
-          ...(showDetailedManagementOutput
-            ? [
-                {
-                  id: "drivers",
-                  label:
-                    stats.scan_type === "retention"
-                      ? "Signalen"
-                      : stats.scan_type === "team"
-                        ? "Lokaal"
-                        : "Drivers",
-                },
-                {
-                  id: "acties",
-                  label:
-                    stats.scan_type === "retention"
-                      ? "Behoudsacties"
-                      : stats.scan_type === "team"
-                        ? "Lokale acties"
-                        : "Acties",
-                },
-                {
-                  id: "route",
-                  label:
-                    stats.scan_type === "retention" ||
-                    stats.scan_type === "exit"
-                      ? "Kernroute"
-                      : stats.scan_type === "team" ||
-                          stats.scan_type === "pulse" ||
-                          stats.scan_type === "onboarding" ||
-                          stats.scan_type === "leadership"
-                        ? "Vervolgroute"
-                        : "Route",
-                },
-              ]
-            : []),
-        ]
-      : []),
-    { id: "methodiek", label: "Methodiek" },
-    ...(utilitySectionVisible
-      ? [
-          {
-            id: showClientExecutionFlow ? "uitvoering" : "operatie",
-            label: showClientExecutionFlow ? "Uitvoering" : "Operatie",
-          },
-        ]
-      : []),
-  ];
-  const promotedSummaryCards =
-    showDetailedManagementOutput && productExperience.promotedSummaryCards > 0
-      ? dashboardViewModel.topSummaryCards.slice(
-          0,
-          productExperience.promotedSummaryCards,
-        )
-      : [];
-  const handoffSummaryCards =
-    showDetailedManagementOutput && productExperience.promotedSummaryCards > 0
-      ? dashboardViewModel.topSummaryCards.slice(
-          productExperience.promotedSummaryCards,
-        )
-      : dashboardViewModel.topSummaryCards;
-  const availableDriverTabs = hasEnoughData
-    ? [
-        ...(stats.scan_type === "team" && teamLocalRead
-          ? [
-              {
-                id: "lokaal",
-                label: "Lokale read",
-                content: (
-                  <div className="space-y-5">
-                    <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4 sm:p-5">
-                      <div className="flex flex-wrap items-center gap-3">
-                        <h3 className="text-sm font-semibold text-slate-950">
-                          {teamLocalRead.summaryTitle}
-                        </h3>
-                        <DashboardChip
-                          label={`${teamLocalRead.coverageCount}/${teamLocalRead.totalResponses} met afdeling`}
-                          tone="slate"
-                        />
-                        <DashboardChip
-                          label={
-                            teamLocalRead.status === "ready"
-                              ? `${teamLocalRead.safeGroupCount} veilige afdelingen`
-                              : "Fallback actief"
-                          }
-                          tone={
-                            teamLocalRead.status === "ready"
-                              ? "emerald"
-                              : "amber"
-                          }
-                        />
-                        <DashboardChip
-                          label={
-                            teamPriorityRead?.status === "ready"
-                              ? `Meenemen in verificatie: ${teamPriorityRead.firstPriorityLabel}`
-                              : teamPriorityRead?.status === "no_hard_order"
-                                ? "Nog geen harde volgorde"
-                                : "Prioriteit nog niet vrijgegeven"
-                          }
-                          tone={
-                            teamPriorityRead?.status === "ready"
-                              ? "amber"
-                              : "slate"
-                          }
-                        />
-                      </div>
-                      <p className="mt-1 text-sm leading-6 text-slate-600">
-                        {teamPriorityRead?.summaryBody ??
-                          teamLocalRead.summaryBody}
-                      </p>
-                      <p className="mt-3 text-xs leading-6 text-slate-500">
-                        {teamPriorityRead?.caution ?? teamLocalRead.caution}
-                      </p>
-                    </div>
-
-                    {teamLocalRead.status === "ready" && teamPriorityRead ? (
-                      <div className="grid gap-4 lg:grid-cols-3">
-                        {teamPriorityRead.groups.map((group) => (
-                          <DashboardPanel
-                            key={group.label}
-                            eyebrow={`${group.priorityTitle} · Afdeling · n = ${group.n}`}
-                            title={group.label}
-                            value={`${group.avgSignal.toFixed(1)}/10`}
-                            body={`${group.summary} ${group.priorityBody} Eerste lokale factor: ${group.topFactorLabel}.`}
-                            tone={group.priorityTone}
-                          />
-                        ))}
-                      </div>
-                    ) : (
-                      <div className="rounded-2xl border border-dashed border-slate-200 bg-white px-4 py-4 text-sm leading-6 text-slate-600">
-                        TeamScan blijft in deze situatie bewust op
-                        organisatieniveau. Zodra genoeg afdelingsmetadata en
-                        veilige groepsgroottes beschikbaar zijn, verschijnt de
-                        lokale read hier.
-                      </div>
-                    )}
-                  </div>
-                ),
-              },
-            ]
-          : []),
-        {
-          id: "signalen",
-          label: productExperience.signalTabLabel,
-          content: (
-            <DashboardChartPanel
-              eyebrow="Signaalbeeld"
-              title={productExperience.signalTabTitle}
-              description={productExperience.signalTabDescription}
-              tone="slate"
-              variant="quiet"
-            >
-              <div className="mt-1">
-                <RiskCharts
-                  distribution={riskDistribution}
-                  histogramBins={riskHistogram}
-                  averageScore={averageRiskScore}
-                  scanType={stats.scan_type}
-                />
-              </div>
-            </DashboardChartPanel>
-          ),
-        },
-        {
-          id: "factoren",
-          label: productExperience.factorTabLabel,
-          content: (
-            <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4 sm:p-5">
-              <h3 className="text-sm font-semibold text-slate-950">
-                {productExperience.factorTabTitle}
-              </h3>
-              <p className="mt-1 text-sm leading-6 text-slate-600">
-                {productExperience.factorTabDescription}
-              </p>
-              <div className="mt-4">
-                <FactorTable
-                  factorAverages={factorData.orgAverages}
-                  scanType={stats.scan_type}
-                />
-              </div>
-            </div>
-          ),
-        },
-        {
-          id: "aanvullend",
-          label: productExperience.supplementalTabLabel,
-          content: (
-            <div className="space-y-5">
-              <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4 sm:p-5">
-                <div className="flex flex-wrap items-center gap-3">
-                  <h3 className="text-sm font-semibold text-slate-950">
-                    {productExperience.supplementalTitle}
-                  </h3>
-                  <DashboardChip
-                    label="Autonomie · Competentie · Verbondenheid"
-                    tone="slate"
-                  />
-                </div>
-                <p className="mt-1 text-sm leading-6 text-slate-600">
-                  {productExperience.supplementalDescription}
-                </p>
-                <div className="mt-4 grid gap-4 sm:grid-cols-3">
-                  {(["autonomy", "competence", "relatedness"] as const).map(
-                    (dimension) => (
-                      <SdtGauge
-                        key={dimension}
-                        label={FACTOR_LABELS[dimension]}
-                        score={factorData.sdtAverages[dimension] ?? 5.5}
-                      />
-                    ),
-                  )}
-                </div>
-              </div>
-
-              {stats.scan_type === "retention" && retentionThemes.length > 0 ? (
-                <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4 sm:p-5">
-                  <h3 className="text-sm font-semibold text-slate-950">
-                    Open signalen op groepsniveau
-                  </h3>
-                  <p className="mt-1 text-sm leading-6 text-slate-600">
-                    Geclusterd zodat open antwoorden als managementsignaal
-                    gelezen kunnen worden, niet als losse klachtenlijst.
-                  </p>
-                  <div className="mt-4 grid gap-4 lg:grid-cols-3">
-                    {retentionThemes.map((theme) => (
-                      <div
-                        key={theme.key}
-                        className="rounded-[20px] border border-white/80 bg-white/80 p-4 shadow-sm"
-                      >
-                        <div className="flex items-center justify-between gap-3">
-                          <p className="text-sm font-semibold text-slate-950">
-                            {theme.title}
-                          </p>
-                          <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-500">
-                            {theme.count}
-                          </span>
-                        </div>
-                        <p className="mt-3 text-sm leading-6 text-slate-700">
-                          {theme.implication}
-                        </p>
-                        <p className="mt-3 text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
-                          Voorbeeldsignaal
-                        </p>
-                        <p className="mt-1 text-sm italic leading-6 text-slate-600">
-                          &quot;{theme.sample}&quot;
-                        </p>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              ) : null}
-            </div>
-          ),
-        },
-        ...(stats.scan_type === "retention" &&
-        previousStats &&
-        currentRetentionSignals &&
-        previousRetentionSignals
-          ? [
-              {
-                id: "trend",
-                label: "Trend",
-                content: (
-                  <RetentionTrendSection
-                    current={currentRetentionSignals}
-                    previous={previousRetentionSignals}
-                    previousDate={previousStats.created_at}
-                    previousCampaignName={previousStats.campaign_name}
-                    trendCards={retentionTrendCards}
-                  />
-                ),
-              },
-            ]
-          : stats.scan_type === "pulse" &&
-              previousStats &&
-              pulseComparison &&
-              pulseComparison.status !== "no_previous"
-            ? [
-                {
-                  id: "trend",
-                  label: "Vergelijking",
-                  content: (
-                    <PulseTrendSection
-                      comparison={pulseComparison}
-                      previousDate={previousStats.created_at}
-                      previousCampaignName={previousStats.campaign_name}
-                    />
-                  ),
-                },
-              ]
-            : []),
-      ]
-    : [];
-  const driverTabs = hasEnoughData
-    ? productExperience.driverTabOrder.flatMap((tabId) =>
-        availableDriverTabs.filter((tab) => tab.id === tabId),
-      )
-    : [];
-  const trustNote = (
-    <div
-      className={`rounded-[22px] border px-4 py-4 ${
-        productExperience.trustNoteTone === "emerald"
-          ? "border-emerald-200 bg-emerald-50"
-          : productExperience.trustNoteTone === "amber"
-            ? "border-amber-200 bg-amber-50"
-            : "border-slate-200 bg-slate-50"
-      }`}
-    >
-      <p
-        className={`text-xs font-semibold uppercase tracking-[0.18em] ${
-          productExperience.trustNoteTone === "emerald"
-            ? "text-emerald-800"
-            : productExperience.trustNoteTone === "amber"
-              ? "text-amber-900"
-              : "text-slate-600"
-        }`}
-      >
-        {productExperience.trustNoteTitle}
-      </p>
-      <p className="mt-2 text-sm leading-6 text-slate-800">
-        {productExperience.trustNoteBody}
-      </p>
-    </div>
-  );
-  const profileCardsSection =
-    dashboardViewModel.profileCards.length > 0 ? (
-      <div className="grid gap-4 md:grid-cols-2">
-        {dashboardViewModel.profileCards.map((card) => (
-          <DashboardPanel
-            key={`${card.title}-${card.value ?? "profile"}`}
-            eyebrow={card.title}
-            title={card.value || card.title}
-            body={card.body}
-            tone={normalizeInformationalTone(card.tone)}
-          />
-        ))}
-      </div>
-    ) : null;
-  const managementBlocksSection =
-    dashboardViewModel.managementBlocks.length > 0 ? (
-      <div className="grid gap-4 lg:grid-cols-3">
-        {dashboardViewModel.managementBlocks.map((block) => (
-          <div
-            key={block.title}
-            className={`rounded-[22px] border p-4 ${
-              block.tone === "emerald"
-                ? "border-[#d2e6e0] bg-[#eef7f4]"
-                : block.tone === "amber"
-                  ? "border-[#eadfbe] bg-[#faf6ea]"
-                  : "border-slate-200 bg-slate-50"
-            }`}
-          >
-            <p
-              className={`text-xs font-semibold uppercase tracking-[0.2em] ${
-                block.tone === "emerald"
-                  ? "text-[#3C8D8A]"
-                  : block.tone === "amber"
-                    ? "text-[#8C6B1F]"
-                    : "text-slate-600"
-              }`}
-            >
-              {block.title}
-            </p>
-            {block.intro ? (
-              <p className="mt-3 text-sm leading-6 text-slate-700">
-                {block.intro}
-              </p>
-            ) : null}
-            <ul className="mt-3 space-y-2">
-              {block.items.map((item) => (
-                <li
-                  key={item}
-                  className="flex gap-2 text-sm leading-6 text-slate-700"
-                >
-                  <span className="text-slate-400">-</span>
-                  <span>{item}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-        ))}
-      </div>
-    ) : null;
-  const focusQuestionsBlock = (
-    <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4 sm:p-5">
-      <h3 className="text-sm font-semibold text-slate-950">
-        {productExperience.focusQuestionTitle}
-      </h3>
-      <p className="mt-1 text-sm leading-6 text-slate-600">
-        {productExperience.focusQuestionDescription}
-      </p>
-      <div className="mt-4">
-        <RecommendationList
-          factorAverages={factorData.orgAverages}
-          scanType={stats.scan_type}
-          bandOverride={
-            stats.scan_type === "onboarding" || stats.scan_type === "leadership"
-              ? dashboardViewModel.managementBandOverride
-              : undefined
-          }
-        />
-      </div>
-    </div>
-  );
-  const playbooksBlock =
-    stats.scan_type === "retention" ||
-    stats.scan_type === "exit" ||
-    stats.scan_type === "pulse" ||
-    stats.scan_type === "team" ||
-    stats.scan_type === "onboarding" ||
-    stats.scan_type === "leadership" ? (
-      <>
-        <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4 sm:p-5">
-          <h3 className="text-sm font-semibold text-slate-950">
-            {productExperience.playbookTitle}
-          </h3>
-          <p className="mt-1 text-sm leading-6 text-slate-600">
-            {productExperience.playbookDescription}
-          </p>
-          {stats.scan_type === "retention" && playbookCalibrationNote ? (
-            <p className="mt-2 text-xs leading-6 text-slate-500">
-              {playbookCalibrationNote}
-            </p>
-          ) : null}
-          <div className="mt-4">
-            <ActionPlaybookList
-              factorAverages={factorData.orgAverages}
-              scanType={stats.scan_type}
-              bandOverride={
-                stats.scan_type === "onboarding" ||
-                stats.scan_type === "leadership"
-                  ? dashboardViewModel.managementBandOverride
-                  : undefined
-              }
-            />
-          </div>
-        </div>
-
-        {stats.scan_type === "retention" && hasSegmentDeepDive ? (
-          <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4 sm:p-5">
-            <h3 className="text-sm font-semibold text-slate-950">
-              Segment-specifieke playbooks
-            </h3>
-            <p className="mt-1 text-sm leading-6 text-slate-600">
-              Alleen zichtbaar als segmentvergelijking voldoende respons en
-              metadata heeft.
-            </p>
-            <div className="mt-4">
-              {retentionSegmentPlaybooks.length > 0 ? (
-                <SegmentPlaybookList segments={retentionSegmentPlaybooks} />
-              ) : (
-                <div className="rounded-2xl border border-dashed border-slate-200 bg-white px-4 py-4 text-sm leading-6 text-slate-600">
-                  Nog geen segmenten met voldoende n en voldoende afwijking om
-                  apart te tonen.
-                </div>
-              )}
-            </div>
-          </div>
-        ) : null}
-      </>
-    ) : null;
-
-  const dominantBand = (["HOOG", "MIDDEN", "LAAG"] as const).reduce(
-    (current, candidate) =>
-      riskDistribution[current] >= riskDistribution[candidate]
-        ? current
-        : candidate,
-  );
-  const totalRiskResponses =
-    riskDistribution.HOOG + riskDistribution.MIDDEN + riskDistribution.LAAG;
-  const dominantPct =
-    totalRiskResponses > 0
-      ? Math.round((riskDistribution[dominantBand] / totalRiskResponses) * 100)
-      : 0;
-  const bandLabels = {
-    HOOG: "Direct prioriteren",
-    MIDDEN: "Eerst toetsen",
-    LAAG: "Volgen",
-  } as const;
-  const focusPanelItems = showManagementOutput
-    ? [
-        {
-          text: dashboardViewModel.primaryQuestion.title,
-          moduleLabel: scanDefinition.productName,
-        },
-        {
-          text: dashboardViewModel.nextStep.title,
-          moduleLabel: scanDefinition.productName,
-        },
-      ]
-    : [];
-  async function openActionCenterRoute() {
-    "use server";
-
-    const admin = createAdminClient();
-    const actionCenterHref = buildActionCenterRouteOpenRedirect(id, "campaign-detail");
-    const { data: currentDeliveryRecord, error: loadError } = await admin
-      .from("campaign_delivery_records")
-      .select("id, lifecycle_stage, first_management_use_confirmed_at")
-      .eq("campaign_id", id)
-      .maybeSingle();
-
-    if (loadError || !currentDeliveryRecord) {
-      redirect(`/campaigns/${id}?bridge=open-unavailable`);
-    }
-
-    if (hasOpenedActionCenterRoute(currentDeliveryRecord)) {
-      redirect(actionCenterHref);
-    }
-
-    if (!canOpenActionCenterRoute(currentDeliveryRecord)) {
-      redirect(`/campaigns/${id}?bridge=open-unavailable`);
-    }
-
-    const openedAt = new Date().toISOString();
-    const { data: updatedRecord, error } = await admin
-      .from("campaign_delivery_records")
-      .update(buildActionCenterRouteOpenPatch(openedAt))
-      .eq("id", currentDeliveryRecord.id)
-      .is("first_management_use_confirmed_at", null)
-      .in("lifecycle_stage", getActionCenterRouteOpenableStages())
-      .select("id")
-      .maybeSingle();
-
-    if (error) {
-      redirect(`/campaigns/${id}?bridge=open-unavailable`);
-    }
-
-    if (!updatedRecord) {
-      const { data: latestDeliveryRecord } = await admin
-        .from("campaign_delivery_records")
-        .select("id, lifecycle_stage, first_management_use_confirmed_at")
         .eq("campaign_id", id)
-        .maybeSingle();
+        .order("completed_at", { ascending: false, nullsFirst: false }),
+    ])
 
-      if (latestDeliveryRecord && hasOpenedActionCenterRoute(latestDeliveryRecord)) {
-        redirect(actionCenterHref);
-      }
+  const responses = (responsesRaw ?? []) as unknown as (SurveyResponse & {
+    respondents: Respondent
+  })[]
+  const respondents = (respondentsRaw ?? []) as Respondent[]
 
-      redirect(`/campaigns/${id}?bridge=open-unavailable`);
-    }
+  const factorData = computeFactorAverages(responses)
+  const factorPriorityRows = buildFactorPriorityRows(factorData.orgAverages)
+  const sdtRows = buildSdtRows(factorData.sdtAverages)
+  const averageRiskScore = computeAverageSignalScore(responses)
+  const hasMinDisplay = responses.length >= MIN_N_DISPLAY
+  const hasEnoughData = responses.length >= MIN_N_PATTERNS
+  const openAnswers = buildVisibleVoices(responses)
+  const openAnswersHref = `/campaigns/${id}/open-antwoorden`
+  const resultsViewModel = buildResultsViewModel({
+    scanType: stats.scan_type,
+    respondentsCount: respondents.length,
+    hasMinDisplay,
+    hasEnoughData,
+    hasOpenAnswers: openAnswers.length > 0,
+  })
+  const blockVisibility = Object.fromEntries(
+    resultsViewModel.blocks.map((block) => [block.key, block.visibility]),
+  ) as Record<"response" | "signal" | "synthesis" | "drivers" | "depth" | "voices", ResultsBlockVisibility>
 
-    redirect(actionCenterHref);
-  }
-  const actionCenterRouteAction =
-    actionCenterBridge.presentation.ctaKind === "open" ? (
-      <div className="flex flex-col gap-2">
-        {actionCenterBridge.bridgeState === "candidate" ? (
-          <form action={openActionCenterRoute}>
-            <button
-              type="submit"
-              className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition-colors hover:border-slate-300 hover:bg-slate-50"
-            >
-              {actionCenterBridge.presentation.ctaLabel}
-            </button>
-          </form>
-        ) : (
-          <Link
-            href={actionCenterRouteHref}
-            className="inline-flex rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition-colors hover:border-slate-300 hover:bg-slate-50"
-          >
-            {actionCenterBridge.presentation.ctaLabel}
-          </Link>
-        )}
-        <p className="max-w-sm text-sm leading-6 text-slate-500">
-          {actionCenterBridge.presentation.body}
-        </p>
-      </div>
-    ) : null;
-  const summaryActions = (
-    <>
-      {actionCenterRouteAction}
-      {!showManagementOutput ? (
-        <div className="rounded-full border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-900">
-          {activationState.heroActionLabel}
-        </div>
-      ) : showPartialManagementOutput ? (
-        <>
-          <div className="rounded-full border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-900">
-            Aanbevelingen blijven nog begrensd
-          </div>
-          <PdfDownloadButton
-            campaignId={id}
-            campaignName={stats.campaign_name}
-            scanType={stats.scan_type}
-          />
-        </>
-      ) : prefersReportFirst ? (
-        <PdfDownloadButton
-          campaignId={id}
-          campaignName={stats.campaign_name}
-          scanType={stats.scan_type}
-        />
-      ) : stats.scan_type === "pulse" ||
-        stats.scan_type === "team" ||
-        stats.scan_type === "onboarding" ||
-        stats.scan_type === "leadership" ? (
-        <div className="rounded-full border border-slate-200 bg-slate-50 px-4 py-2 text-sm font-semibold text-slate-700">
-          {stats.scan_type === "pulse"
-            ? "Pulse: eerste vervolgstap live"
-            : stats.scan_type === "team"
-              ? "TeamScan: lokale read live"
-              : stats.scan_type === "onboarding"
-                ? "Onboarding: checkpoint read live"
-                : "Leadership Scan: management read live"}
-        </div>
-      ) : (
-        <PdfDownloadButton
-          campaignId={id}
-          campaignName={stats.campaign_name}
-          scanType={stats.scan_type}
-        />
-      )}
-    </>
-  );
-
+  const scanDefinition = getScanDefinition(stats.scan_type)
   const organizationName = organization?.name ?? "Organisatie"
   const routePeriodLabel = formatRoutePeriodLabel(stats.campaign_name, stats.created_at)
   const scopeLabel = deriveScopeLabel(respondents)
@@ -2165,1901 +500,236 @@ export default async function CampaignPage({ params }: Props) {
   const moduleLabel = moduleKey ? getDashboardModuleLabel(moduleKey) : scanDefinition.productName
   const moduleHref = moduleKey ? getDashboardModuleHref(moduleKey) : "/dashboard"
   const moduleBackLinkLabel = getDashboardModuleBackLinkLabel(stats.scan_type)
-  const factorPriorityRows = buildFactorPriorityRows(factorData.orgAverages)
-  const sdtRows = buildSdtRows(factorData.sdtAverages)
+  const topFactorLabel = factorPriorityRows[0]?.factor ?? null
+  const secondFactorLabel = factorPriorityRows[1]?.factor ?? null
 
-  if (
-    showManagementOutput &&
-    (stats.scan_type === "exit" || stats.scan_type === "retention")
-  ) {
-    const topFactor = factorPriorityRows[0]?.factor ?? null
-    const secondFactor = factorPriorityRows[1]?.factor ?? null
-    const headerActions = (
-      <PdfDownloadButton
-        campaignId={id}
-        campaignName={stats.campaign_name}
-        scanType={stats.scan_type}
-      />
-    )
+  const responseSection = (
+    <ResultsBlockCard
+      title={PRIMARY_RESULTS_ORDER.response}
+      visibility={blockVisibility.response}
+      value={`${stats.total_completed}/${stats.total_invited} ingevuld · ${stats.completion_rate_pct ?? 0}%`}
+      body={buildResponseContextNote(stats.total_completed, stats.completion_rate_pct ?? 0)}
+      href={stats.scan_type === "exit" ? "#responscontext" : undefined}
+      linkLabel={stats.scan_type === "exit" ? "Ga naar responscontext" : undefined}
+    />
+  )
 
-    if (stats.scan_type === "exit") {
-      const exitDistribution = buildExitPictureDistribution(responses)
-      const exitNarratives = buildExitNarratives({
-        topFactorLabel: topFactor,
-        secondFactorLabel: secondFactor,
-        topExitReasonLabel,
-        topContributingReasonLabel,
-        strongWorkSignalRate,
-        distribution: exitDistribution,
+  const signalSection = (
+    <ResultsBlockCard
+      title={PRIMARY_RESULTS_ORDER.signal}
+      visibility={blockVisibility.signal}
+      value={averageRiskScore !== null && hasMinDisplay ? `${averageRiskScore.toFixed(1)}/10` : "Nog niet beschikbaar"}
+      body={
+        topFactorLabel && hasMinDisplay
+          ? `${scanDefinition.signalLabel} blijft de opening, met ${topFactorLabel.toLowerCase()} als eerste zichtbare factor binnen deze route.`
+          : `Deze laag komt pas vrij vanaf ${MIN_N_DISPLAY} leesbare responses. Tot die tijd blijft het kernsignaal bewust begrensd.`
+      }
+      href={stats.scan_type === "exit" ? "#sterkste-signaal" : undefined}
+      linkLabel={stats.scan_type === "exit" ? "Ga naar sterkste signaal" : undefined}
+    />
+  )
+
+  const synthesisTitle =
+    stats.scan_type === "exit"
+      ? getTopExitReasonLabel(responses) ?? topFactorLabel ?? "Nog niet beschikbaar"
+      : topFactorLabel ?? "Nog niet beschikbaar"
+  const synthesisBody =
+    stats.scan_type === "exit"
+      ? getTopContributingReasonLabel(responses)
+        ? `${getTopContributingReasonLabel(responses)} speelt zichtbaar mee naast de dominante vertrekreden en hoort in dezelfde managementlezing thuis.`
+        : `Deze laag blijft pas echt scherp zodra er naast de hoofdreden ook een tweede contextsignaal stevig terugkomt.`
+      : secondFactorLabel
+        ? `${secondFactorLabel} kleurt het primaire signaal mee en helpt om verschillen in samenhang te lezen, niet als los detail.`
+        : `Gebruik deze laag pas steviger vanaf voldoende respons en meer dan een enkel zichtbaar factorspoor.`
+
+  const synthesisSection = (
+    <ResultsBlockCard
+      title={PRIMARY_RESULTS_ORDER.synthesis}
+      visibility={blockVisibility.synthesis}
+      value={blockVisibility.synthesis === "visible" ? synthesisTitle : "Nog niet beschikbaar"}
+      body={synthesisBody}
+      href={stats.scan_type === "exit" ? "#hoofdreden-vertrekbeeld" : undefined}
+      linkLabel={stats.scan_type === "exit" ? "Ga naar samenhang" : undefined}
+    />
+  )
+
+  const driversValue =
+    factorPriorityRows.length > 0 && hasEnoughData
+      ? factorPriorityRows
+          .slice(0, 3)
+          .map((row) => row.factor)
+          .join(" · ")
+      : "Nog niet beschikbaar"
+  const driversSection = (
+    <ResultsBlockCard
+      title={PRIMARY_RESULTS_ORDER.drivers}
+      visibility={blockVisibility.drivers}
+      value={driversValue}
+      body={
+        hasEnoughData
+          ? "Gebruik deze laag om te zien welke factoren het eerst bestuurlijke aandacht vragen. Prioriteiten blijven groepsmatig en feitelijk."
+          : `Deze laag blijft begrensd tot er minimaal ${MIN_N_PATTERNS} leesbare responses zijn.`
+      }
+      href={stats.scan_type === "exit" ? "#driverlaag" : undefined}
+      linkLabel={stats.scan_type === "exit" ? "Ga naar drivers" : undefined}
+    />
+  )
+
+  const depthValue =
+    blockVisibility.depth === "visible"
+      ? sdtRows.length > 0
+        ? `${sdtRows.length} verdiepingslaag${sdtRows.length === 1 ? "" : "en"}`
+        : `${factorPriorityRows.length} factorlaag${factorPriorityRows.length === 1 ? "" : "en"}`
+      : "Nog niet beschikbaar"
+  const depthSection = (
+    <ResultsBlockCard
+      title={PRIMARY_RESULTS_ORDER.depth}
+      visibility={blockVisibility.depth}
+      value={depthValue}
+      body={
+        blockVisibility.depth === "visible"
+          ? "Verdiepingslagen blijven ondersteunend aan de hoofdlezing: extra factorcontext, SDT en methodische begrenzing."
+          : "Deze laag blijft bewust compact zolang de eerste veilige read nog niet volledig open ligt."
+      }
+      href={stats.scan_type === "exit" ? "#factorlaag" : undefined}
+      linkLabel={stats.scan_type === "exit" ? "Ga naar verdieping" : undefined}
+    />
+  )
+
+  const voicesPreview =
+    openAnswers[0] && blockVisibility.voices === "visible"
+      ? openAnswers[0].length > 120
+        ? `${openAnswers[0].slice(0, 117).trimEnd()}...`
+        : openAnswers[0]
+      : "Nog niet beschikbaar"
+  const voicesBody =
+    blockVisibility.voices === "visible"
+      ? "Survey-stemmen blijven geanonimiseerd en horen bij deze resultatenomgeving. Open antwoorden zijn in een klik bereikbaar."
+      : "Open antwoorden komen pas vrij zodra er daadwerkelijk leesbare survey-stemmen beschikbaar zijn."
+  const voicesSection = (
+    <ResultsBlockCard
+      title={PRIMARY_RESULTS_ORDER.voices}
+      visibility={blockVisibility.voices}
+      value={voicesPreview}
+      body={voicesBody}
+      href={openAnswersHref}
+      linkLabel="Open alle open antwoorden"
+    />
+  )
+
+  const summaryShell = (
+    <ResultsLayout
+      sections={{
+        response: responseSection,
+        signal: signalSection,
+        synthesis: synthesisSection,
+        drivers: driversSection,
+        depth: depthSection,
+        voices: voicesSection,
+      }}
+    />
+  )
+
+  if (stats.scan_type === "exit") {
+    const strongWorkSignalRate = hasMinDisplay ? computeStrongWorkSignalRate(responses) : null
+    const topExitReasonLabel = hasMinDisplay ? getTopExitReasonLabel(responses) : null
+    const topContributingReasonLabel = hasMinDisplay ? getTopContributingReasonLabel(responses) : null
+    const exitDistribution = hasMinDisplay ? buildExitPictureDistribution(responses) : { total: 0, segments: [] }
+    const exitNarratives =
+      hasMinDisplay
+        ? buildExitNarratives({
+            topFactorLabel,
+            secondFactorLabel,
+            topExitReasonLabel,
+            topContributingReasonLabel,
+            strongWorkSignalRate,
+            distribution: buildExitPictureDistribution(responses),
+          })
+        : []
+    const contributingItems: ContributingItem[] = []
+
+    if (topContributingReasonLabel) {
+      contributingItems.push({
+        label: "Contextcode",
+        value: topContributingReasonLabel,
+        body: "Deze meespelende reden ligt zichtbaar onder het vertrekbeeld en helpt om de hoofdrichting beter feitelijk te lezen.",
       })
-      const remainingFactorRows = factorPriorityRows.slice(2)
-      const contextualFactorRows =
-        remainingFactorRows.length > 0 ? remainingFactorRows : factorPriorityRows.slice(0, 4)
-      const strongWorkSignalLabel =
-        strongWorkSignalRate !== null ? `${strongWorkSignalRate}%` : "Nog niet vrij"
-      const responseContextNote = buildResponseContextNote(
-        stats.total_completed,
-        stats.completion_rate_pct ?? 0,
-      )
-      const synthesisCards = [
-        {
-          label: "Hoofdredenen",
-          title: topExitReasonLabel ?? "Dominante vertrekreden nog niet vrij",
-          body:
-            topExitReasonLabel !== null
-              ? "Deze reden geeft de bestuurlijke hoofdrichting van het vertrekbeeld."
-              : "De route heeft nog niet genoeg leesbasis om een dominante vertrekreden stevig vrij te geven.",
-        },
-        {
-          label: "Meespelende factoren",
-          title:
-            topContributingReasonLabel ??
-            secondFactor ??
-            "Meespelende factor nog niet scherp genoeg",
-          body:
-            topContributingReasonLabel || secondFactor
-              ? `${topContributingReasonLabel ?? secondFactor} kleurt mee onder de hoofdreden en hoort daarom in dezelfde managementlezing thuis.`
-              : "Gebruik deze laag pas zodra een tweede factor of contextsignaal zichtbaar genoeg terugkomt.",
-        },
-        {
-          label: "Survey-stemmen",
-          title: `${strongWorkSignalLabel} sterk werksignaal`,
-          body:
-            strongWorkSignalRate !== null
-              ? `In ${strongWorkSignalRate}% van de leesbare responses staat werkfrictie vooraan. Daardoor blijven survey-stemmen vooral relevant als intern werkbeeld, niet als losse casuistiek.`
-              : "Gebruik survey-stemmen hier nog voorzichtig. Het groepsbeeld is nog niet stevig genoeg voor een scherp patroon per stemlaag.",
-        },
-        {
-          label: "Context",
-          title: `${organizationName} · ${scopeLabel}`,
-          body:
-            exitDistribution.total > 0
-              ? `Werkfrictie, trekfactoren en situationele context blijven bestuurlijk los relevant binnen deze scope. Lees ze samen, niet als concurrerende verklaringen.`
-              : "De contextlaag blijft op groepsniveau. Lees het patroon pas steviger zodra voldoende vertrekbeeld zichtbaar is.",
-        },
-      ]
-      const exitSurveyVoices = buildExitSurveyVoices(responses)
-
-      return (
-        <div className="space-y-10">
-          <div className="space-y-4 border-b border-slate-200/80 pb-5">
-            <p className="text-[0.78rem] font-medium tracking-[0.01em] text-slate-500">
-              <Link href="/dashboard" className="transition-colors hover:text-slate-700">
-                Overzicht
-              </Link>{" "}
-              /{" "}
-              <Link href={moduleHref} className="transition-colors hover:text-slate-700">
-                {moduleLabel}
-              </Link>{" "}
-              / <span className="text-slate-700">{stats.campaign_name}</span>
-            </p>
-            <Link
-              href={moduleHref}
-              className="inline-flex items-center gap-2 text-sm font-medium text-slate-500 transition-colors hover:text-slate-700"
-            >
-              ← {moduleBackLinkLabel}
-            </Link>
-            <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-              <div className="space-y-3">
-                <div className="flex flex-wrap items-center gap-2.5">
-                  <span className="inline-flex rounded-full border border-[#E7D3BF] bg-[#FBF3E7] px-3 py-1 text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-[#A96026]">
-                    ExitScan
-                  </span>
-                  <span className="inline-flex rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-slate-600">
-                    {compositionStateMeta.label}
-                  </span>
-                </div>
-                <h1 className="font-serif text-[2.6rem] leading-[0.96] tracking-[-0.055em] text-[color:var(--dashboard-ink)] sm:text-[3.15rem]">
-                  {stats.campaign_name}
-                </h1>
-                <p className="text-sm leading-6 text-slate-600">
-                  {organizationName} · {routePeriodLabel} · {scopeLabel}
-                </p>
-              </div>
-              <div className="flex flex-wrap items-center gap-3">{headerActions}</div>
-            </div>
-          </div>
-
-          <section className="space-y-4 border-t border-slate-200/80 pt-6">
-            <div className="space-y-2">
-              <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-[color:var(--dashboard-muted)]">
-                Respons
-              </p>
-              <h2 className="font-serif text-[1.95rem] leading-[1.02] tracking-[-0.045em] text-[color:var(--dashboard-ink)]">
-                Respons & leescontext
-              </h2>
-            </div>
-            <div className="grid gap-4 lg:grid-cols-[minmax(0,0.95fr),minmax(0,1.05fr)] lg:items-start">
-              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-                {[
-                  { label: "Respons", value: `${stats.completion_rate_pct ?? 0}%` },
-                  { label: "Uitgenodigd", value: `${stats.total_invited}` },
-                  { label: "Ingevuld", value: `${stats.total_completed}` },
-                ].map((item) => (
-                  <div key={item.label} className="rounded-[18px] bg-[color:var(--dashboard-soft)]/62 px-4 py-4">
-                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
-                      {item.label}
-                    </p>
-                    <p className="mt-3 text-base font-semibold tracking-[-0.02em] text-[color:var(--dashboard-ink)]">
-                      {item.value}
-                    </p>
-                  </div>
-                ))}
-              </div>
-              <div className="rounded-[20px] bg-[color:var(--dashboard-soft)]/62 px-5 py-4 text-sm leading-6 text-[color:var(--dashboard-text)]">
-                {responseContextNote}
-              </div>
-            </div>
-          </section>
-
-          <section className="rounded-[30px] bg-[linear-gradient(180deg,rgba(255,250,245,0.98),rgba(249,242,235,0.94))] px-6 py-6 shadow-[0_18px_40px_rgba(17,24,39,0.06)] sm:px-7 sm:py-7">
-            <div className="flex flex-col gap-6 xl:grid xl:grid-cols-[minmax(0,1.2fr),minmax(340px,0.8fr)]">
-              <div className="space-y-5">
-                <div className="space-y-1">
-                  <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-[#A96026]">
-                    Kernbeeld nu
-                  </p>
-                </div>
-                <div className="grid gap-3 lg:grid-cols-2">
-                  <div className="rounded-[22px] border border-[#E7D7C6] bg-white/84 px-4 py-4">
-                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
-                      Wat speelt nu
-                    </p>
-                    <p className="mt-3 text-lg font-semibold tracking-[-0.03em] text-[color:var(--dashboard-ink)]">
-                      {topFactor ?? "De scherpste factor is nog niet vrij"}
-                    </p>
-                    <p className="mt-2 text-sm leading-6 text-[color:var(--dashboard-text)]">
-                      {topFactor
-                        ? `${topFactor} drukt nu het sterkst op het vertrekbeeld en hoort daarom de eerste lezing te openen.`
-                        : "De route is nog niet vrij genoeg om al één dominante factor stevig naar voren te trekken."}
-                    </p>
-                  </div>
-                  <div className="rounded-[22px] border border-[#E7D7C6] bg-white/84 px-4 py-4">
-                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
-                      Scherpste factor(en)
-                    </p>
-                    <div className="mt-3 space-y-3">
-                      <div>
-                        <p className="text-sm font-semibold text-[color:var(--dashboard-ink)]">
-                          {factorPriorityRows[0]?.factor ?? "Nog niet vrij"}
-                        </p>
-                        <p className="mt-1 text-sm text-slate-600">
-                          {factorPriorityRows[0]
-                            ? `${factorPriorityRows[0].score} · ${factorPriorityRows[0].signal ?? "Geen signaal"}`
-                            : "Nog geen stabiel factorbeeld"}
-                        </p>
-                      </div>
-                      <div className="border-t border-[#EEE4D8] pt-3">
-                        <p className="text-sm font-semibold text-[color:var(--dashboard-ink)]">
-                          {factorPriorityRows[1]?.factor ?? topExitReasonLabel ?? "Tweede laag nog niet scherp genoeg"}
-                        </p>
-                        <p className="mt-1 text-sm text-slate-600">
-                          {factorPriorityRows[1]
-                            ? `${factorPriorityRows[1].score} · ${factorPriorityRows[1].signal ?? "Geen signaal"}`
-                            : topExitReasonLabel
-                              ? `Dominante vertrekreden: ${topExitReasonLabel}`
-                              : "Nog geen tweede dragende factor zichtbaar"}
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
-                <div className="rounded-[24px] border border-[#E7D7C6] bg-white/88 px-5 py-5">
-                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
-                    Frictiescore
-                  </p>
-                  <p className="dash-number mt-3 text-[2.3rem] leading-none text-[color:var(--dashboard-ink)]">
-                    {averageRiskScore !== null ? `${averageRiskScore.toFixed(1)}/10` : "Nog niet vrij"}
-                  </p>
-                  <p className="mt-3 text-sm leading-6 text-[color:var(--dashboard-text)]">
-                    Dit is het gemiddelde frictieniveau in de leesbare responses. Hoe hoger de score, hoe vaker antwoorden wijzen op spanning of frictie in het werk.
-                  </p>
-                  <div className="mt-3 space-y-2 text-sm leading-6 text-[color:var(--dashboard-text)]">
-                    <p>
-                      Zie dit als de sterkte van het beeld: niet waar het vandaan komt, maar hoe zwaar de frictie gemiddeld naar voren komt.
-                    </p>
-                    <p>
-                      De score is opgebouwd uit patronen in de antwoorden op groepsniveau, niet uit één losse reden of één individuele response.
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </section>
-
-          <section className="space-y-4 border-t border-slate-200/80 pt-6">
-            <div className="space-y-2">
-              <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-[#2E756E]">
-                Drivers
-              </p>
-              <h2 className="font-serif text-[1.95rem] leading-[1.02] tracking-[-0.045em] text-[color:var(--dashboard-ink)]">
-                Drivers & prioriteitenbeeld
-              </h2>
-              <p className="max-w-4xl text-[1rem] leading-7 text-[color:var(--dashboard-text)]">
-                Deze pagina bundelt SDT-gebaseerde en organisatorische factoren in één prioriteitenbeeld. Daardoor zie je sneller welke thema&apos;s als eerste aandacht vragen.
-              </p>
-            </div>
-            <div className="grid gap-5 xl:grid-cols-[minmax(0,1.08fr),minmax(320px,0.92fr)]">
-              <ExitDriversPriorityChart rows={factorPriorityRows} />
-              <div>
-                <ManagementReadDistribution
-                  tone="exit"
-                  label="Vertrekbeeld"
-                  value={`${exitDistribution.workPercent}% werkfrictie`}
-                  narrative="Werkfrictie laat de richting van het beeld zien. Dit percentage betekent dat de meeste leesbare responses vooral wijzen naar factoren in werk, rol of organisatie, niet naar een externe trekfactor of alleen situatie."
-                  segments={exitDistribution.segments}
-                />
-              </div>
-            </div>
-            <div className="overflow-hidden rounded-[20px] border border-[color:var(--dashboard-frame-border)] bg-white/78">
-              <div className="border-b border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)]/72 px-5 py-3">
-                <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
-                  Factoren
-                </p>
-                <p className="mt-1 text-sm leading-6 text-[color:var(--dashboard-text)]">
-                  Rangorde op basis van lagere beleving en hoger signaal.
-                </p>
-              </div>
-              <div className="divide-y divide-[color:var(--dashboard-frame-border)]/80">
-                {factorPriorityRows.map((row, index) => {
-                  const severityWidth = Math.max(12, Math.min(100, (row.signalValue / 10) * 100))
-                  const severityTone =
-                    index === 0
-                      ? "bg-[#C36A29]"
-                      : index === 1
-                        ? "bg-[#D19422]"
-                        : index === 2
-                          ? "bg-[#D8A96B]"
-                          : "bg-[#D8CBB8]"
-
-                  return (
-                    <div
-                      key={row.factor}
-                      className="grid gap-3 px-5 py-4 lg:grid-cols-[58px_minmax(0,1.15fr)_180px_180px] lg:items-center lg:gap-5"
-                    >
-                      <div className="flex items-center gap-3">
-                        <span className="text-[1.1rem] font-semibold tabular-nums text-[color:var(--dashboard-ink)]">
-                          {String(index + 1).padStart(2, "0")}
-                        </span>
-                        <div className="hidden h-10 w-1.5 overflow-hidden rounded-full bg-[color:var(--dashboard-soft)] lg:block">
-                          <div
-                            className={`w-full rounded-full ${severityTone}`}
-                            style={{ height: `${severityWidth}%`, marginTop: `${100 - severityWidth}%` }}
-                          />
-                        </div>
-                      </div>
-                      <div className="space-y-1.5">
-                        <p className="text-sm font-semibold tracking-[-0.02em] text-[color:var(--dashboard-ink)]">
-                          {row.factor}
-                        </p>
-                        <p className="text-sm leading-6 text-[color:var(--dashboard-text)]">
-                          {row.note}
-                        </p>
-                      </div>
-                      <div>
-                        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
-                          Beleving
-                        </p>
-                        <p className="mt-1 text-sm font-semibold tabular-nums text-[color:var(--dashboard-ink)]">
-                          {row.score}
-                        </p>
-                      </div>
-                      <div>
-                        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
-                          Signaal
-                        </p>
-                        <p className="mt-1 text-sm font-semibold tabular-nums text-[color:var(--dashboard-ink)]">
-                          {row.signal ?? "Nog niet vrij"}
-                        </p>
-                      </div>
-                    </div>
-                  )
-                })}
-              </div>
-            </div>
-          </section>
-
-          <section className="space-y-4 border-t border-slate-200/80 pt-6">
-            <div className="space-y-2">
-              <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-[color:var(--dashboard-muted)]">
-                Synthese
-              </p>
-              <h2 className="font-serif text-[1.95rem] leading-[1.02] tracking-[-0.045em] text-[color:var(--dashboard-ink)]">
-                Synthese van vertrekbeeld
-              </h2>
-            </div>
-            <div className="grid gap-4 xl:grid-cols-2">
-              {synthesisCards.map((card) => (
-                <div
-                  key={card.label}
-                  className="rounded-[20px] bg-[color:var(--dashboard-soft)]/52 px-5 py-5"
-                >
-                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
-                    {card.label}
-                  </p>
-                  <h3 className="mt-3 text-[1.08rem] font-semibold tracking-[-0.03em] text-[color:var(--dashboard-ink)]">
-                    {card.title}
-                  </h3>
-                  <p className="mt-3 text-sm leading-6 text-[color:var(--dashboard-text)]">
-                    {card.body}
-                  </p>
-                </div>
-              ))}
-            </div>
-            <div className="grid gap-4 xl:grid-cols-[minmax(0,0.95fr),minmax(0,1.05fr)]">
-              <div className="rounded-[20px] bg-[color:var(--dashboard-soft)]/52 px-5 py-5">
-                <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
-                  Verdeling van vertrekbeeld
-                </p>
-                <p className="mt-3 text-sm leading-6 text-[color:var(--dashboard-text)]">
-                  Zo zie je hoe het leesbare vertrekbeeld verdeeld is tussen werkfrictie, trekfactoren en situationele context.
-                </p>
-                <div className="mt-4 flex h-3 overflow-hidden rounded-full bg-white/85">
-                  {exitDistribution.segments.map((segment, index) => {
-                    const fillTone =
-                      index === 0 ? "bg-[#C36A29]" : index === 1 ? "bg-[#D7A16B]" : "bg-[#D9D3CA]"
-
-                    return (
-                      <div
-                        key={`stack-${segment.label}`}
-                        className={fillTone}
-                        style={{ width: `${Math.max(0, Math.min(100, segment.percent))}%` }}
-                      />
-                    )
-                  })}
-                </div>
-                <div className="mt-4 space-y-3">
-                  {exitDistribution.segments.map((segment, index) => {
-                    const fillTone =
-                      index === 0 ? "bg-[#C36A29]" : index === 1 ? "bg-[#D7A16B]" : "bg-[#D9D3CA]"
-
-                    return (
-                      <div key={segment.label} className="space-y-1.5">
-                        <div className="flex items-center justify-between gap-3 text-sm text-slate-700">
-                          <span>{segment.label}</span>
-                          <span className="font-semibold text-[color:var(--dashboard-ink)]">
-                            {segment.value}
-                          </span>
-                        </div>
-                        <div className="h-2.5 overflow-hidden rounded-full bg-white/85">
-                          <div
-                            className={`h-full rounded-full ${fillTone}`}
-                            style={{ width: `${Math.max(0, Math.min(100, segment.percent))}%` }}
-                          />
-                        </div>
-                      </div>
-                    )
-                  })}
-                </div>
-              </div>
-              <div className="rounded-[20px] bg-[color:var(--dashboard-soft)]/52 px-5 py-5">
-                <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
-                  Survey-stemmen
-                </p>
-                <p className="mt-3 text-sm leading-6 text-[color:var(--dashboard-text)]">
-                  Korte anonieme stemmen uit de open antwoorden, zodat zichtbaar blijft dat er echte signalen onder het beeld liggen.
-                </p>
-                <div className="mt-4 space-y-3">
-                  {exitSurveyVoices.length > 0 ? (
-                    exitSurveyVoices.map((voice, index) => (
-                      <div key={`${index}-${voice}`} className="rounded-[16px] bg-white/85 px-4 py-4">
-                        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
-                          Anonieme stem {index + 1}
-                        </p>
-                        <p className="mt-2 text-sm italic leading-6 text-[color:var(--dashboard-text)]">
-                          &quot;{voice}&quot;
-                        </p>
-                      </div>
-                    ))
-                  ) : (
-                    <div className="rounded-[16px] bg-white/85 px-4 py-4">
-                      <p className="text-sm leading-6 text-[color:var(--dashboard-text)]">
-                        Nog geen open antwoorden scherp genoeg vrijgegeven voor een compacte stemlaag.
-                      </p>
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div>
-            {exitNarratives.length > 0 ? (
-              <div className="border-t border-slate-200/80 pt-5">
-                <ManagementReadNarratives items={exitNarratives} />
-              </div>
-            ) : null}
-          </section>
-
-          <section className="space-y-4 border-t border-slate-200/80 pt-6">
-            <div className="space-y-2">
-              <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-[color:var(--dashboard-muted)]">
-                Verdieping
-              </p>
-              <h2 className="font-serif text-[1.95rem] leading-[1.02] tracking-[-0.045em] text-[color:var(--dashboard-ink)]">
-                Verdiepingslagen
-              </h2>
-              <p className="max-w-4xl text-[1rem] leading-7 text-[color:var(--dashboard-text)]">
-                SDT, organisatiefactoren en aanvullende context blijven bewust secundair. Ze zijn nuttig voor verdieping, niet voor de eerste lezing.
-              </p>
-            </div>
-            <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr),minmax(0,1fr),minmax(300px,0.82fr)]">
-              <ExitSdtNeedsChart rows={sdtRows} />
-              <ExitOrgFactorsChart rows={contextualFactorRows} />
-              <div className="rounded-[20px] bg-[color:var(--dashboard-soft)]/52 px-5 py-5">
-                <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-[color:var(--dashboard-muted)]">
-                  Aanvullende context
-                </p>
-                <div className="mt-4 space-y-4 text-sm leading-6 text-[color:var(--dashboard-text)]">
-                  <div>
-                    <p className="font-semibold text-[color:var(--dashboard-ink)]">
-                      Dominante vertrekreden
-                    </p>
-                    <p className="mt-1">
-                      {topExitReasonLabel ?? "Nog niet stevig genoeg zichtbaar"}
-                    </p>
-                  </div>
-                  <div className="border-t border-[color:var(--dashboard-frame-border)] pt-4">
-                    <p className="font-semibold text-[color:var(--dashboard-ink)]">
-                      Meelezende context
-                    </p>
-                    <p className="mt-1">
-                      {topContributingReasonLabel ??
-                        "Nog geen meelezende contextcode scherp genoeg vrijgegeven"}
-                    </p>
-                  </div>
-                  <div className="border-t border-[color:var(--dashboard-frame-border)] pt-4">
-                    <p className="font-semibold text-[color:var(--dashboard-ink)]">
-                      Signaalzichtbaarheid
-                    </p>
-                    <p className="mt-1">
-                      {signalVisibilityAverage !== null
-                        ? `${signalVisibilityAverage.toFixed(1)}/10 zichtbaar in deze wave.`
-                        : "Nog niet stevig genoeg om als extra zichtbaarheidssignaal te lezen."}
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </section>
-
-        </div>
-      )
     }
 
-    const retentionNarratives = buildRetentionNarratives({
-      topFactorLabel: topFactor,
-      secondFactorLabel: secondFactor,
-      retentionThemes,
-      averageRiskScore,
-      turnoverIntention: retentionSupplemental.turnoverIntention,
-      engagement: retentionSupplemental.engagement,
-    })
-    const retentionSegments = buildRetentionSignalSegments(riskDistribution)
-    const engagementSegments = buildEngagementSegments(responses)
+    if (secondFactorLabel) {
+      contributingItems.push({
+        label: "Tweede factor",
+        value: secondFactorLabel,
+        body: "Deze factor kleurt mee naast het primaire signaal en hoort daarom in dezelfde analytische laag thuis.",
+      })
+    }
 
     return (
-      <div className="space-y-8">
-        <div className="space-y-3 border-b border-slate-200/80 pb-4">
-          <p className="text-[0.78rem] font-medium tracking-[0.01em] text-slate-500">
-            <Link href="/dashboard" className="transition-colors hover:text-slate-700">
-              Overzicht
-            </Link>{" "}
-            /{" "}
-            <Link href={moduleHref} className="transition-colors hover:text-slate-700">
-              {moduleLabel}
-            </Link>{" "}
-            / <span className="text-slate-700">{stats.campaign_name}</span>
-          </p>
-          <Link
-            href={moduleHref}
-            className="inline-flex items-center gap-2 text-sm font-medium text-slate-500 transition-colors hover:text-slate-700"
-          >
-            ← {moduleBackLinkLabel}
-          </Link>
-        </div>
-
-        <ManagementReadHeader
-          tone="retention"
-          productLabel="RetentieScan"
-          title={stats.campaign_name}
-          orgLabel={organizationName}
-          periodLabel={routePeriodLabel}
+      <div className="space-y-10">
+        {summaryShell}
+        <ExitProductDashboard
+          moduleHref={moduleHref}
+          moduleLabel={moduleLabel}
+          moduleBackLinkLabel={moduleBackLinkLabel}
+          campaignName={stats.campaign_name}
+          organizationName={organizationName}
+          routePeriodLabel={routePeriodLabel}
           scopeLabel={scopeLabel}
-          statusLabel={compositionStateMeta.label}
-          contextLine={`${topFactor ?? "De route"} opent het eerste behoudsbeeld. Behoudsdruk moet hier eerst gelezen worden, niet direct vertaald naar eigenaarschap of actieontwerp.`}
-          actions={headerActions}
-        />
-
-        <ManagementReadSection eyebrow="Bestuurlijke handoff" title="Behoudsdruk en responsbeeld">
-          <div className="space-y-5">
-            <p className="max-w-4xl text-[1rem] leading-7 text-[color:var(--dashboard-text)]">
-              Deze route laat eerst zien waar behoud onder druk staat en welke samenhang daaronder ligt. De pagina bewaakt bewust de grens tussen bestuurlijke duiding en commitment: ze opent de routelezing, maar schuift vervolgstructuur door naar Action Center.
-            </p>
-            <ManagementReadInfoGrid
-              items={[
-                { label: "Retentiesignaal", value: averageRiskScore !== null ? `${averageRiskScore.toFixed(1)}/10` : "Nog niet vrij" },
-                { label: "Vertrekintentie", value: retentionSupplemental.turnoverIntention !== null ? `${retentionSupplemental.turnoverIntention.toFixed(1)}/10` : "Nog niet vrij" },
-                { label: "Bevlogenheid", value: retentionSupplemental.engagement !== null ? `${retentionSupplemental.engagement.toFixed(1)}/10` : "Nog niet vrij" },
-                { label: "Respons", value: `${stats.completion_rate_pct ?? 0}%` },
-              ]}
+          statusLabel={getResultsStatusLabel(resultsViewModel.readState)}
+          headerActions={
+            <PdfDownloadButton campaignId={id} campaignName={stats.campaign_name} scanType={stats.scan_type} />
+          }
+          averageSignalScoreLabel={
+            averageRiskScore !== null && hasMinDisplay ? `${averageRiskScore.toFixed(1)}/10` : "Nog niet beschikbaar"
+          }
+          strongestFactorLabel={topFactorLabel ?? "Nog niet beschikbaar"}
+          strongWorkSignalLabel={
+            strongWorkSignalRate !== null ? `${strongWorkSignalRate}%` : "Nog niet beschikbaar"
+          }
+          primaryReasonTitle={topExitReasonLabel ?? topFactorLabel ?? "Nog niet beschikbaar"}
+          primaryReasonBody={
+            topExitReasonLabel
+              ? `${topExitReasonLabel} geeft de bestuurlijke hoofdrichting van het vertrekbeeld binnen deze route.`
+              : "Nog niet beschikbaar voor een eerlijke analytische hoofdrichting."
+          }
+          whyItMattersItems={exitNarratives}
+          contributingItems={contributingItems}
+          totalInvited={String(stats.total_invited)}
+          totalCompleted={String(stats.total_completed)}
+          responseRate={`${stats.completion_rate_pct ?? 0}%`}
+          responseContextNote={buildResponseContextNote(stats.total_completed, stats.completion_rate_pct ?? 0)}
+          topFactors={blockVisibility.signal === "visible" ? factorPriorityRows : []}
+          distributionSegments={blockVisibility.synthesis === "visible" ? exitDistribution.segments : []}
+          factorRows={blockVisibility.drivers === "visible" ? factorPriorityRows : []}
+          sdtRows={blockVisibility.depth === "visible" ? sdtRows : []}
+          methodologyContent={
+            <MethodologyCard
+              scanType={stats.scan_type}
+              hasSegmentDeepDive={hasCampaignAddOn(campaignMeta, "segment_deep_dive")}
+              signalLabel={scanDefinition.signalLabel}
+              embedded
             />
-          </div>
-        </ManagementReadSection>
-
-        <ManagementReadSection
-          eyebrow="Drivers"
-          title="Drivers en prioriteitenbeeld"
-          note={`Driverbeeld op basis van n = ${responses.length}. Groei, belasting, leiderschap en context blijven afzonderlijk bestuurlijk leesbaar.`}
-        >
-          <ManagementReadFactorTable rows={factorPriorityRows} />
-        </ManagementReadSection>
-
-        <ManagementReadSection
-          eyebrow="Synthese"
-          title="Kernsignalen in samenhang"
-          note="Kernsignalen blijven samengevat, maar niet opgeblazen tot actieontwerp. Het rapport blijft de inhoudelijke waarheid."
-        >
-          <ManagementReadNarratives items={retentionNarratives} />
-        </ManagementReadSection>
-
-        <ManagementReadSection
-          eyebrow="Retentiebeeld"
-          title="Retentiesignaal, vertrekintentie en bevlogenheidsverhouding"
-        >
-          <div className="grid gap-4 xl:grid-cols-2">
-            <ManagementReadDistribution
-              tone="retention"
-              label="Retentiesignaal"
-              value={averageRiskScore !== null ? `${averageRiskScore.toFixed(1)}/10` : "Nog niet vrij"}
-              narrative="De verdeling tussen actief vertrekdenkend, latent risico en stabiel blijft bestuurlijk belangrijk. Juist de middengroep is vaak het eerst relevant voor een managementread."
-              segments={retentionSegments}
-            />
-            <ManagementReadDistribution
-              tone="retention"
-              label="Bevlogenheidsverhouding"
-              value={retentionSupplemental.engagement !== null ? `${retentionSupplemental.engagement.toFixed(1)}/10` : "Nog niet vrij"}
-              narrative="Bevlogenheid leest hier niet los, maar in verhouding tot behoudsdruk en vertrekintentie. Daardoor blijft de route behoudsdruk-first in plaats van actie-first."
-              segments={engagementSegments}
-            />
-          </div>
-        </ManagementReadSection>
-
-        <ManagementReadSection
-          eyebrow="Verdieping"
-          title="SDT en organisatiefactoren"
-          note="Ook hier blijft de verdiepingslaag rapporttrouw: SDT verklaart niet los, maar helpt de primaire organisatiefactoren bestuurlijk scherper te lezen."
-        >
-          <ManagementReadFactorTable rows={sdtRows} />
-        </ManagementReadSection>
-
-        <ManagementReadBridge
-          tone="retention"
-          title="Van behoudsdruk naar mogelijke vervolgrichting"
-          body="De routepagina toont wat bestuurlijk als eerste gelezen moet worden. Eventuele eigenaarschap-, actie- en reviewstructuur hoort pas in Action Center thuis."
-          action={actionCenterRouteAction}
+          }
         />
       </div>
     )
   }
 
   return (
-    <div className="grid gap-8 xl:grid-cols-[minmax(0,1fr),320px] xl:items-start">
-      <div className="min-w-0 space-y-7">
-        <div className="border-b border-slate-200/80 pb-4">
-          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
-            <div className="space-y-3">
-              <p className="text-[0.78rem] font-medium tracking-[0.01em] text-slate-500">
-                <Link href="/dashboard" className="transition-colors hover:text-slate-700">
-                  Overzicht
-                </Link>{" "}
-                /{" "}
-                <Link href={moduleHref} className="transition-colors hover:text-slate-700">
-                  {moduleLabel}
-                </Link>{" "}
-                / <span className="text-slate-700">{stats.campaign_name}</span>
-              </p>
-              <Link
-                href={moduleHref}
-                className="inline-flex items-center gap-2 text-sm font-medium text-slate-500 transition-colors hover:text-slate-700"
-              >
-                ← {moduleBackLinkLabel}
-              </Link>
-            </div>
-            <p className="max-w-2xl text-sm leading-6 text-slate-500 lg:text-right">
-              Campagnedetail brengt samenvatting, uitvoering en vervolgstap
-              bij elkaar zonder onnodige omwegen.
-            </p>
-          </div>
-        </div>
-
-        <div id="samenvatting" className="scroll-mt-36 space-y-5">
-          <DashboardHero
-            eyebrow={scanDefinition.productName}
-            title={stats.campaign_name}
-            description={buildHeroDescription({
-              scanType: stats.scan_type,
-              isActive: stats.is_active,
-              completionRate: stats.completion_rate_pct ?? 0,
-              pendingCount,
-              hasEnoughData,
-              averageRiskScore,
-              scanDefinition,
-            })}
-            tone="slate"
-            variant="editorial"
-            meta={
-              <>
-                <DashboardChip
-                  label={stats.is_active ? "Actief" : "Gesloten"}
-                  tone={stats.is_active ? "emerald" : "slate"}
-                />
-                <DashboardChip
-                  label={productExperience.familyRoleLabel}
-                  tone={productExperience.familyRoleTone}
-                />
-                <DashboardChip
-                  label={`${stats.completion_rate_pct ?? 0}% respons`}
-                  tone="slate"
-                />
-                <DashboardChip
-                  label={compositionStateMeta.label}
-                  tone={compositionStateMeta.tone}
-                />
-                <DashboardChip
-                  label={getDeliveryModeLabel(
-                    campaignMeta?.delivery_mode ?? null,
-                    stats.scan_type,
-                  )}
-                  tone="slate"
-                />
-              </>
-            }
-            actions={
-              !showManagementOutput ? (
-                <div className="rounded-full border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-900">
-                  {activationState.heroActionLabel}
-                </div>
-              ) : showPartialManagementOutput ? (
-                <>
-                  <div className="rounded-full border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-900">
-                    Compacte read zichtbaar, aanbevelingen nog begrensd
-                  </div>
-                  <PdfDownloadButton
-                    campaignId={id}
-                    campaignName={stats.campaign_name}
-                    scanType={stats.scan_type}
-                  />
-                </>
-              ) : prefersReportFirst ? (
-                <>
-                  {!profile?.is_verisight_admin ? (
-                    <OnboardingAdvancer fromStep={1} />
-                  ) : null}
-                  <div className="relative">
-                    {!profile?.is_verisight_admin ? (
-                      <OnboardingBalloon
-                        step={2}
-                        label="Download hier je rapport"
-                        align="left"
-                      />
-                    ) : null}
-                    <PdfDownloadButton
-                      campaignId={id}
-                      campaignName={stats.campaign_name}
-                      scanType={stats.scan_type}
-                    />
-                  </div>
-                </>
-              ) : stats.scan_type === "pulse" ||
-                stats.scan_type === "team" ||
-                stats.scan_type === "onboarding" ||
-                stats.scan_type === "leadership" ? (
-                <>
-                  {!profile?.is_verisight_admin ? (
-                    <OnboardingAdvancer fromStep={1} />
-                  ) : null}
-                  <div className="rounded-full border border-slate-200 bg-slate-50 px-4 py-2 text-sm font-semibold text-slate-700">
-                    {stats.scan_type === "pulse"
-                      ? "Pulse: eerste vervolgstap live"
-                      : stats.scan_type === "team"
-                        ? "TeamScan: lokale read live"
-                        : stats.scan_type === "onboarding"
-                          ? "Onboarding: checkpoint read live"
-                          : "Leadership Scan: management read live"}
-                  </div>
-                </>
-              ) : (
-                <>
-                  {!profile?.is_verisight_admin ? (
-                    <OnboardingAdvancer fromStep={1} />
-                  ) : null}
-                  <div className="relative">
-                    {!profile?.is_verisight_admin ? (
-                      <OnboardingBalloon
-                        step={2}
-                        label="Download hier je rapport"
-                        align="left"
-                      />
-                    ) : null}
-                    <PdfDownloadButton
-                      campaignId={id}
-                      campaignName={stats.campaign_name}
-                      scanType={stats.scan_type}
-                    />
-                  </div>
-                </>
-              )
-            }
-            aside={
-              <div className="space-y-3">
-                <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
-                  {heroAsideItems.map((item) => (
-                    <DashboardKeyValue
-                      key={item.label}
-                      label={item.label}
-                      value={item.value}
-                      accent={item.accent}
-                      helpText={item.helpText}
-                      variant="quiet"
-                    />
-                  ))}
-                </div>
-                <div className="border-t border-[color:var(--dashboard-frame-border)] pt-3">
-                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
-                    Campagnestatus
-                  </p>
-                  <p className="mt-2 text-sm leading-6 text-slate-700">
-                    {`${stats.total_completed}/${stats.total_invited || 0} ingevuld`}
-                    .{" "}
-                    {pendingCount > 0
-                      ? `${pendingCount} respondent(en) zijn nog niet afgerond.`
-                      : "Alle uitgenodigde respondenten hebben afgerond."}
-                  </p>
-                  <p className="mt-2 text-xs leading-5 text-slate-500">
-                    State: {compositionStateMeta.label}.{" "}
-                    {compositionStateMeta.trust}
-                  </p>
-                  <p className="mt-2 text-xs leading-5 text-slate-500">
-                    {activationState.statusDetail}
-                  </p>
-                </div>
-              </div>
-            }
-          />
-
-          {buildInsightWarnings({
-            responsesLength: responses.length,
-            hasMinDisplay,
-            hasEnoughData,
-            scanType: stats.scan_type,
-          }).map((notice) => (
-            <div
-              key={notice.title}
-              className={`rounded-[20px] border px-4 py-3.5 text-sm ${
-                notice.tone === "amber"
-                  ? "border-amber-200 bg-amber-50/85 text-amber-900"
-                  : notice.tone === "red"
-                    ? "border-red-200 bg-red-50/85 text-red-900"
-                    : "border-slate-200 bg-white/80 text-slate-900"
-              }`}
-            >
-              <p className="font-semibold">{notice.title}</p>
-              <p className="mt-1 leading-6">{notice.body}</p>
-            </div>
-          ))}
-
-          {showManagementOutput ? (
-            <div className="grid grid-cols-2 gap-4 xl:grid-cols-4">
-              <SignalStatCard
-                label="Signaal-index"
-                value={
-                  averageRiskScore !== null
-                    ? `${averageRiskScore.toFixed(1)}/10`
-                    : "-"
-                }
-                subline={
-                  averageRiskScore !== null
-                    ? stats.scan_type === "exit"
-                      ? undefined
-                      : bandLabels[getRiskBandFromScore(averageRiskScore)]
-                    : undefined
-                }
-                band={
-                  averageRiskScore !== null
-                    ? stats.scan_type === "exit"
-                      ? "neutral"
-                      : getRiskBandFromScore(averageRiskScore)
-                    : undefined
-                }
-              />
-              <SignalStatCard
-                label="Respons"
-                value={`${stats.completion_rate_pct ?? 0}%`}
-                subline={`${stats.total_completed} van ${stats.total_invited} responsen`}
-                band="neutral"
-              />
-              <SignalStatCard
-                label={stats.scan_type === "exit" ? "Spreiding in beeld" : "Risicoband"}
-                value={`${dominantPct}%`}
-                subline={
-                  stats.scan_type === "exit"
-                    ? "van de responses valt in de grootste zichtbare groep"
-                    : `valt nu in ${bandLabels[dominantBand].toLowerCase()}`
-                }
-                band={stats.scan_type === "exit" ? "neutral" : dominantBand}
-              />
-              <InsightStatCard
-                label="Sterkste factor"
-                value={topExitReasonLabel ?? topContributingReasonLabel ?? "-"}
-                subline="vraagt nu als eerste aandacht"
-              />
-            </div>
-          ) : null}
-        </div>
-
-        <DashboardSummaryBar
-          items={summaryItems}
-          anchors={sectionAnchors}
-          variant="quiet"
-          actions={summaryActions}
-        />
-
-        {showClientExecutionFlow ? (
-          <DashboardSection
-            id="uitvoering"
-            eyebrow="Uitvoering"
-            title="Uitvoering"
-            description="Gebruik dit blok alleen voor uitvoeringsstappen rond uitnodigingen en import."
-            aside={<DashboardChip label="Klantuitvoering" tone="slate" />}
-            variant="quiet"
-          >
-            <GuidedSelfServePanel
-              campaignId={id}
-              scanType={stats.scan_type}
-              isActive={stats.is_active}
-              deliveryMode={campaignMeta?.delivery_mode ?? null}
-              importReady={importReady}
-              hasSegmentDeepDive={hasSegmentDeepDive}
-              totalInvited={stats.total_invited}
-              totalCompleted={stats.total_completed}
-              invitesNotSent={invitesNotSent}
-              hasMinDisplay={hasMinDisplay}
-              hasEnoughData={hasEnoughData}
-              pendingCount={pendingCount}
-              importQaConfirmed={guidedSetupDiscipline.importQaConfirmed}
-              launchTimingConfirmed={
-                guidedSetupDiscipline.launchTimingConfirmed
-              }
-              communicationReady={guidedSetupDiscipline.communicationReady}
-              remindableCount={remindableCount}
-              unsentRespondents={unsentRespondents}
-              launchDate={deliveryRecord?.launch_date ?? null}
-              launchConfirmedAt={deliveryRecord?.launch_confirmed_at ?? null}
-              participantCommsConfig={
-                deliveryRecord?.participant_comms_config ?? null
-              }
-              reminderConfig={deliveryRecord?.reminder_config ?? null}
-              memberRole={membership?.role ?? null}
-            />
-          </DashboardSection>
-        ) : null}
-
-        {showPartialManagementOutput ? (
-          <DashboardSection
-            id="handoff"
-            eyebrow="Eerste vervolgstap"
-            title="Eerste compacte samenvatting"
-            description="De eerste veilige dashboardlaag is zichtbaar, maar deze campagne blijft nog bewust compact tot meer respons en vollediger scores een rijker beeld dragen."
-            aside={
-              <DashboardChip
-                label={compositionStateMeta.label}
-                tone={compositionStateMeta.tone}
-              />
-            }
-            tone="slate"
-            variant="quiet"
-          >
-            <div className="space-y-5">
-              <DashboardRecommendationRail
-                eyebrow="Trustgrens"
-                title="Aanbevelingen blijven nog begrensd"
-                description="Gebruik nu alleen de compacte read, de eerste managementvraag en het bijbehorende trustsignaal. Drivers, playbooks en vervolgblokken blijven bewust nog deels dicht."
-                tone="amber"
-                variant="quiet"
-              >
-                <div className="grid gap-4 lg:grid-cols-2">
-                  <DashboardPanel
-                    eyebrow="Wat nu wel zichtbaar is"
-                    title="Eerste samenvatting"
-                    body="Gebruik de hero, samenvatting en eerste managementvraag om richting te houden zonder het beeld zwaarder te maken dan de data nu draagt."
-                    tone="slate"
-                  />
-                  <DashboardPanel
-                    eyebrow="Wat bewust nog wacht"
-                    title="Nog geen volle aanbevelingslaag"
-                    body="Drivers, aanbevelingen en de vervolgrichting openen pas zodra minstens 10 complete responses beschikbaar zijn en privacygrenzen niet meer onnodig veel verbergen."
-                    tone="amber"
-                  />
-                </div>
-              </DashboardRecommendationRail>
-              <ManagementReadGuide
-                scanType={stats.scan_type}
-                hasMinDisplay={hasMinDisplay}
-                hasEnoughData={hasEnoughData}
-              />
-            </div>
-          </DashboardSection>
-        ) : null}
-
-        {showManagementOutput && promotedSummaryCards.length > 0 ? (
-          <div className="rounded-[28px] border border-[color:var(--border)] bg-[color:var(--bg)] p-4 shadow-[0_12px_32px_rgba(19,32,51,0.05)] sm:p-5">
-            <div className="flex flex-col gap-3 border-b border-[color:var(--border)]/80 pb-4 lg:flex-row lg:items-start lg:justify-between">
-              <div>
-                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
-                  {productExperience.summaryLeadTitle}
-                </p>
-                <p className="mt-2 max-w-3xl text-sm leading-6 text-[color:var(--text)]">
-                  {productExperience.summaryLeadDescription}
-                </p>
-              </div>
-              <DashboardChip
-                label={productExperience.summaryContextLabel}
-                tone={productExperience.summaryContextTone}
-              />
-            </div>
-            <div className="mt-4 grid gap-4 md:grid-cols-2">
-              {promotedSummaryCards.map((card) => (
-                <DashboardPanel
-                  key={`${card.title}-${card.value ?? "summary"}`}
-                  eyebrow={productExperience.summaryCardEyebrow}
-                  title={card.title}
-                  value={card.value}
-                  body={card.body}
-                  tone={normalizeInformationalTone(card.tone)}
-                />
-              ))}
-            </div>
-          </div>
-        ) : null}
-
-        {showDetailedManagementOutput ? (
-          <DashboardSection
-            id="handoff"
-            eyebrow="Eerste vervolgstap"
-            title={handoffTitle}
-            description={handoffDescription}
-            aside={
-              <DashboardChip
-                label={readinessLabel}
-                tone={hasEnoughData ? "emerald" : "amber"}
-              />
-            }
-            tone="slate"
-            variant="quiet"
-          >
-            <div className="space-y-4">
-              <div className="grid gap-4 xl:grid-cols-[minmax(0,1.3fr),minmax(320px,0.7fr)]">
-                <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-                  {buildDecisionPanels({
-                    stats,
-                    averageRiskScore,
-                    scanDefinition,
-                    strongWorkSignalRate,
-                    retentionSupplemental,
-                    factorAverages: factorData.orgAverages,
-                    hasEnoughData,
-                    hasMinDisplay,
-                  }).map((panel) => (
-                    <DashboardPanel
-                      key={panel.title}
-                      eyebrow={panel.eyebrow}
-                      title={panel.title}
-                      value={panel.value}
-                      body={panel.body}
-                      tone={panel.tone}
-                    />
-                  ))}
-                  {handoffSummaryCards.map((card) => (
-                    <DashboardPanel
-                      key={`${card.title}-${card.value ?? "card"}`}
-                      eyebrow={productExperience.summaryCardEyebrow}
-                      title={card.title}
-                      value={card.value}
-                      body={card.body}
-                      tone={normalizeInformationalTone(card.tone)}
-                    />
-                  ))}
-                </div>
-
-                <div className="grid gap-4">
-                  <DashboardPanel
-                    eyebrow="Eerste managementvraag"
-                    title={dashboardViewModel.primaryQuestion.title}
-                    body={dashboardViewModel.primaryQuestion.body}
-                    tone={normalizeInformationalTone(
-                      dashboardViewModel.primaryQuestion.tone,
-                    )}
-                  />
-                  <DashboardPanel
-                    eyebrow="Logische vervolgstap"
-                    title={dashboardViewModel.nextStep.title}
-                    body={dashboardViewModel.nextStep.body}
-                    tone={normalizeInformationalTone(
-                      dashboardViewModel.nextStep.tone,
-                    )}
-                  />
-                </div>
-              </div>
-
-              {stats.scan_type === "team" && hasEnoughData ? (
-                <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4 sm:p-5">
-                  <div className="flex flex-wrap items-center gap-3">
-                    <h3 className="text-sm font-semibold text-slate-950">
-                      Lokale vervolgstap
-                    </h3>
-                    <DashboardChip
-                      label={
-                        primaryTeamPriority
-                          ? `Eerst: ${primaryTeamPriority.label}`
-                          : "Kleine vervolgstap"
-                      }
-                      tone={primaryTeamPriority ? "amber" : "slate"}
-                    />
-                  </div>
-                  <p className="mt-1 text-sm leading-6 text-slate-600">
-                    {primaryTeamPriority && primaryTeamPlaybook
-                      ? `Gebruik deze TeamScan nu als compacte vervolgstap: ${primaryTeamPriority.label} vraagt eerst verificatie op ${primaryTeamPriority.topFactorLabel.toLowerCase()}, daarna kies je bewust wie de eerste lokale stap trekt en hoe klein de review blijft.`
-                      : "TeamScan geeft al wel lokale richting, maar blijft bewust klein zolang er nog geen eerlijke eerste prioriteit kan worden vrijgegeven."}
-                  </p>
-                  <div className="mt-4 grid gap-4 lg:grid-cols-4">
-                    <DashboardPanel
-                      eyebrow="Afdeling"
-                      title={
-                        primaryTeamPriority?.label ?? "Nog niet vrijgegeven"
-                      }
-                      value={primaryTeamPriority?.priorityTitle}
-                      body={
-                        primaryTeamPriority
-                          ? `${primaryTeamPriority.topFactorLabel} is hier nu het scherpste lokale spoor.`
-                          : "Gebruik meerdere zichtbare afdelingen voorlopig als gespreksinput zonder geforceerde top-1."
-                      }
-                      tone={primaryTeamPriority ? "amber" : "slate"}
-                    />
-                    <DashboardPanel
-                      eyebrow="Eerste eigenaar"
-                      title={
-                        primaryTeamPlaybook?.owner ?? "HR + afdelingsleider"
-                      }
-                      body="Maak expliciet wie het eerste lokale gesprek trekt en wie de vervolgstap terugbrengt in de review."
-                      tone="slate"
-                    />
-                    <DashboardPanel
-                      eyebrow="Begrensde eerste actie"
-                      title={
-                        primaryTeamPlaybook?.actions[0] ??
-                        "Kies eerst een kleine lokale check"
-                      }
-                      body={
-                        primaryTeamPlaybook?.decision ??
-                        "TeamScan blijft hier gericht op een kleine lokale verificatie of correctie, niet op een brede interventie."
-                      }
-                      tone="slate"
-                    />
-                    <DashboardPanel
-                      eyebrow="Reviewmoment"
-                      title={
-                        primaryTeamPlaybook?.review ?? "Lokale hercheck eerst"
-                      }
-                      body="Gebruik het reviewmoment om bewust te kiezen: nog een lokale vervolgstap, terug naar het bredere beeld of juist stoppen."
-                      tone="amber"
-                    />
-                  </div>
-                </div>
-              ) : null}
-
-              {productExperience.trustNotePlacement === "handoff"
-                ? trustNote
-                : null}
-
-              {productExperience.evidenceSectionOrder === "management-first" ? (
-                <>
-                  {managementBlocksSection}
-                  {profileCardsSection}
-                </>
-              ) : (
-                <>
-                  {profileCardsSection}
-                  {managementBlocksSection}
-                </>
-              )}
-            </div>
-          </DashboardSection>
-        ) : null}
-
-        {showDetailedManagementOutput ? (
-          <DashboardSection
-            id="drivers"
-            eyebrow="Wat drijft dit beeld?"
-            title={productExperience.driverTitle}
-            description={productExperience.driverDescription}
-            aside={
-              <DashboardChip
-                label={productExperience.driverAsideLabel}
-                tone={productExperience.driverAsideTone}
-              />
-            }
-            variant="quiet"
-          >
-            {hasEnoughData ? (
-              <div className="space-y-5">
-                {productExperience.trustNotePlacement === "drivers"
-                  ? trustNote
-                  : null}
-                <div className="rounded-[22px] border border-[color:var(--border)] bg-[color:var(--bg)] px-4 py-4 text-sm leading-6 text-[color:var(--text)]">
-                  {productExperience.driverIntro}
-                </div>
-                <DashboardTabs tabs={driverTabs} />
-              </div>
-            ) : (
-              <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-4 text-sm leading-6 text-slate-600">
-                Verdiepende analyse wordt zichtbaar vanaf {MIN_N_PATTERNS}{" "}
-                ingevulde responses. Tot die tijd blijft het dashboard bewust
-                compact en voorzichtig.
-              </div>
-            )}
-          </DashboardSection>
-        ) : null}
-
-        {showDetailedManagementOutput ? (
-          <DashboardSection
-            id="acties"
-            eyebrow="Waar eerst op handelen"
-            title={productExperience.actionTitle}
-            description={dashboardViewModel.focusSectionIntro}
-            aside={<DashboardChip label={focusBadgeLabel} tone="slate" />}
-            tone="slate"
-            variant="quiet"
-          >
-            {hasEnoughData ? (
-              <div className="space-y-5">
-                {demoteFollowThroughLayers ? (
-                  <DashboardDisclosure
-                    title="Open focusvragen en vervolgsturing"
-                    description="Gebruik deze laag pas nadat het hoofdbeeld helder is. Zo blijft deze route eerst leesbaar en pas daarna uitvoerbaar."
-                    badge={<DashboardChip label="Secundaire laag" tone="slate" />}
-                  >
-                    <div className="space-y-5">
-                      {stats.scan_type === "team" && teamPriorityRead ? (
-                        <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4 sm:p-5">
-                          <h3 className="text-sm font-semibold text-slate-950">
-                            {teamPriorityRead.status === "ready"
-                              ? "Eerste lokale verificatie en vervolgstap"
-                              : "Lokale prioriteit blijft compact"}
-                          </h3>
-                          <p className="mt-1 text-sm leading-6 text-slate-600">
-                            {teamPriorityRead.summaryBody}
-                          </p>
-                          {primaryTeamPriority && primaryTeamPlaybook ? (
-                            <div className="mt-4 grid gap-4 lg:grid-cols-2 xl:grid-cols-4">
-                              <DashboardPanel
-                                eyebrow="Afdeling eerst"
-                                title={primaryTeamPriority.label}
-                                value={primaryTeamPriority.priorityTitle}
-                                body={`${primaryTeamPriority.topFactorLabel} is hier nu het scherpste lokale spoor. Gebruik deze afdeling als eerste managementcheck, niet als definitieve eindconclusie.`}
-                                tone="amber"
-                              />
-                              <DashboardPanel
-                                eyebrow="Eerste eigenaar"
-                                title={primaryTeamPlaybook.owner}
-                                body="Deze combinatie trekt de eerste lokale check en bewaakt tegelijk dat TeamScan compact blijft."
-                                tone="slate"
-                              />
-                              <DashboardPanel
-                                eyebrow="Eerste check"
-                                title={primaryTeamPlaybook.validate}
-                                body={
-                                  primaryTeamQuestions[0] ??
-                                  "Gebruik het eerstvolgende afdelingsgesprek om dit lokale spoor expliciet te verifieren."
-                                }
-                                tone="slate"
-                              />
-                              <DashboardPanel
-                                eyebrow="Reviewmoment"
-                                title={
-                                  primaryTeamPlaybook.actions[0] ?? primaryTeamPlaybook.title
-                                }
-                                body={
-                                  primaryTeamPlaybook.review ??
-                                  "Leg direct vast wanneer deze lokale check opnieuw wordt gelezen en of TeamScan daarna nog een tweede stap nodig heeft."
-                                }
-                                tone="slate"
-                              />
-                            </div>
-                          ) : (
-                            <div className="mt-4 rounded-2xl border border-dashed border-slate-200 bg-white px-4 py-4 text-sm leading-6 text-slate-600">
-                              TeamScan toont hier bewust nog geen harde eerste volgorde. Gebruik de lokale read om meerdere afdelingen te bespreken, een eigenaar te benoemen en pas na de eerste check te bepalen of een hardere volgorde nodig is.
-                            </div>
-                          )}
-                        </div>
-                      ) : null}
-
-                      {productExperience.recommendationOrder === "playbooks-first" ? (
-                        <>
-                          {playbooksBlock}
-                          {focusQuestionsBlock}
-                        </>
-                      ) : (
-                        <>
-                          {focusQuestionsBlock}
-                          {playbooksBlock}
-                        </>
-                      )}
-                    </div>
-                  </DashboardDisclosure>
-                ) : (
-                  <>
-                {stats.scan_type === "team" && teamPriorityRead ? (
-                  <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4 sm:p-5">
-                    <h3 className="text-sm font-semibold text-slate-950">
-                      {teamPriorityRead.status === "ready"
-                        ? "Eerste lokale verificatie en vervolgstap"
-                        : "Lokale prioriteit blijft compact"}
-                    </h3>
-                    <p className="mt-1 text-sm leading-6 text-slate-600">
-                      {teamPriorityRead.summaryBody}
-                    </p>
-                    {primaryTeamPriority && primaryTeamPlaybook ? (
-                      <div className="mt-4 grid gap-4 lg:grid-cols-2 xl:grid-cols-4">
-                        <DashboardPanel
-                          eyebrow="Afdeling eerst"
-                          title={primaryTeamPriority.label}
-                          value={primaryTeamPriority.priorityTitle}
-                          body={`${primaryTeamPriority.topFactorLabel} is hier nu het scherpste lokale spoor. Gebruik deze afdeling als eerste managementcheck, niet als definitieve eindconclusie.`}
-                          tone="amber"
-                        />
-                        <DashboardPanel
-                          eyebrow="Eerste eigenaar"
-                          title={primaryTeamPlaybook.owner}
-                          body="Deze combinatie trekt de eerste lokale check en bewaakt tegelijk dat TeamScan compact blijft."
-                          tone="slate"
-                        />
-                        <DashboardPanel
-                          eyebrow="Eerste check"
-                          title={primaryTeamPlaybook.validate}
-                          body={
-                            primaryTeamQuestions[0] ??
-                            "Gebruik het eerstvolgende afdelingsgesprek om dit lokale spoor expliciet te verifieren."
-                          }
-                          tone="slate"
-                        />
-                        <DashboardPanel
-                          eyebrow="Reviewmoment"
-                          title={
-                            primaryTeamPlaybook.actions[0] ??
-                            primaryTeamPlaybook.title
-                          }
-                          body={
-                            primaryTeamPlaybook.review ??
-                            "Leg direct vast wanneer deze lokale check opnieuw wordt gelezen en of TeamScan daarna nog een tweede stap nodig heeft."
-                          }
-                          tone="slate"
-                        />
-                      </div>
-                    ) : (
-                      <div className="mt-4 rounded-2xl border border-dashed border-slate-200 bg-white px-4 py-4 text-sm leading-6 text-slate-600">
-                        TeamScan toont hier bewust nog geen harde eerste
-                        volgorde. Gebruik de lokale read om meerdere afdelingen
-                        te bespreken, een eigenaar te benoemen en pas na de
-                        eerste check te bepalen of een hardere volgorde
-                        nodig is.
-                      </div>
-                    )}
-                  </div>
-                ) : null}
-
-                {productExperience.recommendationOrder === "playbooks-first" ? (
-                  <>
-                    {playbooksBlock}
-                    {focusQuestionsBlock}
-                  </>
-                ) : (
-                  <>
-                    {focusQuestionsBlock}
-                    {playbooksBlock}
-                  </>
-                )}
-                  </>
-                )}
-              </div>
-            ) : (
-              <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-4 text-sm leading-6 text-slate-600">
-                Focusvragen en route-uitvoer worden betekenisvoller zodra het
-                dashboard minstens {MIN_N_PATTERNS} responses heeft.
-              </div>
-            )}
-          </DashboardSection>
-        ) : null}
-
-        {showDetailedManagementOutput ? (
-          <DashboardSection
-            id="route"
-            eyebrow="Vervolg na het eerste gesprek"
-            title={productExperience.routeTitle}
-            description={productExperience.routeDescription}
-            aside={
-              <DashboardChip
-                label={productExperience.routeBadgeLabel}
-                tone="slate"
-              />
-            }
-            variant="quiet"
-          >
-            <div className="space-y-5">
-              {demoteFollowThroughLayers ? (
-                <DashboardDisclosure
-                  title="Open vervolgrichting"
-                  description="Gebruik deze laag pas nadat de eerste lezing en verificatie zijn gedaan. Zo blijft vervolg klein en begrensd."
-                  badge={<DashboardChip label="Secundaire laag" tone="slate" />}
-                >
-                  <div className="space-y-5">
-                    <ManagementReadGuide
-                      scanType={stats.scan_type}
-                      hasMinDisplay={hasMinDisplay}
-                      hasEnoughData={hasEnoughData}
-                    />
-
-                    {dashboardViewModel.followThroughCards.length > 0 ? (
-                      <DashboardTimeline
-                        title={dashboardViewModel.followThroughTitle}
-                        description={dashboardViewModel.followThroughIntro}
-                        items={dashboardViewModel.followThroughCards}
-                      />
-                    ) : null}
-
-                    <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4 sm:p-5">
-                      <h3 className="text-sm font-semibold text-slate-950">
-                        {productExperience.afterSessionTitle}
-                      </h3>
-                      <p className="mt-1 text-sm leading-6 text-slate-700">
-                        {productExperience.afterSessionDescription}
-                      </p>
-                      {stats.scan_type === "team" ? (
-                        <div className="mt-4 grid gap-4 lg:grid-cols-3">
-                          <DashboardPanel
-                            eyebrow="Als de lokale check bevestigt"
-                            title="Blijf op dezelfde route"
-                            body="Doe alleen een volgende lokale check als route, lokale actie en reviewmoment uit deze TeamScan al expliciet zijn gemaakt."
-                            tone="slate"
-                          />
-                          <DashboardPanel
-                            eyebrow="Als de vraag breder wordt"
-                            title="Ga terug naar het bredere beeld"
-                            body="Schakel niet door naar extra lokalisatie als de echte vraag weer organisatieniveau, behoudsbeeld of bredere duiding vraagt."
-                            tone="amber"
-                          />
-                          <DashboardPanel
-                            eyebrow="Als de onderbouwing te smal blijft"
-                            title="Stop met verder lokaliseren"
-                            body="Open geen extra TeamScan-verbreding zolang metadata, groepsgrootte of lokale bevestiging daar nog geen eerlijke basis voor geven."
-                            tone="amber"
-                          />
-                        </div>
-                      ) : null}
-                      {stats.scan_type === "leadership" ? (
-                        <div className="mt-4 grid gap-4 lg:grid-cols-3">
-                          <DashboardPanel
-                            eyebrow="Als de managementcheck bevestigt"
-                            title="Blijf op dezelfde route"
-                            body="Doe alleen een volgende Leadership-check als eigenaar, kleine verificatie of correctie en reviewmoment uit deze samenvatting al expliciet zijn gemaakt."
-                            tone="slate"
-                          />
-                          <DashboardPanel
-                            eyebrow="Als de vraag breder wordt"
-                            title="Ga terug naar het bredere beeld"
-                            body="Schakel niet door naar extra Leadership-verbreding als de echte vraag weer lokale lokalisatie, bredere duiding of een ander productspoor vraagt."
-                            tone="amber"
-                          />
-                          <DashboardPanel
-                            eyebrow="Als de onderbouwing te smal blijft"
-                            title="Open geen named leaders of 360"
-                            body="Maak Leadership Scan niet groter dan deze wave draagt zolang groepsniveau, suppressie en de huidige data nog geen eerlijke basis geven voor named leader of 360-output."
-                            tone="amber"
-                          />
-                        </div>
-                      ) : null}
-                      <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-                        {firstNextStepGuidance.cards.map((card) => (
-                          <DashboardPanel
-                            key={card.key}
-                            eyebrow={
-                              card.key === "insight"
-                                ? "Inzicht"
-                                : card.key === "action"
-                                  ? "Eerste actie"
-                                  : "Geen standaard vervolg"
-                            }
-                            title={card.title}
-                            body={card.body}
-                            tone="slate"
-                          />
-                        ))}
-                      </div>
-                      <div className="mt-4 rounded-[24px] border border-white/80 bg-white px-4 py-4 shadow-[0_12px_28px_rgba(19,32,51,0.05)]">
-                        <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-                          <div>
-                            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
-                              Alleen als vervolg echt nodig is
-                            </p>
-                            <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-700">
-                              Gebruik deze routes alleen als de eerste stap al expliciet is gemaakt. Zo blijft vervolg gericht, in plaats van automatisch groter te worden.
-                            </p>
-                          </div>
-                          <DashboardChip label="Compacte vervolgroutes" tone="slate" />
-                        </div>
-                        <div className="mt-4 grid gap-4 md:grid-cols-2">
-                          {firstNextStepGuidance.followOnSuggestions.map((suggestion) => (
-                            <div
-                              key={suggestion.productLabel}
-                              className="rounded-[22px] border border-slate-200 bg-slate-50/88 px-4 py-4"
-                            >
-                              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
-                                Alleen als
-                              </p>
-                              <p className="mt-2 text-sm font-semibold text-slate-950">
-                                {suggestion.productLabel}
-                              </p>
-                              <p className="mt-2 text-sm leading-6 text-slate-700">
-                                {suggestion.when}
-                              </p>
-                              <p className="mt-3 text-xs leading-5 text-slate-500">
-                                {suggestion.boundary}
-                              </p>
-                            </div>
-                          ))}
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </DashboardDisclosure>
-              ) : (
-                <>
-              <ManagementReadGuide
-                scanType={stats.scan_type}
-                hasMinDisplay={hasMinDisplay}
-                hasEnoughData={hasEnoughData}
-              />
-
-              {dashboardViewModel.followThroughCards.length > 0 ? (
-                <DashboardTimeline
-                  title={dashboardViewModel.followThroughTitle}
-                  description={dashboardViewModel.followThroughIntro}
-                  items={dashboardViewModel.followThroughCards}
-                />
-              ) : null}
-
-              <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4 sm:p-5">
-                <h3 className="text-sm font-semibold text-slate-950">
-                  {productExperience.afterSessionTitle}
-                </h3>
-                <p className="mt-1 text-sm leading-6 text-slate-700">
-                  {productExperience.afterSessionDescription}
-                </p>
-                {stats.scan_type === "team" ? (
-                  <div className="mt-4 grid gap-4 lg:grid-cols-3">
-                    <DashboardPanel
-                      eyebrow="Als de lokale check bevestigt"
-                      title="Blijf op dezelfde route"
-                      body="Doe alleen een volgende lokale check als route, lokale actie en reviewmoment uit deze TeamScan al expliciet zijn gemaakt."
-                      tone="slate"
-                    />
-                    <DashboardPanel
-                      eyebrow="Als de vraag breder wordt"
-                        title="Ga terug naar het bredere beeld"
-                      body="Schakel niet door naar extra lokalisatie als de echte vraag weer organisatieniveau, behoudsbeeld of bredere duiding vraagt."
-                      tone="amber"
-                    />
-                    <DashboardPanel
-                      eyebrow="Als de onderbouwing te smal blijft"
-                      title="Stop met verder lokaliseren"
-                      body="Open geen extra TeamScan-verbreding zolang metadata, groepsgrootte of lokale bevestiging daar nog geen eerlijke basis voor geven."
-                      tone="amber"
-                    />
-                  </div>
-                ) : null}
-                {stats.scan_type === "leadership" ? (
-                  <div className="mt-4 grid gap-4 lg:grid-cols-3">
-                    <DashboardPanel
-                      eyebrow="Als de managementcheck bevestigt"
-                      title="Blijf op dezelfde route"
-                      body="Doe alleen een volgende Leadership-check als eigenaar, kleine verificatie of correctie en reviewmoment uit deze samenvatting al expliciet zijn gemaakt."
-                      tone="slate"
-                    />
-                    <DashboardPanel
-                      eyebrow="Als de vraag breder wordt"
-                        title="Ga terug naar het bredere beeld"
-                      body="Schakel niet door naar extra Leadership-verbreding als de echte vraag weer lokale lokalisatie, bredere duiding of een ander productspoor vraagt."
-                      tone="amber"
-                    />
-                    <DashboardPanel
-                      eyebrow="Als de onderbouwing te smal blijft"
-                      title="Open geen named leaders of 360"
-                      body="Maak Leadership Scan niet groter dan deze wave draagt zolang groepsniveau, suppressie en de huidige data nog geen eerlijke basis geven voor named leader of 360-output."
-                      tone="amber"
-                    />
-                  </div>
-                ) : null}
-                <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-                  {firstNextStepGuidance.cards.map((card) => (
-                    <DashboardPanel
-                      key={card.key}
-                      eyebrow={
-                        card.key === "insight"
-                          ? "Inzicht"
-                          : card.key === "action"
-                            ? "Eerste actie"
-                            : "Geen standaard vervolg"
-                      }
-                      title={card.title}
-                      body={card.body}
-                      tone="slate"
-                    />
-                  ))}
-                </div>
-                <div className="mt-4 rounded-[24px] border border-white/80 bg-white px-4 py-4 shadow-[0_12px_28px_rgba(19,32,51,0.05)]">
-                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-                    <div>
-                      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
-                        Alleen als vervolg echt nodig is
-                      </p>
-                      <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-700">
-                        Gebruik deze routes alleen als de eerste stap al expliciet is gemaakt. Zo blijft vervolg
-                        gericht, in plaats van automatisch groter te worden.
-                      </p>
-                    </div>
-                    <DashboardChip label="Compacte vervolgroutes" tone="slate" />
-                  </div>
-                  <div className="mt-4 grid gap-4 md:grid-cols-2">
-                    {firstNextStepGuidance.followOnSuggestions.map(
-                      (suggestion) => (
-                        <div
-                          key={suggestion.productLabel}
-                          className="rounded-[22px] border border-slate-200 bg-slate-50/88 px-4 py-4"
-                        >
-                          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
-                            Alleen als
-                          </p>
-                          <p className="mt-2 text-sm font-semibold text-slate-950">
-                            {suggestion.productLabel}
-                          </p>
-                          <p className="mt-2 text-sm leading-6 text-slate-700">
-                            {suggestion.when}
-                          </p>
-                          <p className="mt-3 text-xs leading-5 text-slate-500">
-                            {suggestion.boundary}
-                          </p>
-                        </div>
-                      ),
-                    )}
-                  </div>
-                </div>
-              </div>
-              </>
-              )}
-            </div>
-          </DashboardSection>
-        ) : null}
-
-        <div id="methodiek" className="scroll-mt-36">
-          <DashboardDisclosure
-            defaultOpen={disclosureDefaults.methodologyOpen}
-            title="Methodiek, privacy en leeswijzer"
-            description="Gebruik dit als contextlaag voor interpretatie, privacy en betrouwbaarheid."
-            badge={<DashboardChip label={methodologyBadgeLabel} tone="slate" />}
-          >
-            <MethodologyCard
-              scanType={stats.scan_type}
-              hasSegmentDeepDive={hasSegmentDeepDive}
-              signalLabel={scanDefinition.signalLabel}
-              embedded
-            />
-          </DashboardDisclosure>
-        </div>
-
-        {utilitySectionVisible ? (
-          <DashboardSection
-            id="operatie"
-            eyebrow={showClientExecutionFlow ? "Uitvoering" : "Utilitylaag"}
-            title={
-              showClientExecutionFlow
-                ? "Responsmonitoring en begrensde uitvoerlaag"
-                : "Operatie, respondenten en uitvoering"
-            }
-            description={
-              showClientExecutionFlow
-                ? "Gebruik deze laag om deelnemers, uitnodigingen en respons netjes te volgen. Productsetup, campagne-inrichting en uitvoercontrole blijven bij Loep."
-                : "Alles onder deze lijn ondersteunt uitvoering en beheer. De managementhoofdlijn blijft hierboven compact en bestuurlijk."
-            }
-            aside={
-              <DashboardChip
-                label={
-                  showClientExecutionFlow
-                    ? "Begeleide uitvoering"
-                : "Beheer en operatie"
-                }
-                tone="slate"
-              />
-            }
-            variant="quiet"
-          >
-            <div className="space-y-4">
-              {canManageCampaign ? (
-                <DashboardDisclosure
-                  defaultOpen={false}
-                  title="Campagnestatus en uitvoercontrole"
-                  description="Gebruik deze laag voor lifecycle, readiness, vervolgstappen en foutopvang nadat het managementbeeld helder is."
-                  badge={
-                    <DashboardChip
-                      label={
-                        readinessState.launchReady
-                          ? "Uitvoer op orde"
-                          : "Aandacht nodig"
-                      }
-                      tone={readinessState.launchReady ? "emerald" : "amber"}
-                    />
-                  }
-                >
-                  <div className="space-y-4">
-                    <CampaignActions
-                      campaignId={id}
-                      isActive={stats.is_active}
-                      pendingCount={pendingCount}
-                      canResendInvites={canExecuteCampaign}
-                      canArchiveCampaign={canManageCampaign}
-                    />
-                    <CampaignHealthIndicator
-                      totalInvited={stats.total_invited}
-                      totalCompleted={stats.total_completed}
-                      invitesNotSent={invitesNotSent}
-                      incompleteScores={incompleteScores}
-                      hasEnoughData={hasEnoughData}
-                      hasMinDisplay={hasMinDisplay}
-                    />
-                    <div
-                      className={`rounded-[24px] border px-4 py-4 ${
-                        readinessState.launchReady
-                          ? "border-emerald-200 bg-emerald-50"
-                          : "border-amber-200 bg-amber-50"
-                      }`}
-                    >
-                      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-                        <div>
-                          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
-                            Implementatiereadiness
-                          </p>
-                          <p className="mt-1 text-base font-semibold text-slate-950">
-                            {readinessState.headline}
-                          </p>
-                        </div>
-                        <span className="rounded-full bg-white/80 px-3 py-1 text-xs font-semibold text-slate-600">
-                          {readinessState.launchReady
-                            ? "Uitvoer op orde"
-                            : "Nog aandacht nodig"}
-                        </span>
-                      </div>
-                      <p className="mt-3 text-sm leading-6 text-slate-700">
-                        {readinessState.detail}
-                      </p>
-                      <p className="mt-3 text-sm font-medium leading-6 text-slate-800">
-                        Volgende stap: {readinessState.nextStep}
-                      </p>
-                    </div>
-                    {stats.is_active ? (
-                      <PreflightChecklist
-                        campaignId={id}
-                        scanType={stats.scan_type}
-                        deliveryMode={campaignMeta?.delivery_mode ?? null}
-                        totalInvited={stats.total_invited}
-                        totalCompleted={stats.total_completed}
-                        invitesNotSent={invitesNotSent}
-                        importReady={importReady}
-                        incompleteScores={incompleteScores}
-                        hasMinDisplay={hasMinDisplay}
-                        hasEnoughData={hasEnoughData}
-                        activeClientAccessCount={activeClientAccessCount ?? 0}
-                        pendingClientInviteCount={pendingClientInviteCount ?? 0}
-                        record={deliveryRecord}
-                        checkpoints={deliveryCheckpoints}
-                        leadOptions={deliveryLeadOptions}
-                        leadLoadError={deliveryLeadError}
-                        linkedLearningDossierCount={learningDossiers.length}
-                        learningCloseoutEvidenceCount={
-                          learningCloseoutEvidenceCount
-                        }
-                        editable={isVerisightAdmin}
-                        auditEvents={auditEvents}
-                      />
-                    ) : (
-                      <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm leading-6 text-slate-700">
-                        Deze campagne is gesloten. Rapportage en dashboard
-                        blijven beschikbaar, maar respondenten kunnen niet meer
-                        invullen.
-                      </div>
-                    )}
-                  </div>
-                </DashboardDisclosure>
-              ) : null}
-
-              <DashboardDisclosure
-                defaultOpen={false}
-                title="Respondenten en uitnodigingen"
-                description="Operationele detailweergave voor import, responsmonitoring en uitnodigingsbeheer."
-                badge={
-                  <DashboardChip
-                    label={`${respondents.length} respondenten`}
-                    tone="slate"
-                  />
-                }
-              >
-                {respondents.length === 0 ? (
-                  <div className="rounded-[24px] border border-dashed border-slate-200 bg-slate-50 px-4 py-8 text-center">
-                    <p className="text-base font-semibold text-slate-900">
-                      Nog geen respondenten toegevoegd
-                    </p>
-                    <p className="mt-2 text-sm leading-6 text-slate-600">
-                      {showClientExecutionFlow
-                        ? "Gebruik de begeleide uitvoerflow hierboven om eerst het deelnemersbestand aan te leveren. Daarna verschijnen uitnodigingen, responsmonitoring en deze tabel automatisch."
-                        : "Voeg eerst respondenten toe via de setupflow. Daarna komen uitnodigingen, responsmonitoring en deze tabel automatisch beschikbaar."}
-                    </p>
-                    {!showClientExecutionFlow && canManageCampaign ? (
-                      <Link
-                        href="/beheer"
-                        className="mt-4 inline-flex rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition-colors hover:border-slate-300 hover:bg-slate-50"
-                      >
-                        Naar setup
-                      </Link>
-                    ) : null}
-                  </div>
-                ) : (
-                  <RespondentTable
-                    respondents={respondents}
-                    responses={safeTableResponses}
-                    scanType={stats.scan_type}
-                    hasMinDisplay={hasMinDisplay}
-                    canManageCampaign={canManageCampaign}
-                  />
-                )}
-              </DashboardDisclosure>
-
-              {profile?.is_verisight_admin ? (
-                <DashboardDisclosure
-                  defaultOpen={false}
-                  title="Pilot- en early-customer-learning"
-                  description="Gebruik de dossierbron om buyer-signalen, implementatielessen, eerste duiding en de gekozen repeat- of expansionrichting expliciet vast te leggen voor deze campagne."
-                  badge={
-                    <DashboardChip
-                      label={
-                        learningDossiers.length === 0
-                          ? "Nog geen dossier"
-                          : learningCloseoutEvidenceCount > 0
-                            ? `${learningCloseoutEvidenceCount} closeout-signaal`
-                            : `${learningDossiers.length} gekoppeld, closeout open`
-                      }
-                      tone={
-                        learningDossiers.length > 0 &&
-                        learningCloseoutEvidenceCount > 0
-                          ? "emerald"
-                          : "amber"
-                      }
-                    />
-                  }
-                >
-                  <div className="grid gap-4 xl:grid-cols-[minmax(0,1.1fr),minmax(320px,0.9fr)]">
-                    <DashboardPanel
-                      eyebrow="Waarom nu"
-                      title={
-                        learningDossiers.length > 0
-                        ? "Deze campagne is al opgenomen in de learninglus"
-                          : "Koppel deze campagne aan een learningdossier"
-                      }
-                      body={
-                        learningDossiers.length > 0
-                          ? "Gebruik gekoppelde dossiers om implementationfrictie, launchsignalen, managementgebruik en gekozen vervolgroutes expliciet terug te laten landen in product, report, onboarding, sales en operations."
-                          : "Zodra deze campagne leerwaarde geeft, koppel je hem aan een dossier in de dossierbron. Zo blijven echte uitvoerlessen en vervolgkeuzes niet hangen in losse notities."
-                      }
-                      tone={learningDossiers.length > 0 ? "slate" : "amber"}
-                    />
-                    <DashboardPanel
-                      eyebrow="Closeoutdiscipline"
-                      title={
-                        learningCloseoutEvidenceCount > 0
-                          ? "Learning kan naar formele closeout toewerken"
-                          : learningDossiers.length > 0
-                            ? "Learning bestaat, maar closeout-evidence mist nog"
-                            : "Nog geen learning-closeout mogelijk"
-                      }
-                      body={
-                        learningCloseoutEvidenceCount > 0
-                          ? "Er is al minstens één expliciete review-, vervolg- of stopuitkomst vastgelegd. Daarmee kan delivery later eerlijker naar opvolging of learning closeout bewegen."
-                          : learningDossiers.length > 0
-                            ? "Er zijn al gekoppelde dossiers, maar nog geen expliciete review-, vervolg- of stopuitkomst. Houd delivery dus bewust open tot die opvolging echt is vastgelegd."
-                            : "Zonder gekoppeld learningdossier hoort delivery-closeout nog niet als afgerond te voelen."
-                      }
-                      tone={
-                        learningCloseoutEvidenceCount > 0 ? "emerald" : "amber"
-                      }
-                    />
-                    <div className="rounded-[22px] border border-slate-200 bg-slate-50/70 p-4">
-                      <p className="text-sm font-semibold text-slate-950">
-                        Gekoppelde dossiers
-                      </p>
-                      {learningDossiers.length === 0 ? (
-                        <p className="mt-2 text-sm leading-6 text-slate-600">
-                      Er is nog geen dossier gekoppeld aan deze campagne.
-                        </p>
-                      ) : (
-                        <div className="mt-3 space-y-3">
-                          {learningDossiers.map((dossier) => (
-                            <div
-                              key={dossier.id}
-                              className="rounded-2xl border border-white/80 bg-white px-4 py-3"
-                            >
-                              <p className="text-sm font-semibold text-slate-950">
-                                {dossier.title}
-                              </p>
-                              <p className="mt-1 text-xs text-slate-500">
-                                Status: {dossier.triage_status}. Laatst
-                                bijgewerkt:{" "}
-                                {new Intl.DateTimeFormat("nl-NL", {
-                                  dateStyle: "medium",
-                                  timeStyle: "short",
-                                  timeZone: "Europe/Amsterdam",
-                                }).format(new Date(dossier.updated_at))}
-                              </p>
-                            </div>
-                          ))}
-                        </div>
-                      )}
-                      <Link
-                        href={`/beheer/klantlearnings?campaign=${id}`}
-                        className="mt-4 inline-flex items-center rounded-full border border-slate-200 bg-white px-4 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:text-slate-900"
-                      >
-                        Open dossierbron
-                      </Link>
-                    </div>
-                  </div>
-                </DashboardDisclosure>
-              ) : null}
-            </div>
-          </DashboardSection>
-        ) : null}
-      </div>
-      {focusPanelItems.length > 0 ? (
-        <div className="xl:pt-[360px]">
-          <FocusPanel items={focusPanelItems} variant="campaign-detail" />
-        </div>
-      ) : null}
+    <div className="space-y-10">
+      <ResultsShellHeader
+        moduleHref={moduleHref}
+        moduleLabel={moduleLabel}
+        moduleBackLinkLabel={moduleBackLinkLabel}
+        campaignName={stats.campaign_name}
+        organizationName={organizationName}
+        routePeriodLabel={routePeriodLabel}
+        scopeLabel={scopeLabel}
+        statusLabel={getResultsStatusLabel(resultsViewModel.readState)}
+        campaignId={id}
+        scanType={stats.scan_type}
+      />
+      {summaryShell}
     </div>
-  );
+  )
 }
-

--- a/frontend/app/(dashboard)/campaigns/[id]/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.tsx
@@ -1,7 +1,15 @@
 import type { ReactNode } from 'react'
 import Link from 'next/link'
-import { notFound } from 'next/navigation'
+import { notFound, redirect } from 'next/navigation'
+import { isLiveActionCenterScanType } from '@/lib/action-center-live'
 import { SuiteAccessDenied } from '@/components/dashboard/suite-access-denied'
+import {
+  buildActionCenterRouteOpenPatch,
+  buildActionCenterRouteOpenRedirect,
+  canOpenActionCenterRoute,
+  getActionCenterRouteOpenableStages,
+  hasOpenedActionCenterRoute,
+} from '@/lib/dashboard/open-action-center-route'
 import { getManagementBandLabel } from '@/lib/management-language'
 import { getScanDefinition } from '@/lib/scan-definitions'
 import {
@@ -10,6 +18,7 @@ import {
   getDashboardModuleLabel,
 } from '@/lib/dashboard/shell-navigation'
 import { loadSuiteAccessContext } from '@/lib/suite-access-server'
+import { createAdminClient } from '@/lib/supabase/admin'
 import { createClient } from '@/lib/supabase/server'
 import { FACTOR_LABELS, hasCampaignAddOn } from '@/lib/types'
 import type { CampaignStats, Respondent, ScanType, SurveyResponse } from '@/lib/types'
@@ -18,6 +27,7 @@ import {
   buildOpenAnswersViewModel,
 } from './open-answers-view-model'
 import {
+  buildCampaignDetailActionCenterBridge,
   MethodologyCard,
   MIN_N_DISPLAY,
   MIN_N_PATTERNS,
@@ -26,6 +36,7 @@ import {
   computeFactorAverages,
   computeRetentionSupplementalAverages,
   computeStrongWorkSignalRate,
+  getLargestDistributionSegment,
   getTopContributingReasonLabel,
   getTopExitReasonLabel,
 } from './page-helpers'
@@ -332,7 +343,9 @@ function buildSynthesisItems(args: {
       })
     }
 
-    const topSegment = args.exitDistribution?.segments[0]
+    const topSegment = args.exitDistribution
+      ? getLargestDistributionSegment(args.exitDistribution.segments)
+      : null
     if (topSegment) {
       items.push({
         label: 'Verdeling',
@@ -593,7 +606,13 @@ export default async function CampaignPage({ params }: Props) {
   if (!statsRow) notFound()
   const stats = statsRow as CampaignStats
 
-  const [{ data: organization }, { data: campaignMeta }, { data: responsesRaw }, { data: respondentsRaw }] =
+  const [
+    { data: organization },
+    { data: campaignMeta },
+    { data: responsesRaw },
+    { data: respondentsRaw },
+    { data: deliveryRecord },
+  ] =
     await Promise.all([
       supabase.from('organizations').select('name').eq('id', stats.organization_id).maybeSingle(),
       supabase.from('campaigns').select('enabled_modules').eq('id', id).maybeSingle(),
@@ -627,6 +646,11 @@ export default async function CampaignPage({ params }: Props) {
         .select('*')
         .eq('campaign_id', id)
         .order('completed_at', { ascending: false, nullsFirst: false }),
+      supabase
+        .from('campaign_delivery_records')
+        .select('id, lifecycle_stage, first_management_use_confirmed_at, updated_at')
+        .eq('campaign_id', id)
+        .maybeSingle(),
     ])
 
   const responses = (responsesRaw ?? []) as unknown as (SurveyResponse & {
@@ -674,6 +698,24 @@ export default async function CampaignPage({ params }: Props) {
   const moduleBackLinkLabel = getDashboardModuleBackLinkLabel(stats.scan_type)
   const topFactorLabel = factorPriorityRows[0]?.factor ?? null
   const secondFactorLabel = factorPriorityRows[1]?.factor ?? null
+  const canOpenActionCenterFromDeliveryRecord = deliveryRecord
+    ? canOpenActionCenterRoute(deliveryRecord)
+    : false
+  const actionCenterBridge = buildCampaignDetailActionCenterBridge({
+    campaignId: id,
+    routeEntryStage:
+      deliveryRecord && hasOpenedActionCenterRoute(deliveryRecord)
+        ? 'active'
+        : null,
+    canOpenRoute:
+      blockVisibility.signal === 'visible' &&
+      isLiveActionCenterScanType(stats.scan_type) &&
+      canOpenActionCenterFromDeliveryRecord,
+    assessedAt: deliveryRecord?.updated_at ?? stats.created_at,
+  })
+  const actionCenterRouteHref = buildActionCenterRouteOpenRedirect(id, 'campaign-detail')
+  const showOpenAnswersRoute =
+    blockVisibility.voices === 'visible' && releasedOpenAnswerItems.length > 0
   const signalHighlights = buildSignalHighlights({
     scanType: stats.scan_type,
     signalLabel: scanDefinition.signalLabel,
@@ -700,6 +742,95 @@ export default async function CampaignPage({ params }: Props) {
     hasEnoughData,
   })
   const openAnswersHref = `/campaigns/${id}/open-antwoorden`
+
+  async function openActionCenterRoute() {
+    'use server'
+
+    const admin = createAdminClient()
+    const actionCenterHref = buildActionCenterRouteOpenRedirect(id, 'campaign-detail')
+    const { data: currentDeliveryRecord, error: loadError } = await admin
+      .from('campaign_delivery_records')
+      .select('id, lifecycle_stage, first_management_use_confirmed_at')
+      .eq('campaign_id', id)
+      .maybeSingle()
+
+    if (loadError || !currentDeliveryRecord) {
+      notFound()
+    }
+
+    if (hasOpenedActionCenterRoute(currentDeliveryRecord)) {
+      redirect(actionCenterHref)
+    }
+
+    if (!canOpenActionCenterRoute(currentDeliveryRecord)) {
+      notFound()
+    }
+
+    const openedAt = new Date().toISOString()
+    const { data: updatedRecord, error } = await admin
+      .from('campaign_delivery_records')
+      .update(buildActionCenterRouteOpenPatch(openedAt))
+      .eq('id', currentDeliveryRecord.id)
+      .is('first_management_use_confirmed_at', null)
+      .in('lifecycle_stage', getActionCenterRouteOpenableStages())
+      .select('id')
+      .maybeSingle()
+
+    if (error) {
+      notFound()
+    }
+
+    if (!updatedRecord) {
+      const { data: latestDeliveryRecord } = await admin
+        .from('campaign_delivery_records')
+        .select('id, lifecycle_stage, first_management_use_confirmed_at')
+        .eq('campaign_id', id)
+        .maybeSingle()
+
+      if (!latestDeliveryRecord || !hasOpenedActionCenterRoute(latestDeliveryRecord)) {
+        notFound()
+      }
+    }
+
+    redirect(actionCenterHref)
+  }
+
+  const actionCenterBridgeCard =
+    actionCenterBridge.presentation.ctaKind === 'open' ? (
+      <div className="rounded-[24px] border border-slate-200 bg-white px-5 py-5 shadow-sm">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="space-y-2">
+            <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
+              Vervolgroute
+            </p>
+            <h2 className="text-lg font-semibold tracking-[-0.02em] text-[color:var(--dashboard-ink)]">
+              {actionCenterBridge.presentation.label}
+            </h2>
+            <p className="max-w-3xl text-sm leading-6 text-[color:var(--dashboard-text)]">
+              {actionCenterBridge.presentation.body}
+            </p>
+          </div>
+
+          {actionCenterBridge.bridgeState === 'candidate' ? (
+            <form action={openActionCenterRoute}>
+              <button
+                type="submit"
+                className="inline-flex rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition-colors hover:border-slate-300 hover:bg-slate-50"
+              >
+                {actionCenterBridge.presentation.ctaLabel}
+              </button>
+            </form>
+          ) : (
+            <Link
+              href={actionCenterRouteHref}
+              className="inline-flex rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition-colors hover:border-slate-300 hover:bg-slate-50"
+            >
+              {actionCenterBridge.presentation.ctaLabel}
+            </Link>
+          )}
+        </div>
+      </div>
+    ) : null
 
   const responseSection = (
     <ResultsBlockCard
@@ -899,8 +1030,8 @@ export default async function CampaignPage({ params }: Props) {
             ? 'Er zijn nog geen vrijgegeven open antwoorden binnen deze route.'
             : `Open antwoorden openen pas vanaf ${MIN_N_DISPLAY} leesbare responses.`
       }
-      href={openAnswersHref}
-      linkLabel="Open alle open antwoorden"
+      href={showOpenAnswersRoute ? openAnswersHref : undefined}
+      linkLabel={showOpenAnswersRoute ? 'Open alle open antwoorden' : undefined}
     >
       {blockVisibility.voices === 'visible' && openAnswersViewModel.groups.length > 0 ? (
         <div className="space-y-4">
@@ -953,6 +1084,8 @@ export default async function CampaignPage({ params }: Props) {
         campaignId={id}
         scanType={stats.scan_type}
       />
+
+      {actionCenterBridgeCard}
 
       <ResultsLayout
         sections={{

--- a/frontend/app/(dashboard)/campaigns/[id]/results-layout.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/results-layout.test.ts
@@ -1,0 +1,28 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { ResultsLayout } from './results-layout'
+
+describe('ResultsLayout', () => {
+  it('renders blocks in the fixed HR order', () => {
+    const html = renderToStaticMarkup(
+      createElement(ResultsLayout, {
+        sections: {
+          response: createElement('div', null, 'Responsbasis'),
+          signal: createElement('div', null, 'Kernsignaal'),
+          synthesis: createElement('div', null, 'Signalen in samenhang'),
+          drivers: createElement('div', null, 'Drivers & prioriteiten'),
+          depth: createElement('div', null, 'Verdiepingslagen'),
+          voices: createElement('div', null, 'Survey-stemmen'),
+        },
+      }),
+    )
+
+    expect(html).toContain('Responsbasis')
+    expect(html).toContain('Kernsignaal')
+    expect(html).toContain('Signalen in samenhang')
+    expect(html).toContain('Drivers &amp; prioriteiten')
+    expect(html).toContain('Verdiepingslagen')
+    expect(html).toContain('Survey-stemmen')
+  })
+})

--- a/frontend/app/(dashboard)/campaigns/[id]/results-layout.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/results-layout.tsx
@@ -1,0 +1,25 @@
+import React, { type ReactNode } from 'react'
+
+type ResultsLayoutProps = {
+  sections: {
+    response: ReactNode
+    signal: ReactNode
+    synthesis: ReactNode
+    drivers: ReactNode
+    depth: ReactNode
+    voices: ReactNode
+  }
+}
+
+export function ResultsLayout({ sections }: ResultsLayoutProps) {
+  return (
+    <div className="space-y-8">
+      <section id="responsbasis">{sections.response}</section>
+      <section id="kernsignaal">{sections.signal}</section>
+      <section id="signalen-in-samenhang">{sections.synthesis}</section>
+      <section id="drivers-en-prioriteiten">{sections.drivers}</section>
+      <section id="verdiepingslagen">{sections.depth}</section>
+      <section id="survey-stemmen">{sections.voices}</section>
+    </div>
+  )
+}

--- a/frontend/app/(dashboard)/campaigns/[id]/results-view-model.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/results-view-model.test.ts
@@ -62,4 +62,16 @@ describe('buildResultsViewModel', () => {
     expect(model.blocks.find((block) => block.key === 'signal')?.visibility).toBe('visible')
     expect(model.blocks.find((block) => block.key === 'drivers')?.visibility).toBe('limited')
   })
+
+  it('keeps survey-stemmen limited until the release threshold is open', () => {
+    const model = buildResultsViewModel({
+      scanType: 'retention',
+      respondentsCount: 4,
+      hasMinDisplay: false,
+      hasEnoughData: false,
+      hasOpenAnswers: true,
+    })
+
+    expect(model.blocks.find((block) => block.key === 'voices')?.visibility).toBe('limited')
+  })
 })

--- a/frontend/app/(dashboard)/campaigns/[id]/results-view-model.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/results-view-model.test.ts
@@ -35,4 +35,31 @@ describe('buildResultsViewModel', () => {
     expect(model.blocks[1]?.visibility).toBe('limited')
     expect(model.blocks[3]?.visibility).toBe('limited')
   })
+
+  it('keeps a limited-but-results-first state before first safe read', () => {
+    const model = buildResultsViewModel({
+      scanType: 'exit',
+      respondentsCount: 3,
+      hasMinDisplay: false,
+      hasEnoughData: false,
+      hasOpenAnswers: false,
+    })
+
+    expect(model.readState).toBe('pre-read')
+    expect(model.blocks.find((block) => block.key === 'signal')?.visibility).toBe('limited')
+  })
+
+  it('unlocks the primary signal on early read but keeps deeper layers limited', () => {
+    const model = buildResultsViewModel({
+      scanType: 'exit',
+      respondentsCount: 5,
+      hasMinDisplay: true,
+      hasEnoughData: false,
+      hasOpenAnswers: true,
+    })
+
+    expect(model.readState).toBe('early-read')
+    expect(model.blocks.find((block) => block.key === 'signal')?.visibility).toBe('visible')
+    expect(model.blocks.find((block) => block.key === 'drivers')?.visibility).toBe('limited')
+  })
 })

--- a/frontend/app/(dashboard)/campaigns/[id]/results-view-model.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/results-view-model.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { buildResultsViewModel } from './results-view-model'
+
+describe('buildResultsViewModel', () => {
+  it('keeps the fixed block order for exit results', () => {
+    const model = buildResultsViewModel({
+      scanType: 'exit',
+      respondentsCount: 8,
+      hasMinDisplay: true,
+      hasEnoughData: true,
+      hasOpenAnswers: true,
+    })
+
+    expect(model.blocks.map((block) => block.key)).toEqual([
+      'response',
+      'signal',
+      'synthesis',
+      'drivers',
+      'depth',
+      'voices',
+    ])
+  })
+
+  it('keeps results mode in pre-read state instead of falling back to campaign detail', () => {
+    const model = buildResultsViewModel({
+      scanType: 'retention',
+      respondentsCount: 2,
+      hasMinDisplay: false,
+      hasEnoughData: false,
+      hasOpenAnswers: false,
+    })
+
+    expect(model.readState).toBe('pre-read')
+    expect(model.blocks[0]?.visibility).toBe('visible')
+    expect(model.blocks[1]?.visibility).toBe('limited')
+    expect(model.blocks[3]?.visibility).toBe('limited')
+  })
+})

--- a/frontend/app/(dashboard)/campaigns/[id]/results-view-model.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/results-view-model.ts
@@ -1,0 +1,43 @@
+import type { ScanType } from '@/lib/types'
+
+export type ResultsReadState = 'pre-read' | 'early-read' | 'readable'
+export type ResultsBlockKey = 'response' | 'signal' | 'synthesis' | 'drivers' | 'depth' | 'voices'
+export type ResultsBlockVisibility = 'visible' | 'limited'
+
+export type ResultsViewModel = {
+  readState: ResultsReadState
+  blocks: Array<{
+    key: ResultsBlockKey
+    visibility: ResultsBlockVisibility
+  }>
+}
+
+type Args = {
+  scanType: ScanType
+  respondentsCount: number
+  hasMinDisplay: boolean
+  hasEnoughData: boolean
+  hasOpenAnswers: boolean
+}
+
+function getReadState(args: Pick<Args, 'hasMinDisplay' | 'hasEnoughData'>): ResultsReadState {
+  if (args.hasEnoughData) return 'readable'
+  if (args.hasMinDisplay) return 'early-read'
+  return 'pre-read'
+}
+
+export function buildResultsViewModel(args: Args): ResultsViewModel {
+  const readState = getReadState(args)
+
+  return {
+    readState,
+    blocks: [
+      { key: 'response', visibility: 'visible' },
+      { key: 'signal', visibility: args.hasMinDisplay ? 'visible' : 'limited' },
+      { key: 'synthesis', visibility: args.hasMinDisplay ? 'visible' : 'limited' },
+      { key: 'drivers', visibility: args.hasEnoughData ? 'visible' : 'limited' },
+      { key: 'depth', visibility: args.hasMinDisplay ? 'visible' : 'limited' },
+      { key: 'voices', visibility: args.hasOpenAnswers ? 'visible' : 'limited' },
+    ],
+  }
+}

--- a/frontend/app/(dashboard)/campaigns/[id]/results-view-model.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/results-view-model.ts
@@ -28,6 +28,7 @@ function getReadState(args: Pick<Args, 'hasMinDisplay' | 'hasEnoughData'>): Resu
 
 export function buildResultsViewModel(args: Args): ResultsViewModel {
   const readState = getReadState(args)
+  const answersReleased = args.hasMinDisplay && args.hasOpenAnswers
 
   return {
     readState,
@@ -37,7 +38,7 @@ export function buildResultsViewModel(args: Args): ResultsViewModel {
       { key: 'synthesis', visibility: args.hasMinDisplay ? 'visible' : 'limited' },
       { key: 'drivers', visibility: args.hasEnoughData ? 'visible' : 'limited' },
       { key: 'depth', visibility: args.hasMinDisplay ? 'visible' : 'limited' },
-      { key: 'voices', visibility: args.hasOpenAnswers ? 'visible' : 'limited' },
+      { key: 'voices', visibility: answersReleased ? 'visible' : 'limited' },
     ],
   }
 }


### PR DESCRIPTION
## What changed
- split HR campaign detail into a results-first `/campaigns/[id]` route with a fixed six-block architecture
- added a dedicated `/campaigns/[id]/open-antwoorden` results subpage with guarded access, grouped themes, and released-answer gating
- added shared results/open-answer view models plus guardrail tests for route structure and gating

## What stayed the same
- existing scan truth and threshold-based release model
- `/campaigns/[id]/beheer` remains the operational worktable
- existing PDF/report navigation and module breadcrumb access

## Verification
- `npm test -- "app/(dashboard)/campaigns/[id]/page.test.ts" "app/(dashboard)/campaigns/[id]/page.route-shell.test.ts" "app/(dashboard)/campaigns/[id]/results-layout.test.ts" "app/(dashboard)/campaigns/[id]/results-view-model.test.ts" "app/(dashboard)/campaigns/[id]/open-answers-view-model.test.ts" "app/(dashboard)/campaigns/[id]/open-antwoorden/page.test.ts"`
- `npx eslint "app/(dashboard)/campaigns/[id]/page.tsx" "app/(dashboard)/campaigns/[id]/open-antwoorden/page.tsx" "app/(dashboard)/campaigns/[id]/open-answers-view-model.ts" "app/(dashboard)/campaigns/[id]/results-view-model.ts"`
- `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key npm run build`