### PR TITLE
Restore HR routebeheer self-serve workspace

### DIFF
--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.test.ts
@@ -33,7 +33,7 @@ function createSupabaseMock() {
     ['profiles|is_verisight_admin', { data: { is_verisight_admin: false } }],
     ['org_members|role', { data: { role: 'owner' } }],
     ['organizations|name', { data: { name: 'Acme HR' } }],
-    ['campaigns|delivery_mode, created_at', { data: { delivery_mode: 'guided_self_serve', created_at: '2026-05-01T08:00:00.000Z' } }],
+    ['campaigns|delivery_mode, created_at, enabled_modules', { data: { delivery_mode: 'guided_self_serve', created_at: '2026-05-01T08:00:00.000Z', enabled_modules: null } }],
     ['org_members|id', { count: 4 }],
     ['org_invites|id', { count: 1 }],
     [
@@ -51,21 +51,21 @@ function createSupabaseMock() {
       },
     ],
     [
-      'respondents|id, sent_at, completed, completed_at',
+      'respondents|id, token, email, sent_at, completed, completed_at',
       {
         data: [
-          { id: 'r1', sent_at: '2026-05-10T10:00:00.000Z', completed: true, completed_at: '2026-05-11T10:00:00.000Z' },
-          { id: 'r2', sent_at: '2026-05-10T10:00:00.000Z', completed: true, completed_at: '2026-05-11T11:00:00.000Z' },
-          { id: 'r3', sent_at: '2026-05-10T10:00:00.000Z', completed: true, completed_at: '2026-05-11T12:00:00.000Z' },
-          { id: 'r4', sent_at: '2026-05-10T10:00:00.000Z', completed: true, completed_at: '2026-05-11T13:00:00.000Z' },
-          { id: 'r5', sent_at: '2026-05-10T10:00:00.000Z', completed: true, completed_at: '2026-05-11T14:00:00.000Z' },
-          { id: 'r6', sent_at: '2026-05-10T10:00:00.000Z', completed: true, completed_at: '2026-05-11T15:00:00.000Z' },
-          { id: 'r7', sent_at: '2026-05-10T10:00:00.000Z', completed: false, completed_at: null },
-          { id: 'r8', sent_at: '2026-05-10T10:00:00.000Z', completed: false, completed_at: null },
-          { id: 'r9', sent_at: '2026-05-10T10:00:00.000Z', completed: false, completed_at: null },
-          { id: 'r10', sent_at: '2026-05-10T10:00:00.000Z', completed: false, completed_at: null },
-          { id: 'r11', sent_at: '2026-05-10T10:00:00.000Z', completed: false, completed_at: null },
-          { id: 'r12', sent_at: '2026-05-10T10:00:00.000Z', completed: false, completed_at: null },
+          { id: 'r1', token: 't1', email: 'r1@example.com', sent_at: '2026-05-10T10:00:00.000Z', completed: true, completed_at: '2026-05-11T10:00:00.000Z' },
+          { id: 'r2', token: 't2', email: 'r2@example.com', sent_at: '2026-05-10T10:00:00.000Z', completed: true, completed_at: '2026-05-11T11:00:00.000Z' },
+          { id: 'r3', token: 't3', email: 'r3@example.com', sent_at: '2026-05-10T10:00:00.000Z', completed: true, completed_at: '2026-05-11T12:00:00.000Z' },
+          { id: 'r4', token: 't4', email: 'r4@example.com', sent_at: '2026-05-10T10:00:00.000Z', completed: true, completed_at: '2026-05-11T13:00:00.000Z' },
+          { id: 'r5', token: 't5', email: 'r5@example.com', sent_at: '2026-05-10T10:00:00.000Z', completed: true, completed_at: '2026-05-11T14:00:00.000Z' },
+          { id: 'r6', token: 't6', email: 'r6@example.com', sent_at: '2026-05-10T10:00:00.000Z', completed: true, completed_at: '2026-05-11T15:00:00.000Z' },
+          { id: 'r7', token: 't7', email: 'r7@example.com', sent_at: '2026-05-10T10:00:00.000Z', completed: false, completed_at: null },
+          { id: 'r8', token: 't8', email: 'r8@example.com', sent_at: '2026-05-10T10:00:00.000Z', completed: false, completed_at: null },
+          { id: 'r9', token: 't9', email: 'r9@example.com', sent_at: '2026-05-10T10:00:00.000Z', completed: false, completed_at: null },
+          { id: 'r10', token: 't10', email: 'r10@example.com', sent_at: '2026-05-10T10:00:00.000Z', completed: false, completed_at: null },
+          { id: 'r11', token: 't11', email: 'r11@example.com', sent_at: '2026-05-10T10:00:00.000Z', completed: false, completed_at: null },
+          { id: 'r12', token: 't12', email: 'r12@example.com', sent_at: '2026-05-10T10:00:00.000Z', completed: false, completed_at: null },
         ],
       },
     ],
@@ -304,13 +304,34 @@ describe('routebeheer data helpers', () => {
       href: '/campaigns/campaign-1',
     })
   })
