### PR TITLE
Restructure HR reports into a download-only index

### DIFF
--- a/frontend/app/(dashboard)/reports/page.route-shell.test.ts
+++ b/frontend/app/(dashboard)/reports/page.route-shell.test.ts
@@ -1,48 +1,26 @@
-import { readFileSync } from "node:fs";
-import { describe, expect, it } from "vitest";
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
 
-describe("reports route shell", () => {
-  it("keeps reports anchored to practical discussion and follow-up", () => {
-    const source = readFileSync(new URL("./page.tsx", import.meta.url), "utf8");
+describe('reports route shell', () => {
+  it('does not keep bridge actions or category filters as the primary HR structure', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
 
-    expect(source).toContain("Rapportbibliotheek");
-    expect(source).toContain("featuredReportBridge");
-    expect(source).toContain('variant="editorial"');
-    expect(source).toContain("Klaar voor bespreking");
-    expect(source).toContain("Open campagnedetail");
-    expect(source).toContain("Action Center");
-    expect(source).not.toContain("Van rapport naar opvolging");
-  });
+    expect(source).not.toContain('featuredReportBridge')
+    expect(source).not.toContain('getReportEntryBridge')
+    expect(source).not.toContain('normalizeCategory')
+    expect(source).not.toContain('filterReportLibraryEntries')
+    expect(source).not.toContain('Open campagnedetail')
+    expect(source).not.toContain('Open route in Action Center')
+    expect(source).not.toContain('CATEGORY_OPTIONS')
+  })
 
-  it("keeps filtering and library access tied to real report readiness", () => {
-    const source = readFileSync(new URL("./page.tsx", import.meta.url), "utf8");
+  it('keeps report access tied to downloadable PDFs only', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
 
-    expect(source).toContain("normalizeCategory");
-    expect(source).toContain("filterReportLibraryEntries");
-    expect(source).toContain(
-      "Rapporten verschijnen pas als een campagne genoeg respons en duiding heeft",
-    );
-    expect(source).toContain("Eerst bespreken");
-    expect(source).not.toContain("download center");
-  });
-
-  it("never offers direct route-open from reports for a candidate", () => {
-    const source = readFileSync(new URL("./page.tsx", import.meta.url), "utf8");
-
-    expect(source).toContain("getReportEntryBridge");
-    expect(source).toContain("Open campagnedetail");
-    expect(source).not.toContain("getReportEntryHref");
-    expect(source).not.toContain('entry.bridgeState === "active"');
-    expect(source).not.toContain("open nog niets direct vanuit deze bibliotheek");
-  });
-
-  it("wires active route truth into the report library model", () => {
-    const source = readFileSync(new URL("./page.tsx", import.meta.url), "utf8");
-
-    expect(source).toContain("lifecycle_stage");
-    expect(source).toContain("first_management_use_confirmed_at");
-    expect(source).toContain("routeEntryStageByCampaignId");
-    expect(source).toContain("routeOpenableByCampaignId");
-    expect(source).toContain("buildReportLibraryEntries(campaigns,");
-  });
-});
+    expect(source).toContain('PdfDownloadButton')
+    expect(source).toContain('Beschikbaar nu')
+    expect(source).toContain('Nog niet beschikbaar')
+    expect(source).not.toContain('Open route')
+    expect(source).not.toContain('Ga naar campaign detail')
+  })
+})

