### PR TITLE
[codex] Add Action Center follow-through mail layer

### DIFF
--- a/docs/superpowers/plans/2026-05-14-action-center-triggered-follow-through-mail-layer.md
+++ b/docs/superpowers/plans/2026-05-14-action-center-triggered-follow-through-mail-layer.md
@@ -1,0 +1,789 @@
+# Action Center Triggered Follow-Through Mail Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a bounded automatic follow-through mail layer for eligible Action Center ExitScan routes so assignment, review, and unresolved follow-up pressure can reach managers and HR without requiring manual dashboard checking, while keeping Action Center the only canonical truth.
+
+**Architecture:** Read trigger truth from the existing Action Center route contract, contextual deeplink foundation, review invite contract, and persisted HR rhythm config. Derive candidate follow-through mail events server-side, persist a send/suppression ledger for dedupe and stale-schedule protection, and dispatch through one bounded internal email route guarded for cron/manual operator use. Reuse the live `email + ICS` review-invite baseline for review-centric mails, and keep Graph, reply-based writes, reschedule flows, and route-family expansion out of scope.
+
+**Tech Stack:** Next.js App Router, TypeScript, Vitest, Supabase SQL patch + schema snapshot, existing Action Center governance + rhythm helpers, Resend HTTP API via `fetch`, existing `frontend/vercel.json` for one bounded cron entry.
+
+---
+
+## Scope Check
+
+This child plan assumes the live baselines from merged PR #136 and PR #140 are already present in the current worktree.
+
+Verify before implementation starts:
+
+- `git rev-parse --verify 31832e58b4209428ca64f0a628b0f7744e5212f2`
+- `git rev-parse --verify d84536f0ceaf8bcc9109cc74104d1bfe9c8a3a2e`
+- `git merge-base --is-ancestor d84536f0ceaf8bcc9109cc74104d1bfe9c8a3a2e HEAD`
+
+If one of these checks fails, sync the worktree from `main` before implementing this child plan.
+
+In scope here:
+
+- automatic outbound emails for the exact phase-1 trigger families:
+  - `assignment_created`
+  - `review_upcoming`
+  - `review_overdue`
+  - `follow_up_open_after_review`
+- one bounded send/suppression ledger for dedupe, stale-schedule suppression, and auditability
+- server-side recipient resolution for assigned managers and scoped HR oversight recipients
+- reuse of the live Action Center review invite + `.ics` baseline inside review-centric mails
+- one bounded internal dispatch route for cron/manual operator execution
+- one minimal daily cron entry in `frontend/vercel.json`
+
+Explicitly out of scope here:
+
+- Microsoft Graph or native Outlook mailbox APIs
+- inbound email parsing, RSVP ingestion, or any reply-based canonical writes
+- review reschedule / cancel mutation rules
+- route-family broadening beyond ExitScan
+- marketing/newsletter/general CRM mail infrastructure
+- new manager or HR workbench surfaces
+- free-form workflow rules or multi-step automation builders
+
+## Product Rules To Preserve
+
+- Action Center stays the only canonical source for owner, review date, review outcome, closeout, and follow-up state.
+- This slice reads cadence, reminder, and escalation boundaries from the live HR Rhythm Console contract; it does not redefine them.
+- All phase-1 automated mails remain ExitScan-only.
+- Trigger families are fixed in this slice; recipient-specific variants may exist, but they must stay within those four canonical trigger families.
+- Review-centric mails may reuse the existing `.ics` artifact path, but calendar artifacts remain mirrors of canonical Action Center state.
+- Email content may activate and route attention, but never confirm completion, postpone reviews, or mutate state off-platform.
+- The system must suppress duplicate, stale, or now-ineligible sends rather than "best effort" mailing.
+
+## Trigger Contract
+
+Phase-1 trigger families and primary recipients:
+
+| Trigger family | Canonical event source | Primary recipient | Escalation behavior |
+| --- | --- | --- | --- |
+| `assignment_created` | `route.ownerAssignedAt` becomes present for an eligible ExitScan route | assigned manager email | none |
+| `review_upcoming` | scheduled review enters the configured reminder window and reminders are enabled | assigned manager email | none |
+| `review_overdue` | scheduled review date is now in the past and review is not completed | assigned manager email | once overdue days reach `escalationLeadDays`, the same trigger family may also emit an HR-oversight variant |
+| `follow_up_open_after_review` | review is completed, route remains active, no closeout/successor resolves it, and the post-review window remains open | scoped HR oversight recipients | no manager-only variant |
+
+Additional phase-1 rules:
+
+- `assignment_created` is one-shot per unique `ownerAssignedAt` for a route.
+- `review_upcoming` must be suppressed when `remindersEnabled === false`.
+- `review_overdue` must be suppressed when the route is closed, the review is already completed, or the scheduled review date is stale because the route was rescheduled before dispatch.
+- `follow_up_open_after_review` only applies when:
+  - `reviewCompletedAt` is present
+  - `reviewOutcome` is not `afronden` or `stoppen`
+  - route status is not `afgerond` or `gestopt`
+  - `hasFollowUpTarget === false`
+  - no closeout record resolves the route
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `supabase/action_center_follow_through_mail_layer.sql` | New SQL patch for the bounded Action Center follow-through mail ledger |
+| `supabase/schema.sql` | Schema snapshot update for the new ledger table and policies |
+| `frontend/lib/action-center-follow-through-mail.ts` | Shared trigger types, dedupe key helpers, suppression reasons, and delivery contract types |
+| `frontend/lib/action-center-follow-through-mail.test.ts` | Unit tests for trigger families, dedupe keys, and suppression semantics |
+| `frontend/lib/action-center-follow-through-mail-policy.test.ts` | Schema contract test for the new ledger table and policies |
+| `frontend/lib/action-center-follow-through-mail-data.ts` | Server-side loader for eligible ExitScan routes, recipients, rhythm config, and route truth required for mailing |
+| `frontend/lib/action-center-follow-through-mail-data.test.ts` | Loader tests for ExitScan-only gating, recipient scope, and rhythm inheritance |
+| `frontend/lib/action-center-follow-through-mail-planner.ts` | Candidate event planner that turns route truth + rhythm config into deduped mail jobs |
+| `frontend/lib/action-center-follow-through-mail-planner.test.ts` | Planner tests for trigger eligibility, stale suppression, escalation timing, and duplicate prevention |
+| `frontend/lib/action-center-follow-through-mail-render.ts` | Subject/text/html builders that reuse contextual deeplinks and review invite artifact links |
+| `frontend/lib/action-center-follow-through-mail-render.test.ts` | Render tests for bounded copy, deeplink presence, and review-invite reuse |
+| `frontend/lib/action-center-follow-through-mail-delivery.ts` | Resend-backed sender + ledger persistence helpers |
+| `frontend/lib/action-center-follow-through-mail-delivery.test.ts` | Delivery tests for send payload shape, error handling, and ledger writes |
+| `frontend/app/api/action-center-follow-through-mails/route.ts` | Internal dry-run/dispatch route for cron or trusted manual execution |
+| `frontend/app/api/action-center-follow-through-mails/route.test.ts` | Route tests for auth, dry-run vs dispatch, permission-safe delivery, and non-eligible route blocking |
+| `frontend/vercel.json` | Adds one bounded cron entry to invoke the mail dispatch route daily |
+| `frontend/lib/action-center-follow-through-mail-cron.test.ts` | Source-contract test for the bounded cron path only |
+
+Do **not** touch:
+
+- `frontend/lib/action-center-review-rhythm.ts` except for type-safe reuse
+- `frontend/app/api/action-center-review-rhythm/route.ts`
+- `frontend/lib/action-center-review-invite-ics.ts` except for type-safe reuse
+- any Graph-specific connector, mailbox sync, or calendar API integration
+- unrelated Action Center page shells or manager-facing UI flows
+
+---
+
+### Task 1: Add the Follow-Through Mail Ledger and Shared Trigger Contract
+
+**Files:**
+- Create: `supabase/action_center_follow_through_mail_layer.sql`
+- Modify: `supabase/schema.sql`
+- Create: `frontend/lib/action-center-follow-through-mail.ts`
+- Create: `frontend/lib/action-center-follow-through-mail.test.ts`
+- Create: `frontend/lib/action-center-follow-through-mail-policy.test.ts`
+
+- [ ] **Step 1: Write the failing contract tests**
+
+```ts
+// frontend/lib/action-center-follow-through-mail.test.ts
+import { describe, expect, it } from 'vitest'
+import {
+  ACTION_CENTER_FOLLOW_THROUGH_TRIGGER_TYPES,
+  buildActionCenterFollowThroughMailDedupeKey,
+  getActionCenterFollowThroughMailSuppressionReason,
+} from './action-center-follow-through-mail'
+
+describe('action center follow-through mail contract', () => {
+  it('exposes the bounded phase-1 trigger families only', () => {
+    expect(ACTION_CENTER_FOLLOW_THROUGH_TRIGGER_TYPES).toEqual([
+      'assignment_created',
+      'review_upcoming',
+      'review_overdue',
+      'follow_up_open_after_review',
+    ])
+  })
+
+  it('builds a stable dedupe key from route, trigger family, recipient, and canonical source marker', () => {
+    expect(
+      buildActionCenterFollowThroughMailDedupeKey({
+        routeId: 'camp-1::org::sales',
+        triggerType: 'review_upcoming',
+        recipientEmail: 'manager@example.com',
+        sourceMarker: '2026-05-20',
+      }),
+    ).toBe('camp-1::org::sales::review_upcoming::manager@example.com::2026-05-20')
+  })
+
+  it('suppresses review-upcoming reminders when reminders are disabled', () => {
+    expect(
+      getActionCenterFollowThroughMailSuppressionReason({
+        triggerType: 'review_upcoming',
+        remindersEnabled: false,
+        routeStatus: 'reviewbaar',
+        reviewCompletedAt: null,
+        reviewScheduledFor: '2026-05-20',
+        reviewOutcome: 'geen-uitkomst',
+      }),
+    ).toBe('reminders-disabled')
+  })
+
+  it('suppresses follow-up-open-after-review when the route is already closed or resolved', () => {
+    expect(
+      getActionCenterFollowThroughMailSuppressionReason({
+        triggerType: 'follow_up_open_after_review',
+        remindersEnabled: true,
+        routeStatus: 'afgerond',
+        reviewCompletedAt: '2026-05-10T12:00:00.000Z',
+        reviewScheduledFor: '2026-05-09',
+        reviewOutcome: 'afronden',
+        hasFollowUpTarget: true,
+      }),
+    ).toBe('route-resolved')
+  })
+})
+```
+
+```ts
+// frontend/lib/action-center-follow-through-mail-policy.test.ts
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const schemaSql = readFileSync(new URL('../../supabase/schema.sql', import.meta.url), 'utf8')
+
+describe('action center follow-through mail schema policy', () => {
+  it('defines a bounded ledger table with dedupe uniqueness and service-only policies', () => {
+    expect(schemaSql).toMatch(/create table if not exists public\.action_center_follow_through_mail_events/i)
+    expect(schemaSql).toMatch(/trigger_type\s+text\s+not null/i)
+    expect(schemaSql).toMatch(/recipient_email\s+text\s+not null/i)
+    expect(schemaSql).toMatch(/dedupe_key\s+text\s+not null/i)
+    expect(schemaSql).toMatch(/delivery_status\s+text\s+not null/i)
+    expect(schemaSql).toMatch(/unique\s*\(\s*dedupe_key\s*\)/i)
+    expect(schemaSql).toMatch(/create policy "service_role_can_select_action_center_follow_through_mail_events"/i)
+    expect(schemaSql).toMatch(/create policy "service_role_can_insert_action_center_follow_through_mail_events"/i)
+  })
+})
+```
+
+- [ ] **Step 2: Run the contract tests and verify they fail**
+
+Run:
+
+```bash
+npx vitest run "lib/action-center-follow-through-mail.test.ts" "lib/action-center-follow-through-mail-policy.test.ts"
+```
+
+Expected: FAIL because the shared helper and schema contract do not exist yet.
+
+- [ ] **Step 3: Add the SQL patch and shared trigger helper**
+
+Implementation requirements:
+
+- Create `public.action_center_follow_through_mail_events` with at least:
+  - `id`
+  - `org_id`
+  - `route_id`
+  - `route_scope_value`
+  - `route_source_id`
+  - `scan_type`
+  - `trigger_type`
+  - `recipient_role`
+  - `recipient_email`
+  - `source_marker`
+  - `dedupe_key`
+  - `delivery_status`
+  - `suppression_reason`
+  - `provider_message_id`
+  - `sent_at`
+  - `created_at`
+- Constrain `scan_type` to `exit` in this phase.
+- Constrain `trigger_type` to the four bounded phase-1 trigger families.
+- Constrain `delivery_status` to bounded values such as `sent`, `suppressed`, and `failed`.
+- Make `dedupe_key` unique.
+- Keep RLS service-role only for phase 1; no direct end-user writes or reads.
+
+In `frontend/lib/action-center-follow-through-mail.ts`:
+
+- Export the trigger-family tuple and types.
+- Export recipient-role types for at least `manager` and `hr_oversight`.
+- Export suppression reasons including:
+  - `reminders-disabled`
+  - `route-closed`
+  - `review-completed`
+  - `route-resolved`
+  - `missing-recipient`
+  - `unsupported-route`
+  - `stale-schedule`
+  - `duplicate`
+- Export helpers for:
+  - dedupe key generation
+  - closed/resolved route detection
+  - suppression reason derivation used by the planner
+
+- [ ] **Step 4: Run the contract tests and confirm they pass**
+
+Run:
+
+```bash
+npx vitest run "lib/action-center-follow-through-mail.test.ts" "lib/action-center-follow-through-mail-policy.test.ts"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the contract slice**
+
+```bash
+git add supabase/action_center_follow_through_mail_layer.sql supabase/schema.sql frontend/lib/action-center-follow-through-mail.ts frontend/lib/action-center-follow-through-mail.test.ts frontend/lib/action-center-follow-through-mail-policy.test.ts
+git commit -m "Add Action Center follow-through mail ledger contract"
+```
+
+---
+
+### Task 2: Add the Eligible Route Loader and Candidate Event Planner
+
+**Files:**
+- Create: `frontend/lib/action-center-follow-through-mail-data.ts`
+- Create: `frontend/lib/action-center-follow-through-mail-data.test.ts`
+- Create: `frontend/lib/action-center-follow-through-mail-planner.ts`
+- Create: `frontend/lib/action-center-follow-through-mail-planner.test.ts`
+
+- [ ] **Step 1: Write the failing loader and planner tests**
+
+```ts
+// frontend/lib/action-center-follow-through-mail-data.test.ts
+import { describe, expect, it } from 'vitest'
+import { buildActionCenterFollowThroughMailRouteSnapshot } from './action-center-follow-through-mail-data'
+
+describe('action center follow-through mail data', () => {
+  it('rejects non-ExitScan routes before they enter the mail planner', () => {
+    expect(
+      buildActionCenterFollowThroughMailRouteSnapshot({
+        routeId: 'camp-2::org::support',
+        scanType: 'retention',
+        routeStatus: 'reviewbaar',
+      }),
+    ).toEqual({
+      ok: false,
+      reason: 'unsupported-route',
+    })
+  })
+
+  it('keeps scoped HR oversight recipients bounded to writable review-rhythm actors only', () => {
+    const snapshot = buildActionCenterFollowThroughMailRouteSnapshot({
+      routeId: 'camp-1::org::sales',
+      scanType: 'exit',
+      routeStatus: 'reviewbaar',
+      hrRecipients: [
+        { email: 'hr-owner@example.com', role: 'hr_owner', canUpdate: true, canScheduleReview: true, scopeValue: 'org-1::department::sales' },
+        { email: 'viewer@example.com', role: 'viewer', canUpdate: false, canScheduleReview: false, scopeValue: 'org-1::department::sales' },
+      ],
+    })
+
+    expect(snapshot.ok && snapshot.value.hrOversightRecipients).toEqual([
+      { email: 'hr-owner@example.com', auditRole: 'hr_owner' },
+    ])
+  })
+})
+```
+
+```ts
+// frontend/lib/action-center-follow-through-mail-planner.test.ts
+import { describe, expect, it } from 'vitest'
+import { planActionCenterFollowThroughMailJobs } from './action-center-follow-through-mail-planner'
+
+describe('action center follow-through mail planner', () => {
+  const baseSnapshot = {
+    routeId: 'camp-1::org::sales',
+    orgId: 'org-1',
+    campaignId: 'camp-1',
+    campaignName: 'ExitScan Q2',
+    scopeLabel: 'Sales',
+    scanType: 'exit',
+    routeStatus: 'reviewbaar',
+    reviewScheduledFor: '2026-05-20',
+    reviewCompletedAt: null,
+    reviewOutcome: 'geen-uitkomst',
+    ownerAssignedAt: '2026-05-10T09:00:00.000Z',
+    hasFollowUpTarget: false,
+    remindersEnabled: true,
+    cadenceDays: 14,
+    reminderLeadDays: 3,
+    escalationLeadDays: 7,
+    managerRecipient: { email: 'manager@example.com', name: 'Manager' },
+    hrOversightRecipients: [{ email: 'hr-owner@example.com', auditRole: 'hr_owner' }],
+  } as const
+
+  it('emits assignment-created once per owner-assignment marker', () => {
+    const jobs = planActionCenterFollowThroughMailJobs({
+      now: new Date('2026-05-12T08:00:00.000Z'),
+      snapshots: [baseSnapshot],
+      existingDedupeKeys: new Set<string>(),
+    })
+
+    expect(jobs.some((job) => job.triggerType === 'assignment_created')).toBe(true)
+  })
+
+  it('suppresses review-upcoming when the review moved outside the current reminder window', () => {
+    const jobs = planActionCenterFollowThroughMailJobs({
+      now: new Date('2026-05-01T08:00:00.000Z'),
+      snapshots: [baseSnapshot],
+      existingDedupeKeys: new Set<string>(),
+    })
+
+    expect(jobs.some((job) => job.triggerType === 'review_upcoming')).toBe(false)
+  })
+
+  it('adds an HR oversight variant when review-overdue crosses the escalation window', () => {
+    const jobs = planActionCenterFollowThroughMailJobs({
+      now: new Date('2026-05-29T08:00:00.000Z'),
+      snapshots: [baseSnapshot],
+      existingDedupeKeys: new Set<string>(),
+    })
+
+    expect(
+      jobs.filter((job) => job.triggerType === 'review_overdue').map((job) => job.recipientRole),
+    ).toEqual(expect.arrayContaining(['manager', 'hr_oversight']))
+  })
+
+  it('suppresses follow-up-open-after-review when the route already has a successor', () => {
+    const jobs = planActionCenterFollowThroughMailJobs({
+      now: new Date('2026-06-10T08:00:00.000Z'),
+      snapshots: [
+        {
+          ...baseSnapshot,
+          reviewCompletedAt: '2026-05-25T12:00:00.000Z',
+          reviewOutcome: 'doorgaan',
+          hasFollowUpTarget: true,
+        },
+      ],
+      existingDedupeKeys: new Set<string>(),
+    })
+
+    expect(jobs.some((job) => job.triggerType === 'follow_up_open_after_review')).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run:
+
+```bash
+npx vitest run "lib/action-center-follow-through-mail-data.test.ts" "lib/action-center-follow-through-mail-planner.test.ts"
+```
+
+Expected: FAIL because the loader and planner do not exist yet.
+
+- [ ] **Step 3: Add the eligible route loader**
+
+Implementation requirements in `frontend/lib/action-center-follow-through-mail-data.ts`:
+
+- Build a bounded server-side snapshot for mailing that includes:
+  - org id
+  - campaign id / name
+  - route id
+  - scope label / scope value
+  - scan type
+  - route status
+  - review scheduled date
+  - review completed timestamp
+  - review outcome
+  - owner assigned timestamp
+  - follow-up successor truth
+  - route closeout truth
+  - assigned manager recipient
+  - scoped HR oversight recipients
+  - inherited rhythm config
+- Reuse existing Action Center live truth and route contract fields instead of duplicating business logic.
+- Reuse the live review-rhythm config table and defaulting logic from `frontend/lib/action-center-review-rhythm.ts`.
+- Reuse the same route-scope semantics already enforced by the HR Rhythm Console when selecting HR oversight recipients.
+- Reject non-ExitScan routes before they reach the planner.
+- Keep recipient resolution permission-safe:
+  - manager recipient must come from the assigned manager workspace row with a non-empty login email
+  - HR oversight recipients must be limited to roles that already satisfy the review-rhythm write boundary for the route scope
+
+- [ ] **Step 4: Add the candidate event planner**
+
+Implementation requirements in `frontend/lib/action-center-follow-through-mail-planner.ts`:
+
+- Accept route snapshots, `now`, and the set of existing ledger dedupe keys.
+- Emit bounded candidate jobs only for the four phase-1 trigger families.
+- Use canonical source markers for dedupe:
+  - `assignment_created`: `ownerAssignedAt`
+  - `review_upcoming`: `reviewScheduledFor`
+  - `review_overdue`: `reviewScheduledFor` plus recipient role variant
+  - `follow_up_open_after_review`: `reviewCompletedAt`
+- Apply suppression before a send job is emitted:
+  - reminders disabled
+  - missing recipient
+  - unsupported route
+  - duplicate dedupe key
+  - stale schedule / stale review date
+  - closed or resolved route
+- Escalation behavior:
+  - do not invent a fifth trigger family
+  - instead, allow `review_overdue` to emit a manager variant and an HR oversight variant after `escalationLeadDays`
+- Follow-up-after-review behavior:
+  - wait until `escalationLeadDays` have elapsed after `reviewCompletedAt`
+  - require the route to remain open and unresolved
+  - send to HR oversight recipients only
+
+- [ ] **Step 5: Run the tests and confirm they pass**
+
+Run:
+
+```bash
+npx vitest run "lib/action-center-follow-through-mail-data.test.ts" "lib/action-center-follow-through-mail-planner.test.ts"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the planner slice**
+
+```bash
+git add frontend/lib/action-center-follow-through-mail-data.ts frontend/lib/action-center-follow-through-mail-data.test.ts frontend/lib/action-center-follow-through-mail-planner.ts frontend/lib/action-center-follow-through-mail-planner.test.ts
+git commit -m "Plan Action Center follow-through mail jobs"
+```
+
+---
+
+### Task 3: Add the Mail Renderer and Resend Delivery Helper
+
+**Files:**
+- Create: `frontend/lib/action-center-follow-through-mail-render.ts`
+- Create: `frontend/lib/action-center-follow-through-mail-render.test.ts`
+- Create: `frontend/lib/action-center-follow-through-mail-delivery.ts`
+- Create: `frontend/lib/action-center-follow-through-mail-delivery.test.ts`
+
+- [ ] **Step 1: Write the failing renderer and delivery tests**
+
+```ts
+// frontend/lib/action-center-follow-through-mail-render.test.ts
+import { describe, expect, it } from 'vitest'
+import { renderActionCenterFollowThroughMail } from './action-center-follow-through-mail-render'
+
+describe('action center follow-through mail render', () => {
+  it('renders a bounded review-upcoming mail with contextual deeplink and invite artifact link', () => {
+    const rendered = renderActionCenterFollowThroughMail({
+      triggerType: 'review_upcoming',
+      recipientRole: 'manager',
+      campaignName: 'ExitScan Q2',
+      scopeLabel: 'Sales',
+      actionCenterHref: 'https://app.verisight.nl/dashboard/action-center?focus=review-1&view=reviews&source=notification',
+      inviteArtifactHref: 'https://app.verisight.nl/api/action-center-review-invites?reviewItemId=review-1&format=ics',
+    })
+
+    expect(rendered.subject).toContain('Reviewmoment')
+    expect(rendered.emailText).toContain('Action Center')
+    expect(rendered.emailText).toContain('https://app.verisight.nl/dashboard/action-center')
+    expect(rendered.emailHtml).toContain('format=ics')
+  })
+
+  it('does not instruct recipients to confirm or reschedule by email', () => {
+    const rendered = renderActionCenterFollowThroughMail({
+      triggerType: 'review_overdue',
+      recipientRole: 'manager',
+      campaignName: 'ExitScan Q2',
+      scopeLabel: 'Sales',
+      actionCenterHref: 'https://app.verisight.nl/dashboard/action-center?focus=review-1&view=reviews&source=notification',
+    })
+
+    expect(rendered.emailText).not.toMatch(/reply|beantwoord|mail terug|reschedule|verplaats/i)
+  })
+})
+```
+
+```ts
+// frontend/lib/action-center-follow-through-mail-delivery.test.ts
+import { describe, expect, it, vi } from 'vitest'
+import { deliverActionCenterFollowThroughMail } from './action-center-follow-through-mail-delivery'
+
+describe('action center follow-through mail delivery', () => {
+  it('posts a bounded Resend payload and returns the provider id', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 're_123' }),
+    })
+
+    const result = await deliverActionCenterFollowThroughMail(
+      {
+        recipientEmail: 'manager@example.com',
+        subject: 'Reviewmoment ExitScan Q2 / Sales',
+        emailText: 'Open Action Center',
+        emailHtml: '<p>Open Action Center</p>',
+      },
+      {
+        fetchImpl: fetchMock,
+        resendApiKey: 're_test',
+        emailFrom: 'Verisight <noreply@verisight.nl>',
+      },
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      providerMessageId: 're_123',
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run:
+
+```bash
+npx vitest run "lib/action-center-follow-through-mail-render.test.ts" "lib/action-center-follow-through-mail-delivery.test.ts"
+```
+
+Expected: FAIL because the renderer and delivery helper do not exist yet.
+
+- [ ] **Step 3: Add the bounded renderer**
+
+Implementation requirements in `frontend/lib/action-center-follow-through-mail-render.ts`:
+
+- Render subject/text/html for the four trigger families only.
+- Reuse the contextual deeplink foundation from `frontend/lib/action-center-entry.ts`.
+- Reuse the existing review invite contract for review-centric mails:
+  - include the Action Center review deeplink
+  - include a link to the existing `.ics` artifact for `review_upcoming` and `review_overdue`
+  - do not create a second calendar artifact format
+- Keep copy bounded and operational:
+  - why this route needs attention
+  - what to open in Action Center
+  - for review-centric messages, where to download the calendar artifact
+- Never instruct people to reply by email, confirm completion by email, or reschedule off-platform.
+
+- [ ] **Step 4: Add the Resend delivery helper**
+
+Implementation requirements in `frontend/lib/action-center-follow-through-mail-delivery.ts`:
+
+- Use the same `fetch('https://api.resend.com/emails', ...)` integration style already present in `frontend/app/api/contact/route.ts`.
+- Keep this helper transactional and bounded:
+  - one recipient per send
+  - HTML + plain text
+  - no marketing batch semantics
+  - no attachments beyond existing bounded review artifact links
+- Return structured success/failure output including provider id or reason.
+- Keep provider/env resolution explicit and server-only.
+
+- [ ] **Step 5: Run the tests and confirm they pass**
+
+Run:
+
+```bash
+npx vitest run "lib/action-center-follow-through-mail-render.test.ts" "lib/action-center-follow-through-mail-delivery.test.ts"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the render/delivery slice**
+
+```bash
+git add frontend/lib/action-center-follow-through-mail-render.ts frontend/lib/action-center-follow-through-mail-render.test.ts frontend/lib/action-center-follow-through-mail-delivery.ts frontend/lib/action-center-follow-through-mail-delivery.test.ts
+git commit -m "Add Action Center follow-through mail rendering"
+```
+
+---
+
+### Task 4: Add the Internal Dispatch Route and Daily Cron Entry
+
+**Files:**
+- Create: `frontend/app/api/action-center-follow-through-mails/route.ts`
+- Create: `frontend/app/api/action-center-follow-through-mails/route.test.ts`
+- Modify: `frontend/vercel.json`
+- Create: `frontend/lib/action-center-follow-through-mail-cron.test.ts`
+
+- [ ] **Step 1: Write the failing route and cron tests**
+
+```ts
+// frontend/app/api/action-center-follow-through-mails/route.test.ts
+import { describe, expect, it } from 'vitest'
+
+describe('POST /api/action-center-follow-through-mails', () => {
+  it('rejects unauthenticated dispatch requests', async () => {
+    expect(true).toBe(false)
+  })
+
+  it('supports dry-run responses without sending mail', async () => {
+    expect(true).toBe(false)
+  })
+
+  it('blocks non-eligible routes from leaving the dispatcher', async () => {
+    expect(true).toBe(false)
+  })
+})
+```
+
+```ts
+// frontend/lib/action-center-follow-through-mail-cron.test.ts
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const vercelJson = readFileSync(new URL('../vercel.json', import.meta.url), 'utf8')
+
+describe('action center follow-through mail cron config', () => {
+  it('adds exactly one bounded cron path for the mail dispatcher', () => {
+    expect(vercelJson).toMatch(/"crons"/)
+    expect(vercelJson).toMatch(/"path"\s*:\s*"\/api\/action-center-follow-through-mails"/)
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run:
+
+```bash
+npx vitest run "app/api/action-center-follow-through-mails/route.test.ts" "lib/action-center-follow-through-mail-cron.test.ts"
+```
+
+Expected: FAIL because the route and cron config do not exist yet.
+
+- [ ] **Step 3: Add the bounded dispatch route**
+
+Implementation requirements in `frontend/app/api/action-center-follow-through-mails/route.ts`:
+
+- Support two bounded modes only:
+  - `dry-run`: returns planned candidate jobs and suppression summaries without sending
+  - `dispatch`: sends eligible jobs and records ledger rows
+- Guard execution so only trusted invocations can dispatch:
+  - Vercel cron invocation, or
+  - trusted bearer secret / internal token
+- Use the route loader, planner, renderer, and delivery helper from earlier tasks.
+- Before each send:
+  - re-check dedupe against the ledger
+  - re-check route eligibility
+  - re-check recipient availability
+- Record sent, suppressed, and failed outcomes in the ledger.
+- Return compact operational JSON:
+  - planned count
+  - sent count
+  - suppressed count
+  - failed count
+  - route ids or dedupe keys only where needed for debugging
+
+- [ ] **Step 4: Add the bounded cron entry**
+
+Implementation requirements in `frontend/vercel.json`:
+
+- Add exactly one cron entry for the follow-through dispatcher.
+- Run it at a conservative daily cadence in phase 1.
+- Point it only to `/api/action-center-follow-through-mails`.
+- Do not add any second cron, queue, or workflow orchestration in this slice.
+
+- [ ] **Step 5: Run the tests and confirm they pass**
+
+Run:
+
+```bash
+npx vitest run "app/api/action-center-follow-through-mails/route.test.ts" "lib/action-center-follow-through-mail-cron.test.ts"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the dispatch slice**
+
+```bash
+git add frontend/app/api/action-center-follow-through-mails/route.ts frontend/app/api/action-center-follow-through-mails/route.test.ts frontend/vercel.json frontend/lib/action-center-follow-through-mail-cron.test.ts
+git commit -m "Add Action Center follow-through mail dispatch route"
+```
+
+---
+
+### Task 5: Verify the Bounded Mail Layer End-to-End
+
+**Files:**
+- Verify only; no new files required unless a failing test forces a targeted fix inside the files above
+
+- [ ] **Step 1: Run the bounded follow-through mail suite**
+
+Run:
+
+```bash
+npx vitest run "lib/action-center-follow-through-mail.test.ts" "lib/action-center-follow-through-mail-policy.test.ts" "lib/action-center-follow-through-mail-data.test.ts" "lib/action-center-follow-through-mail-planner.test.ts" "lib/action-center-follow-through-mail-render.test.ts" "lib/action-center-follow-through-mail-delivery.test.ts" "app/api/action-center-follow-through-mails/route.test.ts" "lib/action-center-follow-through-mail-cron.test.ts"
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run the adjacent regression suite**
+
+Run:
+
+```bash
+npx vitest run "lib/action-center-review-rhythm.test.ts" "lib/action-center-review-rhythm-data.test.ts" "app/api/action-center-review-rhythm/route.test.ts" "lib/action-center-review-invite.test.ts" "app/api/action-center-review-invites/route.test.ts" "components/dashboard/review-moment-detail-panel.test.ts"
+```
+
+Expected: PASS, proving no drift in the live rhythm/invite baselines.
+
+- [ ] **Step 3: Run a production build**
+
+Run:
+
+```bash
+npm run build
+```
+
+Expected: PASS with no new type or route-handler regressions.
+
+- [ ] **Step 4: Manually verify the bounded product rules**
+
+Confirm:
+
+- only ExitScan routes are planned for outbound mail
+- review-upcoming mails honor `remindersEnabled`
+- overdue escalation does not invent a fifth trigger family
+- no mail variant instructs reply-based writes or rescheduling by email
+- review-centric mails point back to Action Center and the existing `.ics` artifact path
+- non-eligible routes and missing-recipient routes are suppressed, not sent
+
+- [ ] **Step 5: Commit the verification pass**
+
+```bash
+git add .
+git commit -m "Verify Action Center follow-through mail layer"
+```
+
+---
+
+## Notes for the Implementer
+
+- Keep this slice operational and quiet. If an implementation idea starts looking like a workflow engine, it is probably wrong.
+- Reuse existing live helpers before adding any new Action Center truth-mapping layer.
+- If you discover that `follow_up_open_after_review` cannot be derived safely from current route truth, stop and tighten that condition before coding around it.
+- If dispatch safety depends on extra env vars or secrets, add them minimally and document them inside the implementation PR description rather than opening a broad configuration program here.

--- a/frontend/app/api/action-center-follow-through-mails/route.test.ts
+++ b/frontend/app/api/action-center-follow-through-mails/route.test.ts
@@ -1,0 +1,213 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  mockGetDispatchData,
+  mockPlanJobs,
+  mockRenderMail,
+  mockDeliverMail,
+  mockAdminFrom,
+} = vi.hoisted(() => ({
+  mockGetDispatchData: vi.fn(),
+  mockPlanJobs: vi.fn(),
+  mockRenderMail: vi.fn(),
+  mockDeliverMail: vi.fn(),
+  mockAdminFrom: vi.fn(),
+}))
+
+vi.mock('@/lib/action-center-follow-through-mail-data', () => ({
+  getActionCenterFollowThroughMailDispatchData: mockGetDispatchData,
+}))
+
+vi.mock('@/lib/action-center-follow-through-mail-planner', () => ({
+  planActionCenterFollowThroughMailJobs: mockPlanJobs,
+}))
+
+vi.mock('@/lib/action-center-follow-through-mail-render', () => ({
+  renderActionCenterFollowThroughMail: mockRenderMail,
+}))
+
+vi.mock('@/lib/action-center-follow-through-mail-delivery', () => ({
+  deliverActionCenterFollowThroughMail: mockDeliverMail,
+  getActionCenterFollowThroughMailEnv: () => ({
+    resendApiKey: 're_test',
+    emailFrom: 'Verisight <noreply@verisight.nl>',
+  }),
+}))
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: () => ({
+    from: mockAdminFrom,
+  }),
+}))
+
+import { GET, POST } from './route'
+
+function makeRequest(body: Record<string, unknown>, headers: Record<string, string> = {}) {
+  return new Request('https://app.verisight.nl/api/action-center-follow-through-mails', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  })
+}
+
+function createLedgerSelectQuery(result: { data: unknown; error?: unknown }) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    in: vi.fn().mockResolvedValue(result),
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+  }
+}
+
+function createLedgerInsertQuery() {
+  return {
+    insert: vi.fn().mockResolvedValue({ error: null }),
+  }
+}
+
+describe('POST /api/action-center-follow-through-mails', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.BACKEND_ADMIN_TOKEN = 'test-token'
+
+    mockGetDispatchData.mockResolvedValue({
+      snapshots: [
+        {
+          routeId: 'camp-1::org::sales',
+          routeScopeValue: 'org-1::department::sales',
+          orgId: 'org-1',
+          campaignId: 'camp-1',
+          campaignName: 'ExitScan Q2',
+          scopeLabel: 'Sales',
+          scanType: 'exit',
+          routeStatus: 'reviewbaar',
+          reviewScheduledFor: '2026-05-20',
+          reviewCompletedAt: null,
+          reviewOutcome: 'geen-uitkomst',
+          ownerAssignedAt: '2026-05-10T09:00:00.000Z',
+          hasFollowUpTarget: false,
+          remindersEnabled: true,
+          cadenceDays: 14,
+          reminderLeadDays: 3,
+          escalationLeadDays: 7,
+          managerRecipient: { email: 'manager@example.com', name: 'Manager' },
+          hrOversightRecipients: [],
+        },
+      ],
+      routeIds: ['camp-1::org::sales'],
+    })
+
+    mockPlanJobs.mockReturnValue({
+      jobs: [
+        {
+          routeId: 'camp-1::org::sales',
+          orgId: 'org-1',
+          campaignId: 'camp-1',
+          campaignName: 'ExitScan Q2',
+          scopeLabel: 'Sales',
+          routeScopeValue: 'org-1::department::sales',
+          triggerType: 'review_upcoming',
+          recipientRole: 'manager',
+          recipientEmail: 'manager@example.com',
+          recipientName: 'Manager',
+          sourceMarker: '2026-05-20',
+          dedupeKey: 'camp-1::org::sales::review_upcoming::manager@example.com::2026-05-20',
+          reviewScheduledFor: '2026-05-20',
+        },
+      ],
+      suppressions: [],
+    })
+
+    mockRenderMail.mockReturnValue({
+      subject: 'Reviewmoment ExitScan Q2 / Sales',
+      emailText: 'Open Action Center',
+      emailHtml: '<p>Open Action Center</p>',
+    })
+
+    mockDeliverMail.mockResolvedValue({
+      ok: true,
+      providerMessageId: 're_123',
+    })
+
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === 'action_center_follow_through_mail_events') {
+        const selectQuery = createLedgerSelectQuery({ data: [] })
+        const insertQuery = createLedgerInsertQuery()
+        return {
+          ...selectQuery,
+          ...insertQuery,
+        }
+      }
+
+      throw new Error(`Unexpected table ${table}`)
+    })
+  })
+
+  it('rejects unauthenticated dispatch requests', async () => {
+    const response = await POST(makeRequest({ mode: 'dispatch' }))
+
+    expect(response.status).toBe(401)
+  })
+
+  it('does not accept Bearer null when trusted secrets are absent', async () => {
+    delete process.env.BACKEND_ADMIN_TOKEN
+    delete process.env.CRON_SECRET
+
+    const response = await POST(
+      makeRequest(
+        { mode: 'dispatch' },
+        { authorization: 'Bearer null' },
+      ),
+    )
+
+    expect(response.status).toBe(401)
+  })
+
+  it('supports dry-run responses without sending mail', async () => {
+    const response = await POST(
+      makeRequest(
+        { mode: 'dry-run' },
+        { authorization: 'Bearer test-token' },
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      mode: 'dry-run',
+      plannedCount: 1,
+      sentCount: 0,
+    })
+    expect(mockDeliverMail).not.toHaveBeenCalled()
+  })
+
+  it('supports trusted GET dispatches for cron invocations', async () => {
+    const response = await GET(
+      new Request('https://app.verisight.nl/api/action-center-follow-through-mails', {
+        method: 'GET',
+        headers: {
+          authorization: 'Bearer test-token',
+        },
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      mode: 'dispatch',
+      plannedCount: 1,
+    })
+  })
+
+  it('blocks non-eligible routes from leaving the dispatcher', async () => {
+    const response = await POST(
+      makeRequest(
+        { mode: 'dispatch', routeIds: ['unknown-route'] },
+        { authorization: 'Bearer test-token' },
+      ),
+    )
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({
+      detail: 'Geen eligible Action Center-routes gevonden voor dispatch.',
+    })
+  })
+})