+
+  it('sends closeout now-doing links back into the routebeheer worktable instead of old operatie anchors', () => {
+    const guidedState = buildGuidedSelfServeState({
+      isActive: false,
+      totalInvited: 12,
+      totalCompleted: 12,
+      invitesNotSent: 0,
+      hasMinDisplay: true,
+      hasEnoughData: true,
+      importQaConfirmed: true,
+      launchTimingConfirmed: true,
+      communicationReady: true,
+      importReady: true,
+    })
+
+    expect(buildHrRouteBeheerNowDoing({ guidedState, campaignId: 'campaign-1' })).toMatchObject({
+      phaseKey: 'afronding',
+      href: '/campaigns/campaign-1/beheer?fase=afronding#status-en-logboek',
+    })
+  })
 })
 
 describe('routebeheer source integration', () => {
   it('does not silently coerce unknown import readiness into a false auto-signal', () => {
     const source = readFileSync(new URL('./beheer-data.ts', import.meta.url), 'utf8')
 
-    expect(source).not.toContain('importReady: importReady === true')
+    expect(source).toContain('importReady,')
+    expect(source).toContain('importReady: importReady ?? undefined')
   })
 
   it('keeps a visible routebeheer entrypoint in the dashboard launcher for setup-heavy campaigns', () => {
@@ -320,6 +341,14 @@ describe('routebeheer source integration', () => {
     )
 
     expect(launcherSource).toContain('href: `/campaigns/${campaign.campaign_id}/beheer`')
+  })
+
+  it('removes stale operatie-anchor fallbacks from the new routebeheer worktable', () => {
+    const dataSource = readFileSync(new URL('./beheer-data.ts', import.meta.url), 'utf8')
+    const componentSource = readFileSync(new URL('./route-beheer-components.tsx', import.meta.url), 'utf8')
+    const combined = `${dataSource}\n${componentSource}`
+
+    expect(combined).not.toContain('#operatie')
   })
 
   it('keeps routebeheer restricted to HR-capable users instead of manager-only action center access', () => {
@@ -356,7 +385,7 @@ describe('routebeheer source integration', () => {
       dashboardReady: true,
       reportReady: true,
       dashboardHref: '/campaigns/campaign-1',
-      reportHref: '/reports',
+      reportHref: null,
       label: 'Dashboard / rapportstatus',
     })
 
@@ -370,6 +399,22 @@ describe('routebeheer source integration', () => {
       status: 'current',
       body: 'Dashboard / rapportstatus',
     })
+  })
+
+  it('keeps the HR self-serve execution workspace available on routebeheer data for owner flows', async () => {
+    const data = await fetchRouteBeheerData({
+      campaignId: 'campaign-1',
+      supabase: createSupabaseMock(),
+      userId: 'user-1',
+    })
+
+    expect(data?.selfServe).toMatchObject({
+      deliveryMode: 'guided_self_serve',
+      importReady: true,
+      remindableCount: 6,
+      launchConfirmedAt: '2026-05-10T08:00:00.000Z',
+    })
+    expect(data?.selfServe.unsentRespondents).toHaveLength(0)
   })
 
   it('keeps route settings inside the communicatie phase instead of as a top-level standalone block', async () => {

--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.test.ts
@@ -409,6 +409,8 @@ describe('routebeheer source integration', () => {
     })
 
     expect(data?.selfServe).toMatchObject({
+      currentStep: 'active',
+      phaseKey: 'live',
       deliveryMode: 'guided_self_serve',
       importReady: true,
       remindableCount: 6,

--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.ts
@@ -13,6 +13,7 @@ import {
   SCAN_TYPE_LABELS,
   type Campaign,
   type CampaignStats,
+  hasCampaignAddOn,
   type MemberRole,
   type Respondent,
   type ScanType,
@@ -115,6 +116,19 @@ export interface RouteBeheerPageData {
   canExecuteCampaign: boolean
   canManageCampaign: boolean
   membershipRole: MemberRole | null
+  selfServe: {
+    deliveryMode: Campaign['delivery_mode']
+    importReady: boolean
+    hasSegmentDeepDive: boolean
+    importQaConfirmed: boolean
+    launchTimingConfirmed: boolean
+    communicationReady: boolean
+    remindableCount: number
+    unsentRespondents: Array<{ token: string; email: string | null }>
+    launchConfirmedAt: string | null
+    participantCommsConfig: unknown
+    reminderConfig: unknown
+  }
 }
 
 export type RouteBeeheerPageData = RouteBeheerPageData
@@ -446,7 +460,7 @@ export function buildHrRouteBeheerNowDoing(
       phaseKey === 'output'
         ? `/campaigns/${args.campaignId}`
         : phaseKey === 'afronding'
-          ? `/campaigns/${args.campaignId}#operatie`
+          ? getRouteBeheerPhaseDetailHref(args.campaignId, phaseKey)
           : getRouteBeheerPhaseDetailHref(args.campaignId, phaseKey),
   }
 }
@@ -552,7 +566,10 @@ function buildHrRouteBeheerPhaseDetail(args: {
         body: 'Deelnemers en importstatus',
         items: [{ label: 'Geimporteerd', value: `${args.respondentCount} deelnemers` }],
         links: [
-          { label: 'Open doelgroep', href: `/campaigns/${args.campaignId}#operatie` },
+          {
+            label: 'Open doelgroep',
+            href: getRouteBeheerPhaseDetailHref(args.campaignId, args.key),
+          },
         ],
       } satisfies HrRouteBeheerPhaseDetail
     case 'communicatie':
@@ -608,7 +625,12 @@ function buildHrRouteBeheerPhaseDetail(args: {
         status: args.status,
         body: 'Status en logboek',
         items: [{ label: 'Laatste logregel', value: args.latestAuditSummary ?? 'Geen activiteit' }],
-        links: [{ label: 'Bekijk logboek', href: `/campaigns/${args.campaignId}#operatie` }],
+        links: [
+          {
+            label: 'Bekijk logboek',
+            href: getRouteBeheerPhaseDetailHref(args.campaignId, args.key),
+          },
+        ],
       } satisfies HrRouteBeheerPhaseDetail
     default:
       return {
@@ -660,7 +682,11 @@ export async function fetchRouteBeheerData(args: {
       .eq('user_id', userId)
       .maybeSingle(),
     supabase.from('organizations').select('name').eq('id', stats.organization_id).maybeSingle(),
-    supabase.from('campaigns').select('delivery_mode, created_at').eq('id', campaignId).maybeSingle(),
+    supabase
+      .from('campaigns')
+      .select('delivery_mode, created_at, enabled_modules')
+      .eq('id', campaignId)
+      .maybeSingle(),
     supabase
       .from('org_members')
       .select('id', { count: 'exact', head: true })
@@ -674,7 +700,7 @@ export async function fetchRouteBeheerData(args: {
     supabase.from('campaign_delivery_records').select('*').eq('campaign_id', campaignId).maybeSingle(),
     supabase
       .from('respondents')
-      .select('id, sent_at, completed, completed_at')
+      .select('id, token, email, sent_at, completed, completed_at')
       .eq('campaign_id', campaignId)
       .order('completed_at', { ascending: false, nullsFirst: false }),
     supabase
@@ -711,14 +737,29 @@ export async function fetchRouteBeheerData(args: {
 
   const respondents = (respondentsRaw ?? []) as Pick<
     Respondent,
-    'id' | 'sent_at' | 'completed' | 'completed_at'
+    'id' | 'token' | 'email' | 'sent_at' | 'completed' | 'completed_at'
   >[]
   const responseRows = (responsesRaw ?? []) as Array<{ id: string; org_scores: unknown; sdt_scores: unknown }>
   const auditEvents = (auditEventsRaw ?? []) as CampaignAuditEventRecord[]
-  const campaign = (campaignMeta ?? null) as Pick<Campaign, 'delivery_mode' | 'created_at'> | null
+  const campaign = (campaignMeta ?? null) as Pick<
+    Campaign,
+    'delivery_mode' | 'created_at' | 'enabled_modules'
+  > | null
 
   const pendingCount = stats.total_invited - stats.total_completed
   const invitesNotSent = respondents.filter((respondent) => !respondent.sent_at && !respondent.completed).length
+  const remindableRespondents = respondents.filter(
+    (respondent) => !respondent.completed && typeof respondent.email === 'string' && respondent.email.trim().length > 0,
+  )
+  const unsentRespondents = respondents
+    .filter(
+      (respondent) =>
+        !respondent.sent_at &&
+        !respondent.completed &&
+        typeof respondent.email === 'string' &&
+        respondent.email.trim().length > 0,
+    )
+    .map((respondent) => ({ token: respondent.token, email: respondent.email }))
   const incompleteScores = responseRows.filter(
     (response) => !response.org_scores || !response.sdt_scores,
   ).length
@@ -804,7 +845,7 @@ export async function fetchRouteBeheerData(args: {
     dashboardReady: hasMinDisplay,
     reportReady: hasMinDisplay,
     dashboardHref: `/campaigns/${campaignId}`,
-    reportHref: hasMinDisplay ? '/reports' : null,
+    reportHref: null,
     label: 'Dashboard / rapportstatus',
   } satisfies RouteBeheerPageData['outputSummary']
   const currentHrPhase = mapGuidedPhaseToHrRoutePhase(guidedState.phase)
@@ -886,6 +927,19 @@ export async function fetchRouteBeheerData(args: {
     canExecuteCampaign,
     canManageCampaign,
     membershipRole: memberRole,
+    selfServe: {
+      deliveryMode: campaign?.delivery_mode ?? null,
+      importReady: importReady === true,
+      hasSegmentDeepDive: hasCampaignAddOn(campaign, 'segment_deep_dive'),
+      importQaConfirmed: guidedSetupDiscipline.importQaConfirmed,
+      launchTimingConfirmed: guidedSetupDiscipline.launchTimingConfirmed,
+      communicationReady: guidedSetupDiscipline.communicationReady,
+      remindableCount: remindableRespondents.length,
+      unsentRespondents,
+      launchConfirmedAt: deliveryRecord?.launch_confirmed_at ?? null,
+      participantCommsConfig: deliveryRecord?.participant_comms_config ?? null,
+      reminderConfig: deliveryRecord?.reminder_config ?? null,
+    },
   } satisfies RouteBeheerPageData
 }
 

--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/beheer-data.ts
@@ -117,6 +117,8 @@ export interface RouteBeheerPageData {
   canManageCampaign: boolean
   membershipRole: MemberRole | null
   selfServe: {
+    currentStep: 'upload' | 'launch' | 'active'
+    phaseKey: 'doelgroep' | 'communicatie' | 'live'
     deliveryMode: Campaign['delivery_mode']
     importReady: boolean
     hasSegmentDeepDive: boolean
@@ -422,6 +424,27 @@ function getHrRouteBeheerPhaseStatus(
   if (phaseIndex < currentIndex) return 'done'
   if (phaseIndex === currentIndex) return 'current'
   return 'open'
+}
+
+function getGuidedSelfServeCurrentStep(args: {
+  totalInvited: number
+  invitesNotSent: number
+}) {
+  if (args.totalInvited === 0) return 'upload' as const
+  if (args.invitesNotSent > 0) return 'launch' as const
+  return 'active' as const
+}
+
+function mapGuidedSelfServeStepToRoutePhase(step: 'upload' | 'launch' | 'active') {
+  switch (step) {
+    case 'upload':
+      return 'doelgroep' as const
+    case 'launch':
+      return 'communicatie' as const
+    case 'active':
+    default:
+      return 'live' as const
+  }
 }
 
 export function getRouteBeheerPhaseHref(campaignId: string, phaseKey: HrRouteBeheerPhaseKey) {
@@ -849,6 +872,10 @@ export async function fetchRouteBeheerData(args: {
     label: 'Dashboard / rapportstatus',
   } satisfies RouteBeheerPageData['outputSummary']
   const currentHrPhase = mapGuidedPhaseToHrRoutePhase(guidedState.phase)
+  const selfServeCurrentStep = getGuidedSelfServeCurrentStep({
+    totalInvited: stats.total_invited,
+    invitesNotSent,
+  })
   const nowDoing = buildHrRouteBeheerNowDoing({ guidedState, campaignId })
   const phaseSummaries = HR_ROUTE_PHASE_ORDER.map((key) =>
     buildHrRouteBeheerPhaseSummary({
@@ -928,6 +955,8 @@ export async function fetchRouteBeheerData(args: {
     canManageCampaign,
     membershipRole: memberRole,
     selfServe: {
+      currentStep: selfServeCurrentStep,
+      phaseKey: mapGuidedSelfServeStepToRoutePhase(selfServeCurrentStep),
       deliveryMode: campaign?.delivery_mode ?? null,
       importReady: importReady === true,
       hasSegmentDeepDive: hasCampaignAddOn(campaign, 'segment_deep_dive'),

--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/route-beheer-components.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/route-beheer-components.tsx
@@ -76,10 +76,10 @@ export function RouteBeheerStructuredBody(args: {
         />
       </DashboardSection>
 
-      <RouteBeheerOutputSummary summary={data.outputSummary} />
+      <RouteBeheerOutputSummary data={data} />
 
       <RouteBeheerLogbookSummary
-        href={`/campaigns/${data.campaignId}#operatie`}
+        href={`/campaigns/${data.campaignId}/beheer?fase=afronding#status-en-logboek`}
         latestAuditSummary={data.latestAuditSummary}
       />
     </div>

--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/route-beheer-phase-sections.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/route-beheer-phase-sections.test.ts
@@ -124,6 +124,8 @@ const routeBeheerData: RouteBeheerPageData = {
   canManageCampaign: true,
   membershipRole: 'owner',
   selfServe: {
+    currentStep: 'active',
+    phaseKey: 'live',
     deliveryMode: 'baseline',
     importReady: true,
     hasSegmentDeepDive: false,
@@ -198,6 +200,39 @@ describe('routebeheer phase sections', () => {
 
     expect(markup).toContain('GuidedSelfServePanel')
     expect(markup).toContain('CampaignActions')
+  })
+
+  it('does not render the self-serve workspace on non-matching phases or closed routes', () => {
+    const nonMatchingMarkup = renderToStaticMarkup(
+      createElement(RouteBeheerPhaseDetailPanel, {
+        phases: [
+          {
+            key: 'communicatie',
+            label: 'Communicatie instellen',
+            status: 'current',
+            body: 'Route en startdatum',
+            items: [],
+            links: [{ label: 'Bekijk instellingen', href: '/campaigns/cmp-1/beheer?fase=communicatie#route-instellingen' }],
+          },
+        ],
+        selectedPhaseKey: 'communicatie',
+        data: routeBeheerData,
+      }),
+    )
+
+    const closedMarkup = renderToStaticMarkup(
+      createElement(RouteBeheerPhaseDetailPanel, {
+        phases: routeBeheerData.phaseDetails,
+        selectedPhaseKey: 'live',
+        data: {
+          ...routeBeheerData,
+          isActive: false,
+        },
+      }),
+    )
+
+    expect(nonMatchingMarkup).not.toContain('GuidedSelfServePanel')
+    expect(closedMarkup).not.toContain('GuidedSelfServePanel')
   })
 
   it('keeps the always-visible output summary compact and action-only', () => {

--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/route-beheer-phase-sections.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/route-beheer-phase-sections.test.ts
@@ -1,7 +1,11 @@
 import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
-import type { HrRouteBeheerPhaseDetail, HrRouteBeheerPhaseSummary } from './beheer-data'
+import type {
+  HrRouteBeheerPhaseDetail,
+  HrRouteBeheerPhaseSummary,
+  RouteBeheerPageData,
+} from './beheer-data'
 
 vi.mock('../campaign-actions', () => ({
   CampaignActions: () => createElement('div', null, 'CampaignActions'),
@@ -9,6 +13,10 @@ vi.mock('../campaign-actions', () => ({
 
 vi.mock('../pdf-download-button', () => ({
   PdfDownloadButton: () => createElement('div', null, 'PdfDownloadButton'),
+}))
+
+vi.mock('@/components/dashboard/guided-self-serve-panel', () => ({
+  GuidedSelfServePanel: () => createElement('div', null, 'GuidedSelfServePanel'),
 }))
 
 import {
@@ -51,6 +59,84 @@ const phaseDetails: HrRouteBeheerPhaseDetail[] = [
     ],
   },
 ]
+
+const routeBeheerData: RouteBeheerPageData = {
+  campaignId: 'cmp-1',
+  campaignName: 'RetentionScan Demo',
+  organizationName: 'Acme',
+  scanType: 'retention',
+  scanTypeLabel: 'RetentieScan',
+  deliveryModeLabel: 'Baseline',
+  routePeriodLabel: 'Q2 2026',
+  isActive: true,
+  statusBadgeLabel: 'Live',
+  statusBadgeTone: 'emerald',
+  lastActivityAt: '2026-05-10T10:00:00.000Z',
+  launchDate: '2026-05-10',
+  totalInvited: 12,
+  totalCompleted: 6,
+  pendingCount: 6,
+  completionRatePct: 50,
+  invitesNotSent: 0,
+  hasMinDisplay: true,
+  hasEnoughData: false,
+  readabilityLabel: 'Indicatief beeld',
+  readabilityBody: 'Dashboard zichtbaar.',
+  nextActionTitle: 'Open dashboard',
+  nextActionBody: 'Dashboard beschikbaar.',
+  blockers: [],
+  lifecycleStage: 'first_value_reached',
+  lifecycleSteps: [],
+  nowDoing: null,
+  phaseSummaries: phases,
+  phaseDetails: [
+    {
+      key: 'live',
+      label: 'Live zetten & volgen',
+      status: 'current',
+      body: 'Uitnodigingen en respons',
+      items: [
+        { label: 'Respons', value: '6/12 ingevuld' },
+        { label: 'Openstaand', value: '6' },
+      ],
+      links: [
+        {
+          label: 'Open uitnodigingen',
+          href: '/campaigns/cmp-1/beheer?fase=live#uitnodigingen-en-respons',
+        },
+      ],
+    },
+  ],
+  outputSummary: {
+    dashboardReady: true,
+    reportReady: true,
+    dashboardHref: '/campaigns/cmp-1',
+    reportHref: null,
+    label: 'Dashboard / rapportstatus',
+  },
+  respondentCount: 12,
+  routeSettingsLabel: 'RetentieScan / Baseline / Q2 2026',
+  routeSettingsBody: 'Startdatum: 10 mei 2026',
+  outputStatusLabel: 'Dashboard / rapportstatus',
+  latestAuditSummary: 'Invites verstuurd',
+  reportAvailable: true,
+  canExecuteCampaign: true,
+  canManageCampaign: true,
+  membershipRole: 'owner',
+  selfServe: {
+    deliveryMode: 'baseline',
+    importReady: true,
+    hasSegmentDeepDive: false,
+    importQaConfirmed: true,
+    launchTimingConfirmed: true,
+    communicationReady: true,
+    remindableCount: 6,
+    unsentRespondents: [],
+    launchConfirmedAt: '2026-05-10T10:00:00.000Z',
+    participantCommsConfig: null,
+    reminderConfig: null,
+  },
+}
 
 describe('routebeheer phase sections', () => {
   it('renders a subtle now-doing row as a direct action link', () => {
@@ -101,21 +187,29 @@ describe('routebeheer phase sections', () => {
     expect(markup).not.toContain('launchafspraken')
   })
 
+  it('renders the guided self-serve workspace inside routebeheer when HR can execute campaign actions', () => {
+    const markup = renderToStaticMarkup(
+      createElement(RouteBeheerPhaseDetailPanel, {
+        phases: routeBeheerData.phaseDetails,
+        selectedPhaseKey: 'live',
+        data: routeBeheerData,
+      }),
+    )
+
+    expect(markup).toContain('GuidedSelfServePanel')
+    expect(markup).toContain('CampaignActions')
+  })
+
   it('keeps the always-visible output summary compact and action-only', () => {
     const markup = renderToStaticMarkup(
       createElement(RouteBeheerOutputSummary, {
-        summary: {
-          dashboardReady: true,
-          reportReady: false,
-          dashboardHref: '/campaigns/cmp-1',
-          reportHref: null,
-          label: 'Dashboard / rapportstatus',
-        },
+        data: routeBeheerData,
       }),
     )
 
     expect(markup).toContain('Dashboard / rapportstatus')
     expect(markup).toContain('href="/campaigns/cmp-1"')
+    expect(markup).toContain('PdfDownloadButton')
     expect(markup).not.toContain('readiness')
   })
 })

--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/route-beheer-phase-sections.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/route-beheer-phase-sections.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 import React, { useState } from 'react'
+import { GuidedSelfServePanel } from '@/components/dashboard/guided-self-serve-panel'
 import { CampaignActions } from '../campaign-actions'
 import { PdfDownloadButton } from '../pdf-download-button'
 import type {
@@ -172,6 +173,9 @@ export function RouteBeheerPhaseWorkspace(args: {
 }
 
 function RouteBeheerPhaseDetailContent({ data, detail }: { data: RouteBeheerPageData; detail: HrRouteBeheerPhaseDetail }) {
+  const showSelfServeWorkspace =
+    data.canExecuteCampaign && (detail.key === 'doelgroep' || detail.key === 'communicatie' || detail.key === 'live')
+
   return (
     <div id={PHASE_DETAIL_IDS[detail.key]} className="space-y-4">
       <div className="flex flex-wrap items-start justify-between gap-3">
@@ -220,6 +224,32 @@ function RouteBeheerPhaseDetailContent({ data, detail }: { data: RouteBeheerPage
               canArchiveCampaign={data.canManageCampaign}
             />
           ) : null}
+          {showSelfServeWorkspace ? (
+            <GuidedSelfServePanel
+              campaignId={data.campaignId}
+              scanType={data.scanType}
+              isActive={data.isActive}
+              deliveryMode={data.selfServe.deliveryMode}
+              importReady={data.selfServe.importReady}
+              hasSegmentDeepDive={data.selfServe.hasSegmentDeepDive}
+              totalInvited={data.totalInvited}
+              totalCompleted={data.totalCompleted}
+              invitesNotSent={data.invitesNotSent}
+              hasMinDisplay={data.hasMinDisplay}
+              hasEnoughData={data.hasEnoughData}
+              pendingCount={data.pendingCount}
+              importQaConfirmed={data.selfServe.importQaConfirmed}
+              launchTimingConfirmed={data.selfServe.launchTimingConfirmed}
+              communicationReady={data.selfServe.communicationReady}
+              remindableCount={data.selfServe.remindableCount}
+              unsentRespondents={data.selfServe.unsentRespondents}
+              launchDate={data.launchDate}
+              launchConfirmedAt={data.selfServe.launchConfirmedAt}
+              participantCommsConfig={data.selfServe.participantCommsConfig}
+              reminderConfig={data.selfServe.reminderConfig}
+              memberRole={data.membershipRole}
+            />
+          ) : null}
         </div>
       ) : detail.key === 'output' ? (
         <div className="flex flex-wrap items-center gap-3">
@@ -239,19 +269,47 @@ function RouteBeheerPhaseDetailContent({ data, detail }: { data: RouteBeheerPage
           )}
         </div>
       ) : (
-        <div className="flex flex-wrap gap-2">
-          {detail.links.map((link, index) => {
-            const label =
-              detail.key === 'communicatie' && index > 0
-                ? ROUTE_SETTINGS_CTA_LABEL
-                : link.label
+        <div className="space-y-3">
+          <div className="flex flex-wrap gap-2">
+            {detail.links.map((link, index) => {
+              const label =
+                detail.key === 'communicatie' && index > 0
+                  ? ROUTE_SETTINGS_CTA_LABEL
+                  : link.label
 
-            return (
-              <Link key={link.href} href={link.href} className={detailActionClass(index === 0 ? 'primary' : 'secondary')}>
-                {label}
-              </Link>
-            )
-          })}
+              return (
+                <Link key={link.href} href={link.href} className={detailActionClass(index === 0 ? 'primary' : 'secondary')}>
+                    {label}
+                </Link>
+              )
+            })}
+          </div>
+          {showSelfServeWorkspace ? (
+            <GuidedSelfServePanel
+              campaignId={data.campaignId}
+              scanType={data.scanType}
+              isActive={data.isActive}
+              deliveryMode={data.selfServe.deliveryMode}
+              importReady={data.selfServe.importReady}
+              hasSegmentDeepDive={data.selfServe.hasSegmentDeepDive}
+              totalInvited={data.totalInvited}
+              totalCompleted={data.totalCompleted}
+              invitesNotSent={data.invitesNotSent}
+              hasMinDisplay={data.hasMinDisplay}
+              hasEnoughData={data.hasEnoughData}
+              pendingCount={data.pendingCount}
+              importQaConfirmed={data.selfServe.importQaConfirmed}
+              launchTimingConfirmed={data.selfServe.launchTimingConfirmed}
+              communicationReady={data.selfServe.communicationReady}
+              remindableCount={data.selfServe.remindableCount}
+              unsentRespondents={data.selfServe.unsentRespondents}
+              launchDate={data.launchDate}
+              launchConfirmedAt={data.selfServe.launchConfirmedAt}
+              participantCommsConfig={data.selfServe.participantCommsConfig}
+              reminderConfig={data.selfServe.reminderConfig}
+              memberRole={data.membershipRole}
+            />
+          ) : null}
         </div>
       )}
     </div>
@@ -358,11 +416,9 @@ export function RouteBeheerPhaseDetailPanel(args: {
   )
 }
 
-export function RouteBeheerOutputSummary({
-  summary,
-}: {
-  summary: RouteBeheerPageData['outputSummary']
-}) {
+export function RouteBeheerOutputSummary({ data }: { data: RouteBeheerPageData }) {
+  const summary = data.outputSummary
+
   return (
     <section className="rounded-[18px] border border-[color:var(--border)] bg-white px-4 py-4 shadow-[0_1px_4px_rgba(10,25,47,0.04)]">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
@@ -385,10 +441,17 @@ export function RouteBeheerOutputSummary({
         <Link href={summary.dashboardHref} className={detailActionClass('secondary')}>
           Open dashboard
         </Link>
-        {summary.reportHref ? (
-          <Link href={summary.reportHref} className={detailActionClass('secondary')}>
-            Open rapport
-          </Link>
+        {data.reportAvailable ? (
+          <PdfDownloadButton
+            campaignId={data.campaignId}
+            campaignName={data.campaignName}
+            scanType={data.scanType}
+            label="Download PDF"
+            loadingLabel="PDF ophalen..."
+            containerClassName="flex flex-col items-start gap-1"
+            buttonClassName="inline-flex items-center justify-center rounded-full border border-[color:var(--border)] bg-white px-4 py-2 text-sm font-semibold text-[color:var(--text)] transition hover:border-[color:var(--teal)] hover:text-[color:var(--ink)]"
+            errorClassName="max-w-48 text-xs text-red-600"
+          />
         ) : null}
       </div>
     </section>

--- a/frontend/app/(dashboard)/campaigns/[id]/beheer/route-beheer-phase-sections.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/beheer/route-beheer-phase-sections.tsx
@@ -174,7 +174,9 @@ export function RouteBeheerPhaseWorkspace(args: {
 
 function RouteBeheerPhaseDetailContent({ data, detail }: { data: RouteBeheerPageData; detail: HrRouteBeheerPhaseDetail }) {
   const showSelfServeWorkspace =
-    data.canExecuteCampaign && (detail.key === 'doelgroep' || detail.key === 'communicatie' || detail.key === 'live')
+    data.canExecuteCampaign &&
+    data.isActive &&
+    data.selfServe.phaseKey === detail.key
 
   return (
     <div id={PHASE_DETAIL_IDS[detail.key]} className="space-y-4">


### PR DESCRIPTION
## Summary
- restore the HR owner self-serve workspace inside routebeheer for upload, invite start, and reminder management
- replace stale routebeheer `#operatie` fallbacks with real routebeheer detail destinations
- align routebeheer output actions with the canonical scan PDF download flow

## Verification
- `npm test -- "app/(dashboard)/campaigns/[id]/beheer/page.test.ts" "app/(dashboard)/campaigns/[id]/beheer/route-beheer-phase-sections.test.ts" "app/(dashboard)/campaigns/[id]/beheer/beheer-data.test.ts"`
- `npx eslint "app/(dashboard)/campaigns/[id]/beheer/page.tsx" "app/(dashboard)/campaigns/[id]/beheer/route-beheer-components.tsx" "app/(dashboard)/campaigns/[id]/beheer/route-beheer-phase-sections.tsx" "app/(dashboard)/campaigns/[id]/beheer/beheer-data.ts" "app/(dashboard)/campaigns/[id]/beheer/page.test.ts" "app/(dashboard)/campaigns/[id]/beheer/route-beheer-phase-sections.test.ts" "app/(dashboard)/campaigns/[id]/beheer/beheer-data.test.ts"`
- `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key npm run build`