### PR TITLE
Fix Action Center route parity persistence guards

### DIFF
--- a/frontend/app/api/action-center-follow-through-mails/route.test.ts
+++ b/frontend/app/api/action-center-follow-through-mails/route.test.ts
@@ -59,9 +59,9 @@ function createLedgerSelectQuery(result: { data: unknown; error?: unknown }) {
   }
 }
 
-function createLedgerInsertQuery() {
+function createLedgerInsertQuery(insertSpy: ReturnType<typeof vi.fn> = vi.fn().mockResolvedValue({ error: null })) {
   return {
-    insert: vi.fn().mockResolvedValue({ error: null }),
+    insert: insertSpy,
   }
 }
 
@@ -209,5 +209,166 @@ describe('POST /api/action-center-follow-through-mails', () => {
     await expect(response.json()).resolves.toEqual({
       detail: 'Geen eligible Action Center-routes gevonden voor dispatch.',
     })
+  })
+
+  it('records RetentieScan sends with the canonical retention scan type in the ledger', async () => {
+    const insertSpy = vi.fn().mockResolvedValue({ error: null })
+
+    mockGetDispatchData.mockResolvedValue({
+      snapshots: [
+        {
+          routeId: 'camp-2::org::support',
+          routeScopeValue: 'org-1::department::support',
+          orgId: 'org-1',
+          campaignId: 'camp-2',
+          campaignName: 'RetentieScan Q2',
+          scopeLabel: 'Support',
+          scanType: 'retention',
+          routeStatus: 'reviewbaar',
+          reviewScheduledFor: '2026-05-20',
+          reviewCompletedAt: null,
+          reviewOutcome: 'geen-uitkomst',
+          ownerAssignedAt: '2026-05-10T09:00:00.000Z',
+          hasFollowUpTarget: false,
+          remindersEnabled: true,
+          cadenceDays: 14,
+          reminderLeadDays: 3,
+          escalationLeadDays: 7,
+          managerRecipient: { email: 'manager@example.com', name: 'Manager' },
+          hrOversightRecipients: [],
+        },
+      ],
+      routeIds: ['camp-2::org::support'],
+    })
+
+    mockPlanJobs.mockReturnValue({
+      jobs: [
+        {
+          routeId: 'camp-2::org::support',
+          orgId: 'org-1',
+          campaignId: 'camp-2',
+          campaignName: 'RetentieScan Q2',
+          scopeLabel: 'Support',
+          routeScopeValue: 'org-1::department::support',
+          triggerType: 'review_upcoming',
+          recipientRole: 'manager',
+          recipientEmail: 'manager@example.com',
+          recipientName: 'Manager',
+          sourceMarker: '2026-05-20',
+          dedupeKey: 'camp-2::org::support::review_upcoming::manager@example.com::2026-05-20',
+          reviewScheduledFor: '2026-05-20',
+        },
+      ],
+      suppressions: [],
+    })
+
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === 'action_center_follow_through_mail_events') {
+        const selectQuery = createLedgerSelectQuery({ data: [] })
+        const insertQuery = createLedgerInsertQuery(insertSpy)
+        return {
+          ...selectQuery,
+          ...insertQuery,
+        }
+      }
+
+      throw new Error(`Unexpected table ${table}`)
+    })
+
+    const response = await POST(
+      makeRequest(
+        { mode: 'dispatch' },
+        { authorization: 'Bearer test-token' },
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    expect(insertSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        route_id: 'camp-2::org::support',
+        scan_type: 'retention',
+      }),
+    )
+  })
+
+  it('records RetentieScan suppressions with the canonical retention scan type in the ledger', async () => {
+    const insertSpy = vi.fn().mockResolvedValue({ error: null })
+
+    mockGetDispatchData.mockResolvedValue({
+      snapshots: [
+        {
+          routeId: 'camp-2::org::support',
+          routeScopeValue: 'org-1::department::support',
+          orgId: 'org-1',
+          campaignId: 'camp-2',
+          campaignName: 'RetentieScan Q2',
+          scopeLabel: 'Support',
+          scanType: 'retention',
+          routeStatus: 'reviewbaar',
+          reviewScheduledFor: '2026-05-20',
+          reviewCompletedAt: null,
+          reviewOutcome: 'geen-uitkomst',
+          ownerAssignedAt: '2026-05-10T09:00:00.000Z',
+          hasFollowUpTarget: false,
+          remindersEnabled: true,
+          cadenceDays: 14,
+          reminderLeadDays: 3,
+          escalationLeadDays: 7,
+          managerRecipient: { email: 'manager@example.com', name: 'Manager' },
+          hrOversightRecipients: [],
+        },
+      ],
+      routeIds: ['camp-2::org::support'],
+    })
+
+    mockPlanJobs.mockReturnValue({
+      jobs: [],
+      suppressions: [
+        {
+          routeId: 'camp-2::org::support',
+          orgId: 'org-1',
+          campaignId: 'camp-2',
+          campaignName: 'RetentieScan Q2',
+          scopeLabel: 'Support',
+          routeScopeValue: 'org-1::department::support',
+          triggerType: 'review_upcoming',
+          recipientRole: 'manager',
+          recipientEmail: 'manager@example.com',
+          recipientName: 'Manager',
+          sourceMarker: '2026-05-20',
+          suppressionReason: 'reminders-disabled',
+          reviewScheduledFor: '2026-05-20',
+        },
+      ],
+    })
+
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === 'action_center_follow_through_mail_events') {
+        const selectQuery = createLedgerSelectQuery({ data: [] })
+        const insertQuery = createLedgerInsertQuery(insertSpy)
+        return {
+          ...selectQuery,
+          ...insertQuery,
+        }
+      }
+
+      throw new Error(`Unexpected table ${table}`)
+    })
+
+    const response = await POST(
+      makeRequest(
+        { mode: 'dispatch' },
+        { authorization: 'Bearer test-token' },
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    expect(insertSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        route_id: 'camp-2::org::support',
+        scan_type: 'retention',
+        delivery_status: 'suppressed',
+      }),
+    )
   })
 })