--- a/frontend/app/(dashboard)/reports/page.test.ts
+++ b/frontend/app/(dashboard)/reports/page.test.ts
@@ -2,17 +2,16 @@ import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
 describe('reports overview guardrails', () => {
-  it('keeps the page focused on report selection and download', () => {
+  it('keeps the page focused on report download instead of featured library framing', () => {
     const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
 
-    expect(source).toContain('eyebrow="Rapportbibliotheek"')
-    expect(source).toContain('title="Rapporten die nu leesbaar zijn."')
-    expect(source).toContain('Open alleen de rapporten die al genoeg basis hebben')
-    expect(source).toContain('title="Wat nu leesbaar is"')
-    expect(source).toContain('Wanneer deze bibliotheek opent.')
-    expect(source).not.toContain('Reports & Exports')
-    expect(source).not.toContain('Open in viewer')
-    expect(source).not.toContain('Beschikbare rapporten')
-    expect(source).not.toContain('Van rapport naar opvolging')
+    expect(source).toContain('Beschikbaar nu')
+    expect(source).toContain('Nog niet beschikbaar')
+    expect(source).toContain('Download PDF')
+    expect(source).not.toContain('DashboardHero')
+    expect(source).not.toContain('Rapportbibliotheek')
+    expect(source).not.toContain('Aanbevolen rapport')
+    expect(source).not.toContain('Wanneer deze bibliotheek opent.')
+    expect(source).not.toContain('Bekijk resultaten')
   })
 })

--- a/frontend/app/(dashboard)/reports/page.tsx
+++ b/frontend/app/(dashboard)/reports/page.tsx
@@ -1,58 +1,95 @@
-import Link from "next/link";
-import { redirect } from "next/navigation";
-import { PdfDownloadButton } from "@/app/(dashboard)/campaigns/[id]/pdf-download-button";
-import {
-  DashboardChip,
-  DashboardHero,
-  DashboardSection,
-} from "@/components/dashboard/dashboard-primitives";
-import {
-  buildReportLibraryEntries,
-  filterReportLibraryEntries,
-  getReportEntryBridge,
-  type ReportLibraryCategory,
-} from "@/lib/dashboard/report-library";
-import {
-  canOpenActionCenterRoute,
-  hasOpenedActionCenterRoute,
-} from "@/lib/dashboard/open-action-center-route";
-import { SuiteAccessDenied } from "@/components/dashboard/suite-access-denied";
-import { createClient } from "@/lib/supabase/server";
-import { loadSuiteAccessContext } from "@/lib/suite-access-server";
-import { getCampaignAverageSignalScore } from "@/lib/types";
+import { redirect } from 'next/navigation'
+import { PdfDownloadButton } from '@/app/(dashboard)/campaigns/[id]/pdf-download-button'
+import { SuiteAccessDenied } from '@/components/dashboard/suite-access-denied'
+import { buildHrReportDownloadRows } from '@/lib/dashboard/report-library'
+import { createClient } from '@/lib/supabase/server'
+import { loadSuiteAccessContext } from '@/lib/suite-access-server'
+import { buildReportDownloadIndex } from './report-download-index'
 
-const CATEGORY_OPTIONS: Array<{ key: ReportLibraryCategory; label: string }> = [
-  { key: "all", label: "Alle" },
-  { key: "management", label: "Management" },
-  { key: "module", label: "Module" },
-  { key: "cohort", label: "Cohort" },
-];
-
-function normalizeCategory(
-  value: string | string[] | undefined,
-): ReportLibraryCategory {
-  return typeof value === "string" &&
-    CATEGORY_OPTIONS.some((option) => option.key === value)
-    ? (value as ReportLibraryCategory)
-    : "all";
+function ReportRow({
+  campaignId,
+  campaignName,
+  scanType,
+  scanName,
+  periodLabel,
+  responseBasis,
+  status,
+  extraDisambiguator,
+}: {
+  campaignId: string
+  campaignName: string
+  scanType: string
+  scanName: string
+  periodLabel: string
+  responseBasis: string
+  status: string
+  extraDisambiguator?: string | null
+}) {
+  return (
+    <article className="grid gap-4 border-b border-[color:var(--dashboard-frame-border)] px-5 py-4 last:border-b-0 lg:grid-cols-[minmax(0,1.25fr),150px,170px,140px,auto] lg:items-start">
+      <div className="min-w-0">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--dashboard-muted)]">
+          {scanName}
+        </p>
+        <p className="mt-2 text-base font-semibold text-[color:var(--dashboard-ink)]">{campaignName}</p>
+        {extraDisambiguator ? (
+          <p className="mt-1 text-xs text-[color:var(--dashboard-muted)]">{extraDisambiguator}</p>
+        ) : null}
+      </div>
+      <p className="text-sm text-[color:var(--dashboard-text)]">{periodLabel}</p>
+      <p className="text-sm text-[color:var(--dashboard-text)]">{responseBasis}</p>
+      <p className="text-sm font-medium text-[color:var(--dashboard-ink)]">{status}</p>
+      <div className="flex justify-start lg:justify-end">
+        <PdfDownloadButton campaignId={campaignId} campaignName={campaignName} scanType={scanType} />
+      </div>
+    </article>
+  )
 }
 
-export default async function ReportsPage({
-  searchParams,
+function UnavailableReportRow({
+  scanName,
+  campaignName,
+  periodLabel,
+  responseBasis,
+  status,
+  extraDisambiguator,
 }: {
-  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+  scanName: string
+  campaignName: string
+  periodLabel: string
+  responseBasis: string
+  status: string
+  extraDisambiguator?: string | null
 }) {
-  const resolvedSearchParams = searchParams ? await searchParams : undefined;
-  const category = normalizeCategory(resolvedSearchParams?.kind);
-  const supabase = await createClient();
+  return (
+    <article className="grid gap-4 border-b border-[color:var(--dashboard-frame-border)] px-5 py-4 last:border-b-0 lg:grid-cols-[minmax(0,1.25fr),150px,170px,1fr] lg:items-start">
+      <div className="min-w-0">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--dashboard-muted)]">
+          {scanName}
+        </p>
+        <p className="mt-2 text-base font-semibold text-[color:var(--dashboard-ink)]">{campaignName}</p>
+        {extraDisambiguator ? (
+          <p className="mt-1 text-xs text-[color:var(--dashboard-muted)]">{extraDisambiguator}</p>
+        ) : null}
+      </div>
+      <p className="text-sm text-[color:var(--dashboard-text)]">{periodLabel}</p>
+      <p className="text-sm text-[color:var(--dashboard-text)]">{responseBasis}</p>
+      <p className="text-sm font-medium text-[color:var(--dashboard-muted)]">{status}</p>
+    </article>
+  )
+}
+
+export default async function ReportsPage() {
+  const supabase = await createClient()
   const {
     data: { user },
-  } = await supabase.auth.getUser();
+  } = await supabase.auth.getUser()
 
   if (!user) {
-    redirect("/login");
+    redirect('/login')
   }
-  const { context } = await loadSuiteAccessContext(supabase, user.id);
+
+  const { context } = await loadSuiteAccessContext(supabase, user.id)
 
   if (!context.canViewReports) {
     return (
@@ -60,286 +97,88 @@ export default async function ReportsPage({
         title="Je ziet hier geen rapporten"
         description="Jouw login opent alleen Action Center. Rapporten, survey-inzichten en campagnedetails blijven zichtbaar voor HR en Loep."
       />
-    );
+    )
   }
 
-  const { data: stats } = await supabase
-    .from("campaign_stats")
-    .select("*")
-    .order("created_at", { ascending: false });
-  const campaigns = stats ?? [];
-  const campaignIds = campaigns.map((campaign) => campaign.campaign_id);
-  const { data: deliveryRecords } =
-    campaignIds.length > 0
-      ? await supabase
-          .from("campaign_delivery_records")
-          .select("campaign_id, lifecycle_stage, first_management_use_confirmed_at")
-          .in("campaign_id", campaignIds)
-      : { data: [] };
-  const routeEntryStageByCampaignId = Object.fromEntries(
-    (deliveryRecords ?? [])
-      .filter((record) => hasOpenedActionCenterRoute(record))
-      .map((record) => [record.campaign_id, "active" as const]),
-  );
-  const routeOpenableByCampaignId = Object.fromEntries(
-    (deliveryRecords ?? [])
-      .filter((record) => canOpenActionCenterRoute(record))
-      .map((record) => [record.campaign_id, true]),
-  );
-  const reportModel = buildReportLibraryEntries(campaigns, {
-    routeEntryStageByCampaignId,
-    routeOpenableByCampaignId,
-  });
-  const filteredEntries = filterReportLibraryEntries(
-    reportModel.entries,
-    category,
-  );
-  const reportCards = filteredEntries.map((entry) => {
-    const reportBridge = getReportEntryBridge(entry);
-
-    return {
-      entry,
-      ...reportBridge,
-    };
-  });
-  const featuredReportBridge = reportModel.featured
-    ? getReportEntryBridge(reportModel.featured)
-    : null;
-  const averageSignal =
-    reportModel.entries.length > 0
-      ? (
-          reportModel.entries.reduce((sum, entry) => {
-            const source = campaigns.find(
-              (campaign) => campaign.campaign_id === entry.campaignId,
-            );
-            return (
-              sum + (source ? (getCampaignAverageSignalScore(source) ?? 0) : 0)
-            );
-          }, 0) / reportModel.entries.length
-        ).toFixed(1)
-      : null;
+  const { data: stats } = await supabase.from('campaign_stats').select('*').order('created_at', { ascending: false })
+  const campaigns = stats ?? []
+  const rowFeed = buildHrReportDownloadRows(campaigns)
+  const reportIndex = buildReportDownloadIndex([...rowFeed.availableRows, ...rowFeed.unavailableRows])
 
   return (
     <div className="space-y-8">
-      <DashboardHero
-        eyebrow="Rapportbibliotheek"
-        title="Rapporten die nu leesbaar zijn."
-        description="Open alleen de rapporten die al genoeg basis hebben voor een goed gesprek. Deze bibliotheek blijft compact: wat is leesbaar, voor welk type gesprek en via welke campagne open je de onderliggende route."
-        tone="slate"
-        variant="editorial"
-        meta={
-          <>
-            <DashboardChip
-              label={`${reportModel.entries.length} rapport${reportModel.entries.length === 1 ? "" : "en"} beschikbaar`}
-              tone="emerald"
-            />
-            <DashboardChip
-              label={
-                averageSignal
-                  ? `${averageSignal}/10 gemiddeld signaal`
-                  : "Respons bepaalt beschikbaarheid"
-              }
-              tone={averageSignal ? "blue" : "slate"}
-            />
-            <DashboardChip
-              label={
-                reportModel.featured
-                  ? "Klaar voor bespreking"
-                  : "Nog geen rapport klaar voor bespreking"
-              }
-              tone={reportModel.featured ? "emerald" : "amber"}
-            />
-          </>
-        }
-        actions={
-          reportModel.featured ? (
-            <>
-              <PdfDownloadButton
-                campaignId={reportModel.featured.campaignId}
-                campaignName={reportModel.featured.campaignName}
-                scanType={reportModel.featured.scanType}
+      <section className="space-y-2">
+        <p className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-[color:var(--dashboard-muted)]">
+          Rapporten
+        </p>
+        <h1 className="text-[2rem] font-semibold tracking-[-0.04em] text-[color:var(--dashboard-ink)]">
+          Download scanrapporten
+        </h1>
+        <p className="max-w-3xl text-sm leading-6 text-[color:var(--dashboard-text)]">
+          Download per scan het beschikbare PDF-rapport. Resultaten lezen en routebeheer gebeuren op andere plekken.
+        </p>
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex items-center justify-between gap-4">
+          <h2 className="text-lg font-semibold text-[color:var(--dashboard-ink)]">Beschikbaar nu</h2>
+          <p className="text-sm text-[color:var(--dashboard-muted)]">
+            {reportIndex.availableRows.length} rapport{reportIndex.availableRows.length === 1 ? '' : 'en'}
+          </p>
+        </div>
+
+        {reportIndex.availableRows.length > 0 ? (
+          <div className="overflow-hidden rounded-xl border border-[color:var(--dashboard-frame-border)] bg-white">
+            <div className="hidden border-b border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)]/45 px-5 py-3 text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--dashboard-muted)] lg:grid lg:grid-cols-[minmax(0,1.25fr),150px,170px,140px,auto] lg:items-center">
+              <span>Scan</span>
+              <span>Periode</span>
+              <span>Responsbasis</span>
+              <span>Status</span>
+              <span className="text-right">Download PDF</span>
+            </div>
+            {reportIndex.availableRows.map((row) => (
+              <ReportRow
+                key={row.campaignId}
+                campaignId={row.campaignId}
+                campaignName={row.campaignName}
+                scanType={row.scanType}
+                scanName={row.scanName}
+                periodLabel={row.periodLabel}
+                responseBasis={row.responseBasis}
+                status={row.status}
+                extraDisambiguator={row.extraDisambiguator}
               />
-              <Link
-                href={featuredReportBridge?.href ?? `/campaigns/${reportModel.featured.campaignId}`}
-                className="inline-flex rounded-[6px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-ink)] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#0f1e30]"
-              >
-                {featuredReportBridge?.bridge.ctaLabel ?? "Open campagnedetail"}
-              </Link>
-            </>
-          ) : (
-            <DashboardChip
-              label="Nog geen rapport beschikbaar"
-              tone="amber"
-            />
-          )
-        }
-        aside={
-          reportModel.featured ? (
-            <div className="space-y-5">
-              <div>
-                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--dashboard-accent-strong)]">
-                  Aanbevolen rapport
-                </p>
-                <p className="mt-2 text-sm font-semibold uppercase tracking-[0.18em] text-[color:var(--dashboard-muted)]">
-                  {reportModel.featured.subtitle}
-                </p>
-                <p className="mt-2 text-[1.55rem] font-semibold leading-tight tracking-[-0.04em] text-[color:var(--dashboard-ink)]">
-                  {reportModel.featured.title}
-                </p>
-                <p className="mt-3 text-sm leading-6 text-[color:var(--dashboard-text)]">
-                  {reportModel.featured.description}
-                </p>
-              </div>
-              <div className="space-y-2 rounded-xl border border-[color:var(--dashboard-frame-border)] bg-white/70 px-4 py-4 shadow-[0_12px_28px_rgba(17,24,39,0.05)]">
-                {reportModel.featured.stats.map((stat) => (
-                  <div
-                    key={stat.label}
-                    className="flex items-center justify-between gap-4 border-b border-[color:var(--dashboard-frame-border)]/70 py-2 first:pt-0 last:border-b-0 last:pb-0"
-                  >
-                    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--dashboard-muted)]">
-                      {stat.label}
-                    </p>
-                    <p className="text-base font-semibold text-[color:var(--dashboard-ink)]">
-                      {stat.value}
-                    </p>
-                  </div>
-                ))}
-              </div>
-            </div>
-          ) : (
-            <div className="space-y-3">
-              <p className="text-sm font-semibold text-[color:var(--dashboard-ink)]">
-                Wanneer de rapportlaag opent
-              </p>
-              <p className="text-sm leading-6 text-[color:var(--dashboard-text)]">
-                Rapporten verschijnen pas als een campagne genoeg respons en duiding heeft om goed te kunnen lezen.
-              </p>
-            </div>
-          )
-        }
-      />
-
-      <DashboardSection
-        eyebrow="Bibliotheek"
-        title="Wat nu leesbaar is"
-        description="Open de rapportlaag alleen waar het beeld al stevig genoeg is. De bibliotheek blijft gekoppeld aan echte campagnes en maakt snel zichtbaar welk type output voor je klaarstaat."
-        variant="quiet"
-        aside={
-          <div className="flex flex-wrap justify-start gap-2 lg:justify-end">
-            {CATEGORY_OPTIONS.map((option) => {
-              const active = option.key === category;
-              return (
-                <Link
-                  key={option.key}
-                  href={
-                    option.key === "all"
-                      ? "/reports"
-                      : `/reports?kind=${option.key}`
-                  }
-                  className={`inline-flex rounded-[4px] border px-4 py-2 text-sm font-semibold transition-colors ${
-                    active
-                      ? "border-[color:var(--dashboard-ink)] bg-[color:var(--dashboard-ink)] text-white"
-                      : "border-transparent bg-[color:var(--dashboard-soft)] text-[color:var(--dashboard-ink)] hover:border-[color:var(--dashboard-frame-border)] hover:bg-white hover:text-[color:var(--dashboard-accent-strong)]"
-                  }`}
-                >
-                  {option.label}
-                </Link>
-              );
-            })}
-          </div>
-        }
-      >
-        {filteredEntries.length > 0 ? (
-          <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr),300px]">
-            <div className="space-y-3">
-              {reportCards.map(({ entry, bridge, href }) => (
-                <article
-                  key={entry.campaignId}
-                  className={`rounded-xl border px-4 py-4 shadow-[0_1px_3px_rgba(10,25,47,0.04)] sm:px-5 sm:py-5 ${
-                    entry.recommended
-                      ? "border-[color:var(--dashboard-accent-soft-border)] bg-[color:var(--dashboard-accent-soft)]"
-                      : "border-[color:var(--dashboard-frame-border)] bg-white"
-                  }`}
-                >
-                  <div className="grid gap-4 xl:grid-cols-[minmax(0,1.35fr),160px,auto] xl:items-start">
-                    <div className="min-w-0">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--dashboard-muted)]">
-                          {entry.categoryLabel}
-                        </p>
-                        {entry.recommended ? (
-                          <DashboardChip
-                            label="Eerst bespreken"
-                            tone="emerald"
-                          />
-                        ) : null}
-                      </div>
-                      <h3 className="mt-2 text-[1.35rem] font-semibold tracking-[-0.04em] text-[color:var(--dashboard-ink)]">
-                        {entry.title}
-                      </h3>
-                      <p className="mt-2 max-w-3xl text-sm leading-6 text-[color:var(--dashboard-text)]">
-                        {entry.summary}
-                      </p>
-                      <p className="mt-3 text-xs font-semibold uppercase tracking-[0.18em] text-[#8b7d6b]">
-                        {bridge.label}
-                      </p>
-                      <p className="mt-2 text-sm leading-6 text-[#5e6b78]">
-                        {bridge.body}
-                      </p>
-                    </div>
-
-                    <div className="grid gap-1.5 text-sm text-[color:var(--dashboard-text)] xl:justify-items-end xl:pt-1 xl:text-right">
-                      <p>{entry.metaLeft}</p>
-                      <p>{entry.metaRight}</p>
-                    </div>
-
-                    <div className="flex flex-wrap items-center gap-2 xl:self-start xl:justify-end">
-                      <Link
-                        href={href}
-                        className="inline-flex rounded-[6px] border border-[color:var(--dashboard-frame-border)] px-4 py-2 text-sm font-semibold text-[color:var(--dashboard-accent-strong)] transition-colors hover:border-[color:var(--dashboard-accent-soft-border)] hover:bg-white"
-                      >
-                        {bridge.ctaLabel}
-                      </Link>
-                      <PdfDownloadButton
-                        campaignId={entry.campaignId}
-                        campaignName={entry.campaignName}
-                        scanType={entry.scanType}
-                      />
-                    </div>
-                  </div>
-                </article>
-              ))}
-            </div>
-
-            <aside className="rounded-xl border border-[color:var(--dashboard-frame-border)] bg-[linear-gradient(180deg,rgba(248,247,243,0.96),rgba(243,240,235,0.82))] px-5 py-5 shadow-[0_12px_28px_rgba(17,24,39,0.05)]">
-              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
-                Leescontext
-              </p>
-              <p className="mt-3 text-[1.35rem] font-semibold leading-tight tracking-[-0.04em] text-[color:var(--dashboard-ink)]">
-                Wanneer deze bibliotheek opent.
-              </p>
-              <div className="mt-5 space-y-4 text-sm leading-6 text-[color:var(--dashboard-text)]">
-                <div className="border-b border-[color:var(--dashboard-frame-border)]/70 pb-4">
-                  Rapporten verschijnen pas als een campagne genoeg respons en duiding heeft om goed te kunnen lezen.
-                </div>
-                <div className="border-b border-[color:var(--dashboard-frame-border)]/70 pb-4">
-                  De lijst blijft gekoppeld aan echte campagnes, niet aan losse exports of handmatige bundels.
-                </div>
-                <div>
-                  Open eerst de campaign detailpagina als je context nodig hebt. Gebruik Action Center pas wanneer een route al in opvolging staat.
-                </div>
-              </div>
-            </aside>
+            ))}
           </div>
         ) : (
           <div className="rounded-xl border border-dashed border-[color:var(--dashboard-frame-border)] bg-white/80 px-5 py-8 text-sm leading-7 text-[color:var(--dashboard-text)]">
-            Er zijn in deze categorie nog geen rapporten met voldoende respons
-            en duiding. Gebruik eerst dashboard en campagnedetail om het eerste
-            overzicht stevig te krijgen.
+            Er zijn nu nog geen downloadbare scanrapporten.
           </div>
         )}
