### PR TITLE
Restructure HR cockpit into a single action-oriented scan index

### DIFF
--- a/frontend/app/(dashboard)/campaigns/[id]/pdf-download-button.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/pdf-download-button.tsx
@@ -6,11 +6,25 @@ interface Props {
   campaignId: string
   campaignName: string
   scanType?: string
+  label?: string
+  loadingLabel?: string
+  buttonClassName?: string
+  containerClassName?: string
+  errorClassName?: string
 }
 
 const UNSUPPORTED_REPORT_MESSAGES: Record<string, string> = {}
 
-export function PdfDownloadButton({ campaignId, campaignName, scanType }: Props) {
+export function PdfDownloadButton({
+  campaignId,
+  campaignName,
+  scanType,
+  label = 'Rapport downloaden',
+  loadingLabel = 'Rapport ophalen...',
+  buttonClassName,
+  containerClassName,
+  errorClassName,
+}: Props) {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -56,15 +70,20 @@ export function PdfDownloadButton({ campaignId, campaignName, scanType }: Props)
   }
 
   return (
-    <div className="flex flex-col items-start gap-1 sm:items-end">
+    <div className={containerClassName ?? 'flex flex-col items-start gap-1 sm:items-end'}>
       <button
         onClick={handleDownload}
         disabled={loading}
-        className="inline-flex rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+        className={
+          buttonClassName ??
+          'inline-flex rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60'
+        }
       >
-        {loading ? 'Rapport ophalen...' : 'Rapport downloaden'}
+        {loading ? loadingLabel : label}
       </button>
-      {error ? <p className="max-w-48 text-xs text-red-600 sm:text-right">{error}</p> : null}
+      {error ? (
+        <p className={errorClassName ?? 'max-w-48 text-xs text-red-600 sm:text-right'}>{error}</p>
+      ) : null}
     </div>
   )
 }

--- a/frontend/app/(dashboard)/dashboard/cockpit-index.test.ts
+++ b/frontend/app/(dashboard)/dashboard/cockpit-index.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest'
+import type { CampaignStats } from '@/lib/types'
+import {
+  buildCockpitIndexRows,
+  buildCockpitSummary,
+  type CockpitRow,
+} from './cockpit-index'
+
+function buildCampaign(overrides: Partial<CampaignStats>): CampaignStats {
+  return {
+    campaign_id: overrides.campaign_id ?? 'campaign-1',
+    campaign_name: overrides.campaign_name ?? 'RetentieScan voorjaar',
+    scan_type: overrides.scan_type ?? 'retention',
+    organization_id: overrides.organization_id ?? 'org-1',
+    is_active: overrides.is_active ?? true,
+    created_at: overrides.created_at ?? '2026-04-10T09:00:00Z',
+    total_invited: overrides.total_invited ?? 40,
+    total_completed: overrides.total_completed ?? 16,
+    completion_rate_pct: overrides.completion_rate_pct ?? 40,
+    avg_risk_score: overrides.avg_risk_score ?? 6.4,
+    avg_signal_score: overrides.avg_signal_score ?? 6.4,
+    band_high: overrides.band_high ?? 5,
+    band_medium: overrides.band_medium ?? 8,
+    band_low: overrides.band_low ?? 3,
+  }
+}
+
+describe('cockpit row mapping', () => {
+  it('shows each scan exactly once with results, pdf and instellingen when all are available', () => {
+    const rows = buildCockpitIndexRows({
+      campaigns: [
+        buildCampaign({
+          campaign_id: 'full-1',
+          scan_type: 'exit',
+          total_invited: 55,
+          total_completed: 19,
+          completion_rate_pct: 35,
+        }),
+      ],
+      invitesNotSentByCampaign: new Map([['full-1', 0]]),
+    })
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.primaryAction.label).toBe('Open resultaten')
+    expect(rows[0]?.secondaryActions.map((action) => action.label)).toEqual(['Download PDF', 'Instellingen'])
+    expect(rows[0]?.factualLine).toBe('Resultaten beschikbaar')
+  })
+
+  it('makes instellingen primary for setup and sparse routes', () => {
+    const rows = buildCockpitIndexRows({
+      campaigns: [
+        buildCampaign({
+          campaign_id: 'setup-1',
+          total_invited: 0,
+          total_completed: 0,
+          completion_rate_pct: 0,
+          avg_risk_score: null,
+          avg_signal_score: null,
+        }),
+        buildCampaign({
+          campaign_id: 'sparse-1',
+          total_invited: 50,
+          total_completed: 3,
+          completion_rate_pct: 6,
+          avg_risk_score: null,
+          avg_signal_score: null,
+        }),
+      ],
+      invitesNotSentByCampaign: new Map([
+        ['setup-1', 0],
+        ['sparse-1', 0],
+      ]),
+    })
+
+    expect(rows.map((row) => row.primaryAction.label)).toEqual(['Instellingen', 'Instellingen'])
+    expect(rows.map((row) => row.factualLine)).toEqual([
+      'Doelgroep of livegang ontbreekt nog',
+      'Nog onvoldoende respons',
+    ])
+  })
+
+  it('sorts open resultaten rows ahead of pdf-only and instellingen-first rows', () => {
+    const rows = buildCockpitIndexRows({
+      campaigns: [
+        buildCampaign({
+          campaign_id: 'setup-1',
+          total_invited: 0,
+          total_completed: 0,
+          completion_rate_pct: 0,
+          avg_risk_score: null,
+          avg_signal_score: null,
+        }),
+        buildCampaign({
+          campaign_id: 'closed-1',
+          is_active: false,
+          total_invited: 45,
+          total_completed: 18,
+          completion_rate_pct: 40,
+          created_at: '2026-03-01T09:00:00Z',
+        }),
+        buildCampaign({
+          campaign_id: 'full-1',
+          total_invited: 55,
+          total_completed: 19,
+          completion_rate_pct: 35,
+          created_at: '2026-04-10T09:00:00Z',
+        }),
+      ],
+      invitesNotSentByCampaign: new Map([
+        ['setup-1', 0],
+        ['closed-1', 0],
+        ['full-1', 0],
+      ]),
+    })
+
+    expect(rows.map((row) => row.campaign.campaign_id)).toEqual(['full-1', 'closed-1', 'setup-1'])
+  })
+
+  it('keeps partial scans with report visibility in the same results bucket and sorts them deterministically by date', () => {
+    const rows = buildCockpitIndexRows({
+      campaigns: [
+        buildCampaign({
+          campaign_id: 'partial-1',
+          scan_type: 'pulse',
+          total_invited: 48,
+          total_completed: 7,
+          completion_rate_pct: 15,
+          avg_risk_score: null,
+          avg_signal_score: null,
+          created_at: '2026-04-10T09:00:00Z',
+        }),
+        buildCampaign({
+          campaign_id: 'full-1',
+          scan_type: 'exit',
+          total_invited: 55,
+          total_completed: 19,
+          completion_rate_pct: 35,
+          created_at: '2026-04-09T09:00:00Z',
+        }),
+      ],
+      invitesNotSentByCampaign: new Map([
+        ['partial-1', 0],
+        ['full-1', 0],
+      ]),
+    })
+
+    expect(rows.map((row) => row.campaign.campaign_id)).toEqual(['partial-1', 'full-1'])
+    expect(rows[0]?.secondaryActions.map((action) => action.label)).toContain('Download PDF')
+    expect(rows[1]?.secondaryActions.map((action) => action.label)).toContain('Download PDF')
+    expect(rows[0]?.factualLine).toBe('Eerste resultaten beschikbaar')
+  })
+
+  it('builds the compact utility summary from row availability', () => {
+    const rows: CockpitRow[] = [
+      {
+        campaign: buildCampaign({ campaign_id: 'full-1' }),
+        productLabel: 'RetentieScan',
+        periodLabel: 'apr 2026',
+        responseValue: '40%',
+        statusLabel: 'Leesbaar',
+        factualLine: 'Resultaten beschikbaar',
+        primaryAction: { kind: 'results', label: 'Open resultaten', href: '/campaigns/full-1' },
+        secondaryActions: [{ kind: 'pdf', label: 'Download PDF', href: '/api/campaigns/full-1/report' }],
+      },
+      {
+        campaign: buildCampaign({
+          campaign_id: 'setup-1',
+          total_invited: 0,
+          total_completed: 0,
+          completion_rate_pct: 0,
+          avg_risk_score: null,
+          avg_signal_score: null,
+        }),
+        productLabel: 'ExitScan',
+        periodLabel: 'apr 2026',
+        responseValue: '0%',
+        statusLabel: 'Nog niet live',
+        factualLine: 'Doelgroep of livegang ontbreekt nog',
+        primaryAction: { kind: 'settings', label: 'Instellingen', href: '/campaigns/setup-1/beheer' },
+        secondaryActions: [],
+      },
+    ]
+
+    expect(buildCockpitSummary(rows)).toEqual({
+      total: 2,
+      resultsAvailable: 1,
+      pdfAvailable: 1,
+      attentionNeeded: 1,
+    })
+  })
+})