--- a/frontend/app/api/action-center-follow-through-mails/route.ts
+++ b/frontend/app/api/action-center-follow-through-mails/route.ts
@@ -105,6 +105,9 @@ async function handleDispatch(args: {
   const filteredSnapshots = args.requestedRouteIds
     ? dispatchData.snapshots.filter((snapshot) => args.requestedRouteIds?.includes(snapshot.routeId))
     : dispatchData.snapshots
+  const filteredSnapshotsByRouteId = new Map(
+    filteredSnapshots.map((snapshot) => [snapshot.routeId, snapshot]),
+  )
 
   if (args.requestedRouteIds && filteredSnapshots.length === 0) {
     return NextResponse.json(
@@ -189,12 +192,18 @@ async function handleDispatch(args: {
       continue
     }
 
+    const snapshot = filteredSnapshotsByRouteId.get(entry.routeId)
+    if (!snapshot) {
+      suppressedCount += 1
+      continue
+    }
+
     const insertResult = await createLedgerQueries().insert({
       org_id: entry.orgId,
       route_id: entry.routeId,
       route_scope_value: entry.routeScopeValue,
       route_source_id: entry.campaignId,
-      scan_type: 'exit',
+      scan_type: snapshot.scanType,
       trigger_type: entry.triggerType,
       recipient_role: entry.recipientRole,
       recipient_email: entry.recipientEmail ?? 'missing-recipient',
@@ -213,6 +222,7 @@ async function handleDispatch(args: {
   }
 
   for (const job of planned.jobs) {
+    const originalSnapshot = filteredSnapshotsByRouteId.get(job.routeId) ?? null
     const refreshedSnapshot = refreshedSnapshotsByRouteId.get(job.routeId) ?? null
     const recheckReason =
       !refreshedSnapshot
@@ -238,12 +248,13 @@ async function handleDispatch(args: {
           })
 
     if (recheckReason) {
+      const ledgerScanType = refreshedSnapshot?.scanType ?? originalSnapshot?.scanType ?? 'exit'
       const suppressionInsert = await createLedgerQueries().insert({
         org_id: job.orgId,
         route_id: job.routeId,
         route_scope_value: job.routeScopeValue,
         route_source_id: job.campaignId,
-        scan_type: 'exit',
+        scan_type: ledgerScanType,
         trigger_type: job.triggerType,
         recipient_role: job.recipientRole,
         recipient_email: job.recipientEmail,
@@ -260,6 +271,11 @@ async function handleDispatch(args: {
       }
       suppressedCount += 1
       existingDedupeKeys.add(job.dedupeKey)
+      continue
+    }
+
+    if (!refreshedSnapshot) {
+      failedCount += 1
       continue
     }
 
@@ -290,7 +306,7 @@ async function handleDispatch(args: {
       route_id: job.routeId,
       route_scope_value: job.routeScopeValue,
       route_source_id: job.campaignId,
-      scan_type: 'exit',
+      scan_type: refreshedSnapshot.scanType,
       trigger_type: job.triggerType,
       recipient_role: job.recipientRole,
       recipient_email: job.recipientEmail,

--- a/frontend/app/api/action-center-review-reschedules/route.test.ts
+++ b/frontend/app/api/action-center-review-reschedules/route.test.ts
@@ -281,6 +281,75 @@ describe('action center review reschedules route', () => {
     })
   })
 
+  it('fails closed when the requested scan type does not match the canonical enabled route family', async () => {
+    let managerResponseCallCount = 0
+    let revisionCallCount = 0
+
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === 'campaigns') {
+        return createCampaignQuery({
+          data: {
+            id: ROUTE_SOURCE_ID,
+            organization_id: ORG_ID,
+            scan_type: 'exit',
+          },
+        })
+      }
+
+      if (table === 'action_center_manager_responses') {
+        managerResponseCallCount += 1
+        if (managerResponseCallCount === 1) {
+          return createManagerResponseQuery({
+            data: {
+              campaign_id: ROUTE_SOURCE_ID,
+              org_id: ORG_ID,
+              route_scope_type: 'department',
+              route_scope_value: ROUTE_SCOPE_VALUE,
+              review_scheduled_for: '2026-05-28',
+            },
+          })
+        }
+
+        return createUpdateManagerResponseQuery({
+          data: null,
+        })
+      }
+
+      if (table === 'action_center_review_schedule_revisions') {
+        revisionCallCount += 1
+        if (revisionCallCount === 1) {
+          return createLatestRevisionQuery({
+            data: {
+              revision: 2,
+              operation: 'reschedule',
+              review_date: '2026-05-28',
+            },
+          })
+        }
+
+        return createInsertRevisionQuery({
+          data: null,
+        })
+      }
+
+      throw new Error(`Unexpected table ${table}`)
+    })
+
+    const response = await POST(
+      makeRequest(
+        buildValidBody({
+          scanType: 'pulse',
+        }),
+      ),
+    )
+
+    expect(response.status).toBe(409)
+    expect(mockSyncActionCenterGraphReview).not.toHaveBeenCalled()
+    await expect(response.json()).resolves.toEqual({
+      detail: 'Review reschedule input kwam niet overeen met de canonieke follow-through-route.',
+    })
+  })
+
   it('allows RetentieScan routes through the same bounded reschedule route', async () => {
     const updateQuery = createUpdateManagerResponseQuery({
       data: {

--- a/frontend/app/api/action-center-review-reschedules/route.ts
+++ b/frontend/app/api/action-center-review-reschedules/route.ts
@@ -12,6 +12,7 @@ import {
   validateActionCenterReviewRescheduleInput,
 } from '@/lib/action-center-review-reschedule'
 import { buildActionCenterReviewInviteDraft } from '@/lib/action-center-review-invite'
+import { getActionCenterEnabledRouteDefaults } from '@/lib/action-center-route-defaults'
 import { loadActionCenterReviewRescheduleData } from '@/lib/action-center-review-reschedule-data'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { createClient } from '@/lib/supabase/server'
@@ -234,6 +235,14 @@ export async function POST(request: Request) {
 
   if (routeData.status !== 'ok') {
     return NextResponse.json({ detail: 'Review reschedule route bestaat niet.' }, { status: 400 })
+  }
+
+  const requestedRouteDefaults = getActionCenterEnabledRouteDefaults(parsed.scanType)
+  if (!requestedRouteDefaults || requestedRouteDefaults.scanType !== routeData.scanType) {
+    return NextResponse.json(
+      { detail: 'Review reschedule input kwam niet overeen met de canonieke follow-through-route.' },
+      { status: 409 },
+    )
   }
 
   const adminClient = createAdminClient()

--- a/frontend/lib/action-center-follow-through-mail-policy.test.ts
+++ b/frontend/lib/action-center-follow-through-mail-policy.test.ts
@@ -8,6 +8,7 @@ const schemaSql = readFileSync(schemaPath, 'utf8')
 describe('action center follow-through mail schema policy', () => {
   it('defines a bounded ledger table with dedupe uniqueness and service-only policies', () => {
     expect(schemaSql).toMatch(/create table if not exists public\.action_center_follow_through_mail_events/i)
+    expect(schemaSql).toMatch(/scan_type\s+text\s+not null\s+check \(scan_type in \('exit', 'retention'\)\)/i)
     expect(schemaSql).toMatch(/trigger_type\s+text\s+not null/i)
     expect(schemaSql).toMatch(/recipient_email\s+text\s+not null/i)
     expect(schemaSql).toMatch(/dedupe_key\s+text\s+not null/i)

--- a/frontend/lib/action-center-follow-through-mail.ts
+++ b/frontend/lib/action-center-follow-through-mail.ts
@@ -3,7 +3,10 @@ import type {
   ActionCenterReviewOutcome,
   ActionCenterRouteStatus,
 } from './action-center-route-contract'
-import { isActionCenterReviewRhythmSupportedScanType } from './action-center-review-rhythm'
+import {
+  isActionCenterReviewRhythmSupportedScanType,
+  type ActionCenterReviewRhythmSupportedScanType,
+} from './action-center-review-rhythm'
 
 export const ACTION_CENTER_FOLLOW_THROUGH_TRIGGER_TYPES = [
   'assignment_created',
@@ -48,7 +51,7 @@ export interface ActionCenterFollowThroughMailLedgerRecord {
   routeId: string
   routeScopeValue: string
   routeSourceId: string
-  scanType: 'exit'
+  scanType: ActionCenterReviewRhythmSupportedScanType
   triggerType: ActionCenterFollowThroughTriggerType
   recipientRole: ActionCenterFollowThroughRecipientRole
   recipientEmail: string

--- a/frontend/lib/action-center-review-reschedule-policy.test.ts
+++ b/frontend/lib/action-center-review-reschedule-policy.test.ts
@@ -41,7 +41,7 @@ function assertReviewScheduleRevisionSchema(sql: string) {
   expect(sql).toMatch(/route_id\s+text\s+not null/i)
   expect(sql).toMatch(/route_scope_value\s+text\s+not null/i)
   expect(sql).toMatch(/route_source_id\s+uuid\s+not null/i)
-  expect(sql).toMatch(/scan_type\s+text\s+not null\s+check \(scan_type in \('exit'\)\)/i)
+  expect(sql).toMatch(/scan_type\s+text\s+not null\s+check \(scan_type in \('exit', 'retention'\)\)/i)
   expect(sql).toMatch(/operation\s+text\s+not null\s+check \(operation in \('reschedule', 'cancel'\)\)/i)
   expect(sql).toMatch(/revision\s+integer\s+not null/i)
   expect(sql).toMatch(/review_date\s+date/i)

--- a/frontend/lib/action-center-review-rhythm-policy.test.ts
+++ b/frontend/lib/action-center-review-rhythm-policy.test.ts
@@ -67,6 +67,7 @@ describe('action center review rhythm schema policy', () => {
   it('keeps the consolidated schema aligned to the bounded review rhythm write policy', () => {
     expect(schemaSql).toMatch(/create table if not exists public\.action_center_review_rhythm_configs/i)
     expect(schemaSql).toMatch(/scan_type\s+text\s+not null/i)
+    expect(schemaSql).toMatch(/check \(scan_type in \('exit', 'retention'\)\)/i)
     expect(schemaSql).toMatch(/cadence_days\s+smallint\s+not null/i)
     expect(schemaSql).toMatch(/reminder_lead_days\s+smallint\s+not null/i)
     expect(schemaSql).toMatch(/escalation_lead_days\s+smallint\s+not null/i)
@@ -81,6 +82,7 @@ describe('action center review rhythm schema policy', () => {
 
   it('keeps the review rhythm migration aligned to the same bounded write policy', () => {
     expect(migrationSql).toMatch(/create table if not exists public\.action_center_review_rhythm_configs/i)
+    expect(migrationSql).toMatch(/check \(scan_type in \('exit', 'retention'\)\)/i)
     assertBoundedReviewRhythmPolicy(migrationSql)
   })
 })

--- a/supabase/action_center_follow_through_mail_layer.sql
+++ b/supabase/action_center_follow_through_mail_layer.sql
@@ -5,7 +5,7 @@ create table if not exists public.action_center_follow_through_mail_events (
   route_scope_value text not null,
   route_source_id uuid references public.campaigns(id) on delete cascade not null,
   scan_type text not null
-    check (scan_type in ('exit')),
+    check (scan_type in ('exit', 'retention')),
   trigger_type text not null
     check (trigger_type in ('assignment_created', 'review_upcoming', 'review_overdue', 'follow_up_open_after_review')),
   recipient_role text not null

--- a/supabase/action_center_review_reschedule_flows.sql
+++ b/supabase/action_center_review_reschedule_flows.sql
@@ -6,7 +6,7 @@ create table if not exists public.action_center_review_schedule_revisions (
   route_id text not null,
   route_scope_value text not null,
   route_source_id uuid not null,
-  scan_type text not null check (scan_type in ('exit')),
+  scan_type text not null check (scan_type in ('exit', 'retention')),
   operation text not null check (operation in ('reschedule', 'cancel')),
   revision integer not null check (revision >= 0),
   review_date date,

--- a/supabase/action_center_review_rhythm_console.sql
+++ b/supabase/action_center_review_rhythm_console.sql
@@ -8,7 +8,7 @@ create table if not exists public.action_center_review_rhythm_configs (
     check (route_source_type in ('campaign')),
   route_source_id uuid references public.campaigns(id) on delete cascade not null,
   scan_type text not null
-    check (scan_type in ('exit')),
+    check (scan_type in ('exit', 'retention')),
   cadence_days smallint not null
     check (cadence_days in (7, 14, 30)),
   reminder_lead_days smallint not null

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -707,7 +707,7 @@ create table if not exists public.action_center_review_rhythm_configs (
     check (route_source_type in ('campaign')),
   route_source_id uuid references public.campaigns(id) on delete cascade not null,
   scan_type text not null
-    check (scan_type in ('exit')),
+    check (scan_type in ('exit', 'retention')),
   cadence_days smallint not null
     check (cadence_days in (7, 14, 30)),
   reminder_lead_days smallint not null
@@ -733,7 +733,7 @@ create table if not exists public.action_center_review_schedule_revisions (
   route_id text not null,
   route_scope_value text not null,
   route_source_id uuid not null,
-  scan_type text not null check (scan_type in ('exit')),
+  scan_type text not null check (scan_type in ('exit', 'retention')),
   operation text not null check (operation in ('reschedule', 'cancel')),
   revision integer not null check (revision >= 0),
   review_date date,
@@ -805,7 +805,7 @@ create table if not exists public.action_center_follow_through_mail_events (
   route_scope_value text not null,
   route_source_id uuid references public.campaigns(id) on delete cascade not null,
   scan_type text not null
-    check (scan_type in ('exit')),
+    check (scan_type in ('exit', 'retention')),
   trigger_type text not null
     check (trigger_type in ('assignment_created', 'review_upcoming', 'review_overdue', 'follow_up_open_after_review')),
   recipient_role text not null


### PR DESCRIPTION
## Summary
- widen the persisted Action Center parity contracts so review rhythm configs, review schedule revisions, and follow-through mail ledger rows accept both `exit` and `retention`
- write canonical scan types into the follow-through mail ledger instead of hard-coding `exit`
- fail closed when a review reschedule request `scanType` does not match the canonical enabled route family

## Testing
- `npx vitest run "lib/action-center-route-defaults.test.ts" "lib/action-center-review-rhythm.test.ts" "lib/action-center-review-rhythm-policy.test.ts" "lib/action-center-review-rhythm-data.test.ts" "lib/action-center-review-invite.test.ts" "lib/action-center-review-reschedule.test.ts" "lib/action-center-review-reschedule-policy.test.ts" "lib/action-center-review-reschedule-data.test.ts" "lib/action-center-follow-through-mail.test.ts" "lib/action-center-follow-through-mail-policy.test.ts" "lib/action-center-follow-through-mail-data.test.ts" "lib/action-center-follow-through-mail-planner.test.ts" "lib/action-center-graph-calendar.test.ts" "lib/action-center-page-data.test.ts" "app/api/action-center-follow-through-mails/route.test.ts" "app/api/action-center-review-invites/route.test.ts" "app/api/action-center-review-reschedules/route.test.ts" "app/api/action-center-review-rhythm/route.test.ts" "components/dashboard/review-moment-detail-panel.test.ts" "components/dashboard/review-moment-page-client.test.ts" "components/dashboard/review-rhythm-console.test.tsx" "app/(dashboard)/action-center/reviewmomenten/page.entry-shell.test.ts"`
- `npm run build` compiles and typechecks; it still stops on the pre-existing Supabase auth env prerender baseline (`/reset-password`)