-      </DashboardSection>
+      </section>
 
+      <details className="overflow-hidden rounded-xl border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)]/40">
+        <summary className="cursor-pointer list-none px-5 py-4 text-sm font-semibold text-[color:var(--dashboard-ink)]">
+          Nog niet beschikbaar ({reportIndex.unavailableRows.length})
+        </summary>
+        <div className="border-t border-[color:var(--dashboard-frame-border)] bg-white">
+          {reportIndex.unavailableRows.length > 0 ? (
+            reportIndex.unavailableRows.map((row) => (
+              <UnavailableReportRow
+                key={row.campaignId}
+                scanName={row.scanName}
+                campaignName={row.campaignName}
+                periodLabel={row.periodLabel}
+                responseBasis={row.responseBasis}
+                status={row.status}
+                extraDisambiguator={row.extraDisambiguator}
+              />
+            ))
+          ) : (
+            <div className="px-5 py-5 text-sm text-[color:var(--dashboard-text)]">Er staan nu geen wachtende rapporten open.</div>
+          )}
+        </div>
+      </details>
     </div>
-  );
+  )
 }

--- a/frontend/app/(dashboard)/reports/report-download-index.test.ts
+++ b/frontend/app/(dashboard)/reports/report-download-index.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import { buildReportDownloadIndex } from './report-download-index'
+
+const reports = [
+  {
+    campaignId: 'ret-2',
+    campaignName: 'Retentie Q2',
+    scanType: 'retention' as const,
+    scanName: 'RetentieScan',
+    periodLabel: 'Q2 2026',
+    createdAt: '2026-05-11T09:00:00Z',
+    responseBasis: '24 responses',
+    status: 'Klaar',
+    isAvailable: true,
+  },
+  {
+    campaignId: 'ret-1',
+    campaignName: 'Retentie Q1',
+    scanType: 'retention' as const,
+    scanName: 'RetentieScan',
+    periodLabel: 'Q1 2026',
+    createdAt: '2026-04-01T09:00:00Z',
+    responseBasis: '18 responses',
+    status: 'Klaar',
+    isAvailable: true,
+  },
+  {
+    campaignId: 'exit-1',
+    campaignName: 'Exit april',
+    scanType: 'exit' as const,
+    scanName: 'ExitScan',
+    periodLabel: 'Q2 2026',
+    createdAt: '2026-05-09T09:00:00Z',
+    responseBasis: '4 responses',
+    status: 'Nog onvoldoende respons',
+    isAvailable: false,
+  },
+]
+
+describe('buildReportDownloadIndex', () => {
+  it('splits rows into available and unavailable sections', () => {
+    const model = buildReportDownloadIndex(reports)
+
+    expect(model.availableRows.map((row) => row.campaignId)).toEqual(['ret-2', 'ret-1'])
+    expect(model.unavailableRows.map((row) => row.campaignId)).toEqual(['exit-1'])
+  })
+
+  it('sorts available rows by period, then date, then name', () => {
+    const model = buildReportDownloadIndex(reports)
+
+    expect(model.availableRows[0]).toMatchObject({
+      campaignId: 'ret-2',
+      periodLabel: 'Q2 2026',
+    })
+  })
+
+  it('requires enough identifying metadata to disambiguate similar reports', () => {
+    const model = buildReportDownloadIndex(reports)
+
+    expect(model.availableRows[0]).toMatchObject({
+      scanName: 'RetentieScan',
+      campaignName: 'Retentie Q2',
+      periodLabel: 'Q2 2026',
+      responseBasis: '24 responses',
+      status: 'Klaar',
+    })
+  })
+
+  it('adds an extra disambiguator when two rows would otherwise look too similar', () => {
+    const model = buildReportDownloadIndex([
+      {
+        campaignId: 'a',
+        campaignName: 'Retentie',
+        scanType: 'retention' as const,
+        scanName: 'RetentieScan',
+        periodLabel: 'Q2 2026',
+        createdAt: '2026-05-12T09:00:00Z',
+        responseBasis: '20 responses',
+        status: 'Klaar',
+        isAvailable: true,
+      },
+      {
+        campaignId: 'b',
+        campaignName: 'Retentie',
+        scanType: 'retention' as const,
+        scanName: 'RetentieScan',
+        periodLabel: 'Q2 2026',
+        createdAt: '2026-05-10T09:00:00Z',
+        responseBasis: '19 responses',
+        status: 'Klaar',
+        isAvailable: true,
+      },
+    ])
+
+    expect(model.availableRows[0]?.extraDisambiguator).toBeTruthy()
+    expect(model.availableRows[1]?.extraDisambiguator).toBeTruthy()
+  })
+})

