### PR TITLE
[codex] Tighten beheer setup clarity

### DIFF
--- a/frontend/app/(dashboard)/beheer/page.test.ts
+++ b/frontend/app/(dashboard)/beheer/page.test.ts
@@ -13,6 +13,8 @@ describe('beheer admin alignment', () => {
     expect(source).toContain('Klanttoegang activeren')
     expect(source).toContain('Secundaire werkbanken')
     expect(source).toContain('Operations & registries')
+    expect(source).toContain('Bestaande organisaties')
+    expect(source).toContain('Bestaande campaigns')
     expect(source).not.toContain('DashboardHero')
     expect(source).not.toContain('DashboardSummaryBar')
     expect(source).not.toContain('Operationele setup')

--- a/frontend/app/(dashboard)/beheer/page.tsx
+++ b/frontend/app/(dashboard)/beheer/page.tsx
@@ -173,41 +173,55 @@ export default async function BeheerPage() {
         surface="ops"
         eyebrow="Setup"
         title="Organisatie, campaign, import en klanttoegang"
-        description="Werk de setup hier direct af in vaste volgorde."
+        description="Werk de setup direct af in vaste volgorde."
         aside={<DashboardChip surface="ops" label={`${campaigns.length} campaign${campaigns.length === 1 ? '' : 's'} totaal`} />}
       >
         <div className="grid gap-5">
           <StepCard done={step1Done} number={1} title="Organisatie aanmaken">
             {orgs.length > 0 ? (
-              <div className="space-y-2">
-                {orgs.map((org) => (
-                  <div key={org.id} className="flex items-start justify-between gap-3 rounded-[18px] border border-slate-200 bg-slate-50 px-3 py-3 text-sm text-slate-700">
-                    <div className="min-w-0">
-                      <div className="flex items-center gap-2">
-                        <span className={org.is_active ? 'text-emerald-600' : 'text-slate-400'}>{org.is_active ? '✓' : '○'}</span>
-                        <span className="font-medium text-slate-900">{org.name}</span>
-                        <span className="truncate text-xs text-slate-400">({org.slug})</span>
-                        {!org.is_active ? (
-                          <span className="rounded-full bg-slate-200 px-2 py-0.5 text-[11px] font-medium text-slate-600">Gearchiveerd</span>
-                        ) : null}
-                      </div>
-                      <p className="mt-1 text-xs text-slate-500">{campaignCountByOrg[org.id] ?? 0} campaign(s) gekoppeld</p>
-                    </div>
-                    <div className="flex items-start gap-2">
-                      <ArchiveOrgButton orgId={org.id} orgName={org.name} isActive={org.is_active} />
-                      <DeleteOrgButton orgId={org.id} orgName={org.name} campaignCount={campaignCountByOrg[org.id] ?? 0} />
-                    </div>
-                  </div>
-                ))}
-
-                {archivedOrgs.length > 0 ? (
-                  <p className="text-xs text-slate-500">Gearchiveerde organisaties blijven beschikbaar voor historie.</p>
-                ) : null}
-
-                <div className="border-t border-slate-200 pt-3">
+              <div className="space-y-4">
+                <div>
                   <p className="mb-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Nieuwe organisatie</p>
                   <NewOrgForm />
                 </div>
+
+                <details className="rounded-[18px] border border-slate-200 bg-slate-50 px-4 py-3">
+                  <summary className="cursor-pointer list-none">
+                    <div className="flex items-center justify-between gap-3">
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Bestaande organisaties</p>
+                        <p className="mt-1 text-sm text-slate-600">{orgs.length} organisatie{orgs.length === 1 ? '' : 's'}</p>
+                      </div>
+                      <span className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+                        {archivedOrgs.length > 0 ? `${archivedOrgs.length} archief` : 'Actueel'}
+                      </span>
+                    </div>
+                  </summary>
+                  <div className="mt-4 space-y-2 border-t border-slate-200 pt-4">
+                    {orgs.map((org) => (
+                      <div
+                        key={org.id}
+                        className="flex flex-col gap-3 rounded-[16px] border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 lg:flex-row lg:items-center lg:justify-between"
+                      >
+                        <div className="min-w-0">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <span className={org.is_active ? 'text-emerald-600' : 'text-slate-400'}>{org.is_active ? '✓' : '○'}</span>
+                            <span className="font-medium text-slate-900">{org.name}</span>
+                            <span className="truncate text-xs text-slate-400">({org.slug})</span>
+                            {!org.is_active ? (
+                              <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[11px] font-medium text-slate-500">Archief</span>
+                            ) : null}
+                          </div>
+                          <p className="mt-1 text-xs text-slate-500">{campaignCountByOrg[org.id] ?? 0} campaign(s)</p>
+                        </div>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <ArchiveOrgButton orgId={org.id} orgName={org.name} isActive={org.is_active} />
+                          <DeleteOrgButton orgId={org.id} orgName={org.name} campaignCount={campaignCountByOrg[org.id] ?? 0} />
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </details>
               </div>
             ) : (
               <div className="space-y-3">
@@ -229,14 +243,11 @@ export default async function BeheerPage() {
             {!selectedCampaign ? (
               <LockedStep message="Import wordt actief nadat je een campaign hebt gekozen." />
             ) : (
-              <div className="space-y-5">
+              <div className="space-y-4">
                 <div className="flex flex-wrap items-center gap-2">
                   <DashboardChip surface="ops" label={selectedCampaign.name} tone="slate" />
                   <DashboardChip surface="ops" label={selectedCampaign.scan_type === 'exit' ? 'ExitScan' : 'RetentieScan'} tone="slate" />
                 </div>
-                <p className="text-sm leading-6 text-slate-600">
-                  Gebruik het templatebestand en controleer de preview voordat je de deelnemers koppelt.
-                </p>
 
                 {campaigns.filter((campaign) => campaign.is_active).length === 0 ? (
                   <div className="rounded-[18px] border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
@@ -246,40 +257,52 @@ export default async function BeheerPage() {
 
                 <AddRespondentsForm campaigns={campaigns} organizations={orgs} />
 
-                <div className="space-y-2 border-t border-slate-200 pt-3">
-                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Bestaande campaigns</p>
-                  {campaigns.map((campaign) => (
-                    <div key={campaign.id} className="flex items-center justify-between rounded-[18px] border border-slate-200 bg-slate-50 px-4 py-3">
-                      <div className="min-w-0 flex-1">
-                        <div className="mb-0.5 flex flex-wrap items-center gap-2">
-                          <DashboardChip surface="ops" label={campaign.scan_type === 'exit' ? 'ExitScan' : 'RetentieScan'} />
-                          <DashboardChip surface="ops" label={getDeliveryModeLabel(campaign.delivery_mode, campaign.scan_type)} />
-                          <span className={`text-xs font-medium ${campaign.is_active ? 'text-emerald-700' : 'text-slate-400'}`}>
-                            {campaign.is_active ? '● Actief' : '○ Gearchiveerd'}
-                          </span>
-                        </div>
-                        <p className="truncate text-sm font-medium text-slate-900">{campaign.name}</p>
-                        {hasCampaignAddOn(campaign, 'segment_deep_dive') ? (
-                          <p className="mt-1 text-xs font-medium text-slate-700">Add-on actief: {REPORT_ADD_ON_LABELS.segment_deep_dive}</p>
-                        ) : null}
-                        <p className="text-xs text-slate-500">
-                          Aangemaakt{' '}
-                          {new Date(campaign.created_at).toLocaleDateString('nl-NL', {
-                            day: 'numeric',
-                            month: 'long',
-                            year: 'numeric',
-                          })}
-                        </p>
+                <details className="rounded-[18px] border border-slate-200 bg-slate-50 px-4 py-3">
+                  <summary className="cursor-pointer list-none">
+                    <div className="flex items-center justify-between gap-3">
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Bestaande campaigns</p>
+                        <p className="mt-1 text-sm text-slate-600">{campaigns.length} campaign{campaigns.length === 1 ? '' : 's'}</p>
                       </div>
-                      <a
-                        href={`/campaigns/${campaign.id}`}
-                        className="ml-4 flex-shrink-0 rounded-full border border-slate-300 bg-white px-3 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
-                      >
-                        {campaign.is_active ? 'Open campaign' : 'Bekijk archief'}
-                      </a>
+                      <span className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Overzicht</span>
                     </div>
-                  ))}
-                </div>
+                  </summary>
+                  <div className="mt-4 space-y-2 border-t border-slate-200 pt-4">
+                    {campaigns.map((campaign) => (
+                      <div
+                        key={campaign.id}
+                        className="flex flex-col gap-3 rounded-[16px] border border-slate-200 bg-white px-4 py-3 lg:flex-row lg:items-center lg:justify-between"
+                      >
+                        <div className="min-w-0 flex-1">
+                          <div className="mb-1 flex flex-wrap items-center gap-2">
+                            <DashboardChip surface="ops" label={campaign.scan_type === 'exit' ? 'ExitScan' : 'RetentieScan'} />
+                            <DashboardChip surface="ops" label={getDeliveryModeLabel(campaign.delivery_mode, campaign.scan_type)} />
+                            <span className={`text-xs font-medium ${campaign.is_active ? 'text-emerald-700' : 'text-slate-400'}`}>
+                              {campaign.is_active ? '● Actief' : '○ Archief'}
+                            </span>
+                          </div>
+                          <p className="truncate text-sm font-medium text-slate-900">{campaign.name}</p>
+                          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-slate-500">
+                            <span>
+                              {new Date(campaign.created_at).toLocaleDateString('nl-NL', {
+                                day: 'numeric',
+                                month: 'short',
+                                year: 'numeric',
+                              })}
+                            </span>
+                            {hasCampaignAddOn(campaign, 'segment_deep_dive') ? <span>{REPORT_ADD_ON_LABELS.segment_deep_dive}</span> : null}
+                          </div>
+                        </div>
+                        <a
+                          href={`/campaigns/${campaign.id}`}
+                          className="flex-shrink-0 rounded-full border border-slate-300 bg-white px-3 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+                        >
+                          {campaign.is_active ? 'Open' : 'Archief'}
+                        </a>
+                      </div>
+                    ))}
+                  </div>
+                </details>
               </div>
             )}
           </StepCard>
@@ -290,25 +313,31 @@ export default async function BeheerPage() {
             ) : !selectedCampaign ? (
               <LockedStep message="Klanttoegang opent na campaign-keuze, maar blijft organisatiegebonden." />
             ) : (
-              <div className="space-y-5">
-                <p className="text-sm leading-6 text-slate-600">
-                  Nodig de klant uit vanuit de gekozen organisatiecontext en controleer daarna de activatiestatus.
-                </p>
+              <div className="space-y-4">
                 {pendingInviteCount > 0 && confirmedClientAccessCount === 0 ? (
                   <div className="rounded-[18px] border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
                     Er lopen al klantactivaties, maar er is nog geen bevestigde dashboardtoegang.
                   </div>
                 ) : null}
                 <InviteClientUserForm orgs={activeOrgs} />
-                <div className="space-y-3 border-t border-slate-200 pt-4">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Klanttoegang en uitnodigingen</p>
-                    {pendingInviteCount > 0 ? (
-                      <DashboardChip surface="ops" label={`${pendingInviteCount} wacht op activatie`} tone="amber" />
-                    ) : null}
+                <details className="rounded-[18px] border border-slate-200 bg-slate-50 px-4 py-3">
+                  <summary className="cursor-pointer list-none">
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Bestaande toegang</p>
+                        <p className="mt-1 text-sm text-slate-600">{confirmedClientAccessCount} bevestigd</p>
+                      </div>
+                      {pendingInviteCount > 0 ? (
+                        <DashboardChip surface="ops" label={`${pendingInviteCount} wacht op activatie`} tone="amber" />
+                      ) : (
+                        <span className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Overzicht</span>
+                      )}
+                    </div>
+                  </summary>
+                  <div className="mt-4 border-t border-slate-200 pt-4">
+                    <ClientAccessList invites={invites} />
                   </div>
-                  <ClientAccessList invites={invites} />
-                </div>
+                </details>
               </div>
             )}
           </StepCard>
@@ -320,20 +349,20 @@ export default async function BeheerPage() {
         surface="ops"
         eyebrow="Werkbanken"
         title="Secundaire werkbanken"
-        description="Open deze pas wanneer de setupcontext staat en er echt vervolgwerk ligt."
+        description="Alleen na setup."
       >
         <div className="grid gap-3 lg:grid-cols-2">
           <WorkbenchLinkCard
             href="/beheer/contact-aanvragen"
             eyebrow="Instroom"
             title="Contact-aanvragen"
-            body="Bekijk nieuwe aanvragen en koppel ze later aan de juiste setupcontext."
+            body="Nieuwe aanvragen."
           />
           <WorkbenchLinkCard
             href="/beheer/klantlearnings"
             eyebrow="Learning"
             title="Klantlearnings"
-            body="Leg klantlessen, pilotfrictie en proof-context vast buiten de setuphoofdlijn."
+            body="Lessen en proof-context."
           />
         </div>
       </DashboardSection>
@@ -343,15 +372,12 @@ export default async function BeheerPage() {
         surface="ops"
         eyebrow="Operations"
         title="Operations & registries"
-        description="Lagere control-laag voor readiness- en expertregistries."
+        description="Alleen wanneer nodig."
       >
         <details className="rounded-[22px] border border-slate-200 bg-white px-5 py-4 shadow-[0_8px_24px_rgba(19,32,51,0.04)]">
           <summary className="cursor-pointer list-none">
             <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-              <div>
-                <p className="text-sm font-semibold text-slate-950">Open operations & registries</p>
-                <p className="mt-1 text-sm text-slate-600">Gebruik deze laag alleen wanneer je een registry of expertcontrole nodig hebt.</p>
-              </div>
+              <p className="text-sm font-semibold text-slate-950">Open operations & registries</p>
               <span className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Secundair</span>
             </div>
           </summary>
@@ -360,19 +386,19 @@ export default async function BeheerPage() {
               href="/beheer/billing"
               eyebrow="Billing"
               title="Billing readiness"
-              body="Contract, betaalwijze en assisted launch readiness blijven beschikbaar als expertlaag."
+              body="Contract en betaalstatus."
             />
             <WorkbenchLinkCard
               href="/beheer/health"
               eyebrow="Health"
               title="Health-signalen"
-              body="Controleer activatie-, denied-access- en follow-through signalen wanneer daar echt reden voor is."
+              body="Activatie en follow-through."
             />
             <WorkbenchLinkCard
               href="/beheer/proof"
               eyebrow="Proof"
               title="Proof-status"
-              body="Bekijk de proof-ladder alleen wanneer learnings of casegebruik dat expliciet vragen."
+              body="Proof-ladder en status."
             />
           </div>
         </details>
@@ -384,16 +410,13 @@ export default async function BeheerPage() {
           surface="ops"
           eyebrow="Campagnes"
           title="Campagne-statusoverzicht"
-          description="Controlelaag voor bestaande campaigns."
+          description="Alleen voor controle."
           aside={<DashboardChip surface="ops" label={`${campaignStats.length} campaignstats`} tone="slate" />}
         >
           <details className="rounded-[22px] border border-slate-200 bg-white px-5 py-4 shadow-[0_8px_24px_rgba(19,32,51,0.04)]">
             <summary className="cursor-pointer list-none">
               <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                <div>
-                  <p className="text-sm font-semibold text-slate-950">Toon campagne-statusoverzicht</p>
-                  <p className="mt-1 text-sm text-slate-600">Gebruik dit alleen wanneer je een bestaande campaign gericht wilt nalopen.</p>
-                </div>
+                <p className="text-sm font-semibold text-slate-950">Toon campagne-statusoverzicht</p>
                 <span className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">{campaignStats.length} campaigns</span>
               </div>
             </summary>

--- a/frontend/components/dashboard/new-campaign-form.tsx
+++ b/frontend/components/dashboard/new-campaign-form.tsx
@@ -2,25 +2,20 @@
 
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
+import {
+  CAMPAIGN_SCAN_OPTIONS,
+  getCampaignNamePlaceholder,
+  getDefaultModulesForScanType,
+  isBaselineOnlyScanType,
+  supportsCampaignModuleSelection,
+  supportsCampaignReportAddOns,
+} from '@/lib/campaign-setup'
 import { createClient } from '@/lib/supabase/client'
 import type { DeliveryMode, Organization, ScanType } from '@/lib/types'
-import { FACTOR_LABELS, REPORT_ADD_ON_DESCRIPTIONS, REPORT_ADD_ON_LABELS } from '@/lib/types'
+import { FACTOR_LABELS, REPORT_ADD_ON_LABELS } from '@/lib/types'
 
 const ORG_FACTORS = ['leadership', 'culture', 'growth', 'compensation', 'workload', 'role_clarity']
 const REPORT_ADD_ONS = ['segment_deep_dive'] as const
-const ONBOARDING_DEFAULT_MODULES = ['leadership', 'role_clarity', 'culture', 'growth']
-const PULSE_DEFAULT_MODULES = ['leadership', 'growth', 'workload']
-const TEAM_DEFAULT_MODULES = ['leadership', 'culture', 'workload', 'role_clarity']
-const LEADERSHIP_DEFAULT_MODULES = ['leadership', 'role_clarity', 'culture', 'growth']
-
-const SCAN_OPTIONS: Array<{ value: ScanType; title: string; short: string }> = [
-  { value: 'exit', title: 'ExitScan', short: 'Vertrek en frictie' },
-  { value: 'retention', title: 'RetentieScan', short: 'Behoud onder druk' },
-  { value: 'pulse', title: 'Pulse', short: 'Korte momentcheck' },
-  { value: 'team', title: 'TeamScan', short: 'Lokaal teambeeld' },
-  { value: 'onboarding', title: 'Onboarding 30-60-90', short: 'Vroege instroomcheck' },
-  { value: 'leadership', title: 'Leadership Scan', short: 'Geaggregeerde managementread' },
-]
 
 interface Props {
   orgs: Organization[]
@@ -39,18 +34,7 @@ export function NewCampaignForm({ orgs }: Props) {
   const supabase = createClient()
 
   const hasSegmentDeepDive = modules.includes('segment_deep_dive')
-  const campaignNamePlaceholder =
-    scanType === 'exit'
-      ? 'ExitScan Q2 2026'
-      : scanType === 'retention'
-        ? 'RetentieScan Voorjaar 2026'
-        : scanType === 'pulse'
-          ? 'Pulse April 2026'
-          : scanType === 'team'
-            ? 'TeamScan Operations Q2 2026'
-            : scanType === 'onboarding'
-              ? 'Onboarding checkpoint Mei 2026'
-              : 'Leadership Scan Juni 2026'
+  const campaignNamePlaceholder = getCampaignNamePlaceholder(scanType)
 
   function toggleModule(module: string) {
     setModules((prev) => (prev.includes(module) ? prev.filter((entry) => entry !== module) : [...prev, module]))
@@ -58,32 +42,10 @@ export function NewCampaignForm({ orgs }: Props) {
 
   function handleScanTypeChange(nextScanType: ScanType) {
     setScanType(nextScanType)
-
-    if (nextScanType === 'pulse') {
+    if (isBaselineOnlyScanType(nextScanType)) {
       setDeliveryMode('baseline')
-      setModules(PULSE_DEFAULT_MODULES)
-      return
     }
-
-    if (nextScanType === 'team') {
-      setDeliveryMode('baseline')
-      setModules(TEAM_DEFAULT_MODULES)
-      return
-    }
-
-    if (nextScanType === 'onboarding') {
-      setDeliveryMode('baseline')
-      setModules(ONBOARDING_DEFAULT_MODULES)
-      return
-    }
-
-    if (nextScanType === 'leadership') {
-      setDeliveryMode('baseline')
-      setModules(LEADERSHIP_DEFAULT_MODULES)
-      return
-    }
-
-    setModules((current) => current.filter((module) => module !== 'segment_deep_dive'))
+    setModules(getDefaultModulesForScanType(nextScanType))
   }
 
   async function handleSubmit(event: React.FormEvent) {
@@ -147,7 +109,7 @@ export function NewCampaignForm({ orgs }: Props) {
       </div>
 
       <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
-        {SCAN_OPTIONS.map((option) => (
+        {CAMPAIGN_SCAN_OPTIONS.map((option) => (
           <button
             key={option.value}
             type="button"
@@ -166,7 +128,7 @@ export function NewCampaignForm({ orgs }: Props) {
         <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Kies route</p>
       </div>
 
-      <div className={`grid gap-2 ${scanType === 'pulse' || scanType === 'team' || scanType === 'onboarding' || scanType === 'leadership' ? 'sm:grid-cols-1' : 'sm:grid-cols-2'}`}>
+      <div className={`grid gap-2 ${isBaselineOnlyScanType(scanType) ? 'sm:grid-cols-1' : 'sm:grid-cols-2'}`}>
         {([
           {
             value: 'baseline',
@@ -178,7 +140,7 @@ export function NewCampaignForm({ orgs }: Props) {
             value: 'live',
             title: 'Live / vervolgroute',
             body: 'Alleen voor vervolggebruik.',
-            disabled: scanType === 'pulse' || scanType === 'team' || scanType === 'onboarding' || scanType === 'leadership',
+            disabled: isBaselineOnlyScanType(scanType),
           },
         ] as const).map((option) => (
           <button
@@ -199,46 +161,48 @@ export function NewCampaignForm({ orgs }: Props) {
       </div>
 
       <div
-        className={`rounded-[22px] border p-4 text-sm leading-6 ${
+        className={`rounded-[22px] border p-3 text-sm ${
           deliveryMode === 'baseline'
             ? 'border-emerald-100 bg-emerald-50 text-emerald-950'
             : 'border-amber-100 bg-amber-50 text-amber-950'
         }`}
       >
-        <p className="font-semibold">{deliveryMode === 'baseline' ? 'Aanbevolen default' : 'Bewuste afwijking op de standaardroute'}</p>
-        {deliveryMode === 'live' ? (
-          <p className="mt-2 text-xs text-amber-900">Gebruik live pas nadat baseline, importkwaliteit en eigenaarschap staan.</p>
-        ) : (
-          <p className="mt-2 text-xs text-emerald-900">Gebruik baseline voor de eerste setup en eerste uitleesbare wave.</p>
-        )}
+        <p className="font-semibold">{deliveryMode === 'baseline' ? 'Baseline is de standaardroute.' : 'Live alleen na een stabiele baseline.'}</p>
       </div>
 
-      <div>
-        <label className="mb-1 block text-sm font-medium text-slate-700">
-          Surveymodules <span className="text-xs font-normal text-slate-400">(leeg = volledige scan)</span>
-        </label>
-        <div className="grid gap-2 sm:grid-cols-2">
-          {ORG_FACTORS.map((factor) => (
-            <label key={factor} className="flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700">
-              <input
-                type="checkbox"
-                checked={modules.includes(factor)}
-                onChange={() => toggleModule(factor)}
-                className="rounded"
-              />
-              {FACTOR_LABELS[factor]}
-            </label>
-          ))}
+      {supportsCampaignModuleSelection(scanType) ? (
+        <div>
+          <label className="mb-1 block text-sm font-medium text-slate-700">
+            Surveymodules <span className="text-xs font-normal text-slate-400">(leeg = volledige scan)</span>
+          </label>
+          <div className="grid gap-2 sm:grid-cols-2">
+            {ORG_FACTORS.map((factor) => (
+              <label key={factor} className="flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700">
+                <input
+                  type="checkbox"
+                  checked={modules.includes(factor)}
+                  onChange={() => toggleModule(factor)}
+                  className="rounded"
+                />
+                {FACTOR_LABELS[factor]}
+              </label>
+            ))}
+          </div>
+          <p className="mt-2 text-xs leading-5 text-slate-500">
+            Pas dit alleen aan wanneer je bewust een compactere subset wilt meten.
+          </p>
         </div>
-        <p className="mt-2 text-xs leading-5 text-slate-500">
-          Pas dit alleen aan wanneer je bewust een compactere subset wilt meten.
-        </p>
-      </div>
+      ) : (
+        <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+          <p className="font-semibold text-slate-900">Vaste instrumentroute</p>
+          <p className="mt-2 text-xs leading-5 text-slate-600">Deze scan gebruikt een vaste baseline-opzet.</p>
+        </div>
+      )}
 
-      {scanType !== 'pulse' && scanType !== 'team' && scanType !== 'onboarding' && scanType !== 'leadership' ? (
+      {supportsCampaignReportAddOns(scanType) ? (
         <div className="rounded-[22px] border border-blue-100 bg-blue-50 p-4">
           <p className="text-sm font-semibold text-slate-900">Rapport-add-ons</p>
-          <div className="mt-3 space-y-3">
+          <div className="mt-3 space-y-2">
             {REPORT_ADD_ONS.map((addOn) => (
               <label key={addOn} className="flex items-start gap-3 rounded-2xl border border-white/80 bg-white/70 p-3 text-sm text-slate-700">
                 <input
@@ -249,7 +213,7 @@ export function NewCampaignForm({ orgs }: Props) {
                 />
                 <span>
                   <span className="block font-medium text-slate-900">{REPORT_ADD_ON_LABELS[addOn]}</span>
-                  <span className="block text-xs leading-5 text-slate-500">{REPORT_ADD_ON_DESCRIPTIONS[addOn]}</span>
+                  <span className="block text-xs leading-5 text-slate-500">Gebruik alleen wanneer extra segmentdetail nodig is.</span>
                 </span>
               </label>
             ))}

--- a/frontend/lib/campaign-setup.test.ts
+++ b/frontend/lib/campaign-setup.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  CAMPAIGN_SCAN_OPTIONS,
+  getAllowedDeliveryModes,
+  getCampaignNamePlaceholder,
+  getDefaultModulesForScanType,
+  isBaselineOnlyScanType,
+  supportsCampaignModuleSelection,
+  supportsCampaignReportAddOns,
+} from '@/lib/campaign-setup'
+
+describe('campaign setup rails', () => {
+  it('keeps the supported scan options available in campaign setup', () => {
+    expect(CAMPAIGN_SCAN_OPTIONS.map((option) => option.value)).toEqual([
+      'exit',
+      'retention',
+      'pulse',
+      'team',
+      'onboarding',
+      'leadership',
+    ])
+    expect(getCampaignNamePlaceholder('exit')).toBe('ExitScan Q2 2026')
+  })
+
+  it('keeps pulse, team, onboarding and leadership baseline-only in campaign setup', () => {
+    expect(isBaselineOnlyScanType('pulse')).toBe(true)
+    expect(isBaselineOnlyScanType('team')).toBe(true)
+    expect(isBaselineOnlyScanType('onboarding')).toBe(true)
+    expect(isBaselineOnlyScanType('leadership')).toBe(true)
+    expect(getAllowedDeliveryModes('pulse')).toEqual(['baseline'])
+  })
+
+  it('keeps non-survey follow-up scans free from report add-ons while exit/retention stay flexible', () => {
+    expect(getDefaultModulesForScanType('leadership')).toEqual(['leadership', 'role_clarity', 'culture', 'growth'])
+    expect(supportsCampaignModuleSelection('exit')).toBe(true)
+    expect(supportsCampaignReportAddOns('exit')).toBe(true)
+    expect(supportsCampaignReportAddOns('pulse')).toBe(false)
+  })
+})

--- a/frontend/lib/campaign-setup.ts
+++ b/frontend/lib/campaign-setup.ts
@@ -1,0 +1,49 @@
+import type { DeliveryMode, ScanType } from '@/lib/types'
+
+export const CAMPAIGN_SCAN_OPTIONS: Array<{ value: ScanType; title: string; short: string }> = [
+  { value: 'exit', title: 'ExitScan', short: 'Vertrek en frictie' },
+  { value: 'retention', title: 'RetentieScan', short: 'Behoud onder druk' },
+  { value: 'pulse', title: 'Pulse', short: 'Korte momentcheck' },
+  { value: 'team', title: 'TeamScan', short: 'Lokaal teambeeld' },
+  { value: 'onboarding', title: 'Onboarding 30-60-90', short: 'Vroege instroomcheck' },
+  { value: 'leadership', title: 'Leadership Scan', short: 'Geaggregeerde managementread' },
+]
+
+const ONBOARDING_DEFAULT_MODULES = ['leadership', 'role_clarity', 'culture', 'growth']
+const PULSE_DEFAULT_MODULES = ['leadership', 'growth', 'workload']
+const TEAM_DEFAULT_MODULES = ['leadership', 'culture', 'workload', 'role_clarity']
+const LEADERSHIP_DEFAULT_MODULES = ['leadership', 'role_clarity', 'culture', 'growth']
+
+export function isBaselineOnlyScanType(scanType: ScanType) {
+  return scanType === 'pulse' || scanType === 'team' || scanType === 'onboarding' || scanType === 'leadership'
+}
+
+export function getCampaignNamePlaceholder(scanType: ScanType) {
+  if (scanType === 'exit') return 'ExitScan Q2 2026'
+  if (scanType === 'retention') return 'RetentieScan Voorjaar 2026'
+  if (scanType === 'pulse') return 'Pulse April 2026'
+  if (scanType === 'team') return 'TeamScan Operations Q2 2026'
+  if (scanType === 'onboarding') return 'Onboarding checkpoint Mei 2026'
+  return 'Leadership Scan Juni 2026'
+}
+
+export function getDefaultModulesForScanType(scanType: ScanType): string[] {
+  if (scanType === 'pulse') return PULSE_DEFAULT_MODULES
+  if (scanType === 'team') return TEAM_DEFAULT_MODULES
+  if (scanType === 'onboarding') return ONBOARDING_DEFAULT_MODULES
+  if (scanType === 'leadership') return LEADERSHIP_DEFAULT_MODULES
+  return []
+}
+
+export function supportsCampaignModuleSelection(scanType: ScanType) {
+  void scanType
+  return true
+}
+
+export function supportsCampaignReportAddOns(scanType: ScanType) {
+  return scanType !== 'pulse' && scanType !== 'team' && scanType !== 'onboarding' && scanType !== 'leadership'
+}
+
+export function getAllowedDeliveryModes(scanType: ScanType): DeliveryMode[] {
+  return isBaselineOnlyScanType(scanType) ? ['baseline'] : ['baseline', 'live']
+}


### PR DESCRIPTION
## What changed
- turned `/beheer` further into a setup-first admin flow by putting `Nieuwe organisatie` first and moving existing organizations into a compact disclosure
- reduced visual and copy noise in the campaign setup form and shortened route/add-on guidance
- moved existing campaign and client-access overviews behind compact disclosures so step 3 and 4 focus on the active setup action
- added guard tests for the reduced-copy campaign form and setup-first beheer layout
- added a small `campaign-setup` helper used by the compact campaign form

## Why
The current admin beheer page still felt too explanatory and visually split. The setup work was competing with existing lists and long product copy, so the page still read as something to interpret instead of something to execute.

## Impact
- admin setup should scan more clearly as: organization -> campaign -> respondents -> client access
- existing organizations, campaigns, and access remain available but no longer dominate the page
- no intended routing or setup capability changes; this is a clarity/UI-focused pass

## Validation
- `npm test -- "app/(dashboard)/beheer/page.test.ts" "app/(dashboard)/beheer/new-campaign-form.guard.test.ts" "app/(dashboard)/beheer/color-semantics.test.ts" "lib/campaign-setup.test.ts"`
- `npx eslint "app/(dashboard)/beheer/page.tsx" "app/(dashboard)/beheer/page.test.ts" "app/(dashboard)/beheer/new-campaign-form.guard.test.ts" "app/(dashboard)/beheer/color-semantics.test.ts" "components/dashboard/new-campaign-form.tsx" "lib/campaign-setup.ts" "lib/campaign-setup.test.ts"`
- `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key npm run build`

## Notes
- production build still reports pre-existing warnings outside this slice, but completed successfully.
- this PR only includes the beheer/admin setup clarity work from the clean release branch.