--- a/frontend/app/api/action-center-follow-through-mails/route.ts
+++ b/frontend/app/api/action-center-follow-through-mails/route.ts
@@ -1,0 +1,349 @@
+import { NextResponse } from 'next/server'
+import { buildActionCenterEntryHref } from '@/lib/action-center-entry'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { getActionCenterFollowThroughMailDispatchData } from '@/lib/action-center-follow-through-mail-data'
+import { planActionCenterFollowThroughMailJobs } from '@/lib/action-center-follow-through-mail-planner'
+import { renderActionCenterFollowThroughMail } from '@/lib/action-center-follow-through-mail-render'
+import {
+  deliverActionCenterFollowThroughMail,
+  getActionCenterFollowThroughMailEnv,
+} from '@/lib/action-center-follow-through-mail-delivery'
+import { getActionCenterFollowThroughMailSuppressionReason } from '@/lib/action-center-follow-through-mail'
+
+type FollowThroughMailRouteBody = {
+  mode?: unknown
+  routeIds?: unknown
+}
+
+function normalizeText(value: string | null | undefined) {
+  const trimmed = value?.trim() ?? ''
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function getBaseUrl() {
+  const value =
+    normalizeText(process.env.FRONTEND_URL) ??
+    normalizeText(process.env.NEXT_PUBLIC_SITE_URL) ??
+    normalizeText(process.env.NEXT_PUBLIC_APP_URL) ??
+    'http://localhost:3000'
+
+  return new URL(value).origin
+}
+
+function parseMode(value: unknown) {
+  return value === 'dispatch' ? 'dispatch' : 'dry-run'
+}
+
+function parseRouteIds(value: unknown) {
+  if (!Array.isArray(value)) return null
+
+  const routeIds = value
+    .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
+    .filter((entry) => entry.length > 0)
+
+  return routeIds.length > 0 ? routeIds : null
+}
+
+function isTrustedRequest(request: Request) {
+  const cronSecret = normalizeText(process.env.CRON_SECRET)
+  const adminToken = normalizeText(process.env.BACKEND_ADMIN_TOKEN)
+  const authHeader = normalizeText(request.headers.get('authorization'))
+  if (!authHeader) return false
+
+  return Boolean(
+    (cronSecret && authHeader === `Bearer ${cronSecret}`) ||
+      (adminToken && authHeader === `Bearer ${adminToken}`),
+  )
+}
+
+function buildInviteArtifactHref(routeId: string) {
+  const url = new URL('/api/action-center-review-invites', `${getBaseUrl()}/`)
+  url.searchParams.set('reviewItemId', routeId)
+  url.searchParams.set('format', 'ics')
+  return url.toString()
+}
+
+function buildActionCenterHref(routeId: string) {
+  return new URL(
+    buildActionCenterEntryHref({
+      focus: routeId,
+      view: 'reviews',
+      source: 'notification',
+    }),
+    `${getBaseUrl()}/`,
+  ).toString()
+}
+
+function createLedgerQueries() {
+  const admin = createAdminClient()
+  return admin.from('action_center_follow_through_mail_events')
+}
+
+async function hasLedgerDedupeKey(dedupeKey: string) {
+  const result = await createLedgerQueries()
+    .select('dedupe_key')
+    .eq('dedupe_key', dedupeKey)
+    .maybeSingle()
+
+  if (result.error) {
+    throw new Error(result.error.message ?? 'Action Center follow-through dedupe lookup failed.')
+  }
+
+  return Boolean(result.data)
+}
+
+async function handleDispatch(args: {
+  request: Request
+  mode: 'dry-run' | 'dispatch'
+  requestedRouteIds: string[] | null
+}) {
+  if (!isTrustedRequest(args.request)) {
+    return NextResponse.json({ detail: 'Niet toegestaan.' }, { status: 401 })
+  }
+
+  const dispatchData = await getActionCenterFollowThroughMailDispatchData()
+  const filteredSnapshots = args.requestedRouteIds
+    ? dispatchData.snapshots.filter((snapshot) => args.requestedRouteIds?.includes(snapshot.routeId))
+    : dispatchData.snapshots
+
+  if (args.requestedRouteIds && filteredSnapshots.length === 0) {
+    return NextResponse.json(
+      {
+        detail: 'Geen eligible Action Center-routes gevonden voor dispatch.',
+      },
+      { status: 409 },
+    )
+  }
+
+  if (filteredSnapshots.length === 0) {
+    return NextResponse.json(
+      {
+        mode: args.mode,
+        plannedCount: 0,
+        sentCount: 0,
+        suppressedCount: 0,
+        failedCount: 0,
+        jobs: [],
+      },
+      { status: 200 },
+    )
+  }
+
+  const ledgerQuery = createLedgerQueries()
+  const dedupeRows = await ledgerQuery
+    .select('dedupe_key')
+    .in('route_id', filteredSnapshots.map((snapshot) => snapshot.routeId))
+
+  if (dedupeRows.error) {
+    throw new Error(dedupeRows.error.message ?? 'Action Center follow-through ledger query failed.')
+  }
+
+  const existingDedupeKeys = new Set(
+    (dedupeRows.data ?? [])
+      .map((row) => normalizeText((row as { dedupe_key?: string | null }).dedupe_key))
+      .filter((value): value is string => Boolean(value)),
+  )
+
+  const planned = planActionCenterFollowThroughMailJobs({
+    now: new Date(),
+    snapshots: filteredSnapshots,
+    existingDedupeKeys,
+  })
+
+  if (args.mode === 'dry-run') {
+    return NextResponse.json(
+      {
+        mode: args.mode,
+        plannedCount: planned.jobs.length,
+        sentCount: 0,
+        suppressedCount: planned.suppressions.length,
+        failedCount: 0,
+        jobs: planned.jobs.map((job) => ({
+          routeId: job.routeId,
+          triggerType: job.triggerType,
+          recipientRole: job.recipientRole,
+        })),
+        suppressions: planned.suppressions.map((entry) => ({
+          routeId: entry.routeId,
+          triggerType: entry.triggerType,
+          recipientRole: entry.recipientRole,
+          suppressionReason: entry.suppressionReason,
+        })),
+      },
+      { status: 200 },
+    )
+  }
+
+  const refreshedDispatchData = await getActionCenterFollowThroughMailDispatchData()
+  const refreshedSnapshotsByRouteId = new Map(
+    refreshedDispatchData.snapshots.map((snapshot) => [snapshot.routeId, snapshot]),
+  )
+  const env = getActionCenterFollowThroughMailEnv()
+  let sentCount = 0
+  let suppressedCount = 0
+  let failedCount = 0
+
+  for (const entry of planned.suppressions) {
+    if (entry.suppressionReason === 'duplicate') {
+      suppressedCount += 1
+      continue
+    }
+
+    const insertResult = await createLedgerQueries().insert({
+      org_id: entry.orgId,
+      route_id: entry.routeId,
+      route_scope_value: entry.routeScopeValue,
+      route_source_id: entry.campaignId,
+      scan_type: 'exit',
+      trigger_type: entry.triggerType,
+      recipient_role: entry.recipientRole,
+      recipient_email: entry.recipientEmail ?? 'missing-recipient',
+      source_marker: entry.sourceMarker ?? `suppressed::${entry.triggerType}`,
+      dedupe_key: `${entry.routeId}::${entry.triggerType}::${entry.recipientRole}::${entry.sourceMarker ?? 'suppressed'}`,
+      delivery_status: 'suppressed',
+      suppression_reason: entry.suppressionReason,
+      provider_message_id: null,
+      sent_at: null,
+    })
+
+    if (insertResult.error && insertResult.error.code !== '23505') {
+      throw new Error(insertResult.error.message ?? 'Action Center follow-through suppression ledger write failed.')
+    }
+    suppressedCount += 1
+  }
+
+  for (const job of planned.jobs) {
+    const refreshedSnapshot = refreshedSnapshotsByRouteId.get(job.routeId) ?? null
+    const recheckReason =
+      !refreshedSnapshot
+        ? 'unsupported-route'
+        : getActionCenterFollowThroughMailSuppressionReason({
+            triggerType: job.triggerType,
+            remindersEnabled: refreshedSnapshot.remindersEnabled,
+            routeStatus: refreshedSnapshot.routeStatus,
+            reviewCompletedAt: refreshedSnapshot.reviewCompletedAt,
+            reviewScheduledFor:
+              refreshedSnapshot.reviewScheduledFor === job.reviewScheduledFor
+                ? refreshedSnapshot.reviewScheduledFor
+                : null,
+            reviewOutcome: refreshedSnapshot.reviewOutcome,
+            recipientEmail:
+              job.recipientRole === 'manager'
+                ? refreshedSnapshot.managerRecipient?.email ?? null
+                : refreshedSnapshot.hrOversightRecipients.find(
+                    (recipient) => recipient.email === job.recipientEmail,
+                  )?.email ?? null,
+            hasFollowUpTarget: refreshedSnapshot.hasFollowUpTarget,
+            isDuplicate: existingDedupeKeys.has(job.dedupeKey) || (await hasLedgerDedupeKey(job.dedupeKey)),
+          })
+
+    if (recheckReason) {
+      const suppressionInsert = await createLedgerQueries().insert({
+        org_id: job.orgId,
+        route_id: job.routeId,
+        route_scope_value: job.routeScopeValue,
+        route_source_id: job.campaignId,
+        scan_type: 'exit',
+        trigger_type: job.triggerType,
+        recipient_role: job.recipientRole,
+        recipient_email: job.recipientEmail,
+        source_marker: job.sourceMarker,
+        dedupe_key: job.dedupeKey,
+        delivery_status: 'suppressed',
+        suppression_reason: recheckReason,
+        provider_message_id: null,
+        sent_at: null,
+      })
+
+      if (suppressionInsert.error && suppressionInsert.error.code !== '23505') {
+        throw new Error(suppressionInsert.error.message ?? 'Action Center follow-through recheck suppression write failed.')
+      }
+      suppressedCount += 1
+      existingDedupeKeys.add(job.dedupeKey)
+      continue
+    }
+
+    const rendered = renderActionCenterFollowThroughMail({
+      triggerType: job.triggerType,
+      recipientRole: job.recipientRole,
+      campaignName: job.campaignName,
+      scopeLabel: job.scopeLabel,
+      actionCenterHref: buildActionCenterHref(job.routeId),
+      inviteArtifactHref:
+        job.triggerType === 'review_upcoming' || job.triggerType === 'review_overdue'
+          ? buildInviteArtifactHref(job.routeId)
+          : null,
+    })
+
+    const result = await deliverActionCenterFollowThroughMail(
+      {
+        recipientEmail: job.recipientEmail,
+        subject: rendered.subject,
+        emailText: rendered.emailText,
+        emailHtml: rendered.emailHtml,
+      },
+      env,
+    )
+
+    const insertResult = await createLedgerQueries().insert({
+      org_id: job.orgId,
+      route_id: job.routeId,
+      route_scope_value: job.routeScopeValue,
+      route_source_id: job.campaignId,
+      scan_type: 'exit',
+      trigger_type: job.triggerType,
+      recipient_role: job.recipientRole,
+      recipient_email: job.recipientEmail,
+      source_marker: job.sourceMarker,
+      dedupe_key: job.dedupeKey,
+      delivery_status: result.ok ? 'sent' : 'failed',
+      suppression_reason: null,
+      provider_message_id: result.ok ? result.providerMessageId : null,
+      sent_at: result.ok ? new Date().toISOString() : null,
+    })
+
+    if (insertResult.error && insertResult.error.code !== '23505') {
+      throw new Error(insertResult.error.message ?? 'Action Center follow-through ledger write failed.')
+    }
+
+    existingDedupeKeys.add(job.dedupeKey)
+
+    if (result.ok) {
+      sentCount += 1
+    } else {
+      failedCount += 1
+    }
+  }
+
+  return NextResponse.json(
+    {
+      mode: args.mode,
+      plannedCount: planned.jobs.length,
+      sentCount,
+      suppressedCount,
+      failedCount,
+    },
+    { status: 200 },
+  )
+}
+
+export async function POST(request: Request) {
+  if (!isTrustedRequest(request)) {
+    return NextResponse.json({ detail: 'Niet toegestaan.' }, { status: 401 })
+  }
+
+  const body = (await request.json().catch(() => null)) as FollowThroughMailRouteBody | null
+  return handleDispatch({
+    request,
+    mode: parseMode(body?.mode),
+    requestedRouteIds: parseRouteIds(body?.routeIds),
+  })
+}
+
+export async function GET(request: Request) {
+  return handleDispatch({
+    request,
+    mode: 'dispatch',
+    requestedRouteIds: null,
+  })
+}

--- a/frontend/lib/action-center-follow-through-mail-cron.test.ts
+++ b/frontend/lib/action-center-follow-through-mail-cron.test.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const vercelJson = readFileSync(new URL('../vercel.json', import.meta.url), 'utf8')
+
+describe('action center follow-through mail cron config', () => {
+  it('adds exactly one bounded cron path for the mail dispatcher', () => {
+    expect(vercelJson).toMatch(/"crons"/)
+    expect(vercelJson).toMatch(/"path"\s*:\s*"\/api\/action-center-follow-through-mails"/)
+  })
+})

--- a/frontend/lib/action-center-follow-through-mail-data.test.ts
+++ b/frontend/lib/action-center-follow-through-mail-data.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: () => ({
+    from: vi.fn(),
+  }),
+}))
+
+import { buildActionCenterFollowThroughMailRouteSnapshot } from './action-center-follow-through-mail-data'
+
+describe('action center follow-through mail data', () => {
+  it('rejects non-ExitScan routes before they enter the mail planner', () => {
+    expect(
+      buildActionCenterFollowThroughMailRouteSnapshot({
+        routeId: 'camp-2::org::support',
+        scanType: 'retention',
+        routeStatus: 'reviewbaar',
+      }),
+    ).toEqual({
+      ok: false,
+      reason: 'unsupported-route',
+    })
+  })
+
+  it('keeps scoped HR oversight recipients bounded to writable review-rhythm actors only', () => {
+    const snapshot = buildActionCenterFollowThroughMailRouteSnapshot({
+      routeId: 'camp-1::org::sales',
+      routeScopeValue: 'org-1::department::sales',
+      scanType: 'exit',
+      routeStatus: 'reviewbaar',
+      hrRecipients: [
+        {
+          email: 'hr-owner@example.com',
+          role: 'hr_owner',
+          canUpdate: true,
+          canScheduleReview: true,
+          scopeType: 'department',
+          scopeValue: 'org-1::department::sales',
+        },
+        {
+          email: 'viewer@example.com',
+          role: 'viewer',
+          canUpdate: false,
+          canScheduleReview: false,
+          scopeType: 'department',
+          scopeValue: 'org-1::department::sales',
+        },
+      ],
+    })
+
+    expect(snapshot.ok && snapshot.value.hrOversightRecipients).toEqual([
+      { email: 'hr-owner@example.com', auditRole: 'hr_owner' },
+    ])
+  })
+})