--- a/frontend/app/(dashboard)/reports/report-download-index.ts
+++ b/frontend/app/(dashboard)/reports/report-download-index.ts
@@ -1,0 +1,82 @@
+import type { ScanType } from '@/lib/types'
+
+export type ReportDownloadRow = {
+  campaignId: string
+  campaignName: string
+  scanType: ScanType
+  scanName: string
+  periodLabel: string
+  createdAt: string
+  responseBasis: string
+  status: string
+  isAvailable: boolean
+  extraDisambiguator?: string | null
+}
+
+export type ReportDownloadIndex = {
+  availableRows: ReportDownloadRow[]
+  unavailableRows: ReportDownloadRow[]
+}
+
+function getPeriodSortKey(periodLabel: string, createdAt: string) {
+  const quarterMatch = /^Q([1-4]) (\d{4})$/.exec(periodLabel.trim())
+  if (quarterMatch) {
+    const [, quarter, year] = quarterMatch
+    return Number(year) * 10 + Number(quarter)
+  }
+
+  const created = new Date(createdAt).getTime()
+  if (Number.isNaN(created)) return 0
+  const date = new Date(created)
+  const quarter = Math.floor(date.getUTCMonth() / 3) + 1
+  return date.getUTCFullYear() * 10 + quarter
+}
+
+function compareRows(left: ReportDownloadRow, right: ReportDownloadRow) {
+  const periodDiff =
+    getPeriodSortKey(right.periodLabel, right.createdAt) -
+    getPeriodSortKey(left.periodLabel, left.createdAt)
+  if (periodDiff !== 0) return periodDiff
+
+  const createdDiff = new Date(right.createdAt).getTime() - new Date(left.createdAt).getTime()
+  if (createdDiff !== 0) return createdDiff
+
+  const campaignDiff = left.campaignName.localeCompare(right.campaignName, 'nl')
+  if (campaignDiff !== 0) return campaignDiff
+
+  return left.scanName.localeCompare(right.scanName, 'nl')
+}
+
+function addDisambiguators(rows: ReportDownloadRow[]) {
+  return rows.map((row, _, allRows) => {
+    const similarRows = allRows.filter(
+      (candidate) =>
+        candidate.scanName === row.scanName &&
+        candidate.campaignName === row.campaignName &&
+        candidate.periodLabel === row.periodLabel,
+    )
+
+    if (similarRows.length < 2) {
+      return row
+    }
+
+    return {
+      ...row,
+      extraDisambiguator: new Intl.DateTimeFormat('nl-NL', {
+        day: 'numeric',
+        month: 'short',
+        year: 'numeric',
+      }).format(new Date(row.createdAt)),
+    }
+  })
+}
+
+export function buildReportDownloadIndex(rows: ReportDownloadRow[]): ReportDownloadIndex {
+  const availableRows = rows.filter((row) => row.isAvailable).sort(compareRows)
+  const unavailableRows = rows.filter((row) => !row.isAvailable).sort(compareRows)
+
+  return {
+    availableRows: addDisambiguators(availableRows),
+    unavailableRows: addDisambiguators(unavailableRows),
+  }
+}

