### PR TITLE
Tighten beheer campaign setup UI

### DIFF
--- a/frontend/app/(dashboard)/beheer/new-campaign-form.guard.test.ts
+++ b/frontend/app/(dashboard)/beheer/new-campaign-form.guard.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('new campaign form clarity', () => {
+  it('keeps the campaign step compact and strips long route explanations', () => {
+    const source = readFileSync(new URL('../../../components/dashboard/new-campaign-form.tsx', import.meta.url), 'utf8')
+
+    expect(source).toContain('Kies product')
+    expect(source).toContain('Kies route')
+    expect(source).toContain('Surveymodules')
+    expect(source).not.toContain('Onboardingverwachting voor deze route')
+    expect(source).not.toContain('RetentieScan v1.1-validatievoorbereiding')
+    expect(source).not.toContain('Pulse wave 1-boundary')
+    expect(source).not.toContain('Leadership Scan management boundary')
+    expect(source).not.toContain('Deze setup blijft assisted')
+    expect(source).not.toContain('Hier bepaal je of de campagne als ExitScan, RetentieScan, Pulse, TeamScan, Onboarding 30-60-90 of Leadership Scan wordt opgezet')
+  })
+})

--- a/frontend/app/(dashboard)/beheer/page.tsx
+++ b/frontend/app/(dashboard)/beheer/page.tsx
@@ -176,7 +176,7 @@ export default async function BeheerPage() {
         description="Werk de setup hier direct af in vaste volgorde."
         aside={<DashboardChip surface="ops" label={`${campaigns.length} campaign${campaigns.length === 1 ? '' : 's'} totaal`} />}
       >
-        <div className="grid gap-5 lg:grid-cols-2">
+        <div className="grid gap-5">
           <StepCard done={step1Done} number={1} title="Organisatie aanmaken">
             {orgs.length > 0 ? (
               <div className="space-y-2">

--- a/frontend/components/dashboard/new-campaign-form.tsx
+++ b/frontend/components/dashboard/new-campaign-form.tsx
@@ -3,7 +3,6 @@
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { createClient } from '@/lib/supabase/client'
-import { getDeliveryModeDescription } from '@/lib/implementation-readiness'
 import type { DeliveryMode, Organization, ScanType } from '@/lib/types'
 import { FACTOR_LABELS, REPORT_ADD_ON_DESCRIPTIONS, REPORT_ADD_ON_LABELS } from '@/lib/types'
 
@@ -13,6 +12,15 @@ const ONBOARDING_DEFAULT_MODULES = ['leadership', 'role_clarity', 'culture', 'gr
 const PULSE_DEFAULT_MODULES = ['leadership', 'growth', 'workload']
 const TEAM_DEFAULT_MODULES = ['leadership', 'culture', 'workload', 'role_clarity']
 const LEADERSHIP_DEFAULT_MODULES = ['leadership', 'role_clarity', 'culture', 'growth']
+
+const SCAN_OPTIONS: Array<{ value: ScanType; title: string; short: string }> = [
+  { value: 'exit', title: 'ExitScan', short: 'Vertrek en frictie' },
+  { value: 'retention', title: 'RetentieScan', short: 'Behoud onder druk' },
+  { value: 'pulse', title: 'Pulse', short: 'Korte momentcheck' },
+  { value: 'team', title: 'TeamScan', short: 'Lokaal teambeeld' },
+  { value: 'onboarding', title: 'Onboarding 30-60-90', short: 'Vroege instroomcheck' },
+  { value: 'leadership', title: 'Leadership Scan', short: 'Geaggregeerde managementread' },
+]
 
 interface Props {
   orgs: Organization[]
@@ -30,7 +38,6 @@ export function NewCampaignForm({ orgs }: Props) {
   const router = useRouter()
   const supabase = createClient()
 
-  const hasSelectedFactorSubset = modules.some((module) => ORG_FACTORS.includes(module))
   const hasSegmentDeepDive = modules.includes('segment_deep_dive')
   const campaignNamePlaceholder =
     scanType === 'exit'
@@ -110,12 +117,7 @@ export function NewCampaignForm({ orgs }: Props) {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
-      <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4">
-        <p className="text-sm font-semibold text-slate-900">1. Kies organisatie en campagnenaam</p>
-        <p className="mt-1 text-sm text-slate-600">
-          Leg eerst vast voor welke klant de campagne draait en hoe de campagne in het dashboard moet terugkomen.
-        </p>
-      </div>
+      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Context</p>
 
       <div>
         <label className="mb-1 block text-sm font-medium text-slate-700">Organisatie</label>
@@ -140,90 +142,28 @@ export function NewCampaignForm({ orgs }: Props) {
         />
       </div>
 
-      <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4">
-        <p className="text-sm font-semibold text-slate-900">2. Kies product en verdiepniveau</p>
-        <p className="mt-1 text-sm text-slate-600">
-          Hier bepaal je of de campagne als ExitScan, RetentieScan, Pulse, TeamScan, Onboarding 30-60-90 of Leadership Scan wordt opgezet en of je de standaarddiepte gebruikt of een bewuste subset.
-        </p>
+      <div className="border-t border-slate-200 pt-2">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Kies product</p>
       </div>
 
-      <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-6">
-        {(['exit', 'retention', 'pulse', 'team', 'onboarding', 'leadership'] as const).map((option) => (
+      <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+        {SCAN_OPTIONS.map((option) => (
           <button
-            key={option}
+            key={option.value}
             type="button"
-            onClick={() => handleScanTypeChange(option)}
+            onClick={() => handleScanTypeChange(option.value)}
             className={`rounded-[22px] border p-4 text-left transition-colors ${
-              scanType === option ? 'border-blue-600 bg-blue-600 text-white' : 'border-slate-200 bg-white text-slate-700 hover:border-blue-300'
+              scanType === option.value ? 'border-blue-600 bg-blue-600 text-white' : 'border-slate-200 bg-white text-slate-700 hover:border-blue-300'
             }`}
           >
-            <p className="text-sm font-semibold">
-              {option === 'exit'
-                ? 'ExitScan'
-                : option === 'retention'
-                  ? 'RetentieScan'
-                  : option === 'pulse'
-                    ? 'Pulse'
-                    : option === 'team'
-                      ? 'TeamScan'
-                      : option === 'onboarding'
-                        ? 'Onboarding 30-60-90'
-                        : 'Leadership Scan'}
-            </p>
-            <p className={`mt-1 text-sm ${scanType === option ? 'text-blue-100' : 'text-slate-500'}`}>
-              {option === 'exit'
-                ? 'Terugkijken op vertrek, frictie en beinvloedbare werkfactoren.'
-                : option === 'retention'
-                  ? 'Vroeg signaleren waar behoud onder druk komt te staan.'
-                  : option === 'pulse'
-                    ? 'Korte check-in om te zien of signalen of acties nu bijsturing vragen.'
-                    : option === 'team'
-                      ? 'Lokaliseren waar een al zichtbaar signaal lokaal het scherpst speelt.'
-                      : option === 'onboarding'
-                        ? 'Vroege lifecycle-check voor nieuwe medewerkers op een enkel checkpoint.'
-                        : 'Geaggregeerde managementread over leidingcontext, prioritering en werkbaarheid.'}
-            </p>
+            <p className="text-sm font-semibold">{option.title}</p>
+            <p className={`mt-1 text-sm ${scanType === option.value ? 'text-blue-100' : 'text-slate-500'}`}>{option.short}</p>
           </button>
         ))}
       </div>
 
-      <div className="rounded-[22px] border border-slate-200 bg-white p-4 text-sm leading-6 text-slate-700">
-        <p className="font-semibold text-slate-900">Onboardingverwachting voor deze route</p>
-        <p className="mt-2">
-          {deliveryMode === 'live'
-            ? scanType === 'exit'
-              ? 'Je kiest nu bewust voor een live / doorlopende ExitScan-route. Gebruik dit alleen als baseline, volumelogica en intern eigenaarschap al staan.'
-              : scanType === 'retention'
-                ? 'Je kiest nu bewust voor een ritme- of live-route voor RetentieScan. Gebruik dit alleen als baseline, eerste opvolging en meetritme al scherp zijn.'
-                : scanType === 'pulse'
-                  ? 'Pulse live of ritme is nog niet opengezet in deze wave. Gebruik Pulse nu alleen als eerste compacte baseline-snapshot.'
-                : scanType === 'team'
-                    ? 'TeamScan live of ritme is nog niet opengezet in deze wave. Gebruik TeamScan nu alleen als eerste veilige department-first baseline-read.'
-                    : scanType === 'onboarding'
-                      ? 'Onboarding live of ritme is nog niet opengezet in deze wave. Gebruik onboarding nu alleen als eerste checkpoint-read voor een enkele instroomfase.'
-                      : 'Leadership Scan live of ritme is nog niet opengezet in deze wave. Gebruik Leadership Scan nu alleen als eerste geaggregeerde managementcontext-read.'
-            : scanType === 'exit'
-              ? 'ExitScan wordt meestal eerst als baseline opgezet. Live opvolging wordt pas logisch nadat de nulmeting, het volume en het eigenaarschap scherp staan.'
-              : scanType === 'retention'
-                ? 'RetentieScan start meestal als baseline. Ritme of herhaalmeting komt pas daarna, zodra de eerste duiding en opvolging helder zijn.'
-                : scanType === 'pulse'
-                  ? 'Pulse start in deze wave altijd als baseline. Eerst bewijzen we de compacte snapshot en reviewlus; echte ritme- of trendlogica volgt later.'
-                  : scanType === 'team'
-                    ? 'TeamScan start in deze wave altijd als baseline. Eerst bewijzen we de veilige lokale read op afdelingsniveau; ranking of bredere lokalisatie volgt pas later.'
-                    : scanType === 'onboarding'
-                      ? 'Onboarding start in deze wave altijd als baseline. Eerst bewijzen we een enkel checkpoint per campaign; journey- of 30-60-90-automation volgt pas later.'
-                      : 'Leadership Scan start in deze wave altijd als baseline. Eerst bewijzen we een geaggregeerde managementread zonder named leaders, hierarchy of 360-logica.'}
-        </p>
-        <p className="mt-2 text-xs text-slate-500">
-          Deze setup blijft assisted: Loep beheert campaign, importcontrole en activatie; de klant levert input en gebruikt daarna dashboard en rapport.
-        </p>
-      </div>
-
-      <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4">
-        <p className="text-sm font-semibold text-slate-900">3. Kies implementatieroute</p>
-        <p className="mt-1 text-sm text-slate-600">
-          Baseline is de standaard eerste route. Kies live alleen als je bewust afwijkt van de canonical assisted flow.
-        </p>
+      <div className="border-t border-slate-200 pt-2">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Kies route</p>
       </div>
 
       <div className={`grid gap-2 ${scanType === 'pulse' || scanType === 'team' || scanType === 'onboarding' || scanType === 'leadership' ? 'sm:grid-cols-1' : 'sm:grid-cols-2'}`}>
@@ -231,13 +171,13 @@ export function NewCampaignForm({ orgs }: Props) {
           {
             value: 'baseline',
             title: 'Baseline',
-            body: 'Standaard eerste route voor gecontroleerde setup, import en eerste managementwaarde.',
+            body: 'Standaard eerste route.',
             disabled: false,
           },
           {
             value: 'live',
             title: 'Live / vervolgroute',
-            body: 'Bewuste vervolgroute voor doorlopend of ritmisch gebruik nadat baseline en eigenaarschap staan.',
+            body: 'Alleen voor vervolggebruik.',
             disabled: scanType === 'pulse' || scanType === 'team' || scanType === 'onboarding' || scanType === 'leadership',
           },
         ] as const).map((option) => (
@@ -252,24 +192,11 @@ export function NewCampaignForm({ orgs }: Props) {
           >
             <p className="text-sm font-semibold">{option.title}</p>
             <p className={`mt-1 text-sm ${deliveryMode === option.value ? 'text-blue-100' : 'text-slate-500'}`}>
-              {option.disabled
-                ? `Niet beschikbaar in ${
-                    scanType === 'team' ? 'TeamScan' : scanType === 'onboarding' ? 'Onboarding' : 'Pulse'
-                  } wave 1.`
-                : option.body}
+              {option.disabled ? 'Nog niet beschikbaar voor dit product.' : option.body}
             </p>
           </button>
         ))}
       </div>
-      
-      {scanType === 'leadership' ? (
-        <div className="rounded-[22px] border border-blue-100 bg-blue-50 p-4 text-sm text-blue-950">
-          <p className="font-semibold">Leadership Scan wave 1-boundary</p>
-          <p className="mt-1 text-blue-900">
-            Leadership Scan blijft in deze wave bewust begrensd: alleen een geaggregeerde managementread op groepsniveau, zonder named leaders, hierarchylogica of 360-output.
-          </p>
-        </div>
-      ) : null}
 
       <div
         className={`rounded-[22px] border p-4 text-sm leading-6 ${
@@ -278,62 +205,13 @@ export function NewCampaignForm({ orgs }: Props) {
             : 'border-amber-100 bg-amber-50 text-amber-950'
         }`}
       >
-        <p className="font-semibold">
-          {deliveryMode === 'baseline' ? 'Aanbevolen default' : 'Bewuste afwijking op de standaardroute'}
-        </p>
-        <p className="mt-2">{getDeliveryModeDescription(deliveryMode, scanType)}</p>
+        <p className="font-semibold">{deliveryMode === 'baseline' ? 'Aanbevolen default' : 'Bewuste afwijking op de standaardroute'}</p>
         {deliveryMode === 'live' ? (
-          <p className="mt-2 text-xs text-amber-900">
-            Gebruik live pas nadat importkwaliteit, inviteflow en eerste klantread bij eerdere trajecten stabiel genoeg zijn.
-          </p>
-        ) : null}
+          <p className="mt-2 text-xs text-amber-900">Gebruik live pas nadat baseline, importkwaliteit en eigenaarschap staan.</p>
+        ) : (
+          <p className="mt-2 text-xs text-emerald-900">Gebruik baseline voor de eerste setup en eerste uitleesbare wave.</p>
+        )}
       </div>
-
-      {scanType === 'retention' ? (
-        <div className="rounded-[22px] border border-emerald-100 bg-emerald-50 p-4 text-sm text-emerald-950">
-          <p className="font-semibold">RetentieScan v1.1-validatievoorbereiding</p>
-          <p className="mt-1 text-emerald-900">
-            Gebruik bij respondentimport bij voorkeur altijd <code className="font-mono">email</code>, <code className="font-mono">department</code> en <code className="font-mono">role_level</code>.
-            Daarmee houd je niet alleen segmentanalyse bruikbaar, maar ook de latere validatie van betrouwbaarheid, factorcontrole en pragmatische follow-up op orde.
-          </p>
-        </div>
-      ) : null}
-
-      {scanType === 'pulse' ? (
-        <div className="rounded-[22px] border border-blue-100 bg-blue-50 p-4 text-sm text-blue-950">
-          <p className="font-semibold">Pulse wave 1-boundary</p>
-          <p className="mt-1 text-blue-900">
-            Pulse blijft in deze wave bewust compact: korte werkbelevingscheck, geselecteerde werkfactoren en een eerste managementsnapshot zonder trendclaims of PDF-rapport.
-          </p>
-        </div>
-      ) : null}
-
-      {scanType === 'team' ? (
-        <div className="rounded-[22px] border border-blue-100 bg-blue-50 p-4 text-sm text-blue-950">
-          <p className="font-semibold">TeamScan wave 1-boundary</p>
-          <p className="mt-1 text-blue-900">
-            TeamScan blijft in deze wave bewust begrensd: department-first lokale read, compacte werkcontextcheck en expliciete fallback wanneer metadata of groepsgrootte onvoldoende zijn.
-          </p>
-        </div>
-      ) : null}
-
-      {scanType === 'onboarding' ? (
-        <div className="rounded-[22px] border border-blue-100 bg-blue-50 p-4 text-sm text-blue-950">
-          <p className="font-semibold">Onboarding wave 1-boundary</p>
-          <p className="mt-1 text-blue-900">
-            Onboarding blijft in deze wave bewust begrensd: een enkel checkpoint per campaign, compacte startcheck op groepsniveau en expliciete afbakening zonder 30-60-90-automation of individuele claims.
-          </p>
-        </div>
-      ) : null}
-
-      {scanType === 'leadership' ? (
-        <div className="rounded-[22px] border border-blue-100 bg-blue-50 p-4 text-sm text-blue-950">
-          <p className="font-semibold">Leadership Scan management boundary</p>
-          <p className="mt-1 text-blue-900">
-            Gebruik deze route alleen voor een geaggregeerde managementcontext-read. De wave ondersteunt nog geen individuele leider-readout, named leader ranking of performanceframing.
-          </p>
-        </div>
-      ) : null}
 
       <div>
         <label className="mb-1 block text-sm font-medium text-slate-700">
@@ -353,15 +231,7 @@ export function NewCampaignForm({ orgs }: Props) {
           ))}
         </div>
         <p className="mt-2 text-xs leading-5 text-slate-500">
-          {scanType === 'pulse'
-            ? 'Pulse start standaard met leiderschap, groeiperspectief en werkbelasting. Pas dit alleen aan als je bewust een andere compacte focus wilt meten.'
-            : scanType === 'team'
-              ? 'TeamScan start standaard met leiderschap, cultuur, werkbelasting en rolhelderheid. Pas dit alleen aan als je bewust een andere lokale focus wilt toetsen.'
-              : scanType === 'onboarding'
-                ? 'Onboarding start standaard met leiderschap, rolhelderheid, cultuur en groeiperspectief. Pas dit alleen aan als je bewust een andere checkpointfocus wilt toetsen.'
-                : scanType === 'leadership'
-                  ? 'Leadership Scan start standaard met leiderschap, rolhelderheid, cultuur en groeiperspectief. Pas dit alleen aan als je bewust een andere managementcontext-focus wilt toetsen.'
-            : `Laat dit leeg als je de volledige ${scanType === 'exit' ? 'ExitScan' : 'RetentieScan'} wilt draaien.`}
+          Pas dit alleen aan wanneer je bewust een compactere subset wilt meten.
         </p>
       </div>
 
@@ -385,14 +255,7 @@ export function NewCampaignForm({ orgs }: Props) {
             ))}
           </div>
           {hasSegmentDeepDive ? (
-            <p className="mt-3 rounded-2xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs leading-5 text-amber-800">
-              Segment deep dive gebruikt bestaande metadata in het rapport. Zorg daarom bij de respondentimport bij voorkeur voor ingevulde kolommen <code className="font-mono">email</code>, <code className="font-mono">department</code> en <code className="font-mono">role_level</code>.
-            </p>
-          ) : null}
-          {!hasSelectedFactorSubset && hasSegmentDeepDive ? (
-            <p className="mt-2 text-xs text-blue-800">
-              De add-on wijzigt de survey niet: alle standaardfactoren blijven actief en het rapport krijgt extra segmentanalyse.
-            </p>
+            <p className="mt-3 text-xs leading-5 text-blue-800">Segment deep dive gebruikt bestaande metadata in het rapport.</p>
           ) : null}
         </div>
       ) : null}


### PR DESCRIPTION
## Summary
- compress the campaign setup form in `/beheer` by stripping long route and product explanations
- make product selection cards shorter and easier to scan
- stack the first setup steps so the admin setup flow no longer splits into competing columns

## Verification
- `npm test -- "app/(dashboard)/beheer/new-campaign-form.guard.test.ts" "app/(dashboard)/beheer/page.test.ts" "app/(dashboard)/beheer/color-semantics.test.ts"`
- `npx eslint "app/(dashboard)/beheer/page.tsx" "app/(dashboard)/beheer/page.test.ts" "app/(dashboard)/beheer/color-semantics.test.ts" "app/(dashboard)/beheer/new-campaign-form.guard.test.ts" "components/dashboard/new-campaign-form.tsx"`
- `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key npm run build`