--- a/frontend/lib/action-center-follow-through-mail-data.ts
+++ b/frontend/lib/action-center-follow-through-mail-data.ts
@@ -1,0 +1,387 @@
+import { getActionCenterPageData } from '@/lib/action-center-page-data'
+import {
+  buildDefaultActionCenterReviewRhythmConfig,
+  isActionCenterReviewRhythmSupportedScanType,
+  normalizeActionCenterReviewRhythmConfig,
+  type ActionCenterReviewRhythmConfig,
+} from '@/lib/action-center-review-rhythm'
+import { createAdminClient } from '@/lib/supabase/admin'
+import type { ActionCenterPreviewStatus } from '@/lib/action-center-preview-model'
+import type { ActionCenterReviewOutcome } from '@/lib/action-center-route-contract'
+import type {
+  ActionCenterWorkspaceMember,
+  SuiteAccessContext,
+  SuiteOrgMembership,
+} from '@/lib/suite-access'
+
+export interface ActionCenterFollowThroughMailManagerRecipient {
+  email: string
+  name: string | null
+}
+
+export interface ActionCenterFollowThroughMailHrOversightRecipient {
+  email: string
+  auditRole: 'hr_owner' | 'hr_member'
+}
+
+export interface ActionCenterFollowThroughMailRouteSnapshot {
+  routeId: string
+  routeScopeValue: string
+  orgId: string
+  campaignId: string
+  campaignName: string
+  scopeLabel: string
+  scanType: 'exit'
+  routeStatus: ActionCenterPreviewStatus
+  reviewScheduledFor: string | null
+  reviewCompletedAt: string | null
+  reviewOutcome: ActionCenterReviewOutcome
+  ownerAssignedAt: string | null
+  hasFollowUpTarget: boolean
+  remindersEnabled: boolean
+  cadenceDays: ActionCenterReviewRhythmConfig['cadenceDays']
+  reminderLeadDays: ActionCenterReviewRhythmConfig['reminderLeadDays']
+  escalationLeadDays: ActionCenterReviewRhythmConfig['escalationLeadDays']
+  managerRecipient: ActionCenterFollowThroughMailManagerRecipient | null
+  hrOversightRecipients: ActionCenterFollowThroughMailHrOversightRecipient[]
+}
+
+export type ActionCenterFollowThroughMailSnapshotBuildInput = {
+  routeId: string
+  routeScopeValue?: string | null
+  orgId?: string | null
+  campaignId?: string | null
+  campaignName?: string | null
+  scopeLabel?: string | null
+  scanType: string | null | undefined
+  routeStatus: ActionCenterPreviewStatus
+  reviewScheduledFor?: string | null
+  reviewCompletedAt?: string | null
+  reviewOutcome?: ActionCenterReviewOutcome | null
+  ownerAssignedAt?: string | null
+  hasFollowUpTarget?: boolean
+  managerRecipient?: ActionCenterFollowThroughMailManagerRecipient | null
+  hrRecipients?: Array<{
+    email: string | null
+    role: string
+    canUpdate: boolean
+    canScheduleReview: boolean
+    scopeType?: 'org' | 'department' | 'item'
+    scopeValue?: string | null
+  }>
+  config?: Partial<ActionCenterReviewRhythmConfig> | null
+}
+
+type ReviewRhythmRow = {
+  route_id: string | null
+  cadence_days: number | null
+  reminder_lead_days: number | null
+  escalation_lead_days: number | null
+  reminders_enabled: boolean | null
+}
+
+type WorkspaceMemberRow = Pick<
+  ActionCenterWorkspaceMember,
+  | 'org_id'
+  | 'user_id'
+  | 'display_name'
+  | 'login_email'
+  | 'access_role'
+  | 'scope_type'
+  | 'scope_value'
+  | 'can_view'
+  | 'can_update'
+  | 'can_schedule_review'
+>
+
+type CampaignRow = {
+  id: string
+  name: string
+  organization_id: string
+  scan_type: string
+}
+
+function normalizeText(value: string | null | undefined) {
+  const trimmed = value?.trim() ?? ''
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function normalizeEmail(value: string | null | undefined) {
+  return normalizeText(value)?.toLowerCase() ?? null
+}
+
+function normalizeConfig(
+  config: Partial<ActionCenterReviewRhythmConfig> | null | undefined,
+): ActionCenterReviewRhythmConfig {
+  const defaults = buildDefaultActionCenterReviewRhythmConfig()
+
+  return {
+    cadenceDays:
+      config?.cadenceDays === 7 || config?.cadenceDays === 30 ? config.cadenceDays : defaults.cadenceDays,
+    reminderLeadDays:
+      config?.reminderLeadDays === 1 || config?.reminderLeadDays === 5
+        ? config.reminderLeadDays
+        : defaults.reminderLeadDays,
+    escalationLeadDays:
+      config?.escalationLeadDays === 3 || config?.escalationLeadDays === 14
+        ? config.escalationLeadDays
+        : defaults.escalationLeadDays,
+    remindersEnabled: config?.remindersEnabled ?? defaults.remindersEnabled,
+  }
+}
+
+function getEligibleHrOversightRecipients(args: {
+  routeScopeValue: string
+  hrRecipients: NonNullable<ActionCenterFollowThroughMailSnapshotBuildInput['hrRecipients']>
+}) {
+  const eligible = args.hrRecipients.reduce<ActionCenterFollowThroughMailHrOversightRecipient[]>(
+    (acc, recipient) => {
+      const email = normalizeEmail(recipient.email)
+      const auditRole =
+        recipient.role === 'hr_owner' || recipient.role === 'hr_member' ? recipient.role : null
+
+      if (!email || !auditRole) return acc
+      if (!recipient.canUpdate || !recipient.canScheduleReview) return acc
+      const matchesScope =
+        recipient.scopeType === 'org' || recipient.scopeValue === args.routeScopeValue
+
+      if (!matchesScope) return acc
+      if (acc.some((entry) => entry.email === email)) return acc
+
+      acc.push({ email, auditRole })
+      return acc
+    },
+    [],
+  )
+
+  return eligible
+}
+
+export function buildActionCenterFollowThroughMailRouteSnapshot(
+  input: ActionCenterFollowThroughMailSnapshotBuildInput,
+):
+  | { ok: false; reason: 'unsupported-route' }
+  | { ok: true; value: ActionCenterFollowThroughMailRouteSnapshot } {
+  if (!isActionCenterReviewRhythmSupportedScanType(input.scanType)) {
+    return {
+      ok: false,
+      reason: 'unsupported-route',
+    }
+  }
+
+  const config = normalizeConfig(input.config)
+  const routeScopeValue = normalizeText(input.routeScopeValue) ?? 'unknown-scope'
+
+  return {
+    ok: true,
+    value: {
+      routeId: input.routeId,
+      routeScopeValue,
+      orgId: normalizeText(input.orgId) ?? 'unknown-org',
+      campaignId: normalizeText(input.campaignId) ?? input.routeId.split('::')[0] ?? input.routeId,
+      campaignName: normalizeText(input.campaignName) ?? 'ExitScan',
+      scopeLabel: normalizeText(input.scopeLabel) ?? routeScopeValue,
+      scanType: 'exit',
+      routeStatus: input.routeStatus,
+      reviewScheduledFor: normalizeText(input.reviewScheduledFor),
+      reviewCompletedAt: normalizeText(input.reviewCompletedAt),
+      reviewOutcome: input.reviewOutcome ?? 'geen-uitkomst',
+      ownerAssignedAt: normalizeText(input.ownerAssignedAt),
+      hasFollowUpTarget: input.hasFollowUpTarget ?? false,
+      remindersEnabled: config.remindersEnabled,
+      cadenceDays: config.cadenceDays,
+      reminderLeadDays: config.reminderLeadDays,
+      escalationLeadDays: config.escalationLeadDays,
+      managerRecipient: input.managerRecipient?.email
+        ? {
+            email: input.managerRecipient.email.trim().toLowerCase(),
+            name: input.managerRecipient.name ?? null,
+          }
+        : null,
+      hrOversightRecipients: getEligibleHrOversightRecipients({
+        routeScopeValue,
+        hrRecipients: input.hrRecipients ?? [],
+      }),
+    },
+  }
+}
+
+function buildManagerRecipient(
+  rows: WorkspaceMemberRow[],
+  orgId: string,
+  routeScopeValue: string,
+): ActionCenterFollowThroughMailManagerRecipient | null {
+  const assignment =
+    rows.find(
+      (row) =>
+        row.org_id === orgId &&
+        row.access_role === 'manager_assignee' &&
+        row.scope_value === routeScopeValue &&
+        row.can_view,
+    ) ?? null
+
+  const email = normalizeEmail(assignment?.login_email)
+  if (!email) return null
+
+  return {
+    email,
+    name: normalizeText(assignment?.display_name),
+  }
+}
+
+function buildHrRecipientInputs(
+  rows: WorkspaceMemberRow[],
+  orgId: string,
+) {
+  return rows
+    .filter(
+      (row) =>
+        row.org_id === orgId &&
+        (row.access_role === 'hr_owner' || row.access_role === 'hr_member') &&
+        row.can_view,
+    )
+    .map((row) => ({
+      email: row.login_email,
+      role: row.access_role,
+      canUpdate: row.can_update,
+      canScheduleReview: row.can_schedule_review,
+      scopeType: row.scope_type,
+      scopeValue: row.scope_value,
+    }))
+}
+
+export async function getActionCenterFollowThroughMailData(args: {
+  context: SuiteAccessContext
+  orgMemberships: SuiteOrgMembership[]
+  currentUserWorkspaceMemberships: ActionCenterWorkspaceMember[]
+}) {
+  const pageData = await getActionCenterPageData({
+    context: args.context,
+    orgMemberships: args.orgMemberships,
+    currentUserWorkspaceMemberships: args.currentUserWorkspaceMemberships,
+  })
+
+  const eligibleItems = pageData.items.filter((item) => item.sourceLabel === 'ExitScan')
+  if (eligibleItems.length === 0) {
+    return {
+      snapshots: [] as ActionCenterFollowThroughMailRouteSnapshot[],
+      routeIds: [] as string[],
+    }
+  }
+
+  const routeIds = eligibleItems.map((item) => item.id)
+  const campaignIds = [...new Set(eligibleItems.map((item) => item.coreSemantics.route.campaignId))]
+  const orgIds = [...new Set(eligibleItems.map((item) => item.orgId).filter((value): value is string => Boolean(value)))]
+  const admin = createAdminClient()
+
+  const [
+    workspaceRowsResult,
+    rhythmRowsResult,
+    campaignsResult,
+  ] = await Promise.all([
+    admin
+      .from('action_center_workspace_members')
+      .select(
+        'org_id, user_id, display_name, login_email, access_role, scope_type, scope_value, can_view, can_update, can_schedule_review',
+      )
+      .in('org_id', orgIds),
+    admin
+      .from('action_center_review_rhythm_configs')
+      .select('route_id, cadence_days, reminder_lead_days, escalation_lead_days, reminders_enabled')
+      .in('route_id', routeIds),
+    admin.from('campaigns').select('id, name, organization_id, scan_type').in('id', campaignIds),
+  ])
+
+  if (workspaceRowsResult.error) {
+    throw new Error(workspaceRowsResult.error.message ?? 'Action Center workspace members query failed.')
+  }
+  if (rhythmRowsResult.error) {
+    throw new Error(rhythmRowsResult.error.message ?? 'Action Center review rhythm query failed.')
+  }
+  if (campaignsResult.error) {
+    throw new Error(campaignsResult.error.message ?? 'Action Center campaign query failed.')
+  }
+
+  const workspaceRows = (workspaceRowsResult.data ?? []) as WorkspaceMemberRow[]
+  const campaignsById = new Map(
+    ((campaignsResult.data ?? []) as CampaignRow[]).map((campaign) => [campaign.id, campaign]),
+  )
+  const rhythmConfigByRouteId = ((rhythmRowsResult.data ?? []) as ReviewRhythmRow[]).reduce<
+    Record<string, ActionCenterReviewRhythmConfig>
+  >((acc, row) => {
+    if (!row.route_id) return acc
+
+    acc[row.route_id] = normalizeActionCenterReviewRhythmConfig({
+      cadence_days: row.cadence_days,
+      reminder_lead_days: row.reminder_lead_days,
+      escalation_lead_days: row.escalation_lead_days,
+      reminders_enabled: row.reminders_enabled,
+    })
+    return acc
+  }, {})
+
+  const snapshots = eligibleItems.flatMap((item) => {
+    const route = item.coreSemantics.route
+    const campaign = campaignsById.get(route.campaignId)
+    if (!campaign) return []
+
+    const snapshot = buildActionCenterFollowThroughMailRouteSnapshot({
+      routeId: item.id,
+      routeScopeValue: item.teamId,
+      orgId: item.orgId ?? campaign.organization_id,
+      campaignId: campaign.id,
+      campaignName: campaign.name,
+      scopeLabel: item.teamLabel,
+      scanType: campaign.scan_type,
+      routeStatus: item.status,
+      reviewScheduledFor: item.reviewDate,
+      reviewCompletedAt: route.reviewCompletedAt,
+      reviewOutcome: route.reviewOutcome,
+      ownerAssignedAt: route.ownerAssignedAt,
+      hasFollowUpTarget: route.hasFollowUpTarget,
+      managerRecipient: buildManagerRecipient(workspaceRows, campaign.organization_id, item.teamId),
+      hrRecipients: buildHrRecipientInputs(workspaceRows, campaign.organization_id),
+      config: rhythmConfigByRouteId[item.id] ?? buildDefaultActionCenterReviewRhythmConfig(),
+    })
+
+    return snapshot.ok ? [snapshot.value] : []
+  })
+
+  return { snapshots, routeIds }
+}
+
+export async function getActionCenterFollowThroughMailDispatchData() {
+  const admin = createAdminClient()
+  const { data, error } = await admin
+    .from('campaigns')
+    .select('organization_id')
+    .eq('scan_type', 'exit')
+
+  if (error) {
+    throw new Error(error.message ?? 'Action Center dispatch campaign discovery failed.')
+  }
+
+  const orgIds = [...new Set((data ?? []).map((row) => row.organization_id).filter(Boolean))]
+  const context: SuiteAccessContext = {
+    persona: 'verisight_admin',
+    isVerisightAdmin: true,
+    memberRole: null,
+    primaryOrgId: orgIds[0] ?? null,
+    organizationIds: orgIds,
+    workspaceOrgIds: orgIds,
+    managerScopeValues: [],
+    canViewInsights: true,
+    canViewReports: true,
+    canViewActionCenter: true,
+    canUpdateActionCenter: true,
+    canManageActionCenterAssignments: true,
+    canScheduleActionCenterReview: true,
+    managerOnly: false,
+  }
+
+  return getActionCenterFollowThroughMailData({
+    context,
+    orgMemberships: [],
+    currentUserWorkspaceMemberships: [],
+  })
+}

--- a/frontend/lib/action-center-follow-through-mail-delivery.test.ts
+++ b/frontend/lib/action-center-follow-through-mail-delivery.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest'
+import { deliverActionCenterFollowThroughMail } from './action-center-follow-through-mail-delivery'
+
+describe('action center follow-through mail delivery', () => {
+  it('posts a bounded Resend payload and returns the provider id', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 're_123' }),
+    })
+
+    const result = await deliverActionCenterFollowThroughMail(
+      {
+        recipientEmail: 'manager@example.com',
+        subject: 'Reviewmoment ExitScan Q2 / Sales',
+        emailText: 'Open Action Center',
+        emailHtml: '<p>Open Action Center</p>',
+      },
+      {
+        fetchImpl: fetchMock,
+        resendApiKey: 're_test',
+        emailFrom: 'Verisight <noreply@verisight.nl>',
+      },
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      providerMessageId: 're_123',
+    })
+  })
+})