--- a/frontend/lib/dashboard/report-library.test.ts
+++ b/frontend/lib/dashboard/report-library.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { buildReportLibraryEntries, filterReportLibraryEntries, getReportEntryBridge } from './report-library'
+import {
+  buildHrReportDownloadRows,
+  buildReportLibraryEntries,
+  filterReportLibraryEntries,
+  getReportEntryBridge,
+} from './report-library'
 import type { CampaignStats } from '@/lib/types'
 
 const campaigns: CampaignStats[] = [
@@ -133,7 +138,7 @@ describe('report library', () => {
     expect(getReportEntryBridge(model.featured!)).toMatchObject({
       href: '/action-center',
       bridge: {
-        ctaLabel: 'Open in Action Center',
+        ctaLabel: 'Open route in Action Center',
       },
     })
   })
@@ -161,7 +166,7 @@ describe('report library', () => {
     expect(getReportEntryBridge(activeEntry!)).toMatchObject({
       href: '/action-center',
       bridge: {
-        ctaLabel: 'Open in Action Center',
+        ctaLabel: 'Open route in Action Center',
       },
     })
   })
@@ -188,6 +193,29 @@ describe('report library', () => {
     })
     expect(model.entries.find((entry) => entry.campaignId === 'pulse-1')?.recommended).toBe(true)
     expect(model.entries.find((entry) => entry.campaignId === 'exit-1')?.recommended).toBe(false)
+  })
+
+  it('keeps report entries rich enough to flatten into a download-only HR list', () => {
+    const model = buildReportLibraryEntries(campaigns)
+    const first = model.entries[0]
+
+    expect(first).toMatchObject({
+      campaignId: 'exit-1',
+      campaignName: 'ExitScan Ops — Q3',
+    })
+    expect(first.metaLeft).toContain('responses')
+    expect(first.metaRight).toBeTruthy()
+  })
+
+  it('can derive unavailable report rows with compact factual reasons', () => {
+    const model = buildHrReportDownloadRows(campaigns)
+
+    expect(model.availableRows.map((row) => row.campaignId)).toEqual(['exit-1', 'onboarding-1', 'pulse-1'])
+    expect(model.unavailableRows.map((row) => row.campaignId)).toEqual(['tiny-1'])
+    expect(model.unavailableRows[0]).toMatchObject({
+      status: 'Nog onvoldoende respons',
+      isAvailable: false,
+    })
   })
 })
 

