### PR TITLE
Restyle HR results to Loep visual direction

### DIFF
--- a/frontend/app/(dashboard)/campaigns/[id]/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.tsx
@@ -133,6 +133,24 @@ function truncateText(value: string, limit = 140) {
   return value.length > limit ? `${value.slice(0, limit - 3).trimEnd()}...` : value
 }
 
+function getVisualMetricWidth(value: string) {
+  if (value === 'Nog niet beschikbaar') return null
+
+  const percentMatch = value.match(/(-?\d+(?:\.\d+)?)%/)
+  if (percentMatch) {
+    const percent = Number(percentMatch[1])
+    if (!Number.isNaN(percent)) return Math.max(10, Math.min(100, percent))
+  }
+
+  const scoreMatch = value.match(/(-?\d+(?:\.\d+)?)\/10/)
+  if (scoreMatch) {
+    const score = Number(scoreMatch[1])
+    if (!Number.isNaN(score)) return Math.max(10, Math.min(100, score * 10))
+  }
+
+  return null
+}
+
 function buildResponseContextNote(totalCompleted: number, completionRate: number) {
   if (totalCompleted >= MIN_N_PATTERNS) {
     return `${completionRate}% respons en ${totalCompleted} ingevulde responses liggen boven de analysegrens van ${MIN_N_PATTERNS}.`
@@ -426,6 +444,34 @@ function buildDepthNotes(args: {
   ]
 }
 
+function SectionKicker({
+  title,
+  visibility,
+}: {
+  title: string
+  visibility: ResultsBlockVisibility
+}) {
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3">
+      <div className="flex items-center gap-3">
+        <span className="h-px w-10 bg-[#C36A29]" />
+        <span className="text-[0.72rem] font-semibold uppercase tracking-[0.28em] text-slate-500">
+          {title}
+        </span>
+      </div>
+      <span
+        className={`inline-flex rounded-full border px-3 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.18em] ${
+          visibility === 'visible'
+            ? 'border-amber-200 bg-amber-50 text-[#8B4A17]'
+            : 'border-slate-200 bg-slate-50 text-slate-500'
+        }`}
+      >
+        {visibility === 'visible' ? 'Zichtbaar' : 'Begrensd'}
+      </span>
+    </div>
+  )
+}
+
 function ResultsBlockCard({
   title,
   visibility,
@@ -434,6 +480,10 @@ function ResultsBlockCard({
   href,
   linkLabel,
   children,
+  className,
+  summaryClassName,
+  bodyClassName,
+  hideSummary,
 }: {
   title: string
   visibility: ResultsBlockVisibility
@@ -442,33 +492,36 @@ function ResultsBlockCard({
   href?: string
   linkLabel?: string
   children?: ReactNode
+  className?: string
+  summaryClassName?: string
+  bodyClassName?: string
+  hideSummary?: boolean
 }) {
   const toneClasses =
     visibility === 'visible'
       ? 'border-slate-200 bg-white'
-      : 'border-dashed border-slate-200 bg-slate-50'
+      : 'border-dashed border-slate-200 bg-[color:var(--dashboard-soft)]/36'
 
   return (
-    <div className={`rounded-[24px] border px-5 py-5 shadow-sm ${toneClasses}`}>
-      <div className="flex items-start justify-between gap-3">
-        <h2 className="text-lg font-semibold tracking-[-0.02em] text-[color:var(--dashboard-ink)]">
-          {title}
-        </h2>
-        <span className="rounded-full bg-slate-100 px-3 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-slate-600">
-          {visibility === 'visible' ? 'Vrij' : 'Begrensd'}
-        </span>
-      </div>
-      {summary ? (
-        <p className="mt-4 text-xl font-semibold tracking-[-0.03em] text-[color:var(--dashboard-ink)]">
+    <div className={`border px-5 py-5 md:px-7 md:py-7 ${toneClasses} ${className ?? 'rounded-[18px]'}`}>
+      <SectionKicker title={title} visibility={visibility} />
+      {summary && !hideSummary ? (
+        <p
+          className={`mt-5 text-[1.8rem] font-semibold leading-none tracking-[-0.05em] text-[color:var(--dashboard-ink)] md:text-[2.2rem] ${
+            summaryClassName ?? ''
+          }`}
+        >
           {summary}
         </p>
       ) : null}
-      <p className="mt-3 text-sm leading-6 text-[color:var(--dashboard-text)]">{body}</p>
-      {children ? <div className="mt-5">{children}</div> : null}
+      <p className={`mt-3 max-w-3xl text-sm leading-6 text-[color:var(--dashboard-text)] ${bodyClassName ?? ''}`}>
+        {body}
+      </p>
+      {children ? <div className="mt-6">{children}</div> : null}
       {href && linkLabel ? (
         <Link
           href={href}
-          className="mt-5 inline-flex items-center gap-2 text-sm font-semibold text-slate-700 transition-colors hover:text-slate-950"
+          className="mt-6 inline-flex items-center gap-2 rounded-full border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-semibold text-[#8B4A17] transition-colors hover:border-amber-300 hover:bg-amber-100"
         >
           {linkLabel}
         </Link>
@@ -478,14 +531,21 @@ function ResultsBlockCard({
 }
 
 function MetricTile({ item }: { item: MetricItem }) {
+  const width = getVisualMetricWidth(item.value)
+
   return (
-    <div className="rounded-[20px] bg-[color:var(--dashboard-soft)]/55 px-4 py-4">
+    <div className="border border-slate-200 bg-[color:var(--dashboard-soft)]/45 px-4 py-4">
       <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
         {item.label}
       </p>
-      <p className="mt-3 text-lg font-semibold tracking-[-0.03em] text-[color:var(--dashboard-ink)]">
+      <p className="mt-3 text-lg font-semibold tracking-[-0.04em] text-[color:var(--dashboard-ink)]">
         {item.value}
       </p>
+      {width ? (
+        <div className="mt-3 h-2 overflow-hidden rounded-full bg-white/90">
+          <div className="h-full bg-[#C36A29]" style={{ width: `${width}%` }} />
+        </div>
+      ) : null}
       <p className="mt-2 text-sm leading-6 text-[color:var(--dashboard-text)]">{item.caption}</p>
     </div>
   )
@@ -493,11 +553,11 @@ function MetricTile({ item }: { item: MetricItem }) {
 
 function SummaryCard({ item }: { item: SummaryItem }) {
   return (
-    <div className="rounded-[20px] bg-[color:var(--dashboard-soft)]/52 px-5 py-5">
+    <div className="border border-slate-200 bg-white px-5 py-5">
       <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
         {item.label}
       </p>
-      <h3 className="mt-3 text-[1.08rem] font-semibold tracking-[-0.03em] text-[color:var(--dashboard-ink)]">
+      <h3 className="mt-3 text-[1.08rem] font-semibold tracking-[-0.04em] text-[color:var(--dashboard-ink)]">
         {item.title}
       </h3>
       <p className="mt-3 text-sm leading-6 text-[color:var(--dashboard-text)]">{item.body}</p>
@@ -507,7 +567,7 @@ function SummaryCard({ item }: { item: SummaryItem }) {
 
 function EmptyInlineState({ body }: { body: string }) {
   return (
-    <div className="rounded-[20px] border border-dashed border-slate-200 bg-slate-50 px-5 py-5 text-sm leading-6 text-[color:var(--dashboard-text)]">
+    <div className="border border-dashed border-slate-200 bg-[color:var(--dashboard-soft)]/28 px-5 py-5 text-sm leading-6 text-[color:var(--dashboard-text)]">
       {body}
     </div>
   )
@@ -537,7 +597,7 @@ function ResultsShellHeader({
   scanType: string
 }) {
   return (
-    <div className="space-y-4 border-b border-slate-200/80 pb-5">
+    <div className="space-y-5 border-b border-slate-200/80 pb-6">
       <p className="text-[0.78rem] font-medium tracking-[0.01em] text-slate-500">
         <Link href="/dashboard" className="transition-colors hover:text-slate-700">
           Overzicht
@@ -557,8 +617,11 @@ function ResultsShellHeader({
       <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
         <div className="space-y-3">
           <div className="flex flex-wrap items-center gap-2.5">
-            <span className="inline-flex rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-slate-600">
+            <span className="inline-flex rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-[0.72rem] font-semibold uppercase tracking-[0.2em] text-[#8B4A17]">
               {statusLabel}
+            </span>
+            <span className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-slate-400">
+              Resultatenomgeving
             </span>
           </div>
           <h1 className="font-serif text-[2.6rem] leading-[0.96] tracking-[-0.055em] text-[color:var(--dashboard-ink)] sm:text-[3.15rem]">
@@ -569,7 +632,16 @@ function ResultsShellHeader({
             <span aria-hidden="true">&middot;</span> {scopeLabel}
           </p>
         </div>
-        <PdfDownloadButton campaignId={campaignId} campaignName={campaignName} scanType={scanType} />
+        <PdfDownloadButton
+          campaignId={campaignId}
+          campaignName={campaignName}
+          scanType={scanType}
+          label="Download PDF"
+          loadingLabel="PDF ophalen..."
+          buttonClassName="inline-flex rounded-full border border-slate-950 bg-slate-950 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
+          containerClassName="flex flex-col items-start gap-2 lg:items-end"
+          errorClassName="max-w-56 text-xs text-red-600 lg:text-right"
+        />
       </div>
     </div>
   )
@@ -836,23 +908,26 @@ export default async function CampaignPage({ params }: Props) {
     <ResultsBlockCard
       title={PRIMARY_RESULTS_ORDER.response}
       visibility={blockVisibility.response}
-      summary={`${stats.total_completed}/${stats.total_invited} ingevuld · ${stats.completion_rate_pct ?? 0}%`}
       body={buildResponseContextNote(stats.total_completed, stats.completion_rate_pct ?? 0)}
+      hideSummary
+      className="rounded-[18px] border-0 bg-transparent px-0 py-0"
+      bodyClassName="px-5 md:px-7"
     >
-      <div className="grid gap-3 sm:grid-cols-3">
+      <div className="grid border border-slate-200 bg-white md:grid-cols-4">
         {[
           { label: 'Uitgenodigd', value: String(stats.total_invited) },
           { label: 'Ingevuld', value: String(stats.total_completed) },
+          { label: 'Respons', value: `${stats.completion_rate_pct ?? 0}%` },
           { label: 'Status', value: getResultsStatusLabel(resultsViewModel.readState) },
         ].map((item) => (
           <div
             key={item.label}
-            className="rounded-[18px] bg-[color:var(--dashboard-soft)]/62 px-4 py-4"
+            className="border-b border-slate-200 px-5 py-4 last:border-b-0 md:border-b-0 md:border-r last:md:border-r-0"
           >
             <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
               {item.label}
             </p>
-            <p className="mt-3 text-base font-semibold tracking-[-0.02em] text-[color:var(--dashboard-ink)]">
+            <p className="mt-3 text-xl font-semibold tracking-[-0.04em] text-[color:var(--dashboard-ink)]">
               {item.value}
             </p>
           </div>
@@ -868,14 +943,61 @@ export default async function CampaignPage({ params }: Props) {
       summary={blockVisibility.signal === 'visible' ? formatScore(averageSignalScore) : 'Nog niet beschikbaar'}
       body={
         blockVisibility.signal === 'visible'
-          ? `${scanDefinition.signalLabel} is vrijgegeven voor deze route. De aanvullende metrics hieronder tonen de scan-specifieke context die samen met het hoofdsignaal is opgeslagen.`
+          ? `${scanDefinition.signalLabel} is vrijgegeven voor deze route. Lees dit blok samen met de verdeling, de responsbasis en de sterkste ondersteunende signalen hieronder.`
           : `Deze laag opent vanaf ${MIN_N_DISPLAY} leesbare responses.`
       }
+      className="rounded-[20px]"
+      summaryClassName="text-[3.25rem] md:text-[4.5rem]"
     >
-      <div className="grid gap-4 md:grid-cols-3">
-        {signalHighlights.map((item) => (
-          <MetricTile key={item.label} item={item} />
-        ))}
+      <div className="grid gap-5 xl:grid-cols-[minmax(0,1.2fr),minmax(0,0.8fr)]">
+        <div className="border border-slate-200 bg-[color:var(--dashboard-soft)]/35 px-5 py-5 md:px-6 md:py-6">
+          <div className="flex flex-wrap items-end justify-between gap-4 border-b border-slate-200 pb-4">
+            <div>
+              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                {scanDefinition.signalLabel}
+              </p>
+              <p className="mt-2 text-4xl font-semibold tracking-[-0.06em] text-[color:var(--dashboard-ink)] md:text-[5rem]">
+                {blockVisibility.signal === 'visible' ? formatScore(averageSignalScore) : '—'}
+              </p>
+            </div>
+            <div className="max-w-xs text-sm leading-6 text-[color:var(--dashboard-text)]">
+              {blockVisibility.signal === 'visible'
+                ? 'Gebruik de verdeling en de aanvullende metrics om het groepsbeeld te lezen, zonder het al als aanbeveling te framen.'
+                : `Deze laag wordt zichtbaar vanaf ${MIN_N_DISPLAY} leesbare responses.`}
+            </div>
+          </div>
+
+          {exitDistribution ? (
+            <div className="mt-5 space-y-4">
+              {exitDistribution.segments.map((segment) => (
+                <div key={segment.label} className="space-y-2">
+                  <div className="flex items-center justify-between gap-3 text-sm text-[color:var(--dashboard-text)]">
+                    <span>{segment.label}</span>
+                    <span className="font-semibold text-[color:var(--dashboard-ink)]">{segment.value}</span>
+                  </div>
+                  <div className="h-2.5 overflow-hidden rounded-full bg-white">
+                    <div
+                      className="h-full bg-[#C36A29]"
+                      style={{ width: `${Math.max(8, segment.percent)}%` }}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="mt-5 grid gap-4 md:grid-cols-2">
+              {signalHighlights.map((item) => (
+                <MetricTile key={item.label} item={item} />
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-1">
+          {signalHighlights.map((item) => (
+            <MetricTile key={item.label} item={item} />
+          ))}
+        </div>
       </div>
     </ResultsBlockCard>
   )
@@ -887,14 +1009,17 @@ export default async function CampaignPage({ params }: Props) {
       summary={blockVisibility.synthesis === 'visible' ? synthesisItems[0]?.title ?? 'Nog niet beschikbaar' : 'Nog niet beschikbaar'}
       body={
         blockVisibility.synthesis === 'visible'
-          ? 'Deze laag bundelt de eerste samenhang die op groepsniveau zichtbaar is.'
+          ? 'Deze laag bundelt de eerste zichtbare samenhang op groepsniveau, zonder interpretatie of vervolgstapadvies.'
           : `Deze laag opent samen met het kernsignaal vanaf ${MIN_N_DISPLAY} responses.`
       }
+      className="rounded-[20px]"
     >
       {blockVisibility.synthesis === 'visible' && synthesisItems.length > 0 ? (
         <div className="grid gap-4 xl:grid-cols-3">
-          {synthesisItems.map((item) => (
-            <SummaryCard key={`${item.label}-${item.title}`} item={item} />
+          {synthesisItems.map((item, index) => (
+            <div key={`${item.label}-${item.title}`} className={index === 0 ? 'xl:col-span-2' : undefined}>
+              <SummaryCard item={item} />
+            </div>
           ))}
         </div>
       ) : (
@@ -917,32 +1042,84 @@ export default async function CampaignPage({ params }: Props) {
       }
       body={
         blockVisibility.drivers === 'visible'
-          ? 'Factoren zijn geordend op huidige signaalsterkte binnen deze route.'
+          ? 'Factoren zijn geordend op huidige signaalsterkte binnen deze route en blijven feitelijk geformuleerd.'
           : `Deze laag blijft begrensd tot er minimaal ${MIN_N_PATTERNS} leesbare responses zijn.`
       }
+      className="rounded-[20px]"
     >
       {blockVisibility.drivers === 'visible' && factorPriorityRows.length > 0 ? (
-        <div className="space-y-4">
-          {factorPriorityRows.slice(0, 4).map((row) => (
-            <div key={row.factor} className="rounded-[20px] bg-[color:var(--dashboard-soft)]/52 px-5 py-4">
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                <div>
+        <>
+          <div className="hidden overflow-hidden border border-slate-200 md:block">
+            <div className="grid grid-cols-[minmax(0,1.8fr),140px,140px,160px] border-b border-slate-200 bg-[color:var(--dashboard-soft)]/45 px-5 py-3 text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              <span>Factor</span>
+              <span>Score</span>
+              <span>Signaal</span>
+              <span>Band</span>
+            </div>
+            {factorPriorityRows.slice(0, 6).map((row) => (
+              <div
+                key={row.factor}
+                className="grid grid-cols-[minmax(0,1.8fr),140px,140px,160px] border-b border-slate-200 px-5 py-4 last:border-b-0"
+              >
+                <div className="pr-4">
                   <p className="text-sm font-semibold text-[color:var(--dashboard-ink)]">{row.factor}</p>
                   <p className="mt-2 text-sm leading-6 text-[color:var(--dashboard-text)]">{row.note}</p>
                 </div>
-                <div className="rounded-full bg-white px-3 py-1 text-xs font-semibold text-slate-600">
-                  {row.signal}
+                <div className="text-sm font-semibold text-[color:var(--dashboard-ink)]">{row.score}</div>
+                <div>
+                  <p className="text-sm font-semibold text-[color:var(--dashboard-ink)]">{row.signal}</p>
+                  <div className="mt-3 h-2 overflow-hidden rounded-full bg-[color:var(--dashboard-soft)]">
+                    <div
+                      className="h-full bg-[#C36A29]"
+                      style={{ width: `${Math.max(10, Math.min(100, row.signalValue * 10))}%` }}
+                    />
+                  </div>
+                </div>
+                <div>
+                  <span className="inline-flex rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-600">
+                    {row.band}
+                  </span>
                 </div>
               </div>
-              <div className="mt-3 h-2.5 overflow-hidden rounded-full bg-white/85">
-                <div
-                  className="h-full rounded-full bg-[#C36A29]"
-                  style={{ width: `${Math.max(12, Math.min(100, row.signalValue * 10))}%` }}
-                />
+            ))}
+          </div>
+
+          <div className="grid gap-4 md:hidden">
+            {factorPriorityRows.slice(0, 6).map((row) => (
+              <div key={row.factor} className="border border-slate-200 bg-[color:var(--dashboard-soft)]/38 px-5 py-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold text-[color:var(--dashboard-ink)]">{row.factor}</p>
+                    <p className="mt-2 text-sm leading-6 text-[color:var(--dashboard-text)]">{row.note}</p>
+                  </div>
+                  <span className="inline-flex rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-600">
+                    {row.band}
+                  </span>
+                </div>
+                <div className="mt-4 grid grid-cols-2 gap-3 text-sm">
+                  <div>
+                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                      Score
+                    </p>
+                    <p className="mt-2 font-semibold text-[color:var(--dashboard-ink)]">{row.score}</p>
+                  </div>
+                  <div>
+                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                      Signaal
+                    </p>
+                    <p className="mt-2 font-semibold text-[color:var(--dashboard-ink)]">{row.signal}</p>
+                  </div>
+                </div>
+                <div className="mt-3 h-2 overflow-hidden rounded-full bg-white">
+                  <div
+                    className="h-full bg-[#C36A29]"
+                    style={{ width: `${Math.max(10, Math.min(100, row.signalValue * 10))}%` }}
+                  />
+                </div>
               </div>
-            </div>
-          ))}
-        </div>
+            ))}
+          </div>
+        </>
       ) : (
         <EmptyInlineState body={`Volledige factorprioritering opent vanaf ${MIN_N_PATTERNS} responses.`} />
       )}
@@ -962,54 +1139,88 @@ export default async function CampaignPage({ params }: Props) {
       }
       body={
         blockVisibility.depth === 'visible'
-          ? 'Verdiepingslagen tonen extra context en methodische grenzen binnen dezelfde route.'
+          ? 'Verdiepingslagen tonen extra context en meetgrenzen binnen dezelfde route, zonder aparte methodiekpagina.'
           : `Deze laag opent vanaf ${MIN_N_DISPLAY} leesbare responses.`
       }
+      className="rounded-[20px]"
     >
-      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr),minmax(0,1fr)]">
-        <div className="space-y-4">
-          {blockVisibility.depth === 'visible' && sdtRows.length > 0 ? (
-            <div className="grid gap-3">
-              {sdtRows.map((row) => (
-                <div
-                  key={row.factor}
-                  className="rounded-[20px] bg-[color:var(--dashboard-soft)]/52 px-5 py-4"
-                >
-                  <div className="flex items-center justify-between gap-3">
-                    <p className="text-sm font-semibold text-[color:var(--dashboard-ink)]">{row.factor}</p>
-                    <span className="rounded-full bg-white px-3 py-1 text-xs font-semibold text-slate-600">
-                      {row.score}
-                    </span>
-                  </div>
-                  <p className="mt-2 text-sm leading-6 text-[color:var(--dashboard-text)]">{row.note}</p>
-                </div>
-              ))}
+      <div className="space-y-5">
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+          {depthNotes.map((note) => (
+            <div key={note.label} className="border border-slate-200 bg-white px-4 py-4">
+              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                {note.label}
+              </p>
+              <p className="mt-3 text-sm leading-6 text-[color:var(--dashboard-text)]">{note.body}</p>
             </div>
-          ) : (
-            <EmptyInlineState body="Nog geen extra verdiepingslaag zichtbaar binnen de huidige routegegevens." />
-          )}
-
-          <div className="grid gap-3 md:grid-cols-2">
-            {depthNotes.map((note) => (
-              <div
-                key={note.label}
-                className="rounded-[20px] border border-slate-200 bg-white px-4 py-4"
-              >
-                <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
-                  {note.label}
-                </p>
-                <p className="mt-3 text-sm leading-6 text-[color:var(--dashboard-text)]">{note.body}</p>
-              </div>
-            ))}
-          </div>
+          ))}
         </div>
 
-        <MethodologyCard
-          scanType={stats.scan_type}
-          hasSegmentDeepDive={hasCampaignAddOn(campaignMeta, 'segment_deep_dive')}
-          signalLabel={scanDefinition.signalLabel}
-          embedded
-        />
+        <div className="grid gap-4 xl:grid-cols-[minmax(0,0.95fr),minmax(0,1.05fr)]">
+          <div className="space-y-4">
+            {blockVisibility.depth === 'visible' && sdtRows.length > 0 ? (
+              <div className="grid gap-3">
+                {sdtRows.map((row) => (
+                  <div key={row.factor} className="border border-slate-200 bg-[color:var(--dashboard-soft)]/38 px-5 py-4">
+                    <div className="flex items-center justify-between gap-3">
+                      <p className="text-sm font-semibold text-[color:var(--dashboard-ink)]">{row.factor}</p>
+                      <span className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-600">
+                        {row.score}
+                      </span>
+                    </div>
+                    <p className="mt-2 text-sm leading-6 text-[color:var(--dashboard-text)]">{row.note}</p>
+                    <div className="mt-3 h-2 overflow-hidden rounded-full bg-white">
+                      <div
+                        className="h-full bg-[#C36A29]"
+                        style={{ width: `${Math.max(10, Math.min(100, row.scoreValue * 10))}%` }}
+                      />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <EmptyInlineState body="Nog geen extra verdiepingslaag zichtbaar binnen de huidige routegegevens." />
+            )}
+          </div>
+
+          <div className="space-y-4">
+            {blockVisibility.depth === 'visible' && factorPriorityRows.length > 0 ? (
+              <div className="border border-slate-200 bg-white px-5 py-5">
+                <div className="border-b border-slate-200 pb-3">
+                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                    Organisatiefactoren
+                  </p>
+                  <p className="mt-2 text-sm leading-6 text-[color:var(--dashboard-text)]">
+                    Rangorde van de sterkst zichtbare factoren binnen deze route.
+                  </p>
+                </div>
+                <div className="mt-4 space-y-4">
+                  {factorPriorityRows.slice(0, 5).map((row) => (
+                    <div key={row.factor} className="space-y-2">
+                      <div className="flex items-center justify-between gap-3 text-sm">
+                        <span className="font-medium text-[color:var(--dashboard-ink)]">{row.factor}</span>
+                        <span className="font-semibold text-[color:var(--dashboard-ink)]">{row.signal}</span>
+                      </div>
+                      <div className="h-2 overflow-hidden rounded-full bg-[color:var(--dashboard-soft)]">
+                        <div
+                          className="h-full bg-[#C36A29]"
+                          style={{ width: `${Math.max(10, Math.min(100, row.signalValue * 10))}%` }}
+                        />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
+            <MethodologyCard
+              scanType={stats.scan_type}
+              hasSegmentDeepDive={hasCampaignAddOn(campaignMeta, 'segment_deep_dive')}
+              signalLabel={scanDefinition.signalLabel}
+              embedded
+            />
+          </div>
+        </div>
       </div>
     </ResultsBlockCard>
   )
@@ -1031,7 +1242,8 @@ export default async function CampaignPage({ params }: Props) {
             : `Open antwoorden openen pas vanaf ${MIN_N_DISPLAY} leesbare responses.`
       }
       href={showOpenAnswersRoute ? openAnswersHref : undefined}
-      linkLabel={showOpenAnswersRoute ? 'Open alle open antwoorden' : undefined}
+      linkLabel={showOpenAnswersRoute ? 'Bekijk alle open antwoorden' : undefined}
+      className="rounded-[20px]"
     >
       {blockVisibility.voices === 'visible' && openAnswersViewModel.groups.length > 0 ? (
         <div className="space-y-4">
@@ -1045,14 +1257,14 @@ export default async function CampaignPage({ params }: Props) {
               </span>
             ))}
           </div>
-          <div className="grid gap-4 xl:grid-cols-2">
+          <div className="grid gap-4 xl:grid-cols-3">
             {openAnswersViewModel.groups
               .flatMap((group) => group.answers.slice(0, 1).map((answer) => ({ group, answer })))
-              .slice(0, 2)
+              .slice(0, 3)
               .map(({ group, answer }) => (
                 <div
                   key={answer.id}
-                  className="rounded-[20px] bg-[color:var(--dashboard-soft)]/52 px-5 py-5"
+                  className="border border-slate-200 bg-[color:var(--dashboard-soft)]/35 px-5 py-5"
                 >
                   <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
                     {group.title}

--- a/frontend/app/(dashboard)/campaigns/[id]/results-layout.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/results-layout.tsx
@@ -13,7 +13,7 @@ type ResultsLayoutProps = {
 
 export function ResultsLayout({ sections }: ResultsLayoutProps) {
   return (
-    <div className="space-y-8">
+    <div className="space-y-10">
       <section id="responsbasis">{sections.response}</section>
       <section id="kernsignaal">{sections.signal}</section>
       <section id="signalen-in-samenhang">{sections.synthesis}</section>


### PR DESCRIPTION
## Summary
- restyle the HR results page to the Loep visual direction
- keep the existing results block order, routing, gating, and PDF/open-answers behavior intact
- upgrade the visual hierarchy for response basis, kernsignaal, synthesis, drivers, depth, and survey voices

## Testing
- npm test -- "app/(dashboard)/campaigns/[id]/page.test.ts" "app/(dashboard)/campaigns/[id]/page.route-shell.test.ts" "app/(dashboard)/campaigns/[id]/results-layout.test.ts" "app/(dashboard)/campaigns/[id]/results-view-model.test.ts" "app/(dashboard)/campaigns/[id]/open-antwoorden/page.test.ts" "app/(dashboard)/campaigns/[id]/open-answers-view-model.test.ts" "app/(dashboard)/campaigns/[id]/page-helpers.test.ts"
- npx eslint "app/(dashboard)/campaigns/[id]/page.tsx" "app/(dashboard)/campaigns/[id]/results-layout.tsx"
- NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key npm run build

## Notes
- visual pass only; no changes to results logic or action wiring
- no browser smoke was run because no local app server was active in this session