--- a/frontend/lib/action-center-follow-through-mail-delivery.ts
+++ b/frontend/lib/action-center-follow-through-mail-delivery.ts
@@ -1,0 +1,70 @@
+export interface ActionCenterFollowThroughMailDeliveryPayload {
+  recipientEmail: string
+  subject: string
+  emailText: string
+  emailHtml: string
+}
+
+export interface ActionCenterFollowThroughMailDeliveryOptions {
+  fetchImpl?: typeof fetch
+  resendApiKey: string
+  emailFrom: string
+}
+
+export type ActionCenterFollowThroughMailDeliveryResult =
+  | { ok: true; providerMessageId: string | null }
+  | { ok: false; reason: string }
+
+export function getActionCenterFollowThroughMailEnv() {
+  return {
+    resendApiKey: process.env.RESEND_API_KEY?.trim() ?? '',
+    emailFrom: process.env.EMAIL_FROM?.trim() ?? 'Verisight <noreply@verisight.nl>',
+  }
+}
+
+export async function deliverActionCenterFollowThroughMail(
+  payload: ActionCenterFollowThroughMailDeliveryPayload,
+  options: ActionCenterFollowThroughMailDeliveryOptions,
+): Promise<ActionCenterFollowThroughMailDeliveryResult> {
+  const fetchImpl = options.fetchImpl ?? fetch
+
+  let response: Response
+  try {
+    response = await fetchImpl('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${options.resendApiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from: options.emailFrom,
+        to: [payload.recipientEmail],
+        subject: payload.subject,
+        text: payload.emailText,
+        html: payload.emailHtml,
+      }),
+      cache: 'no-store',
+    })
+  } catch (error) {
+    return {
+      ok: false,
+      reason: error instanceof Error ? error.message : 'resend_network_error',
+    }
+  }
+
+  if (!response.ok) {
+    const errorPayload = await response.json().catch(() => ({}))
+    const reason =
+      typeof errorPayload?.message === 'string'
+        ? errorPayload.message
+        : `resend_http_${response.status}`
+
+    return { ok: false, reason }
+  }
+
+  const body = (await response.json().catch(() => ({}))) as { id?: string | null }
+  return {
+    ok: true,
+    providerMessageId: body.id ?? null,
+  }
+}