--- a/frontend/lib/dashboard/report-library.ts
+++ b/frontend/lib/dashboard/report-library.ts
@@ -42,6 +42,19 @@ export interface BuildReportLibraryEntriesOptions {
   hrDemoArtifact?: Pick<HrDemoPilotArtifact, 'campaignId'> | null
 }
 
+export interface HrReportDownloadRow {
+  campaignId: string
+  campaignName: string
+  scanType: ScanType
+  scanName: string
+  periodLabel: string
+  createdAt: string
+  responseBasis: string
+  status: string
+  isAvailable: boolean
+  extraDisambiguator?: string | null
+}
+
 const MANAGEMENT_SCAN_TYPES: ScanType[] = ['exit', 'retention', 'leadership']
 const MODULE_SCAN_TYPES: ScanType[] = ['pulse', 'team']
 
@@ -116,6 +129,12 @@ function getPriority(campaign: CampaignStats) {
               : 1
 
   return base * 1000 + campaign.total_completed
+}
+
+function getUnavailableStatus(campaign: CampaignStats): string {
+  if (!campaign.is_active) return 'Nog niet vrijgegeven'
+  if (campaign.total_completed < FIRST_DASHBOARD_THRESHOLD) return 'Nog onvoldoende respons'
+  return 'Nog in opbouw'
 }
 
 function getReportBridgeState(args: {
@@ -233,4 +252,49 @@ export function buildReportLibraryEntries(campaigns: CampaignStats[], options: B
 export function filterReportLibraryEntries(entries: ReportLibraryEntry[], category: ReportLibraryCategory) {
   if (category === 'all') return entries
   return entries.filter((entry) => entry.category === category)
+}
+
+export function buildHrReportDownloadRows(campaigns: CampaignStats[]): {
+  availableRows: HrReportDownloadRow[]
+  unavailableRows: HrReportDownloadRow[]
+} {
+  const availableEntries = buildReportLibraryEntries(campaigns).entries
+  const availableIds = new Set(availableEntries.map((entry) => entry.campaignId))
+
+  const availableRows: HrReportDownloadRow[] = availableEntries.map((entry) => {
+    const campaign = campaigns.find((candidate) => candidate.campaign_id === entry.campaignId)
+
+    return {
+      campaignId: entry.campaignId,
+      campaignName: entry.campaignName,
+      scanType: entry.scanType,
+      scanName: SCAN_TYPE_LABELS[entry.scanType],
+      periodLabel: formatDutchQuarter(campaign?.created_at ?? entry.metaRight),
+      createdAt: campaign?.created_at ?? '',
+      responseBasis: entry.metaLeft,
+      status: 'Klaar',
+      isAvailable: true,
+      extraDisambiguator: null,
+    }
+  })
+
+  const unavailableRows: HrReportDownloadRow[] = campaigns
+    .filter((campaign) => !availableIds.has(campaign.campaign_id))
+    .map((campaign) => ({
+      campaignId: campaign.campaign_id,
+      campaignName: campaign.campaign_name,
+      scanType: campaign.scan_type,
+      scanName: SCAN_TYPE_LABELS[campaign.scan_type],
+      periodLabel: formatDutchQuarter(campaign.created_at),
+      createdAt: campaign.created_at,
+      responseBasis: `${campaign.total_completed} responses`,
+      status: getUnavailableStatus(campaign),
+      isAvailable: false,
+      extraDisambiguator: null,
+    }))
+
+  return {
+    availableRows,
+    unavailableRows,
+  }
 }


### PR DESCRIPTION
## What changed
- replaced the old featured/library reports page with a compact HR download index
- split `/reports` into `Beschikbaar nu` and collapsed `Nog niet beschikbaar`
- removed category filters, bridge CTA’s, and side-panel read context from the primary HR flow
- kept `/reports` and `/campaigns/[id]` on the same canonical PDF output

## What stayed the same
- report readiness truth
- PDF generator and output
- report permissions
- campaign/report source data

## Verification
- `npm test -- "app/(dashboard)/reports/page.test.ts" "app/(dashboard)/reports/page.route-shell.test.ts" "app/(dashboard)/reports/report-download-index.test.ts" "lib/dashboard/report-library.test.ts"`
- `npx eslint "app/(dashboard)/reports/page.tsx" "app/(dashboard)/reports/report-download-index.ts" "lib/dashboard/report-library.ts"`
- `npm run build`