### PR TITLE
Add Action Center HR oversight stale-route governance

### DIFF
--- a/docs/superpowers/plans/2026-05-17-action-center-hr-oversight-stale-route-governance.md
+++ b/docs/superpowers/plans/2026-05-17-action-center-hr-oversight-stale-route-governance.md
@@ -1,0 +1,317 @@
+# Action Center HR Oversight / Stale-Route Governance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a bounded HR oversight layer to the existing Action Center reviewmomenten flow so HR can see which enabled follow-through routes are upcoming, overdue, stale, or escalation-sensitive, without introducing a generic operations cockpit or new Action Center layer.
+
+**Architecture:** Reuse the existing Action Center route defaults, review rhythm config, follow-through mail truth, and reviewmomenten page shell. Compute oversight state server-side from canonical route, schedule, and rhythm data; expose one bounded HR-facing summary/overview block; and keep review actions, assignment changes, and route-family broadening out of scope.
+
+**Tech Stack:** Next.js App Router, TypeScript, React 19, Vitest, existing Action Center page-data + review rhythm loaders, existing route defaults contract, existing reviewmomenten page shell, Supabase-backed Action Center truth.
+
+---
+
+## Scope Check
+
+This child plan assumes the live baselines from the following merged work are already present in the current worktree:
+
+- contextual entry / deeplink foundation
+- HR Rhythm Console
+- Triggered Follow-Through Mail Layer
+- Review Reschedule Flows
+- Native Outlook / Graph integration
+- Route Defaults and bounded suite parity
+- parity follow-up hotfix for persistence guards
+
+Verify before implementation starts:
+
+- `git merge-base --is-ancestor b8e2bb9c08de680a3846801db0453a2b2dc93f66 HEAD`
+
+If this check fails, sync the worktree from `main` before implementing this child plan.
+
+In scope here:
+
+- one bounded HR oversight summary for enabled Action Center route families
+- explicit classification of visible routes into:
+  - `upcoming`
+  - `overdue`
+  - `stale`
+  - `escalation-sensitive`
+  - `resolved`
+- server-derived stale-route detection from canonical review date + rhythm config
+- server-derived escalation-sensitive detection from overdue age + rhythm config
+- a compact HR-facing overview block inside the existing reviewmomenten route
+- guardrails that keep blocked families out of oversight counts and lists
+
+Explicitly out of scope here:
+
+- new outbound mail trigger families
+- changing reminder cadence or reminder delivery semantics
+- manager assignment or reassignment execution
+- review reschedule mutation changes
+- closeout/reopen redesign
+- new Action Center pages, tabs, or query views
+- route-family expansion beyond currently enabled families
+- buyer-facing packaging or commercialization work
+
+## Product Rules To Preserve
+
+- Action Center remains canonical truth; oversight state is derived, not hand-entered.
+- HR oversight stays inside the existing reviewmomenten surface and must not create another workbench layer.
+- Enabled route families remain bounded to the shared route-defaults contract.
+- Blocked families (`pulse`, `onboarding`, `leadership`, `team`) stay fail-closed in overview state.
+- Escalation-sensitive is a read/governance signal only in this slice; it must not auto-trigger new behavior by itself.
+- This slice may expose “what needs HR attention now,” but it must not turn reviewmomenten into a generic planning or task-management board.
+
+## Oversight Contract
+
+This slice should introduce one shared oversight model derived from existing truth:
+
+| Oversight state | Meaning |
+| --- | --- |
+| `upcoming` | review is scheduled in the future and still within bounded cadence health |
+| `overdue` | review date is in the past but not yet stale and not yet escalation-sensitive |
+| `stale` | review date is missing, invalid, or overdue beyond the configured cadence window |
+| `escalation-sensitive` | review is overdue and has crossed the configured escalation threshold while route is still unresolved |
+| `resolved` | route is effectively no longer active for HR follow-through pressure |
+
+Additional rules:
+
+- `resolved` should include closed routes and routes whose follow-through has already resolved through closeout/successor semantics.
+- `stale` must be derived from canonical route + rhythm state, not from mail-send history.
+- `escalation-sensitive` must be impossible for resolved routes.
+- one route may only contribute to one oversight state at a time.
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `frontend/lib/action-center-review-oversight.ts` | Shared oversight types, classification helpers, and bounded summary derivation |
+| `frontend/lib/action-center-review-oversight.test.ts` | Unit tests for state classification, stale detection, escalation-sensitive detection, and blocked-family guarding |
+| `frontend/lib/action-center-review-rhythm-data.ts` | Extend the existing loader with oversight summary/list payloads derived from canonical route truth |
+| `frontend/lib/action-center-review-rhythm-data.test.ts` | Loader tests for oversight grouping, enabled-family-only behavior, and permission-safe visibility |
+| `frontend/components/dashboard/review-rhythm-oversight.tsx` | Compact HR oversight summary/list component inside reviewmomenten |
+| `frontend/components/dashboard/review-rhythm-oversight.test.tsx` | Render/source-contract tests for bounded overview copy and no extra layer creation |
+| `frontend/components/dashboard/review-moment-page-client.tsx` | Thread the new oversight block into the existing reviewmomenten client surface |
+| `frontend/components/dashboard/review-moment-page-client.test.ts` | Source-contract updates for bounded oversight placement |
+| `frontend/app/(dashboard)/action-center/reviewmomenten/page.tsx` | Server shell wiring for oversight payload into the existing reviewmomenten route |
+| `frontend/app/(dashboard)/action-center/reviewmomenten/page.entry-shell.test.ts` | Source-contract test for oversight wiring inside the existing route |
+
+Do **not** touch:
+
+- `frontend/app/api/action-center-follow-through-mails/route.ts`
+- `frontend/app/api/action-center-review-reschedules/route.ts`
+- `frontend/app/api/action-center-review-rhythm/route.ts`
+- `frontend/lib/action-center-route-defaults.ts` except for type-safe reuse
+- Outlook / Graph sync helpers
+- unrelated Action Center overview, action, or manager pages
+
+---
+
+### Task 1: Add the Shared Review Oversight Contract
+
+**Files:**
+- Create: `frontend/lib/action-center-review-oversight.ts`
+- Create: `frontend/lib/action-center-review-oversight.test.ts`
+
+- [ ] **Step 1: Write the failing contract tests**
+
+Test requirements:
+
+- classify an enabled route as `upcoming` when the review is scheduled in the future
+- classify an enabled route as `overdue` when the review is in the past but still inside cadence health
+- classify an enabled route as `stale` when:
+  - review date is missing
+  - review date is invalid
+  - overdue age is greater than cadence window
+- classify an enabled route as `escalation-sensitive` when overdue age crosses escalation threshold and the route is unresolved
+- never classify blocked route families into oversight output
+- never classify resolved routes as `overdue`, `stale`, or `escalation-sensitive`
+
+- [ ] **Step 2: Run the contract tests and verify they fail**
+
+Run:
+
+```bash
+npx vitest run "lib/action-center-review-oversight.test.ts"
+```
+
+Expected: FAIL because the shared oversight helper does not exist yet.
+
+- [ ] **Step 3: Add the shared oversight helper**
+
+Implementation requirements:
+
+- define a bounded oversight state union
+- expose one classification helper that takes:
+  - route scan type
+  - route status
+  - review date
+  - review completed date
+  - review outcome
+  - follow-up target presence
+  - rhythm config
+  - current time
+- expose one summary helper that turns visible route items into count buckets
+- use existing route-default and rhythm helpers rather than re-encoding cadence math ad hoc
+
+- [ ] **Step 4: Re-run the oversight contract tests**
+
+Run:
+
+```bash
+npx vitest run "lib/action-center-review-oversight.test.ts"
+```
+
+Expected: PASS.
+
+### Task 2: Thread Oversight State Through the Existing Review Rhythm Loader
+
+**Files:**
+- Modify: `frontend/lib/action-center-review-rhythm-data.ts`
+- Modify: `frontend/lib/action-center-review-rhythm-data.test.ts`
+- Import: `frontend/lib/action-center-review-oversight.ts`
+
+- [ ] **Step 1: Extend the failing loader tests first**
+
+Test requirements:
+
+- the loader returns an oversight summary for visible enabled routes only
+- blocked families do not appear in oversight counts
+- visible enabled routes can appear in stale/escalation-sensitive groupings
+- overview remains permission-safe and scoped to what the user can already see in reviewmomenten
+
+- [ ] **Step 2: Run the loader tests and verify they fail**
+
+Run:
+
+```bash
+npx vitest run "lib/action-center-review-rhythm-data.test.ts"
+```
+
+Expected: FAIL because the oversight payload is not returned yet.
+
+- [ ] **Step 3: Extend the loader**
+
+Implementation requirements:
+
+- derive oversight summary and optional spotlight lists from already-visible reviewmomenten items
+- keep route-family eligibility strictly bound to shared route defaults
+- do not add any new write behavior
+- keep returned payload compact; prefer counts + a small spotlight list rather than a second giant page dataset
+
+- [ ] **Step 4: Re-run the loader tests**
+
+Run:
+
+```bash
+npx vitest run "lib/action-center-review-rhythm-data.test.ts" "lib/action-center-review-oversight.test.ts"
+```
+
+Expected: PASS.
+
+### Task 3: Add the Bounded HR Oversight Block to Reviewmomenten
+
+**Files:**
+- Create: `frontend/components/dashboard/review-rhythm-oversight.tsx`
+- Create: `frontend/components/dashboard/review-rhythm-oversight.test.tsx`
+- Modify: `frontend/components/dashboard/review-moment-page-client.tsx`
+- Modify: `frontend/components/dashboard/review-moment-page-client.test.ts`
+- Modify: `frontend/app/(dashboard)/action-center/reviewmomenten/page.tsx`
+- Modify: `frontend/app/(dashboard)/action-center/reviewmomenten/page.entry-shell.test.ts`
+
+- [ ] **Step 1: Add failing source/render tests first**
+
+Test requirements:
+
+- oversight stays inside the existing reviewmomenten route
+- visible copy stays bounded to rhythm/governance language
+- forbidden copy stays out:
+  - `automation builder`
+  - `workflow`
+  - `project planning`
+  - `task board`
+  - `new tool`
+- the page threads the oversight payload from the server shell into the client surface
+
+- [ ] **Step 2: Run the page/component tests and verify they fail**
+
+Run:
+
+```bash
+npx vitest run "components/dashboard/review-rhythm-oversight.test.tsx" "components/dashboard/review-moment-page-client.test.ts" "app/(dashboard)/action-center/reviewmomenten/page.entry-shell.test.ts"
+```
+
+Expected: FAIL because the component and wiring do not exist yet.
+
+- [ ] **Step 3: Implement the bounded oversight UI**
+
+Implementation requirements:
+
+- render one compact summary block for:
+  - overdue
+  - stale
+  - escalation-sensitive
+  - upcoming
+- optionally render a short “needs HR attention now” list using already-visible routes only
+- preserve the current reviewmomenten information hierarchy
+- avoid adding new filters, tabs, or global navigation
+- keep the UI useful on desktop and mobile
+
+- [ ] **Step 4: Re-run the page/component tests**
+
+Run:
+
+```bash
+npx vitest run "components/dashboard/review-rhythm-oversight.test.tsx" "components/dashboard/review-moment-page-client.test.ts" "app/(dashboard)/action-center/reviewmomenten/page.entry-shell.test.ts"
+```
+
+Expected: PASS.
+
+### Task 4: Run the Bounded Verification Suite
+
+**Files:**
+- No new files
+
+- [ ] Run the bounded reviewmomenten / oversight verification suite:
+
+```bash
+npx vitest run "lib/action-center-review-oversight.test.ts" "lib/action-center-review-rhythm-data.test.ts" "components/dashboard/review-rhythm-oversight.test.tsx" "components/dashboard/review-moment-page-client.test.ts" "components/dashboard/review-rhythm-console.test.tsx" "app/(dashboard)/action-center/reviewmomenten/page.entry-shell.test.ts"
+```
+
+Expected: PASS.
+
+- [ ] Run the adjacent bounded Action Center regression suite:
+
+```bash
+npx vitest run "lib/action-center-route-defaults.test.ts" "lib/action-center-review-rhythm.test.ts" "lib/action-center-review-invite.test.ts" "lib/action-center-review-reschedule.test.ts" "lib/action-center-follow-through-mail-planner.test.ts" "components/dashboard/review-moment-detail-panel.test.ts"
+```
+
+Expected: PASS.
+
+- [ ] If practical, run:
+
+```bash
+npm run build
+```
+
+Expected:
+
+- compile/typecheck must stay green for this slice
+- if build still stops on the known auth/Supabase prerender env baseline, document that explicitly and do not misattribute it to this slice
+
+## Acceptance Criteria
+
+- HR can see a compact oversight summary for enabled follow-through routes inside `reviewmomenten`.
+- Oversight state is fully derived from canonical Action Center truth and shared rhythm config.
+- `stale` and `escalation-sensitive` are explicit and test-covered.
+- Blocked route families remain absent from oversight output.
+- No new Action Center page, workflow layer, or route family is introduced.
+- Bounded reviewmomenten and adjacent Action Center regression suites are green.
+
+## Commit
+
+Suggested commit message:
+
+```bash
+Add Action Center HR oversight stale-route governance
+```