--- a/frontend/lib/action-center-follow-through-mail-planner.test.ts
+++ b/frontend/lib/action-center-follow-through-mail-planner.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import { planActionCenterFollowThroughMailJobs } from './action-center-follow-through-mail-planner'
+
+describe('action center follow-through mail planner', () => {
+  const baseSnapshot = {
+    routeId: 'camp-1::org::sales',
+    routeScopeValue: 'org-1::department::sales',
+    orgId: 'org-1',
+    campaignId: 'camp-1',
+    campaignName: 'ExitScan Q2',
+    scopeLabel: 'Sales',
+    scanType: 'exit',
+    routeStatus: 'reviewbaar',
+    reviewScheduledFor: '2026-05-20',
+    reviewCompletedAt: null,
+    reviewOutcome: 'geen-uitkomst',
+    ownerAssignedAt: '2026-05-10T09:00:00.000Z',
+    hasFollowUpTarget: false,
+    remindersEnabled: true,
+    cadenceDays: 14,
+    reminderLeadDays: 3,
+    escalationLeadDays: 7,
+    managerRecipient: { email: 'manager@example.com', name: 'Manager' },
+    hrOversightRecipients: [{ email: 'hr-owner@example.com', auditRole: 'hr_owner' }],
+  } as const
+
+  it('emits assignment-created once per owner-assignment marker', () => {
+    const result = planActionCenterFollowThroughMailJobs({
+      now: new Date('2026-05-12T08:00:00.000Z'),
+      snapshots: [baseSnapshot],
+      existingDedupeKeys: new Set<string>(),
+    })
+
+    expect(result.jobs.some((job) => job.triggerType === 'assignment_created')).toBe(true)
+  })
+
+  it('suppresses review-upcoming when the review moved outside the current reminder window', () => {
+    const result = planActionCenterFollowThroughMailJobs({
+      now: new Date('2026-05-01T08:00:00.000Z'),
+      snapshots: [baseSnapshot],
+      existingDedupeKeys: new Set<string>(),
+    })
+
+    expect(result.jobs.some((job) => job.triggerType === 'review_upcoming')).toBe(false)
+  })
+
+  it('adds an HR oversight variant when review-overdue crosses the escalation window', () => {
+    const result = planActionCenterFollowThroughMailJobs({
+      now: new Date('2026-05-29T08:00:00.000Z'),
+      snapshots: [baseSnapshot],
+      existingDedupeKeys: new Set<string>(),
+    })
+
+    expect(
+      result.jobs.filter((job) => job.triggerType === 'review_overdue').map((job) => job.recipientRole),
+    ).toEqual(expect.arrayContaining(['manager', 'hr_oversight']))
+  })
+
+  it('suppresses follow-up-open-after-review when the route already has a successor', () => {
+    const result = planActionCenterFollowThroughMailJobs({
+      now: new Date('2026-06-10T08:00:00.000Z'),
+      snapshots: [
+        {
+          ...baseSnapshot,
+          reviewCompletedAt: '2026-05-25T12:00:00.000Z',
+          reviewOutcome: 'doorgaan',
+          hasFollowUpTarget: true,
+        },
+      ],
+      existingDedupeKeys: new Set<string>(),
+    })
+
+    expect(result.jobs.some((job) => job.triggerType === 'follow_up_open_after_review')).toBe(false)
+  })
+
+  it('keeps manager and hr-overdue variants distinct when they share one mailbox', () => {
+    const result = planActionCenterFollowThroughMailJobs({
+      now: new Date('2026-05-29T08:00:00.000Z'),
+      snapshots: [
+        {
+          ...baseSnapshot,
+          hrOversightRecipients: [{ email: 'manager@example.com', auditRole: 'hr_owner' }],
+        },
+      ],
+      existingDedupeKeys: new Set<string>(),
+    })
+
+    expect(
+      result.jobs
+        .filter((job) => job.triggerType === 'review_overdue')
+        .map((job) => `${job.recipientRole}:${job.dedupeKey}`),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('manager'),
+        expect.stringContaining('hr_oversight'),
+      ]),
+    )
+  })
+})