--- a/frontend/app/(dashboard)/dashboard/cockpit-index.ts
+++ b/frontend/app/(dashboard)/dashboard/cockpit-index.ts
@@ -1,0 +1,165 @@
+import {
+  getCampaignCompositionState,
+  type CampaignCompositionState,
+} from '@/lib/dashboard/dashboard-state-composition'
+import { buildHrReportDownloadRows } from '@/lib/dashboard/report-library'
+import { getScanDefinition } from '@/lib/scan-definitions'
+import type { CampaignStats } from '@/lib/types'
+
+export type CockpitActionKind = 'results' | 'pdf' | 'settings'
+
+export type CockpitAction = {
+  kind: CockpitActionKind
+  label: 'Open resultaten' | 'Download PDF' | 'Instellingen'
+  href: string
+}
+
+export type CockpitRow = {
+  campaign: CampaignStats
+  productLabel: string
+  periodLabel: string
+  responseValue: string
+  statusLabel: string
+  factualLine: string
+  primaryAction: CockpitAction
+  secondaryActions: CockpitAction[]
+}
+
+export function buildCockpitIndexRows(args: {
+  campaigns: CampaignStats[]
+  invitesNotSentByCampaign: Map<string, number>
+}) {
+  const availablePdfCampaignIds = new Set(
+    buildHrReportDownloadRows(args.campaigns).availableRows.map((row) => row.campaignId),
+  )
+
+  return [...args.campaigns]
+    .map((campaign) =>
+      buildCockpitRow({
+        campaign,
+        invitesNotSent: args.invitesNotSentByCampaign.get(campaign.campaign_id) ?? 0,
+        pdfAvailable: availablePdfCampaignIds.has(campaign.campaign_id),
+      }),
+    )
+    .sort(compareCockpitRows)
+}
+
+export function buildCockpitSummary(rows: CockpitRow[]) {
+  return {
+    total: rows.length,
+    resultsAvailable: rows.filter((row) => row.primaryAction.kind === 'results').length,
+    pdfAvailable: rows.filter(
+      (row) =>
+        row.primaryAction.kind === 'pdf' || row.secondaryActions.some((action) => action.kind === 'pdf'),
+    ).length,
+    attentionNeeded: rows.filter((row) => row.primaryAction.kind === 'settings').length,
+  }
+}
+
+function buildCockpitRow(args: {
+  campaign: CampaignStats
+  invitesNotSent: number
+  pdfAvailable: boolean
+}): CockpitRow {
+  const { campaign, invitesNotSent, pdfAvailable } = args
+  const state = getCampaignCompositionState({
+    isActive: campaign.is_active,
+    totalInvited: campaign.total_invited,
+    totalCompleted: campaign.total_completed,
+    invitesNotSent,
+    incompleteScores: 0,
+    hasMinDisplay: campaign.total_completed >= 5,
+    hasEnoughData: campaign.total_completed >= 10,
+  })
+  const scanDefinition = getScanDefinition(campaign.scan_type)
+  const actions = buildCockpitActions({ campaign, state, pdfAvailable })
+
+  return {
+    campaign,
+    productLabel: scanDefinition.productName,
+    periodLabel: formatCampaignPeriod(campaign),
+    responseValue: Number.isFinite(campaign.completion_rate_pct) ? `${campaign.completion_rate_pct}%` : '—',
+    statusLabel: getStatusLabel(state),
+    factualLine: getFactualLine(state, pdfAvailable),
+    primaryAction: actions[0]!,
+    secondaryActions: actions.slice(1),
+  }
+}
+
+function buildCockpitActions(args: {
+  campaign: CampaignStats
+  state: CampaignCompositionState
+  pdfAvailable: boolean
+}): CockpitAction[] {
+  const { campaign, state, pdfAvailable } = args
+  const settingsAction: CockpitAction = {
+    kind: 'settings',
+    label: 'Instellingen',
+    href: `/campaigns/${campaign.campaign_id}/beheer`,
+  }
+  const resultsAction: CockpitAction = {
+    kind: 'results',
+    label: 'Open resultaten',
+    href: `/campaigns/${campaign.campaign_id}`,
+  }
+  const pdfAction: CockpitAction = {
+    kind: 'pdf',
+    label: 'Download PDF',
+    href: `/api/campaigns/${campaign.campaign_id}/report`,
+  }
+
+  if (state === 'full' || state === 'partial') {
+    return pdfAvailable ? [resultsAction, pdfAction, settingsAction] : [resultsAction, settingsAction]
+  }
+
+  if (state === 'closed') {
+    return pdfAvailable ? [resultsAction, pdfAction] : [resultsAction]
+  }
+
+  return [settingsAction]
+}
+
+function getStatusLabel(state: CampaignCompositionState) {
+  if (state === 'full') return 'Leesbaar'
+  if (state === 'partial') return 'Deels zichtbaar'
+  if (state === 'closed') return 'Afgerond'
+  if (state === 'setup') return 'Nog niet live'
+  return 'Nog in opbouw'
+}
+
+function getFactualLine(state: CampaignCompositionState, pdfAvailable: boolean) {
+  if (state === 'full') return 'Resultaten beschikbaar'
+  if (state === 'partial') return 'Eerste resultaten beschikbaar'
+  if (state === 'closed') return pdfAvailable ? 'Resultaten en PDF beschikbaar' : 'Resultaten beschikbaar'
+  if (state === 'ready_to_launch') return 'Uitnodiging nog niet verstuurd'
+  if (state === 'setup') return 'Doelgroep of livegang ontbreekt nog'
+  return 'Nog onvoldoende respons'
+}
+
+function compareCockpitRows(left: CockpitRow, right: CockpitRow) {
+  const rank = (row: CockpitRow) => {
+    if (row.primaryAction.kind === 'results' && row.secondaryActions.some((action) => action.kind === 'pdf')) return 0
+    if (row.primaryAction.kind === 'results') return 1
+    if (row.primaryAction.kind === 'pdf') return 2
+    if (row.primaryAction.kind === 'settings') return 3
+    return 4
+  }
+
+  const rankDelta = rank(left) - rank(right)
+  if (rankDelta !== 0) return rankDelta
+
+  const dateDelta = new Date(right.campaign.created_at).getTime() - new Date(left.campaign.created_at).getTime()
+  if (dateDelta !== 0) return dateDelta
+
+  return left.campaign.campaign_name.localeCompare(right.campaign.campaign_name, 'nl')
+}
+
+function formatCampaignPeriod(campaign: CampaignStats) {
+  const quarterMatch = campaign.campaign_name.match(/Q[1-4]\s?\d{4}/i)
+  if (quarterMatch) return quarterMatch[0].replace(/\s+/, ' ')
+
+  return new Intl.DateTimeFormat('nl-NL', {
+    month: 'short',
+    year: 'numeric',
+  }).format(new Date(campaign.created_at))
+}