--- a/frontend/app/(dashboard)/action-center/reviewmomenten/page.entry-shell.test.ts
+++ b/frontend/app/(dashboard)/action-center/reviewmomenten/page.entry-shell.test.ts
@@ -25,5 +25,7 @@ describe('action center reviewmomenten entry shell', () => {
     expect(source).toContain('manageableReviewRhythmRouteIds=')
     expect(source).toContain('nativeCalendarEligibleRouteIds=')
     expect(source).toContain('rhythmConfigByRouteId=')
+    expect(source).toContain('oversightSummary={rhythmData.oversight.summary}')
+    expect(source).toContain('oversightAttentionItems={rhythmData.oversight.attentionItems}')
   })
 })

--- a/frontend/app/(dashboard)/action-center/reviewmomenten/page.tsx
+++ b/frontend/app/(dashboard)/action-center/reviewmomenten/page.tsx
@@ -133,6 +133,8 @@ export default async function ActionCenterReviewmomentenPage() {
       manageableReviewRhythmRouteIds={manageableReviewRhythmRouteIds}
       nativeCalendarEligibleRouteIds={nativeCalendarEligibleRouteIds}
       rhythmConfigByRouteId={rhythmData.configByRouteId}
+      oversightSummary={rhythmData.oversight.summary}
+      oversightAttentionItems={rhythmData.oversight.attentionItems}
     />
   )
 }