--- a/frontend/lib/action-center-follow-through-mail-planner.ts
+++ b/frontend/lib/action-center-follow-through-mail-planner.ts
@@ -1,0 +1,241 @@
+import {
+  buildActionCenterFollowThroughMailDedupeKey,
+  getActionCenterFollowThroughMailSuppressionReason,
+  type ActionCenterFollowThroughMailSuppressionReason,
+  type ActionCenterFollowThroughMailTriggerType,
+} from '@/lib/action-center-follow-through-mail'
+import type { ActionCenterFollowThroughMailRouteSnapshot } from '@/lib/action-center-follow-through-mail-data'
+
+export interface ActionCenterFollowThroughMailPlannedJob {
+  routeId: string
+  orgId: string
+  campaignId: string
+  campaignName: string
+  scopeLabel: string
+  routeScopeValue: string
+  triggerType: ActionCenterFollowThroughMailTriggerType
+  recipientRole: 'manager' | 'hr_oversight'
+  recipientEmail: string
+  recipientName: string | null
+  sourceMarker: string
+  dedupeKey: string
+  reviewScheduledFor: string | null
+}
+
+export interface ActionCenterFollowThroughMailSuppressedJob {
+  routeId: string
+  orgId: string
+  campaignId: string
+  campaignName: string
+  scopeLabel: string
+  routeScopeValue: string
+  triggerType: ActionCenterFollowThroughMailTriggerType
+  recipientRole: 'manager' | 'hr_oversight'
+  recipientEmail: string | null
+  recipientName: string | null
+  sourceMarker: string | null
+  suppressionReason: ActionCenterFollowThroughMailSuppressionReason
+  reviewScheduledFor: string | null
+}
+
+function getUtcDayDiff(dateValue: string, now: Date) {
+  const [year, month, day] = dateValue.split('-').map((value) => Number(value))
+  if (!year || !month || !day) return null
+
+  const targetDay = Date.UTC(year, month - 1, day)
+  const nowDay = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+
+  return Math.round((nowDay - targetDay) / 86_400_000)
+}
+
+function isResolvedRoute(snapshot: ActionCenterFollowThroughMailRouteSnapshot) {
+  return (
+    snapshot.routeStatus === 'afgerond' ||
+    snapshot.routeStatus === 'gestopt' ||
+    snapshot.reviewOutcome === 'afronden' ||
+    snapshot.reviewOutcome === 'stoppen' ||
+    snapshot.hasFollowUpTarget
+  )
+}
+
+function pushJob(args: {
+  jobs: ActionCenterFollowThroughMailPlannedJob[]
+  suppressions: ActionCenterFollowThroughMailSuppressedJob[]
+  existingDedupeKeys: Set<string>
+  snapshot: ActionCenterFollowThroughMailRouteSnapshot
+  triggerType: ActionCenterFollowThroughMailTriggerType
+  recipientRole: 'manager' | 'hr_oversight'
+  recipientEmail: string | null
+  recipientName?: string | null
+  sourceMarker: string | null
+}) {
+  if (!args.recipientEmail || !args.sourceMarker) return
+
+  const suppressionReason = getActionCenterFollowThroughMailSuppressionReason({
+    triggerType: args.triggerType,
+    remindersEnabled: args.snapshot.remindersEnabled,
+    routeStatus: args.snapshot.routeStatus,
+    reviewCompletedAt: args.snapshot.reviewCompletedAt,
+    reviewScheduledFor: args.snapshot.reviewScheduledFor,
+    reviewOutcome: args.snapshot.reviewOutcome,
+    hasFollowUpTarget: args.snapshot.hasFollowUpTarget,
+  })
+
+  if (suppressionReason) {
+    args.suppressions.push({
+      routeId: args.snapshot.routeId,
+      orgId: args.snapshot.orgId,
+      campaignId: args.snapshot.campaignId,
+      campaignName: args.snapshot.campaignName,
+      scopeLabel: args.snapshot.scopeLabel,
+      routeScopeValue: args.snapshot.routeScopeValue,
+      triggerType: args.triggerType,
+      recipientRole: args.recipientRole,
+      recipientEmail: args.recipientEmail,
+      recipientName: args.recipientName ?? null,
+      sourceMarker: args.sourceMarker,
+      suppressionReason,
+      reviewScheduledFor: args.snapshot.reviewScheduledFor,
+    })
+    return
+  }
+
+  const dedupeKey = buildActionCenterFollowThroughMailDedupeKey({
+    routeId: args.snapshot.routeId,
+    triggerType: args.triggerType,
+    recipientEmail: args.recipientEmail,
+    sourceMarker: args.sourceMarker,
+  })
+
+  if (args.existingDedupeKeys.has(dedupeKey)) return
+  args.existingDedupeKeys.add(dedupeKey)
+
+  args.jobs.push({
+    routeId: args.snapshot.routeId,
+    orgId: args.snapshot.orgId,
+    campaignId: args.snapshot.campaignId,
+    campaignName: args.snapshot.campaignName,
+    scopeLabel: args.snapshot.scopeLabel,
+    routeScopeValue: args.snapshot.routeScopeValue,
+    triggerType: args.triggerType,
+    recipientRole: args.recipientRole,
+    recipientEmail: args.recipientEmail,
+    recipientName: args.recipientName ?? null,
+    sourceMarker: args.sourceMarker,
+    dedupeKey,
+    reviewScheduledFor: args.snapshot.reviewScheduledFor,
+  })
+}
+
+export function planActionCenterFollowThroughMailJobs(args: {
+  now: Date
+  snapshots: readonly ActionCenterFollowThroughMailRouteSnapshot[]
+  existingDedupeKeys: ReadonlySet<string>
+}) {
+  const jobs: ActionCenterFollowThroughMailPlannedJob[] = []
+  const suppressions: ActionCenterFollowThroughMailSuppressedJob[] = []
+  const activeDedupeKeys = new Set(args.existingDedupeKeys)
+
+  for (const snapshot of args.snapshots) {
+    if (isResolvedRoute(snapshot) && snapshot.reviewCompletedAt) {
+      continue
+    }
+
+    pushJob({
+      jobs,
+      suppressions,
+      existingDedupeKeys: activeDedupeKeys,
+      snapshot,
+      triggerType: 'assignment_created',
+      recipientRole: 'manager',
+      recipientEmail: snapshot.managerRecipient?.email ?? null,
+      recipientName: snapshot.managerRecipient?.name ?? null,
+      sourceMarker: snapshot.ownerAssignedAt,
+    })
+
+    if (snapshot.reviewScheduledFor) {
+      const dayDiff = getUtcDayDiff(snapshot.reviewScheduledFor, args.now)
+      if (dayDiff !== null) {
+        const daysUntilReview = -dayDiff
+        if (
+          daysUntilReview >= 0 &&
+          daysUntilReview <= snapshot.reminderLeadDays &&
+          snapshot.remindersEnabled
+        ) {
+          pushJob({
+            jobs,
+            suppressions,
+            existingDedupeKeys: activeDedupeKeys,
+            snapshot,
+            triggerType: 'review_upcoming',
+            recipientRole: 'manager',
+            recipientEmail: snapshot.managerRecipient?.email ?? null,
+            recipientName: snapshot.managerRecipient?.name ?? null,
+            sourceMarker: snapshot.reviewScheduledFor,
+          })
+        }
+
+        if (dayDiff > 0 && !snapshot.reviewCompletedAt && !isResolvedRoute(snapshot)) {
+          pushJob({
+            jobs,
+            suppressions,
+            existingDedupeKeys: activeDedupeKeys,
+            snapshot,
+            triggerType: 'review_overdue',
+            recipientRole: 'manager',
+            recipientEmail: snapshot.managerRecipient?.email ?? null,
+            recipientName: snapshot.managerRecipient?.name ?? null,
+            sourceMarker: `${snapshot.reviewScheduledFor}::manager`,
+          })
+
+          if (dayDiff >= snapshot.escalationLeadDays) {
+            for (const recipient of snapshot.hrOversightRecipients) {
+              pushJob({
+                jobs,
+                suppressions,
+                existingDedupeKeys: activeDedupeKeys,
+                snapshot,
+                triggerType: 'review_overdue',
+                recipientRole: 'hr_oversight',
+                recipientEmail: recipient.email,
+                sourceMarker: `${snapshot.reviewScheduledFor}::hr_oversight`,
+              })
+            }
+          }
+        }
+      }
+    }
+
+    if (
+      snapshot.reviewCompletedAt &&
+      snapshot.reviewOutcome !== 'afronden' &&
+      snapshot.reviewOutcome !== 'stoppen' &&
+      !snapshot.hasFollowUpTarget &&
+      !isResolvedRoute(snapshot)
+    ) {
+      const completedAt = new Date(snapshot.reviewCompletedAt)
+      if (!Number.isNaN(completedAt.getTime())) {
+        const daysSinceReviewComplete = Math.floor(
+          (args.now.getTime() - completedAt.getTime()) / 86_400_000,
+        )
+
+        if (daysSinceReviewComplete >= snapshot.escalationLeadDays) {
+          for (const recipient of snapshot.hrOversightRecipients) {
+            pushJob({
+              jobs,
+              suppressions,
+              existingDedupeKeys: activeDedupeKeys,
+              snapshot,
+              triggerType: 'follow_up_open_after_review',
+              recipientRole: 'hr_oversight',
+              recipientEmail: recipient.email,
+              sourceMarker: snapshot.reviewCompletedAt,
+            })
+          }
+        }
+      }
+    }
+  }
+
+  return { jobs, suppressions }
+}