--- a/frontend/app/(dashboard)/dashboard/page.test.ts
+++ b/frontend/app/(dashboard)/dashboard/page.test.ts
@@ -39,46 +39,50 @@ const campaigns: CampaignStats[] = [
 ]
 
 describe('dashboard home UX guardrails', () => {
-  it('renders the overview route as a cockpit with explicit triage buckets and sections', () => {
+  it('renders the overview route as a compact cockpit list with visible multi-action controls', () => {
     const pageSource = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
 
     expect(pageSource).toContain('Dashboard overview')
     expect(pageSource).toContain('Cockpit')
-    expect(pageSource).toContain('ACTIE NODIG')
-    expect(pageSource).toContain('BIJNA KLAAR')
-    expect(pageSource).toContain('LIVE EN LEESBAAR')
-    expect(pageSource).toContain('GEBLOKKEERD / NIET GESTART')
-    expect(pageSource).toContain('Nu eerst')
-    expect(pageSource).toContain('Geblokkeerd / niet gestart')
-    expect(pageSource).toContain('Recente afgeronde routes')
-    expect(pageSource).toContain('WAAROM')
-    expect(pageSource).toContain('VOLGENDE STAP')
+    expect(pageSource).toContain('Open scans, download rapporten en beheer instellingen vanuit een overzicht.')
+    expect(pageSource).toContain('PdfDownloadButton')
+    expect(pageSource).toContain('primaryAction')
+    expect(pageSource).toContain('secondaryActions')
+    expect(pageSource).toContain('CockpitActionButton')
+    expect(pageSource).not.toContain('ACTIE NODIG')
+    expect(pageSource).not.toContain('BIJNA KLAAR')
+    expect(pageSource).not.toContain('LIVE EN LEESBAAR')
+    expect(pageSource).not.toContain('GEBLOKKEERD / NIET GESTART')
+    expect(pageSource).not.toContain('Nu eerst')
+    expect(pageSource).not.toContain('Geblokkeerd / niet gestart')
+    expect(pageSource).not.toContain('Recente afgeronde routes')
+    expect(pageSource).not.toContain('WAAROM')
+    expect(pageSource).not.toContain('VOLGENDE STAP')
   })
 
-  it('drops the old flat overview IA and keeps product boundaries sharp', () => {
+  it('drops the old bucket-first overview IA and keeps one canonical scan list', () => {
     const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
 
-    expect(source).not.toContain('Ook aandacht')
-    expect(source).not.toContain('Actieve routes')
-    expect(source).not.toContain('Wat nu leesbaar is')
-    expect(source).not.toContain('Wat blokkeert')
-    expect(source).not.toContain('OverviewLeadCard')
-    expect(source).not.toContain('Overige actieve routes')
-    expect(source).not.toContain('Portfolio samenvatting')
-    expect(source).not.toContain('Aanbevolen focus')
-    expect(source).not.toContain('factor-breakdown')
-    expect(source).not.toContain('setupwizard')
+    expect(source).toContain('buildCockpitIndexRows')
+    expect(source).toContain('buildCockpitSummary')
+    expect(source).not.toContain('buildTriageItems')
+    expect(source).not.toContain('buildBlockedItems')
+    expect(source).not.toContain('buildRecentClosedItems')
+    expect(source).not.toContain('TriageRouteCard')
+    expect(source).not.toContain('BlockerRouteRow')
+    expect(source).not.toContain('ClosedRouteRow')
   })
 
-  it('keeps access boundaries and route scope intact on overview', () => {
+  it('keeps access boundaries and route scope intact on overview while demoting status filters', () => {
     const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
 
     expect(source).toContain("if (context.managerOnly) redirect('/action-center')")
     expect(source).toContain("const requestedModuleFilter = normalizeDashboardModuleFilter(")
-    expect(source).toContain("const requestedStatusFilter = normalizeDashboardStatusFilter(")
-    expect(source).toContain("if (state === 'ready_to_launch' || state === 'running' || state === 'sparse') return 'action_needed'")
-    expect(source).toContain(".filter((entry) => entry.state === 'setup')")
-    expect(source).toContain('Geen routes met deze status.')
+    expect(source).not.toContain("const requestedStatusFilter = normalizeDashboardStatusFilter(")
+    expect(source).toContain('Product')
+    expect(source).toContain('FilterPill')
+    expect(source).not.toContain('Status')
+    expect(source).not.toContain('Geen routes met deze status.')
     expect(source).not.toContain('Accepteren')
     expect(source).not.toContain('Afwijzen')
     expect(source).not.toContain('Toewijzen')
@@ -91,12 +95,14 @@ describe('dashboard home UX guardrails', () => {
     expect(source).not.toContain('export function getCtaHrefForState')
   })
 
-  it('keeps signal scoring out of the visible overview card metrics', () => {
+  it('keeps the cockpit summary compact instead of score-heavy route cards', () => {
     const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
 
-    expect(source).toContain('MetricBlock label="RESPONS" value={item.responseValue} compact')
-    expect(source).not.toContain('MetricBlock label={item.signalLabel.toUpperCase()}')
-    expect(source).not.toContain('signalValue:')
+    expect(source).toContain('<SummaryCard label="Scans"')
+    expect(source).toContain('<SummaryCard label="Resultaten"')
+    expect(source).toContain('<SummaryCard label="PDF"')
+    expect(source).toContain('<SummaryCard label="Aandacht"')
+    expect(source).not.toContain('getCampaignAverageSignalScore')
   })
 
   it('allows the seeded HR demo campaign to override the default overview focus route', () => {

--- a/frontend/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/page.tsx
@@ -1,10 +1,7 @@
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
+import { PdfDownloadButton } from '@/app/(dashboard)/campaigns/[id]/pdf-download-button'
 import { DashboardSection } from '@/components/dashboard/dashboard-primitives'
-import {
-  getCampaignCompositionState,
-  type CampaignCompositionState,
-} from '@/lib/dashboard/dashboard-state-composition'
 import {
   getDashboardModuleKeyForScanType,
   getDashboardModuleLabel,
@@ -12,63 +9,12 @@ import {
   normalizeDashboardModuleFilter,
   type DashboardCategoryModuleKey,
 } from '@/lib/dashboard/shell-navigation'
-import { getScanDefinition } from '@/lib/scan-definitions'
 import { loadSuiteAccessContext } from '@/lib/suite-access-server'
 import { createClient } from '@/lib/supabase/server'
-import { getCampaignAverageSignalScore, type CampaignStats } from '@/lib/types'
+import type { CampaignStats } from '@/lib/types'
+import { buildCockpitIndexRows, buildCockpitSummary, type CockpitAction, type CockpitRow } from './cockpit-index'
 
-type CampaignHomeEntry = {
-  campaign: CampaignStats
-  state: CampaignCompositionState
-  invitesNotSent: number
-}
-
-type OverviewRouteTone = 'slate' | 'blue' | 'emerald' | 'amber'
-type CockpitBucket =
-  | 'action_needed'
-  | 'nearly_ready'
-  | 'live_readable'
-  | 'blocked_not_started'
-  | 'recent_closed'
-type CockpitStatusFilter = Exclude<CockpitBucket, 'recent_closed'> | 'all'
-
-type CockpitRouteItem = {
-  entry: CampaignHomeEntry
-  bucket: CockpitBucket
-  productLabel: string
-  contextLabel: string
-  stateLabel: string
-  stateTone: OverviewRouteTone
-  why: string
-  nextStep: string
-  ctaLabel: string
-  ctaHref: string
-  responseValue: string
-}
-
-type CockpitCounter = {
-  key: Exclude<CockpitBucket, 'recent_closed'>
-  label: string
-  tone: OverviewRouteTone
-  count: number
-  body: string
-}
-
-const STATUS_FILTERS: Array<{ key: CockpitStatusFilter; label: string }> = [
-  { key: 'all', label: 'Alle statussen' },
-  { key: 'action_needed', label: 'Actie nodig' },
-  { key: 'nearly_ready', label: 'Bijna klaar' },
-  { key: 'live_readable', label: 'Live en leesbaar' },
-  { key: 'blocked_not_started', label: 'Geblokkeerd / niet gestart' },
-]
-
-const MODULE_ORDER: DashboardCategoryModuleKey[] = [
-  'exit',
-  'retention',
-  'onboarding',
-  'pulse',
-  'leadership',
-]
+const MODULE_ORDER: DashboardCategoryModuleKey[] = ['exit', 'retention', 'onboarding', 'pulse', 'leadership']
 
 export default async function DashboardHomePage({
   searchParams,
@@ -78,9 +24,6 @@ export default async function DashboardHomePage({
   const resolvedSearchParams = searchParams ? await searchParams : undefined
   const requestedModuleFilter = normalizeDashboardModuleFilter(
     typeof resolvedSearchParams?.module === 'string' ? resolvedSearchParams.module : undefined,
-  )
-  const requestedStatusFilter = normalizeDashboardStatusFilter(
-    typeof resolvedSearchParams?.status === 'string' ? resolvedSearchParams.status : undefined,
   )
   const supabase = await createClient()
   const {
@@ -92,13 +35,13 @@ export default async function DashboardHomePage({
   if (context.managerOnly) redirect('/action-center')
 
   const isAdmin = profile?.is_verisight_admin === true
-
   const { data: stats } = await supabase.from('campaign_stats').select('*').order('created_at', { ascending: false })
 
   const allCampaigns = (stats ?? []) as CampaignStats[]
   const campaigns = requestedModuleFilter
     ? allCampaigns.filter((campaign) => campaign.scan_type === getScanTypeForDashboardModule(requestedModuleFilter))
     : allCampaigns
+  const productFilters = buildAvailableModuleFilters(allCampaigns)
   const campaignIds = campaigns.map((campaign) => campaign.campaign_id)
   const { data: respondentStateRowsRaw } =
     campaignIds.length > 0
@@ -113,62 +56,9 @@ export default async function DashboardHomePage({
     completed: boolean
   }>
   const invitesNotSentByCampaign = buildInvitesNotSentByCampaign(campaigns, respondentStateRows)
-  const campaignEntries = campaigns.map((campaign) => {
-    const invitesNotSent = invitesNotSentByCampaign.get(campaign.campaign_id)
-    if (invitesNotSent === undefined) {
-      throw new Error(`Missing invite state for campaign ${campaign.campaign_id}`)
-    }
-
-    return {
-      campaign,
-      invitesNotSent,
-      state: getCampaignCompositionState({
-        isActive: campaign.is_active,
-        totalInvited: campaign.total_invited,
-        totalCompleted: campaign.total_completed,
-        invitesNotSent,
-        incompleteScores: 0,
-        hasMinDisplay: campaign.total_completed >= 5,
-        hasEnoughData: campaign.total_completed >= 10,
-      }),
-    }
-  })
-
-  const moduleLabel = requestedModuleFilter ? getDashboardModuleLabel(requestedModuleFilter) : null
-  const productFilters = buildAvailableModuleFilters(allCampaigns)
-  const counters = buildCockpitCounters(campaignEntries)
-  const activeEntries = campaignEntries.filter((entry) => entry.campaign.is_active)
-  const primaryActiveEntries = activeEntries.filter((entry) =>
-    ['exit', 'retention'].includes(entry.campaign.scan_type),
-  )
-  const readableEntries = [...campaignEntries]
-    .filter((entry) => ['full', 'partial', 'closed'].includes(entry.state))
-    .sort(
-      (left, right) =>
-        new Date(right.campaign.created_at).getTime() - new Date(left.campaign.created_at).getTime(),
-    )
-  const primaryLeadEntry = selectPrimaryLeadEntry(primaryActiveEntries, readableEntries)
-  const triageItems = buildTriageItems(campaignEntries, primaryLeadEntry)
-  const blockedItems = buildBlockedItems(campaignEntries)
-  const closedItems = buildRecentClosedItems(campaignEntries).slice(0, 3)
-  const hasStatusFilter = requestedStatusFilter !== 'all'
-  const filteredTriageItems =
-    requestedStatusFilter === 'all'
-      ? triageItems
-      : triageItems.filter((item) => item.bucket === requestedStatusFilter)
-  const showTriageSection =
-    requestedStatusFilter === 'all' ||
-    requestedStatusFilter === 'action_needed' ||
-    requestedStatusFilter === 'nearly_ready' ||
-    requestedStatusFilter === 'live_readable'
-  const showBlockedSection =
-    blockedItems.length > 0 &&
-    (requestedStatusFilter === 'all' || requestedStatusFilter === 'blocked_not_started')
-  const showClosedSection = closedItems.length > 0 && requestedStatusFilter === 'all'
-  const filterEmptyMessage = hasStatusFilter && !showBlockedSection && filteredTriageItems.length === 0
-  const contextLabel = moduleLabel ?? 'Alle routes'
-  const activeStatusLabel = getStatusFilterLabel(requestedStatusFilter)
-  const hasActiveFilters = requestedModuleFilter !== null || requestedStatusFilter !== 'all'
+  const rows = buildCockpitIndexRows({ campaigns, invitesNotSentByCampaign })
+  const summary = buildCockpitSummary(rows)
+  const contextLabel = requestedModuleFilter ? getDashboardModuleLabel(requestedModuleFilter) : 'Alle routes'
 
   return (
     <div className="space-y-8">
@@ -177,7 +67,7 @@ export default async function DashboardHomePage({
       ) : campaigns.length === 0 ? (
         requestedModuleFilter ? (
           <DashboardSection
-            eyebrow={moduleLabel ?? 'Route'}
+            eyebrow={contextLabel}
             title="Nog geen campagnes voor deze route"
             description="Zodra deze route live staat, verschijnt hier automatisch het volledige overzicht."
           >
@@ -198,7 +88,7 @@ export default async function DashboardHomePage({
           <header className="space-y-5 border-b border-[color:var(--dashboard-frame-border)] pb-6">
             {requestedModuleFilter ? (
               <Link
-                href={buildDashboardOverviewHref({ statusFilter: requestedStatusFilter })}
+                href="/dashboard"
                 className="inline-flex text-sm font-semibold text-[color:var(--dashboard-accent-strong)] transition-colors hover:text-[color:var(--dashboard-ink)]"
               >
                 Terug naar alle routes
@@ -216,67 +106,27 @@ export default async function DashboardHomePage({
                   Dashboard overview
                 </h1>
                 <p className="max-w-3xl text-[0.98rem] leading-7 text-[color:var(--dashboard-text)]">
-                  Bekijk welke routes aandacht vragen en ga direct naar de juiste vervolglaag.
+                  Open scans, download rapporten en beheer instellingen vanuit een overzicht.
                 </p>
               </div>
-              <div className="rounded-[20px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)] px-4 py-4 shadow-[0_1px_3px_rgba(15,23,42,0.03)] sm:px-5">
-                <div className="flex flex-col gap-3 border-b border-[color:var(--dashboard-frame-border)] pb-4 sm:flex-row sm:items-start sm:justify-between">
-                  <div className="space-y-1.5">
-                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
-                      Filters
-                    </p>
-                    <p className="text-sm leading-6 text-[color:var(--dashboard-text)]">
-                      <span className="font-semibold text-[color:var(--dashboard-ink)]">Actief:</span>{' '}
-                      {activeStatusLabel} · {contextLabel}
-                    </p>
-                  </div>
-                  {hasActiveFilters ? (
-                    <Link
-                      href="/dashboard"
-                      className="inline-flex text-sm font-semibold text-[color:var(--dashboard-accent-strong)] transition-colors hover:text-[color:var(--dashboard-ink)]"
-                    >
-                      Wis filters
-                    </Link>
-                  ) : (
-                    <span className="text-sm text-[color:var(--dashboard-muted)]">Geen extra filters actief</span>
-                  )}
+              <div className="grid gap-4 lg:grid-cols-[minmax(0,1.35fr),minmax(0,1fr)]">
+                <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                  <SummaryCard label="Scans" value={summary.total} />
+                  <SummaryCard label="Resultaten" value={summary.resultsAvailable} />
+                  <SummaryCard label="PDF" value={summary.pdfAvailable} />
+                  <SummaryCard label="Aandacht" value={summary.attentionNeeded} />
                 </div>
-                <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1.35fr),minmax(0,1fr)]">
-                  <div className="space-y-2">
-                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
-                      Status
-                    </p>
-                    <div className="flex flex-wrap gap-2">
-                      {STATUS_FILTERS.map((filter) => (
-                        <FilterPill
-                          key={filter.key}
-                          href={buildDashboardOverviewHref({
-                            moduleFilter: requestedModuleFilter,
-                            statusFilter: filter.key,
-                          })}
-                          active={requestedStatusFilter === filter.key}
-                          label={filter.label}
-                        />
-                      ))}
-                    </div>
-                  </div>
+                <div className="rounded-[20px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)] px-4 py-4 shadow-[0_1px_3px_rgba(15,23,42,0.03)] sm:px-5">
                   <div className="space-y-2">
                     <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
                       Product
                     </p>
                     <div className="flex flex-wrap gap-2">
-                      <FilterPill
-                        href={buildDashboardOverviewHref({ statusFilter: requestedStatusFilter })}
-                        active={requestedModuleFilter === null}
-                        label="Alle routes"
-                      />
+                      <FilterPill href="/dashboard" active={requestedModuleFilter === null} label="Alle routes" />
                       {productFilters.map((filterKey) => (
                         <FilterPill
                           key={filterKey}
-                          href={buildDashboardOverviewHref({
-                            moduleFilter: filterKey,
-                            statusFilter: requestedStatusFilter,
-                          })}
+                          href={buildDashboardOverviewHref(filterKey)}
                           active={requestedModuleFilter === filterKey}
                           label={getDashboardModuleLabel(filterKey)}
                         />
@@ -288,122 +138,21 @@ export default async function DashboardHomePage({
             </div>
           </header>
 
-          <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-            {counters.map((counter) => (
-              <StatusCounterCard key={counter.key} counter={counter} />
+          <section className="space-y-3">
+            {rows.map((row) => (
+              <CockpitScanRow key={row.campaign.campaign_id} row={row} />
             ))}
           </section>
-
-          {showTriageSection ? (
-            <section className="space-y-4">
-              <div className="space-y-1.5">
-                <h2 className="text-[1.55rem] font-semibold tracking-[-0.04em] text-[color:var(--dashboard-ink)]">
-                  Nu eerst
-                </h2>
-                <p className="max-w-3xl text-sm leading-6 text-[color:var(--dashboard-text)]">
-                  Deze routes vragen als eerste aandacht op basis van status, volgende stap of beschikbare output.
-                </p>
-              </div>
-              {filteredTriageItems.length === 0 ? (
-                <InlineEmptyState message="Geen routes vragen op dit moment actie." />
-              ) : (
-                <div className="space-y-4">
-                  {filteredTriageItems.map((item, index) => (
-                    <TriageRouteCard
-                      key={item.entry.campaign.campaign_id}
-                      item={item}
-                      highlightLabel={index === 0 && requestedStatusFilter === 'all' ? 'Nu eerst' : undefined}
-                    />
-                  ))}
-                </div>
-              )}
-            </section>
-          ) : null}
-
-          {showBlockedSection ? (
-            <section className="space-y-4">
-              <div className="space-y-1.5">
-                <h2 className="text-[1.35rem] font-semibold tracking-[-0.04em] text-[color:var(--dashboard-ink)]">
-                  Geblokkeerd / niet gestart
-                </h2>
-                <p className="text-sm leading-6 text-[color:var(--dashboard-text)]">
-                  Deze routes missen nog livegang en vragen eerst een operationele startstap.
-                </p>
-              </div>
-              <div className="space-y-3">
-                {blockedItems.map((item) => (
-                  <BlockerRouteRow key={item.entry.campaign.campaign_id} item={item} />
-                ))}
-              </div>
-            </section>
-          ) : null}
-
-          {filterEmptyMessage ? (
-            <InlineEmptyState message="Geen routes met deze status." />
-          ) : null}
-
-          {showClosedSection ? (
-            <section className="space-y-4">
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-                <div className="space-y-1.5">
-                  <h2 className="text-[1.35rem] font-semibold tracking-[-0.04em] text-[color:var(--dashboard-ink)]">
-                    Recente afgeronde routes
-                  </h2>
-                  <p className="text-sm leading-6 text-[color:var(--dashboard-text)]">
-                    Gesloten routes die nu vooral rapport-first gelezen worden.
-                  </p>
-                </div>
-                <Link
-                  href="/reports"
-                  className="text-sm font-semibold text-[color:var(--dashboard-accent-strong)] transition-colors hover:text-[color:var(--dashboard-ink)]"
-                >
-                  Open rapporten
-                </Link>
-              </div>
-              <div className="space-y-3">
-                {closedItems.map((item) => (
-                  <ClosedRouteRow key={item.entry.campaign.campaign_id} item={item} />
-                ))}
-              </div>
-            </section>
-          ) : null}
         </>
       )}
     </div>
   )
 }
 
-function normalizeDashboardStatusFilter(value: string | undefined): CockpitStatusFilter {
-  if (
-    value === 'action_needed' ||
-    value === 'nearly_ready' ||
-    value === 'live_readable' ||
-    value === 'blocked_not_started'
-  ) {
-    return value
-  }
-
-  return 'all'
-}
-
-function getStatusFilterLabel(filter: CockpitStatusFilter) {
-  return STATUS_FILTERS.find((item) => item.key === filter)?.label ?? 'Alle statussen'
-}
-
-function buildDashboardOverviewHref(args: {
-  moduleFilter?: DashboardCategoryModuleKey | null
-  statusFilter?: CockpitStatusFilter
-}) {
+function buildDashboardOverviewHref(moduleFilter: DashboardCategoryModuleKey) {
   const params = new URLSearchParams()
-  if (args.moduleFilter) {
-    params.set('module', args.moduleFilter)
-  }
-  if (args.statusFilter && args.statusFilter !== 'all') {
-    params.set('status', args.statusFilter)
-  }
-
-  const query = params.toString()
-  return query ? `/dashboard?${query}` : '/dashboard'
+  params.set('module', moduleFilter)
+  return `/dashboard?${params.toString()}`
 }
 
 function buildAvailableModuleFilters(campaigns: CampaignStats[]) {
@@ -415,175 +164,6 @@ function buildAvailableModuleFilters(campaigns: CampaignStats[]) {
   }
 
   return MODULE_ORDER.filter((key) => availableKeys.has(key))
-}
-
-function mapStateToCockpitBucket(state: CampaignCompositionState): CockpitBucket {
-  if (state === 'setup') return 'blocked_not_started'
-  if (state === 'ready_to_launch' || state === 'running' || state === 'sparse') return 'action_needed'
-  if (state === 'partial') return 'nearly_ready'
-  if (state === 'full') return 'live_readable'
-  return 'recent_closed'
-}
-
-function buildCockpitCounters(entries: CampaignHomeEntry[]): CockpitCounter[] {
-  return [
-    {
-      key: 'action_needed',
-      label: 'ACTIE NODIG',
-      tone: 'amber',
-      count: entries.filter((entry) => mapStateToCockpitBucket(entry.state) === 'action_needed').length,
-      body: 'Routes waar livegang of extra respons eerst expliciet aandacht vraagt.',
-    },
-    {
-      key: 'nearly_ready',
-      label: 'BIJNA KLAAR',
-      tone: 'blue',
-      count: entries.filter((entry) => mapStateToCockpitBucket(entry.state) === 'nearly_ready').length,
-      body: 'Routes waar de eerste leeslaag open is, maar de read nog begrensd blijft.',
-    },
-    {
-      key: 'live_readable',
-      label: 'LIVE EN LEESBAAR',
-      tone: 'emerald',
-      count: entries.filter((entry) => mapStateToCockpitBucket(entry.state) === 'live_readable').length,
-      body: 'Routes die nu veilig genoeg zijn voor dashboardlezing.',
-    },
-    {
-      key: 'blocked_not_started',
-      label: 'GEBLOKKEERD / NIET GESTART',
-      tone: 'slate',
-      count: entries.filter((entry) => mapStateToCockpitBucket(entry.state) === 'blocked_not_started').length,
-      body: 'Routes die nog niet live zijn en eerst operationeel gestart moeten worden.',
-    },
-  ]
-}
-
-function buildTriageItems(
-  entries: CampaignHomeEntry[],
-  primaryLeadEntry: CampaignHomeEntry | null,
-) {
-  const activeEntries = entries.filter((entry) => entry.campaign.is_active)
-  const primaryEntries = activeEntries.filter((entry) => ['exit', 'retention'].includes(entry.campaign.scan_type))
-  const boundedEntries = activeEntries.filter((entry) => !['exit', 'retention'].includes(entry.campaign.scan_type))
-  const orderedEntries = [
-    ...(primaryLeadEntry ? [primaryLeadEntry] : []),
-    ...primaryEntries
-      .filter((entry) => entry.campaign.campaign_id !== primaryLeadEntry?.campaign.campaign_id)
-      .sort(compareOverviewEntries),
-    ...boundedEntries.sort(compareOverviewEntries),
-  ]
-
-  return orderedEntries
-    .filter((entry) => {
-      const bucket = mapStateToCockpitBucket(entry.state)
-      return bucket === 'action_needed' || bucket === 'nearly_ready' || bucket === 'live_readable'
-    })
-    .map(buildCockpitRouteItem)
-}
-
-function buildBlockedItems(entries: CampaignHomeEntry[]) {
-  return entries
-    .filter((entry) => entry.state === 'setup')
-    .sort(compareOverviewEntries)
-    .map(buildCockpitRouteItem)
-}
-
-function buildRecentClosedItems(entries: CampaignHomeEntry[]) {
-  return entries
-    .filter((entry) => entry.state === 'closed')
-    .sort(
-      (left, right) =>
-        new Date(right.campaign.created_at).getTime() - new Date(left.campaign.created_at).getTime(),
-    )
-    .map(buildCockpitRouteItem)
-}
-
-function buildCockpitRouteItem(entry: CampaignHomeEntry): CockpitRouteItem {
-  const scanDefinition = getScanDefinition(entry.campaign.scan_type)
-  const stateMeta = getHomeStateMeta(entry.state)
-  const completionValue = Number.isFinite(entry.campaign.completion_rate_pct)
-    ? `${entry.campaign.completion_rate_pct}%`
-    : '—'
-  const ctaLabel = getCtaLabelForState(entry.state)
-  const bucket = mapStateToCockpitBucket(entry.state)
-
-  return {
-    entry,
-    bucket,
-    productLabel: scanDefinition.productName,
-    contextLabel: `${formatCampaignPeriod(entry.campaign)} · ${scanDefinition.productName}`,
-    stateLabel: stateMeta.label,
-    stateTone: getToneForBucket(bucket),
-    why: getWhyCopy(entry),
-    nextStep: ctaLabel,
-    ctaLabel,
-    ctaHref:
-      entry.state === 'setup' || entry.state === 'ready_to_launch' || entry.state === 'running'
-        ? `/campaigns/${entry.campaign.campaign_id}/beheer`
-        : `/campaigns/${entry.campaign.campaign_id}`,
-    responseValue: completionValue,
-  }
-}
-
-function getToneForBucket(bucket: CockpitBucket): OverviewRouteTone {
-  if (bucket === 'live_readable') return 'emerald'
-  if (bucket === 'nearly_ready') return 'blue'
-  if (bucket === 'action_needed') return 'amber'
-  return 'slate'
-}
-
-function getCtaLabelForState(state: CampaignCompositionState) {
-  if (state === 'partial' || state === 'full') return 'Open dashboard'
-  if (state === 'closed') return 'Open rapport'
-  return 'Beheer route'
-}
-
-function getWhyCopy(entry: CampaignHomeEntry) {
-  if (entry.state === 'setup' || entry.state === 'running') {
-    return getOverviewBlockerCopy(entry)
-  }
-
-  return getHomeStateMeta(entry.state).body
-}
-
-function compareOverviewEntries(left: CampaignHomeEntry, right: CampaignHomeEntry) {
-  const stateRank: Record<CampaignCompositionState, number> = {
-    full: 0,
-    partial: 1,
-    sparse: 2,
-    ready_to_launch: 3,
-    running: 4,
-    setup: 5,
-    closed: 6,
-  }
-
-  const rankDelta = stateRank[left.state] - stateRank[right.state]
-  if (rankDelta !== 0) return rankDelta
-
-  const scoreDelta =
-    (getCampaignAverageSignalScore(right.campaign) ?? -1) - (getCampaignAverageSignalScore(left.campaign) ?? -1)
-  if (scoreDelta !== 0) return scoreDelta
-
-  return new Date(right.campaign.created_at).getTime() - new Date(left.campaign.created_at).getTime()
-}
-
-function selectPrimaryLeadEntry(
-  primaryActiveEntries: CampaignHomeEntry[],
-  readableEntries: CampaignHomeEntry[],
-) {
-  const readablePrimary = primaryActiveEntries
-    .filter((entry) => ['full', 'partial'].includes(entry.state))
-    .sort(compareOverviewEntries)[0]
-
-  if (readablePrimary) return readablePrimary
-
-  const readableAny = readableEntries
-    .filter((entry) => ['exit', 'retention'].includes(entry.campaign.scan_type))
-    .sort(compareOverviewEntries)[0]
-
-  if (readableAny) return readableAny
-
-  return primaryActiveEntries.sort(compareOverviewEntries)[0] ?? null
 }
 
 function buildInvitesNotSentByCampaign(
@@ -605,106 +185,6 @@ function buildInvitesNotSentByCampaign(
   }
 
   return counts
-}
-
-function getHomeStateMeta(state: CampaignCompositionState) {
-  const meta = {
-    setup: {
-      label: 'Nog niet live',
-      body: 'Respondentimport of livegang ontbreekt nog.',
-    },
-    ready_to_launch: {
-      label: 'Nog in opbouw',
-      body: 'Uitnodigingen zijn nog niet volledig live gezet.',
-    },
-    running: {
-      label: 'Nog in opbouw',
-      body: 'Er is nog geen eerste veilige responslaag zichtbaar.',
-    },
-    sparse: {
-      label: 'Nog in opbouw',
-      body: 'Meer respons nodig voordat deze route echt leesbaar wordt.',
-    },
-    partial: {
-      label: 'Deels zichtbaar',
-      body: 'Eerste read beschikbaar.',
-    },
-    full: {
-      label: 'Leesbaar',
-      body: 'Dashboard beschikbaar.',
-    },
-    closed: {
-      label: 'Afgerond',
-      body: 'Rapport beschikbaar.',
-    },
-  } satisfies Record<
-    CampaignCompositionState,
-    {
-      label: string
-      body: string
-    }
-  >
-
-  return meta[state]
-}
-
-function getOverviewBlockerCopy(entry: CampaignHomeEntry) {
-  if (entry.state === 'setup') return 'Respondentimport ontbreekt nog.'
-  return 'Meer respons nodig voor een eerste read.'
-}
-
-function formatCampaignPeriod(campaign: CampaignStats) {
-  const quarterMatch = campaign.campaign_name.match(/Q[1-4]\s?\d{4}/i)
-  if (quarterMatch) return quarterMatch[0].replace(/\s+/, ' ')
-
-  return new Intl.DateTimeFormat('nl-NL', {
-    month: 'short',
-    year: 'numeric',
-  }).format(new Date(campaign.created_at))
-}
-
-function getOverviewToneClasses(tone: OverviewRouteTone) {
-  if (tone === 'emerald') {
-    return {
-      border: 'border-[color:var(--dashboard-accent-soft-border)]',
-      accent: 'bg-[color:var(--dashboard-accent-strong)]',
-      rail: 'border-l-[color:var(--dashboard-accent-strong)]',
-      chip:
-        'border-[color:var(--dashboard-accent-soft-border)] bg-[color:var(--dashboard-accent-soft)] text-[color:var(--dashboard-accent-strong)]',
-      button:
-        'bg-[color:var(--dashboard-accent-strong)] text-white hover:bg-[#00584f]',
-    }
-  }
-
-  if (tone === 'blue') {
-    return {
-      border: 'border-[#c7d0dc]',
-      accent: 'bg-[#8292a5]',
-      rail: 'border-l-[#8292a5]',
-      chip: 'border-[#d9e1ea] bg-[#f5f7fa] text-[#506071]',
-      button: 'bg-[#1B2B3A] text-white hover:bg-[#24384b]',
-    }
-  }
-
-  if (tone === 'amber') {
-    return {
-      border: 'border-[#e7d7af]',
-      accent: 'bg-[#C88C20]',
-      rail: 'border-l-[#C88C20]',
-      chip: 'border-[#E7D7AF] bg-[#FBF4DF] text-[#7A5B18]',
-      button: 'bg-[#1B2B3A] text-white hover:bg-[#24384b]',
-    }
-  }
-
-  return {
-    border: 'border-[color:var(--dashboard-frame-border)]',
-    accent: 'bg-slate-300',
-    rail: 'border-l-slate-300',
-    chip:
-      'border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)] text-[color:var(--dashboard-text)]',
-    button:
-      'bg-transparent text-[color:var(--dashboard-accent-strong)] hover:text-[color:var(--dashboard-ink)]',
-  }
 }
 
 function FilterPill({
@@ -730,162 +210,104 @@ function FilterPill({
   )
 }
 
-function StatusCounterCard({ counter }: { counter: CockpitCounter }) {
-  const tone = getOverviewToneClasses(counter.tone)
-
+function SummaryCard({ label, value }: { label: string; value: number }) {
   return (
-    <div className={`relative overflow-hidden rounded-[18px] border bg-white px-4 py-3.5 ${tone.border}`}>
-      <div className={`absolute left-0 top-0 h-full w-[3px] ${tone.accent}`} />
-      <p className="pl-2 text-[0.64rem] font-semibold uppercase tracking-[0.22em] text-[color:var(--dashboard-muted)]">
-        {counter.label}
-      </p>
-      <div className="mt-2.5 pl-2">
-        <p className="dash-number text-[1.65rem] leading-none text-[color:var(--dashboard-ink)]">{counter.count}</p>
-        <p className="mt-2 text-sm leading-6 text-[color:var(--dashboard-text)]">{counter.body}</p>
-      </div>
-      {counter.key === 'blocked_not_started' ? (
-        <span className="absolute right-4 top-4 inline-flex h-2 w-2 rounded-full bg-[#C88C20]" />
-      ) : null}
-    </div>
-  )
-}
-
-function TriageRouteCard({
-  item,
-  highlightLabel,
-}: {
-  item: CockpitRouteItem
-  highlightLabel?: string
-}) {
-  const tone = getOverviewToneClasses(item.stateTone)
-
-  return (
-    <article className={`overflow-hidden rounded-[18px] border bg-white shadow-[0_1px_3px_rgba(17,24,39,0.04)] transition-shadow hover:shadow-[0_12px_24px_rgba(17,24,39,0.08)] ${tone.border}`}>
-      <div className={`h-full border-l-4 ${tone.rail}`}>
-        <div className="flex flex-col gap-5 px-5 py-5 xl:flex-row xl:items-center xl:justify-between">
-          <div className="min-w-0 flex-1 space-y-4">
-            <div className="space-y-2">
-              <div className="flex flex-wrap items-center gap-2">
-                {highlightLabel ? (
-                  <span className="inline-flex rounded-full border border-[color:var(--dashboard-accent-soft-border)] bg-[color:var(--dashboard-accent-soft)] px-2.5 py-1 text-[0.72rem] font-semibold text-[color:var(--dashboard-accent-strong)]">
-                    {highlightLabel}
-                  </span>
-                ) : null}
-                <span className="text-[0.72rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
-                  {item.contextLabel}
-                </span>
-              </div>
-              <div className="flex flex-wrap items-center gap-2.5">
-                <h3 className="text-[1.08rem] font-semibold tracking-[-0.03em] text-[color:var(--dashboard-ink)]">
-                  {item.entry.campaign.campaign_name}
-                </h3>
-                <span className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-[0.78rem] font-semibold ${tone.chip}`}>
-                  <span className={`inline-flex h-2 w-2 rounded-full ${tone.accent}`} />
-                  {item.stateLabel}
-                </span>
-              </div>
-              <p className="text-sm font-medium uppercase tracking-[0.16em] text-[color:var(--dashboard-muted)]">
-                Product: {item.productLabel}
-              </p>
-            </div>
-            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-[minmax(0,1.2fr),180px,140px] xl:items-start">
-              <MetricBlock label="WAAROM" value={item.why} />
-              <MetricBlock label="VOLGENDE STAP" value={item.nextStep} />
-              <MetricBlock label="RESPONS" value={item.responseValue} compact />
-            </div>
-          </div>
-          <div className="xl:pl-6">
-            <Link
-              href={item.ctaHref}
-              className={`inline-flex w-full items-center justify-center rounded-lg px-5 py-3 text-sm font-semibold transition-colors xl:min-w-[158px] ${tone.button}`}
-            >
-              {item.ctaLabel}
-            </Link>
-          </div>
-        </div>
-      </div>
-    </article>
-  )
-}
-
-function BlockerRouteRow({ item }: { item: CockpitRouteItem }) {
-  return (
-    <article className="rounded-[18px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)] px-4 py-4 shadow-[0_1px_3px_rgba(10,25,47,0.03)]">
-      <div className="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
-        <div className="grid gap-4 md:grid-cols-[minmax(0,0.9fr),minmax(0,1.1fr),160px] xl:flex-1 xl:grid-cols-[minmax(0,0.8fr),minmax(0,1fr),160px]">
-          <div className="min-w-0">
-            <p className="text-sm font-semibold tracking-[-0.02em] text-[color:var(--dashboard-ink)]">
-              {item.entry.campaign.campaign_name}
-            </p>
-            <p className="mt-1 text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--dashboard-muted)]">
-              {item.productLabel}
-            </p>
-          </div>
-          <MetricBlock label="REDEN" value={item.why} />
-          <MetricBlock label="NEXT" value={item.nextStep} />
-        </div>
-        <Link
-          href={item.ctaHref}
-          className="text-sm font-semibold text-[color:var(--dashboard-accent-strong)] transition-colors hover:text-[color:var(--dashboard-ink)]"
-        >
-          {item.ctaLabel}
-        </Link>
-      </div>
-    </article>
-  )
-}
-
-function ClosedRouteRow({ item }: { item: CockpitRouteItem }) {
-  return (
-    <article className="rounded-[18px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)] px-4 py-4 opacity-70 transition-opacity hover:opacity-100">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="min-w-0">
-          <p className="text-sm font-semibold tracking-[-0.02em] text-[color:var(--dashboard-ink)]">
-            {item.entry.campaign.campaign_name}
-          </p>
-          <p className="mt-1 text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--dashboard-muted)]">
-            {item.productLabel}
-          </p>
-        </div>
-        <Link
-          href={item.ctaHref}
-          className="text-sm font-semibold text-[color:var(--dashboard-accent-strong)] transition-colors hover:text-[color:var(--dashboard-ink)]"
-        >
-          {item.ctaLabel}
-        </Link>
-      </div>
-    </article>
-  )
-}
-
-function MetricBlock({
-  label,
-  value,
-  compact = false,
-}: {
-  label: string
-  value: string
-  compact?: boolean
-}) {
-  return (
-    <div className="min-w-0">
-      <p className="text-[0.64rem] font-semibold uppercase tracking-[0.18em] text-[color:var(--dashboard-muted)]">
+    <div className="rounded-[18px] border border-[color:var(--dashboard-frame-border)] bg-white px-4 py-3.5">
+      <p className="text-[0.64rem] font-semibold uppercase tracking-[0.22em] text-[color:var(--dashboard-muted)]">
         {label}
       </p>
-      <p
-        className={`mt-1.5 ${compact ? 'dash-number text-[1.02rem] leading-none' : 'text-sm leading-6'} text-[color:var(--dashboard-ink)]`}
-      >
-        {value}
-      </p>
+      <p className="dash-number mt-2 text-[1.65rem] leading-none text-[color:var(--dashboard-ink)]">{value}</p>
     </div>
   )
 }
 
-function InlineEmptyState({ message }: { message: string }) {
+function CockpitScanRow({ row }: { row: CockpitRow }) {
   return (
-    <div className="rounded-[18px] border border-dashed border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-surface)] px-5 py-6 text-sm leading-6 text-[color:var(--dashboard-text)]">
-      {message}
-    </div>
+    <article className="rounded-[18px] border border-[color:var(--dashboard-frame-border)] bg-white px-5 py-5 shadow-[0_1px_3px_rgba(17,24,39,0.04)] transition-shadow hover:shadow-[0_12px_24px_rgba(17,24,39,0.08)]">
+      <div className="flex flex-col gap-5 xl:flex-row xl:items-center xl:justify-between">
+        <div className="min-w-0 flex-1 space-y-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-[0.72rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
+              {row.periodLabel} - {row.productLabel}
+            </span>
+            <span className="inline-flex rounded-full border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-soft)] px-3 py-1 text-[0.78rem] font-semibold text-[color:var(--dashboard-text)]">
+              {row.statusLabel}
+            </span>
+          </div>
+          <h2 className="text-[1.08rem] font-semibold tracking-[-0.03em] text-[color:var(--dashboard-ink)]">
+            {row.campaign.campaign_name}
+          </h2>
+          <div className="flex flex-wrap items-center gap-4 text-sm text-[color:var(--dashboard-text)]">
+            <span>Respons {row.responseValue}</span>
+            <span>{row.factualLine}</span>
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-2 xl:justify-end">
+          <CockpitActionButton
+            action={row.primaryAction}
+            campaignId={row.campaign.campaign_id}
+            campaignName={row.campaign.campaign_name}
+            scanType={row.campaign.scan_type}
+            primary
+          />
+          {row.secondaryActions.map((action) => (
+            <CockpitActionButton
+              key={`${row.campaign.campaign_id}-${action.kind}`}
+              action={action}
+              campaignId={row.campaign.campaign_id}
+              campaignName={row.campaign.campaign_name}
+              scanType={row.campaign.scan_type}
+            />
+          ))}
+        </div>
+      </div>
+    </article>
+  )
+}
+
+function CockpitActionButton({
+  action,
+  campaignId,
+  campaignName,
+  scanType,
+  primary = false,
+}: {
+  action: CockpitAction
+  campaignId: string
+  campaignName: string
+  scanType: CampaignStats['scan_type']
+  primary?: boolean
+}) {
+  if (action.kind === 'pdf') {
+    return (
+      <PdfDownloadButton
+        campaignId={campaignId}
+        campaignName={campaignName}
+        scanType={scanType}
+        label="Download PDF"
+        loadingLabel="PDF ophalen..."
+        containerClassName="flex flex-col items-start gap-1"
+        errorClassName="max-w-48 text-xs text-red-600"
+        buttonClassName={
+          primary
+            ? 'inline-flex rounded-lg bg-[color:var(--dashboard-accent-strong)] px-5 py-3 text-sm font-semibold text-white transition-colors hover:bg-[#00584f] disabled:cursor-not-allowed disabled:opacity-60'
+            : 'inline-flex rounded-lg border border-[color:var(--dashboard-frame-border)] bg-white px-4 py-3 text-sm font-semibold text-[color:var(--dashboard-ink)] transition-colors hover:border-[color:var(--dashboard-accent-soft-border)] hover:text-[color:var(--dashboard-accent-strong)] disabled:cursor-not-allowed disabled:opacity-60'
+        }
+      />
+    )
+  }
+
+  return (
+    <Link
+      href={action.href}
+      className={
+        primary
+          ? 'inline-flex rounded-lg bg-[color:var(--dashboard-accent-strong)] px-5 py-3 text-sm font-semibold text-white transition-colors hover:bg-[#00584f]'
+          : 'inline-flex rounded-lg border border-[color:var(--dashboard-frame-border)] bg-white px-4 py-3 text-sm font-semibold text-[color:var(--dashboard-ink)] transition-colors hover:border-[color:var(--dashboard-accent-soft-border)] hover:text-[color:var(--dashboard-accent-strong)]'
+      }
+    >
+      {action.label}
+    </Link>
   )
 }
 


### PR DESCRIPTION
## Summary
- turn `/dashboard` into a single HR scan index with one canonical row per scan
- replace bucketed why/next-step cards with a compact factual line and visible action bar
- reuse the canonical campaign PDF download flow from cockpit items

## Verification
- `npm test -- "app/(dashboard)/dashboard/page.test.ts" "app/(dashboard)/dashboard/cockpit-index.test.ts" "app/(dashboard)/dashboard/home-launcher.test.ts"`
- `npx eslint "app/(dashboard)/dashboard/page.tsx" "app/(dashboard)/dashboard/cockpit-index.ts" "app/(dashboard)/campaigns/[id]/pdf-download-button.tsx"`
- `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key npm run build`