--- a/frontend/components/dashboard/review-moment-page-client.test.ts
+++ b/frontend/components/dashboard/review-moment-page-client.test.ts
@@ -57,10 +57,13 @@ describe('review moment page client source', () => {
     const source = readFileSync(new URL('./review-moment-page-client.tsx', import.meta.url), 'utf8')
 
     expect(source).toContain('ReviewRhythmConsole')
+    expect(source).toContain('ReviewRhythmOversight')
     expect(source).toContain('manageableReviewRhythmRouteIds')
     expect(source).toContain('new Set(manageableReviewRhythmRouteIds)')
     expect(source).toContain('canManageSelectedReviewRhythm')
     expect(source).toContain('rhythmConfigByRouteId')
+    expect(source).toContain('oversightSummary')
+    expect(source).toContain('oversightAttentionItems')
     expect(source).toContain('buildDefaultActionCenterReviewRhythmConfig')
     expect(source).toContain('getActionCenterEnabledRouteDefaults(routeScanTypeByRouteId[getReviewMomentRouteId(selectedItem)])')
     expect(source).toContain('selectedRouteId={selectedRhythmItem ? selectedRhythmItem.coreSemantics.route.routeId : null}')
@@ -84,6 +87,8 @@ describe('review moment page client source', () => {
       'uitnodiging',
       'activatie',
       'workflow builder',
+      'task board',
+      'project planning',
       'outlook',
       'mail engine',
       'pending',

--- a/frontend/components/dashboard/review-moment-page-client.tsx
+++ b/frontend/components/dashboard/review-moment-page-client.tsx
@@ -9,7 +9,12 @@ import {
   DashboardSection,
 } from '@/components/dashboard/dashboard-primitives'
 import { ReviewRhythmConsole } from '@/components/dashboard/review-rhythm-console'
+import { ReviewRhythmOversight } from '@/components/dashboard/review-rhythm-oversight'
 import type { ActionCenterPreviewItem, ActionCenterPreviewStatus } from '@/lib/action-center-preview-model'
+import type {
+  ActionCenterReviewOversightAttentionItem,
+  ActionCenterReviewOversightSummary,
+} from '@/lib/action-center-review-oversight'
 import {
   getActionCenterEnabledRouteDefaults,
   type ActionCenterRouteDefaultsKnownScanType,
@@ -113,6 +118,8 @@ export function ReviewMomentPageClient({
   manageableReviewRhythmRouteIds,
   nativeCalendarEligibleRouteIds,
   rhythmConfigByRouteId,
+  oversightSummary,
+  oversightAttentionItems,
 }: {
   items: ActionCenterPreviewItem[]
   governanceCounts: ReviewMomentGovernanceCounts
@@ -124,6 +131,8 @@ export function ReviewMomentPageClient({
   manageableReviewRhythmRouteIds: string[]
   nativeCalendarEligibleRouteIds: string[]
   rhythmConfigByRouteId: Record<string, ActionCenterReviewRhythmConfig>
+  oversightSummary: ActionCenterReviewOversightSummary
+  oversightAttentionItems: ActionCenterReviewOversightAttentionItem[]
 }) {
   const [statusFilter, setStatusFilter] = useState<'all' | ActionCenterPreviewStatus>('all')
   const [scopeFilter, setScopeFilter] = useState<string>('all')
@@ -334,6 +343,11 @@ export function ReviewMomentPageClient({
         completedCount={grouped.completed.length}
         showCompleted={showCompleted}
         onToggleCompleted={() => setShowCompleted((current) => !current)}
+      />
+
+      <ReviewRhythmOversight
+        summary={oversightSummary}
+        attentionItems={oversightAttentionItems}
       />
 
       <div id="review-lanes" className="grid gap-6 xl:grid-cols-[minmax(0,1.45fr),minmax(320px,0.82fr)]">

--- a/frontend/components/dashboard/review-rhythm-oversight.test.tsx
+++ b/frontend/components/dashboard/review-rhythm-oversight.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { ReviewRhythmOversight } from './review-rhythm-oversight'
+
+describe('review rhythm oversight', () => {
+  it('renders bounded HR oversight summary and attention items inside reviewmomenten language', () => {
+    const markup = renderToStaticMarkup(
+      <ReviewRhythmOversight
+        summary={{
+          upcomingCount: 3,
+          overdueCount: 1,
+          staleCount: 2,
+          escalationSensitiveCount: 1,
+          resolvedCount: 4,
+        }}
+        attentionItems={[
+          {
+            routeId: 'route-1',
+            state: 'escalation-sensitive',
+            scopeLabel: 'Operations',
+            sourceLabel: 'RetentieScan',
+            reviewDateLabel: '20 mei',
+          },
+          {
+            routeId: 'route-2',
+            state: 'stale',
+            scopeLabel: 'Support',
+            sourceLabel: 'ExitScan',
+            reviewDateLabel: 'Nog niet gepland',
+          },
+        ]}
+      />,
+    )
+
+    expect(markup).toContain('HR overzicht')
+    expect(markup).toContain('Waar HR nu moet kijken')
+    expect(markup).toContain('Escalatiegevoelig')
+    expect(markup).toContain('Achter cadans')
+    expect(markup).toContain('Achter op review')
+    expect(markup).toContain('Binnen cadans')
+    expect(markup).toContain('Operations')
+    expect(markup).toContain('RetentieScan')
+    expect(markup).not.toContain('workflow')
+    expect(markup).not.toContain('task board')
+    expect(markup).not.toContain('project planning')
+  })
+})

--- a/frontend/components/dashboard/review-rhythm-oversight.tsx
+++ b/frontend/components/dashboard/review-rhythm-oversight.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import React from 'react'
+import { DashboardPanel, DashboardSection } from '@/components/dashboard/dashboard-primitives'
+import type {
+  ActionCenterReviewOversightAttentionItem,
+  ActionCenterReviewOversightSummary,
+} from '@/lib/action-center-review-oversight'
+
+function getOversightStateLabel(
+  state: ActionCenterReviewOversightAttentionItem['state'],
+) {
+  if (state === 'escalation-sensitive') return 'Escalatiegevoelig'
+  if (state === 'stale') return 'Achter cadans'
+  return 'Achter op review'
+}
+
+export function ReviewRhythmOversight({
+  summary,
+  attentionItems,
+}: {
+  summary: ActionCenterReviewOversightSummary
+  attentionItems: ActionCenterReviewOversightAttentionItem[]
+}) {
+  const totalCount =
+    summary.upcomingCount +
+    summary.overdueCount +
+    summary.staleCount +
+    summary.escalationSensitiveCount +
+    summary.resolvedCount
+
+  if (totalCount === 0) {
+    return null
+  }
+
+  return (
+    <DashboardSection
+      surface="ops"
+      eyebrow="HR overzicht"
+      title="Waar HR nu moet kijken"
+      description="Bewaak welke follow-through-routes binnen cadans lopen, waar reviewdruk oploopt en waar opvolging om HR-aandacht vraagt."
+    >
+      <div className="grid gap-4 lg:grid-cols-2 xl:grid-cols-4">
+        <DashboardPanel
+          surface="ops"
+          eyebrow="Escalatiegevoelig"
+          title={`${summary.escalationSensitiveCount} open`}
+          body="Routes die over hun reviewdatum heen zijn en inmiddels de ingestelde escalatiegrens hebben bereikt."
+          tone={summary.escalationSensitiveCount > 0 ? 'amber' : 'slate'}
+        />
+        <DashboardPanel
+          surface="ops"
+          eyebrow="Achter cadans"
+          title={`${summary.staleCount} open`}
+          body="Routes zonder geldige reviewplanning of met reviewdruk buiten het ingestelde cadansvenster."
+          tone={summary.staleCount > 0 ? 'amber' : 'slate'}
+        />
+        <DashboardPanel
+          surface="ops"
+          eyebrow="Achter op review"
+          title={`${summary.overdueCount} open`}
+          body="Routes met een gemiste reviewdatum die nog niet vervallen of geëscaleerd zijn."
+          tone={summary.overdueCount > 0 ? 'slate' : 'slate'}
+        />
+        <DashboardPanel
+          surface="ops"
+          eyebrow="Binnen cadans"
+          title={`${summary.upcomingCount} actief`}
+          body="Zichtbare routes met een geldige reviewplanning die nog binnen het ingestelde ritme vallen."
+          tone="slate"
+        />
+      </div>
+
+      {attentionItems.length > 0 ? (
+        <div className="mt-4 rounded-[22px] border border-[color:var(--dashboard-frame-border)] bg-white p-5 shadow-[0_10px_24px_rgba(19,32,51,0.05)]">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-text)]">
+            Nu aandacht nodig
+          </p>
+          <div className="mt-4 space-y-3">
+            {attentionItems.map((item) => (
+              <div
+                key={`${item.routeId}:${item.state}`}
+                className="flex flex-wrap items-center justify-between gap-3 rounded-[18px] border border-[color:var(--dashboard-frame-border)] bg-[color:var(--dashboard-muted-surface)] px-4 py-3"
+              >
+                <div className="space-y-1">
+                  <p className="text-sm font-semibold text-[color:var(--dashboard-ink)]">{item.scopeLabel}</p>
+                  <p className="text-xs text-[color:var(--dashboard-text)]">
+                    {item.sourceLabel} · {item.reviewDateLabel}
+                  </p>
+                </div>
+                <span className="rounded-full border border-[color:var(--dashboard-frame-border)] bg-white px-3 py-1 text-xs font-semibold text-[color:var(--dashboard-ink)]">
+                  {getOversightStateLabel(item.state)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </DashboardSection>
+  )
+}

--- a/frontend/lib/action-center-review-oversight.test.ts
+++ b/frontend/lib/action-center-review-oversight.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest'
+import { buildDefaultActionCenterReviewRhythmConfig } from './action-center-review-rhythm'
+import {
+  buildActionCenterReviewOversightSummary,
+  classifyActionCenterReviewOversightState,
+} from './action-center-review-oversight'
+
+const DEFAULT_CONFIG = buildDefaultActionCenterReviewRhythmConfig()
+
+describe('action center review oversight contract', () => {
+  it('classifies enabled future review routes as upcoming', () => {
+    expect(
+      classifyActionCenterReviewOversightState({
+        scanType: 'exit',
+        routeStatus: 'reviewbaar',
+        reviewDate: '2026-05-20',
+        reviewCompletedAt: null,
+        reviewOutcome: 'geen-uitkomst',
+        hasFollowUpTarget: false,
+        config: DEFAULT_CONFIG,
+        now: new Date('2026-05-17T12:00:00.000Z'),
+      }),
+    ).toBe('upcoming')
+  })
+
+  it('classifies enabled overdue routes inside cadence health as overdue', () => {
+    expect(
+      classifyActionCenterReviewOversightState({
+        scanType: 'exit',
+        routeStatus: 'reviewbaar',
+        reviewDate: '2026-05-15',
+        reviewCompletedAt: null,
+        reviewOutcome: 'geen-uitkomst',
+        hasFollowUpTarget: false,
+        config: DEFAULT_CONFIG,
+        now: new Date('2026-05-17T12:00:00.000Z'),
+      }),
+    ).toBe('overdue')
+  })
+
+  it('classifies overdue unresolved routes beyond escalation threshold as escalation-sensitive', () => {
+    expect(
+      classifyActionCenterReviewOversightState({
+        scanType: 'retention',
+        routeStatus: 'reviewbaar',
+        reviewDate: '2026-05-08',
+        reviewCompletedAt: null,
+        reviewOutcome: 'geen-uitkomst',
+        hasFollowUpTarget: false,
+        config: DEFAULT_CONFIG,
+        now: new Date('2026-05-17T12:00:00.000Z'),
+      }),
+    ).toBe('escalation-sensitive')
+  })
+
+  it('classifies missing or expired review cadence as stale', () => {
+    expect(
+      classifyActionCenterReviewOversightState({
+        scanType: 'exit',
+        routeStatus: 'reviewbaar',
+        reviewDate: null,
+        reviewCompletedAt: null,
+        reviewOutcome: 'geen-uitkomst',
+        hasFollowUpTarget: false,
+        config: DEFAULT_CONFIG,
+        now: new Date('2026-05-17T12:00:00.000Z'),
+      }),
+    ).toBe('stale')
+
+    expect(
+      classifyActionCenterReviewOversightState({
+        scanType: 'exit',
+        routeStatus: 'reviewbaar',
+        reviewDate: '2026-04-20',
+        reviewCompletedAt: null,
+        reviewOutcome: 'geen-uitkomst',
+        hasFollowUpTarget: false,
+        config: DEFAULT_CONFIG,
+        now: new Date('2026-05-17T12:00:00.000Z'),
+      }),
+    ).toBe('stale')
+  })
+
+  it('classifies closed or resolved routes as resolved before stale/overdue states', () => {
+    expect(
+      classifyActionCenterReviewOversightState({
+        scanType: 'exit',
+        routeStatus: 'afgerond',
+        reviewDate: '2026-04-20',
+        reviewCompletedAt: '2026-05-01T09:00:00.000Z',
+        reviewOutcome: 'afronden',
+        hasFollowUpTarget: false,
+        config: DEFAULT_CONFIG,
+        now: new Date('2026-05-17T12:00:00.000Z'),
+      }),
+    ).toBe('resolved')
+
+    expect(
+      classifyActionCenterReviewOversightState({
+        scanType: 'retention',
+        routeStatus: 'reviewbaar',
+        reviewDate: '2026-05-08',
+        reviewCompletedAt: '2026-05-10T09:00:00.000Z',
+        reviewOutcome: 'doorgaan',
+        hasFollowUpTarget: true,
+        config: DEFAULT_CONFIG,
+        now: new Date('2026-05-17T12:00:00.000Z'),
+      }),
+    ).toBe('resolved')
+  })
+
+  it('keeps blocked route families out of oversight output', () => {
+    expect(
+      classifyActionCenterReviewOversightState({
+        scanType: 'pulse',
+        routeStatus: 'reviewbaar',
+        reviewDate: '2026-05-08',
+        reviewCompletedAt: null,
+        reviewOutcome: 'geen-uitkomst',
+        hasFollowUpTarget: false,
+        config: DEFAULT_CONFIG,
+        now: new Date('2026-05-17T12:00:00.000Z'),
+      }),
+    ).toBeNull()
+  })
+
+  it('builds a bounded oversight summary and spotlight list from eligible routes only', () => {
+    const summary = buildActionCenterReviewOversightSummary({
+      items: [
+        {
+          id: 'route-upcoming',
+          title: 'Upcoming',
+          sourceLabel: 'ExitScan',
+          teamLabel: 'Operations',
+          status: 'reviewbaar',
+          reviewDate: '2026-05-20',
+          reviewDateLabel: '20 mei',
+          reviewOutcome: 'geen-uitkomst',
+          coreSemantics: {
+            route: {
+              routeId: 'route-upcoming',
+              reviewCompletedAt: null,
+              hasFollowUpTarget: false,
+            },
+          },
+        },
+        {
+          id: 'route-stale',
+          title: 'Stale',
+          sourceLabel: 'RetentieScan',
+          teamLabel: 'Support',
+          status: 'reviewbaar',
+          reviewDate: null,
+          reviewDateLabel: 'Nog niet gepland',
+          reviewOutcome: 'geen-uitkomst',
+          coreSemantics: {
+            route: {
+              routeId: 'route-stale',
+              reviewCompletedAt: null,
+              hasFollowUpTarget: false,
+            },
+          },
+        },
+        {
+          id: 'route-blocked',
+          title: 'Blocked family',
+          sourceLabel: 'Pulse',
+          teamLabel: 'HR',
+          status: 'reviewbaar',
+          reviewDate: '2026-05-10',
+          reviewDateLabel: '10 mei',
+          reviewOutcome: 'geen-uitkomst',
+          coreSemantics: {
+            route: {
+              routeId: 'route-blocked',
+              reviewCompletedAt: null,
+              hasFollowUpTarget: false,
+            },
+          },
+        },
+      ] as never,
+      configByRouteId: {
+        'route-upcoming': DEFAULT_CONFIG,
+        'route-stale': DEFAULT_CONFIG,
+      },
+      routeScanTypeByRouteId: {
+        'route-upcoming': 'exit',
+        'route-stale': 'retention',
+        'route-blocked': 'pulse',
+      },
+      now: new Date('2026-05-17T12:00:00.000Z'),
+    })
+
+    expect(summary.summary).toEqual({
+      upcomingCount: 1,
+      overdueCount: 0,
+      staleCount: 1,
+      escalationSensitiveCount: 0,
+      resolvedCount: 0,
+    })
+    expect(summary.attentionItems.map((item) => item.routeId)).toEqual(['route-stale'])
+  })
+})

--- a/frontend/lib/action-center-review-oversight.ts
+++ b/frontend/lib/action-center-review-oversight.ts
@@ -1,0 +1,181 @@
+import type { ActionCenterPreviewItem } from '@/lib/action-center-preview-model'
+import { getReviewMomentScopeLabel } from '@/lib/action-center-review-moments'
+import {
+  getActionCenterEnabledRouteDefaults,
+  type ActionCenterRouteDefaultsKnownScanType,
+} from '@/lib/action-center-route-defaults'
+import {
+  classifyActionCenterReviewRhythmStatus,
+  type ActionCenterReviewRhythmConfig,
+} from '@/lib/action-center-review-rhythm'
+import { isActionCenterFollowThroughMailRouteResolved } from '@/lib/action-center-follow-through-mail'
+import type { ActionCenterReviewOutcome } from '@/lib/action-center-route-contract'
+import type { ActionCenterPreviewStatus } from '@/lib/action-center-preview-model'
+
+export type ActionCenterReviewOversightState =
+  | 'upcoming'
+  | 'overdue'
+  | 'stale'
+  | 'escalation-sensitive'
+  | 'resolved'
+
+export interface ActionCenterReviewOversightSummary {
+  upcomingCount: number
+  overdueCount: number
+  staleCount: number
+  escalationSensitiveCount: number
+  resolvedCount: number
+}
+
+export interface ActionCenterReviewOversightAttentionItem {
+  routeId: string
+  state: Exclude<ActionCenterReviewOversightState, 'upcoming' | 'resolved'>
+  scopeLabel: string
+  sourceLabel: string
+  reviewDateLabel: string
+}
+
+function getOverdueDayDiff(reviewDate: string | null, now: Date) {
+  if (!reviewDate) return null
+
+  const normalized = /^\d{4}-\d{2}-\d{2}$/.test(reviewDate)
+    ? `${reviewDate}T00:00:00.000Z`
+    : reviewDate
+  const parsed = new Date(normalized)
+  if (Number.isNaN(parsed.getTime())) return null
+
+  const nowDay = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+  const reviewDay = Date.UTC(parsed.getUTCFullYear(), parsed.getUTCMonth(), parsed.getUTCDate())
+  return Math.round((nowDay - reviewDay) / 86_400_000)
+}
+
+export function classifyActionCenterReviewOversightState(args: {
+  scanType: ActionCenterRouteDefaultsKnownScanType | string | null | undefined
+  routeStatus: ActionCenterPreviewStatus
+  reviewDate: string | null
+  reviewCompletedAt: string | null
+  reviewOutcome: ActionCenterReviewOutcome
+  hasFollowUpTarget: boolean
+  config: ActionCenterReviewRhythmConfig
+  now: Date
+}): ActionCenterReviewOversightState | null {
+  const routeDefaults = getActionCenterEnabledRouteDefaults(args.scanType)
+  if (!routeDefaults) {
+    return null
+  }
+
+  if (
+    isActionCenterFollowThroughMailRouteResolved({
+      routeStatus: args.routeStatus,
+      reviewOutcome: args.reviewOutcome,
+      hasFollowUpTarget: args.hasFollowUpTarget,
+    })
+  ) {
+    return 'resolved'
+  }
+
+  const health = classifyActionCenterReviewRhythmStatus({
+    reviewDate: args.reviewDate,
+    now: args.now,
+    config: args.config,
+    itemStatus: args.routeStatus,
+  })
+
+  if (health === 'completed') {
+    return 'resolved'
+  }
+
+  if (health === 'stale') {
+    return 'stale'
+  }
+
+  if (health === 'upcoming') {
+    return 'upcoming'
+  }
+
+  const overdueDayDiff = getOverdueDayDiff(args.reviewDate, args.now)
+  if (overdueDayDiff !== null && overdueDayDiff >= args.config.escalationLeadDays) {
+    return 'escalation-sensitive'
+  }
+
+  return 'overdue'
+}
+
+export function buildActionCenterReviewOversightSummary(args: {
+  items: ActionCenterPreviewItem[]
+  configByRouteId: Record<string, ActionCenterReviewRhythmConfig>
+  routeScanTypeByRouteId: Record<string, ActionCenterRouteDefaultsKnownScanType>
+  now: Date
+}) {
+  const summary: ActionCenterReviewOversightSummary = {
+    upcomingCount: 0,
+    overdueCount: 0,
+    staleCount: 0,
+    escalationSensitiveCount: 0,
+    resolvedCount: 0,
+  }
+  const stateByRouteId: Record<string, ActionCenterReviewOversightState> = {}
+  const attentionItems: ActionCenterReviewOversightAttentionItem[] = []
+
+  for (const item of args.items) {
+    const routeId = item.coreSemantics.route.routeId
+    const scanType = args.routeScanTypeByRouteId[routeId]
+    const routeDefaults = getActionCenterEnabledRouteDefaults(scanType)
+
+    if (!routeDefaults) {
+      continue
+    }
+
+    const state = classifyActionCenterReviewOversightState({
+      scanType,
+      routeStatus: item.status,
+      reviewDate: item.reviewDate,
+      reviewCompletedAt: item.coreSemantics.route.reviewCompletedAt,
+      reviewOutcome: item.reviewOutcome,
+      hasFollowUpTarget: item.coreSemantics.route.hasFollowUpTarget,
+      config: args.configByRouteId[routeId] ?? routeDefaults,
+      now: args.now,
+    })
+
+    if (!state) {
+      continue
+    }
+
+    stateByRouteId[routeId] = state
+
+    if (state === 'upcoming') summary.upcomingCount += 1
+    if (state === 'overdue') summary.overdueCount += 1
+    if (state === 'stale') summary.staleCount += 1
+    if (state === 'escalation-sensitive') summary.escalationSensitiveCount += 1
+    if (state === 'resolved') summary.resolvedCount += 1
+
+    if (state === 'stale' || state === 'overdue' || state === 'escalation-sensitive') {
+      attentionItems.push({
+        routeId,
+        state,
+        scopeLabel: getReviewMomentScopeLabel(item),
+        sourceLabel: item.sourceLabel,
+        reviewDateLabel: item.reviewDateLabel,
+      })
+    }
+  }
+
+  attentionItems.sort((left, right) => {
+    const priority = (state: ActionCenterReviewOversightAttentionItem['state']) => {
+      if (state === 'escalation-sensitive') return 0
+      if (state === 'stale') return 1
+      return 2
+    }
+
+    const stateDiff = priority(left.state) - priority(right.state)
+    if (stateDiff !== 0) return stateDiff
+
+    return left.scopeLabel.localeCompare(right.scopeLabel)
+  })
+
+  return {
+    summary,
+    stateByRouteId,
+    attentionItems: attentionItems.slice(0, 5),
+  }
+}

--- a/frontend/lib/action-center-review-rhythm-data.test.ts
+++ b/frontend/lib/action-center-review-rhythm-data.test.ts
@@ -19,6 +19,26 @@ function createRhythmConfigQuery(result: { data: unknown; error?: unknown }) {
   }
 }
 
+function buildItem(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'cmp-exit-1::org-1::department::operations',
+    status: 'reviewbaar',
+    reviewDate: '2026-05-01',
+    sourceLabel: 'ExitScan',
+    teamLabel: 'Operations',
+    reviewDateLabel: '1 mei',
+    reviewOutcome: 'geen-uitkomst',
+    coreSemantics: {
+      route: {
+        routeId: 'cmp-exit-1::org-1::department::operations',
+        reviewCompletedAt: null,
+        hasFollowUpTarget: false,
+      },
+    },
+    ...overrides,
+  }
+}
+
 describe('action center review rhythm data', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -47,18 +67,21 @@ describe('action center review rhythm data', () => {
 
     const result = await getActionCenterReviewRhythmData({
       items: [
-        {
-          id: 'cmp-exit-1::org-1::department::operations',
-          status: 'reviewbaar',
-          reviewDate: '2026-05-01',
-          sourceLabel: 'ExitScan',
-        },
-        {
+        buildItem(),
+        buildItem({
           id: 'cmp-exit-2::org-1::department::finance',
-          status: 'reviewbaar',
-          reviewDate: '2026-05-27',
+          reviewDate: '2026-05-20',
+          reviewDateLabel: '20 mei',
           sourceLabel: 'RetentieScan',
-        },
+          teamLabel: 'Finance',
+          coreSemantics: {
+            route: {
+              routeId: 'cmp-exit-2::org-1::department::finance',
+              reviewCompletedAt: null,
+              hasFollowUpTarget: false,
+            },
+          },
+        }),
       ] as never,
       now: new Date('2026-05-28T12:00:00.000Z'),
       routeScanTypeByRouteId: {
@@ -89,6 +112,23 @@ describe('action center review rhythm data', () => {
       upcomingCount: 0,
       reminderManagedCount: 2,
     })
+    expect(result.oversight.summary).toEqual({
+      upcomingCount: 0,
+      overdueCount: 0,
+      staleCount: 1,
+      escalationSensitiveCount: 1,
+      resolvedCount: 0,
+    })
+    expect(result.oversight.attentionItems).toMatchObject([
+      {
+        routeId: 'cmp-exit-2::org-1::department::finance',
+        state: 'escalation-sensitive',
+      },
+      {
+        routeId: 'cmp-exit-1::org-1::department::operations',
+        state: 'stale',
+      },
+    ])
   })
 
   it('ignores blocked route families for persistence and summary counts', async () => {
@@ -106,12 +146,17 @@ describe('action center review rhythm data', () => {
 
     const result = await getActionCenterReviewRhythmData({
       items: [
-        {
+        buildItem({
           id: 'cmp-pulse-1::org-1::department::operations',
-          status: 'reviewbaar',
-          reviewDate: '2026-05-01',
           sourceLabel: 'Pulse',
-        },
+          coreSemantics: {
+            route: {
+              routeId: 'cmp-pulse-1::org-1::department::operations',
+              reviewCompletedAt: null,
+              hasFollowUpTarget: false,
+            },
+          },
+        }),
       ] as never,
       now: new Date('2026-05-28T12:00:00.000Z'),
       routeScanTypeByRouteId: {
@@ -127,6 +172,14 @@ describe('action center review rhythm data', () => {
       upcomingCount: 0,
       reminderManagedCount: 0,
     })
+    expect(result.oversight.summary).toEqual({
+      upcomingCount: 0,
+      overdueCount: 0,
+      staleCount: 0,
+      escalationSensitiveCount: 0,
+      resolvedCount: 0,
+    })
+    expect(result.oversight.attentionItems).toEqual([])
   })
 
   it('surfaces a failed review rhythm config query instead of silently defaulting', async () => {
@@ -148,12 +201,7 @@ describe('action center review rhythm data', () => {
     await expect(
       getActionCenterReviewRhythmData({
         items: [
-          {
-            id: 'cmp-exit-1::org-1::department::operations',
-            status: 'reviewbaar',
-            reviewDate: '2026-05-01',
-            sourceLabel: 'ExitScan',
-          },
+          buildItem(),
         ] as never,
         now: new Date('2026-05-28T12:00:00.000Z'),
         routeScanTypeByRouteId: {

--- a/frontend/lib/action-center-review-rhythm-data.ts
+++ b/frontend/lib/action-center-review-rhythm-data.ts
@@ -1,4 +1,5 @@
 import type { ActionCenterPreviewItem } from '@/lib/action-center-preview-model'
+import { buildActionCenterReviewOversightSummary } from '@/lib/action-center-review-oversight'
 import {
   getActionCenterEnabledRouteDefaults,
   type ActionCenterRouteDefaultsKnownScanType,
@@ -92,9 +93,16 @@ export async function getActionCenterReviewRhythmData(args: {
       reminderManagedCount: 0,
     },
   )
+  const oversight = buildActionCenterReviewOversightSummary({
+    items: eligibleItems,
+    configByRouteId,
+    routeScanTypeByRouteId: args.routeScanTypeByRouteId,
+    now: args.now,
+  })
 
   return {
     configByRouteId,
     summary,
+    oversight,
   }
 }


### PR DESCRIPTION
## Summary
- add a bounded HR oversight contract for upcoming, overdue, stale, escalation-sensitive, and resolved review routes
- thread a server-derived oversight payload through the existing review rhythm loader and reviewmomenten shell
- add a compact HR overview block to reviewmomenten without creating a new Action Center layer

## Testing
- `npx vitest run "lib/action-center-review-oversight.test.ts" "lib/action-center-review-rhythm-data.test.ts" "components/dashboard/review-rhythm-oversight.test.tsx" "components/dashboard/review-moment-page-client.test.ts" "components/dashboard/review-rhythm-console.test.tsx" "app/(dashboard)/action-center/reviewmomenten/page.entry-shell.test.ts" "lib/action-center-route-defaults.test.ts" "lib/action-center-review-rhythm.test.ts" "lib/action-center-review-invite.test.ts" "lib/action-center-review-reschedule.test.ts" "lib/action-center-follow-through-mail-planner.test.ts" "components/dashboard/review-moment-detail-panel.test.ts"`
- `npm run build` compiles and typechecks; it still stops on the pre-existing Supabase auth env prerender baseline (`/forgot-password`)