--- a/frontend/lib/action-center-follow-through-mail-policy.test.ts
+++ b/frontend/lib/action-center-follow-through-mail-policy.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const schemaPath = fileURLToPath(new URL('../../supabase/schema.sql', import.meta.url))
+const schemaSql = readFileSync(schemaPath, 'utf8')
+
+describe('action center follow-through mail schema policy', () => {
+  it('defines a bounded ledger table with dedupe uniqueness and service-only policies', () => {
+    expect(schemaSql).toMatch(/create table if not exists public\.action_center_follow_through_mail_events/i)
+    expect(schemaSql).toMatch(/trigger_type\s+text\s+not null/i)
+    expect(schemaSql).toMatch(/recipient_email\s+text\s+not null/i)
+    expect(schemaSql).toMatch(/dedupe_key\s+text\s+not null/i)
+    expect(schemaSql).toMatch(/delivery_status\s+text\s+not null/i)
+    expect(schemaSql).toMatch(/unique\s*\(\s*dedupe_key\s*\)/i)
+    expect(schemaSql).toMatch(/create policy "service_role_can_select_action_center_follow_through_mail_events"/i)
+    expect(schemaSql).toMatch(/create policy "service_role_can_insert_action_center_follow_through_mail_events"/i)
+  })
+})

--- a/frontend/lib/action-center-follow-through-mail-render.test.ts
+++ b/frontend/lib/action-center-follow-through-mail-render.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { renderActionCenterFollowThroughMail } from './action-center-follow-through-mail-render'
+
+describe('action center follow-through mail render', () => {
+  it('renders a bounded review-upcoming mail with contextual deeplink and invite artifact link', () => {
+    const rendered = renderActionCenterFollowThroughMail({
+      triggerType: 'review_upcoming',
+      recipientRole: 'manager',
+      campaignName: 'ExitScan Q2',
+      scopeLabel: 'Sales',
+      actionCenterHref: 'https://app.verisight.nl/dashboard/action-center?focus=review-1&view=reviews&source=notification',
+      inviteArtifactHref: 'https://app.verisight.nl/api/action-center-review-invites?reviewItemId=review-1&format=ics',
+    })
+
+    expect(rendered.subject).toContain('Reviewmoment')
+    expect(rendered.emailText).toContain('Action Center')
+    expect(rendered.emailText).toContain('https://app.verisight.nl/dashboard/action-center')
+    expect(rendered.emailHtml).toContain('format=ics')
+  })
+
+  it('does not instruct recipients to confirm or reschedule by email', () => {
+    const rendered = renderActionCenterFollowThroughMail({
+      triggerType: 'review_overdue',
+      recipientRole: 'manager',
+      campaignName: 'ExitScan Q2',
+      scopeLabel: 'Sales',
+      actionCenterHref: 'https://app.verisight.nl/dashboard/action-center?focus=review-1&view=reviews&source=notification',
+    })
+
+    expect(rendered.emailText).not.toMatch(/reply|beantwoord|mail terug|reschedule|verplaats/i)
+  })
+})

--- a/frontend/lib/action-center-follow-through-mail-render.ts
+++ b/frontend/lib/action-center-follow-through-mail-render.ts
@@ -1,0 +1,70 @@
+import type { ActionCenterFollowThroughMailTriggerType } from '@/lib/action-center-follow-through-mail'
+
+export interface ActionCenterFollowThroughMailRenderInput {
+  triggerType: ActionCenterFollowThroughMailTriggerType
+  recipientRole: 'manager' | 'hr_oversight'
+  campaignName: string
+  scopeLabel: string
+  actionCenterHref: string
+  inviteArtifactHref?: string | null
+}
+
+export interface ActionCenterFollowThroughMailRendered {
+  subject: string
+  emailText: string
+  emailHtml: string
+}
+
+function buildSubject(args: Pick<ActionCenterFollowThroughMailRenderInput, 'triggerType' | 'campaignName' | 'scopeLabel'>) {
+  switch (args.triggerType) {
+    case 'assignment_created':
+      return `Nieuwe Action Center-route ${args.campaignName} / ${args.scopeLabel}`
+    case 'review_upcoming':
+      return `Reviewmoment ${args.campaignName} / ${args.scopeLabel}`
+    case 'review_overdue':
+      return `Review achterstallig ${args.campaignName} / ${args.scopeLabel}`
+    case 'follow_up_open_after_review':
+      return `Open follow-up na review ${args.campaignName} / ${args.scopeLabel}`
+  }
+}
+
+function buildLead(args: Pick<ActionCenterFollowThroughMailRenderInput, 'triggerType' | 'recipientRole'>) {
+  switch (args.triggerType) {
+    case 'assignment_created':
+      return 'Er staat een nieuwe toegewezen route klaar die aandacht vraagt in Action Center.'
+    case 'review_upcoming':
+      return 'Het geplande reviewmoment komt eraan. Open dit reviewmoment in Action Center.'
+    case 'review_overdue':
+      return args.recipientRole === 'manager'
+        ? 'Het geplande reviewmoment is verstreken en vraagt nu aandacht in Action Center.'
+        : 'Een reviewmoment blijft achterstallig en vraagt HR-oversight in Action Center.'
+    case 'follow_up_open_after_review':
+      return 'De review is vastgelegd, maar de route blijft open en vraagt nog bounded vervolg in Action Center.'
+  }
+}
+
+export function renderActionCenterFollowThroughMail(
+  args: ActionCenterFollowThroughMailRenderInput,
+): ActionCenterFollowThroughMailRendered {
+  const subject = buildSubject(args)
+  const lead = buildLead(args)
+  const instruction = 'Leg status, reviewuitkomst en vervolg alleen in Action Center vast.'
+  const artifactBlock = args.inviteArtifactHref
+    ? `Download desgewenst het bestaande agenda-artifact: ${args.inviteArtifactHref}`
+    : null
+
+  return {
+    subject,
+    emailText: [lead, `Open Action Center: ${args.actionCenterHref}`, artifactBlock, instruction]
+      .filter(Boolean)
+      .join('\n\n'),
+    emailHtml: [
+      `<p>${lead}</p>`,
+      `<p>Open <a href="${args.actionCenterHref}">Action Center</a>.</p>`,
+      args.inviteArtifactHref
+        ? `<p>Download desgewenst het bestaande <a href="${args.inviteArtifactHref}">agenda-artifact</a>.</p>`
+        : '',
+      `<p>${instruction}</p>`,
+    ].join(''),
+  }
+}

--- a/frontend/lib/action-center-follow-through-mail.test.ts
+++ b/frontend/lib/action-center-follow-through-mail.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  ACTION_CENTER_FOLLOW_THROUGH_TRIGGER_TYPES,
+  buildActionCenterFollowThroughMailDedupeKey,
+  getActionCenterFollowThroughMailSuppressionReason,
+} from './action-center-follow-through-mail'
+
+describe('action center follow-through mail contract', () => {
+  it('exposes the bounded phase-1 trigger families only', () => {
+    expect(ACTION_CENTER_FOLLOW_THROUGH_TRIGGER_TYPES).toEqual([
+      'assignment_created',
+      'review_upcoming',
+      'review_overdue',
+      'follow_up_open_after_review',
+    ])
+  })
+
+  it('builds a stable dedupe key from route, trigger family, recipient, and canonical source marker', () => {
+    expect(
+      buildActionCenterFollowThroughMailDedupeKey({
+        routeId: 'camp-1::org::sales',
+        triggerType: 'review_upcoming',
+        recipientEmail: 'manager@example.com',
+        sourceMarker: '2026-05-20',
+      }),
+    ).toBe('camp-1::org::sales::review_upcoming::manager@example.com::2026-05-20')
+  })
+
+  it('suppresses review-upcoming reminders when reminders are disabled', () => {
+    expect(
+      getActionCenterFollowThroughMailSuppressionReason({
+        triggerType: 'review_upcoming',
+        remindersEnabled: false,
+        routeStatus: 'reviewbaar',
+        reviewCompletedAt: null,
+        reviewScheduledFor: '2026-05-20',
+        reviewOutcome: 'geen-uitkomst',
+      }),
+    ).toBe('reminders-disabled')
+  })
+
+  it('suppresses follow-up-open-after-review when the route is already closed or resolved', () => {
+    expect(
+      getActionCenterFollowThroughMailSuppressionReason({
+        triggerType: 'follow_up_open_after_review',
+        remindersEnabled: true,
+        routeStatus: 'afgerond',
+        reviewCompletedAt: '2026-05-10T12:00:00.000Z',
+        reviewScheduledFor: '2026-05-09',
+        reviewOutcome: 'afronden',
+        hasFollowUpTarget: true,
+      }),
+    ).toBe('route-resolved')
+  })
+})

--- a/frontend/lib/action-center-follow-through-mail.ts
+++ b/frontend/lib/action-center-follow-through-mail.ts
@@ -1,0 +1,182 @@
+import type {
+  ActionCenterAggregatedRouteStatus,
+  ActionCenterReviewOutcome,
+  ActionCenterRouteStatus,
+} from './action-center-route-contract'
+import { isActionCenterReviewRhythmSupportedScanType } from './action-center-review-rhythm'
+
+export const ACTION_CENTER_FOLLOW_THROUGH_TRIGGER_TYPES = [
+  'assignment_created',
+  'review_upcoming',
+  'review_overdue',
+  'follow_up_open_after_review',
+] as const
+
+export type ActionCenterFollowThroughTriggerType =
+  (typeof ACTION_CENTER_FOLLOW_THROUGH_TRIGGER_TYPES)[number]
+
+export type ActionCenterFollowThroughMailTriggerType = ActionCenterFollowThroughTriggerType
+
+export const ACTION_CENTER_FOLLOW_THROUGH_RECIPIENT_ROLES = ['manager', 'hr_oversight'] as const
+
+export type ActionCenterFollowThroughRecipientRole =
+  (typeof ACTION_CENTER_FOLLOW_THROUGH_RECIPIENT_ROLES)[number]
+
+export type ActionCenterFollowThroughMailRecipientRole = ActionCenterFollowThroughRecipientRole
+
+export const ACTION_CENTER_FOLLOW_THROUGH_DELIVERY_STATUSES = ['sent', 'suppressed', 'failed'] as const
+
+export type ActionCenterFollowThroughDeliveryStatus =
+  (typeof ACTION_CENTER_FOLLOW_THROUGH_DELIVERY_STATUSES)[number]
+
+export const ACTION_CENTER_FOLLOW_THROUGH_MAIL_SUPPRESSION_REASONS = [
+  'reminders-disabled',
+  'route-closed',
+  'review-completed',
+  'route-resolved',
+  'missing-recipient',
+  'unsupported-route',
+  'stale-schedule',
+  'duplicate',
+] as const
+
+export type ActionCenterFollowThroughMailSuppressionReason =
+  (typeof ACTION_CENTER_FOLLOW_THROUGH_MAIL_SUPPRESSION_REASONS)[number]
+
+export interface ActionCenterFollowThroughMailLedgerRecord {
+  orgId: string
+  routeId: string
+  routeScopeValue: string
+  routeSourceId: string
+  scanType: 'exit'
+  triggerType: ActionCenterFollowThroughTriggerType
+  recipientRole: ActionCenterFollowThroughRecipientRole
+  recipientEmail: string
+  sourceMarker: string
+  dedupeKey: string
+  deliveryStatus: ActionCenterFollowThroughDeliveryStatus
+  suppressionReason: ActionCenterFollowThroughMailSuppressionReason | null
+  providerMessageId: string | null
+  sentAt: string | null
+}
+
+type ActionCenterFollowThroughMailRouteStatus =
+  | ActionCenterRouteStatus
+  | ActionCenterAggregatedRouteStatus
+  | null
+  | undefined
+
+export interface BuildActionCenterFollowThroughMailDedupeKeyArgs {
+  routeId: string
+  triggerType: ActionCenterFollowThroughTriggerType
+  recipientEmail: string
+  sourceMarker: string
+}
+
+export interface GetActionCenterFollowThroughMailSuppressionReasonArgs {
+  triggerType: ActionCenterFollowThroughTriggerType
+  remindersEnabled: boolean
+  routeStatus: ActionCenterFollowThroughMailRouteStatus
+  reviewCompletedAt: string | null
+  reviewScheduledFor: string | null
+  reviewOutcome: ActionCenterReviewOutcome
+  scanType?: string | null
+  recipientEmail?: string | null
+  hasFollowUpTarget?: boolean
+  isDuplicate?: boolean
+  isStaleSchedule?: boolean
+}
+
+function normalizeEmail(email: string) {
+  return email.trim().toLowerCase()
+}
+
+function hasText(value: string | null | undefined) {
+  return (value?.trim().length ?? 0) > 0
+}
+
+export function buildActionCenterFollowThroughMailDedupeKey(
+  args: BuildActionCenterFollowThroughMailDedupeKeyArgs,
+) {
+  return [
+    args.routeId,
+    args.triggerType,
+    normalizeEmail(args.recipientEmail),
+    args.sourceMarker.trim(),
+  ].join('::')
+}
+
+export function isActionCenterFollowThroughMailRouteClosed(routeStatus: ActionCenterFollowThroughMailRouteStatus) {
+  return routeStatus === 'afgerond' || routeStatus === 'gestopt'
+}
+
+export function isActionCenterFollowThroughMailRouteResolved(args: {
+  routeStatus: ActionCenterFollowThroughMailRouteStatus
+  reviewOutcome: ActionCenterReviewOutcome
+  hasFollowUpTarget?: boolean
+}) {
+  if (isActionCenterFollowThroughMailRouteClosed(args.routeStatus)) {
+    return true
+  }
+
+  return (
+    args.reviewOutcome === 'afronden' ||
+    args.reviewOutcome === 'stoppen' ||
+    args.hasFollowUpTarget === true
+  )
+}
+
+export function getActionCenterFollowThroughMailSuppressionReason(
+  args: GetActionCenterFollowThroughMailSuppressionReasonArgs,
+): ActionCenterFollowThroughMailSuppressionReason | null {
+  if (args.scanType && !isActionCenterReviewRhythmSupportedScanType(args.scanType)) {
+    return 'unsupported-route'
+  }
+
+  if (args.isDuplicate) {
+    return 'duplicate'
+  }
+
+  if (args.isStaleSchedule) {
+    return 'stale-schedule'
+  }
+
+  if (args.recipientEmail !== undefined && !hasText(args.recipientEmail)) {
+    return 'missing-recipient'
+  }
+
+  if (args.triggerType === 'review_upcoming' && !args.remindersEnabled) {
+    return 'reminders-disabled'
+  }
+
+  if (args.triggerType === 'follow_up_open_after_review') {
+    if (
+      isActionCenterFollowThroughMailRouteResolved({
+        routeStatus: args.routeStatus,
+        reviewOutcome: args.reviewOutcome,
+        hasFollowUpTarget: args.hasFollowUpTarget,
+      })
+    ) {
+      return 'route-resolved'
+    }
+
+    return null
+  }
+
+  if (isActionCenterFollowThroughMailRouteClosed(args.routeStatus)) {
+    return 'route-closed'
+  }
+
+  if (hasText(args.reviewCompletedAt)) {
+    return 'review-completed'
+  }
+
+  if (
+    (args.triggerType === 'review_upcoming' || args.triggerType === 'review_overdue') &&
+    !hasText(args.reviewScheduledFor)
+  ) {
+    return 'stale-schedule'
+  }
+
+  return null
+}

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -2,5 +2,11 @@
   "framework": "nextjs",
   "buildCommand": "npm run build",
   "devCommand": "npm run dev",
-  "installCommand": "npm install"
+  "installCommand": "npm install",
+  "crons": [
+    {
+      "path": "/api/action-center-follow-through-mails",
+      "schedule": "0 7 * * *"
+    }
+  ]
 }

--- a/supabase/action_center_follow_through_mail_layer.sql
+++ b/supabase/action_center_follow_through_mail_layer.sql
@@ -1,0 +1,45 @@
+create table if not exists public.action_center_follow_through_mail_events (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid references public.organizations(id) on delete cascade not null,
+  route_id text not null,
+  route_scope_value text not null,
+  route_source_id uuid references public.campaigns(id) on delete cascade not null,
+  scan_type text not null
+    check (scan_type in ('exit')),
+  trigger_type text not null
+    check (trigger_type in ('assignment_created', 'review_upcoming', 'review_overdue', 'follow_up_open_after_review')),
+  recipient_role text not null
+    check (recipient_role in ('manager', 'hr_oversight')),
+  recipient_email text not null,
+  source_marker text not null,
+  dedupe_key text not null,
+  delivery_status text not null
+    check (delivery_status in ('sent', 'suppressed', 'failed')),
+  suppression_reason text,
+  provider_message_id text,
+  sent_at timestamptz,
+  created_at timestamptz not null default now(),
+  unique (dedupe_key)
+);
+
+create index if not exists idx_action_center_follow_through_mail_events_org
+  on public.action_center_follow_through_mail_events(org_id, created_at desc);
+
+create index if not exists idx_action_center_follow_through_mail_events_route
+  on public.action_center_follow_through_mail_events(route_id, trigger_type);
+
+alter table public.action_center_follow_through_mail_events enable row level security;
+
+drop policy if exists "service_role_can_select_action_center_follow_through_mail_events" on public.action_center_follow_through_mail_events;
+create policy "service_role_can_select_action_center_follow_through_mail_events"
+  on public.action_center_follow_through_mail_events for select
+  to service_role
+  using (true);
+
+drop policy if exists "service_role_can_insert_action_center_follow_through_mail_events" on public.action_center_follow_through_mail_events;
+create policy "service_role_can_insert_action_center_follow_through_mail_events"
+  on public.action_center_follow_through_mail_events for insert
+  to service_role
+  with check (true);
+
+notify pgrst, 'reload schema';

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -725,6 +725,30 @@ create table if not exists public.action_center_review_rhythm_configs (
   unique (route_id)
 );
 
+create table if not exists public.action_center_follow_through_mail_events (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid references public.organizations(id) on delete cascade not null,
+  route_id text not null,
+  route_scope_value text not null,
+  route_source_id uuid references public.campaigns(id) on delete cascade not null,
+  scan_type text not null
+    check (scan_type in ('exit')),
+  trigger_type text not null
+    check (trigger_type in ('assignment_created', 'review_upcoming', 'review_overdue', 'follow_up_open_after_review')),
+  recipient_role text not null
+    check (recipient_role in ('manager', 'hr_oversight')),
+  recipient_email text not null,
+  source_marker text not null,
+  dedupe_key text not null,
+  delivery_status text not null
+    check (delivery_status in ('sent', 'suppressed', 'failed')),
+  suppression_reason text,
+  provider_message_id text,
+  sent_at timestamptz,
+  created_at timestamptz not null default now(),
+  unique (dedupe_key)
+);
+
 -- ============================================================
 -- INDEXES
 -- ============================================================
@@ -756,6 +780,10 @@ create unique index if not exists idx_action_center_route_relations_active_direc
 create index if not exists idx_action_center_review_rhythm_configs_org on public.action_center_review_rhythm_configs(org_id);
 create index if not exists idx_action_center_review_rhythm_configs_route_source
   on public.action_center_review_rhythm_configs(route_source_type, route_source_id);
+create index if not exists idx_action_center_follow_through_mail_events_org
+  on public.action_center_follow_through_mail_events(org_id, created_at desc);
+create index if not exists idx_action_center_follow_through_mail_events_route
+  on public.action_center_follow_through_mail_events(route_id, trigger_type);
 create index if not exists idx_delivery_records_org on public.campaign_delivery_records(organization_id);
 create index if not exists idx_delivery_records_contact_request on public.campaign_delivery_records(contact_request_id);
 create index if not exists idx_delivery_records_lifecycle on public.campaign_delivery_records(lifecycle_stage);
@@ -781,6 +809,7 @@ alter table public.action_center_review_decisions enable row level security;
 alter table public.action_center_manager_responses enable row level security;
 alter table public.action_center_route_relations enable row level security;
 alter table public.action_center_review_rhythm_configs enable row level security;
+alter table public.action_center_follow_through_mail_events enable row level security;
 
 -- ── Hulpfuncties ─────────────────────────────────────────────────────────────
 
@@ -1397,6 +1426,19 @@ create policy "hr_and_admins_can_update_action_center_review_rhythm_configs"
         and m.can_schedule_review
     )
   );
+
+drop policy if exists "service_role_can_select_action_center_follow_through_mail_events" on public.action_center_follow_through_mail_events;
+drop policy if exists "service_role_can_insert_action_center_follow_through_mail_events" on public.action_center_follow_through_mail_events;
+
+create policy "service_role_can_select_action_center_follow_through_mail_events"
+  on public.action_center_follow_through_mail_events for select
+  to service_role
+  using (true);
+
+create policy "service_role_can_insert_action_center_follow_through_mail_events"
+  on public.action_center_follow_through_mail_events for insert
+  to service_role
+  with check (true);
 
 -- ============================================================
 -- PROFILES: is_verisight_admin per gebruiker


### PR DESCRIPTION
## What changed
Adds the bounded Action Center follow-through mail layer for eligible ExitScan routes.

This PR introduces:
- a dedicated follow-through mail ledger in Supabase
- server-side route loading and trigger planning for the four phase-1 trigger families
- bounded mail rendering and Resend delivery helpers
- an internal dispatch route for dry-run and dispatch execution
- a daily Vercel cron entry for the dispatcher
- targeted tests for contract, planner, render, delivery, route auth, and cron wiring

## Why this changed
Action Center already had contextual entry, review invite artifacts, and HR rhythm configuration, but it still depended on managers or HR actively revisiting the dashboard.

This slice externalizes the first bounded rhythm layer without turning Action Center into a workflow engine:
- assignment created
- review upcoming
- review overdue
- follow-up still open after review

Action Center remains the canonical truth. Mail only activates attention and links back into the existing Action Center review flow.

## Product and boundary notes
This remains intentionally bounded:
- ExitScan-only in phase 1
- no Microsoft Graph dependency
- no reply-based or off-platform canonical writes
- no reschedule engine
- no route-family broadening

The dispatcher now also includes:
- bearer-secret auth for manual and cron execution
- GET support for cron-style invocation
- role-safe overdue dedupe
- suppression auditing
- per-send rechecks before outbound mail

## Validation
Passed:
- `npx vitest run "lib/action-center-follow-through-mail.test.ts" "lib/action-center-follow-through-mail-policy.test.ts" "lib/action-center-follow-through-mail-data.test.ts" "lib/action-center-follow-through-mail-planner.test.ts" "lib/action-center-follow-through-mail-render.test.ts" "lib/action-center-follow-through-mail-delivery.test.ts" "app/api/action-center-follow-through-mails/route.test.ts" "lib/action-center-follow-through-mail-cron.test.ts"`
- `npx vitest run "lib/action-center-review-rhythm.test.ts" "lib/action-center-review-rhythm-data.test.ts" "app/api/action-center-review-rhythm/route.test.ts" "lib/action-center-review-invite.test.ts" "app/api/action-center-review-invites/route.test.ts" "components/dashboard/review-moment-detail-panel.test.ts"`

Build note:
- `npm run build` compiles, lints, and type-checks this slice successfully, but the build still stops on a pre-existing Supabase env/prerender blocker in auth pages like `/forgot-password` and `/reset-password`. That blocker is outside this PR's scope.