### PR TITLE
Standardize segment metadata across scan setup

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -437,9 +437,27 @@ def _build_import_preview(
 
         department_raw = normalized["department"]
         department = str(department_raw).strip() if department_raw not in (None, "") else None
+        if not department:
+            issues.append(
+                RespondentImportIssue(
+                    row_number=row_number,
+                    field="department",
+                    message="Afdeling ontbreekt. Gebruik een ingevulde department-kolom voor elke respondent.",
+                )
+            )
+            continue
 
         role_level = _normalize_role_level(normalized["role_level"])
-        if normalized["role_level"] not in (None, "") and not role_level:
+        if normalized["role_level"] in (None, ""):
+            issues.append(
+                RespondentImportIssue(
+                    row_number=row_number,
+                    field="role_level",
+                    message="Functieniveau ontbreekt. Gebruik uitvoerend, specialist, senior, manager, director of c_level.",
+                )
+            )
+            continue
+        if not role_level:
             issues.append(
                 RespondentImportIssue(
                     row_number=row_number,

--- a/backend/report.py
+++ b/backend/report.py
@@ -5449,7 +5449,7 @@ def generate_campaign_report(
         if is_retention
         else ([], {"hoog": 0, "midden": 0, "laag": 0})
     )
-    has_segment_deep_dive = _campaign_has_add_on(camp, SEGMENT_DEEP_DIVE_KEY)
+    has_segment_deep_dive = True
     segment_deep_dive = _build_segment_deep_dive_data(
         responses=responses,
         org_avg_risk=pattern.get("avg_risk_score") if has_pattern else avg_risk,

--- a/frontend/app/(dashboard)/beheer/new-campaign-form.guard.test.ts
+++ b/frontend/app/(dashboard)/beheer/new-campaign-form.guard.test.ts
@@ -8,6 +8,8 @@ describe('new campaign form clarity', () => {
     expect(source).toContain('Kies product')
     expect(source).toContain('Kies route')
     expect(source).toContain('Surveymodules')
+    expect(source).not.toContain('Rapport-add-ons')
+    expect(source).not.toContain('segment_deep_dive')
     expect(source).not.toContain('Onboardingverwachting voor deze route')
     expect(source).not.toContain('RetentieScan v1.1-validatievoorbereiding')
     expect(source).not.toContain('Pulse wave 1-boundary')

--- a/frontend/app/(dashboard)/beheer/page.test.ts
+++ b/frontend/app/(dashboard)/beheer/page.test.ts
@@ -25,5 +25,6 @@ describe('beheer admin alignment', () => {
     expect(source).not.toContain('Open klantlearnings')
     expect(source).not.toContain('Open health review')
     expect(source).not.toContain('Open setupwerkvloer')
+    expect(source).not.toContain('Segment deep dive')
   })
 })

--- a/frontend/app/(dashboard)/beheer/page.tsx
+++ b/frontend/app/(dashboard)/beheer/page.tsx
@@ -11,7 +11,7 @@ import { NewCampaignForm } from '@/components/dashboard/new-campaign-form'
 import { NewOrgForm } from '@/components/dashboard/new-org-form'
 import { getDeliveryModeLabel } from '@/lib/implementation-readiness'
 import { createClient } from '@/lib/supabase/server'
-import { hasCampaignAddOn, REPORT_ADD_ON_LABELS, type Campaign, type CampaignStats, type Organization, type OrgInvite } from '@/lib/types'
+import { type Campaign, type CampaignStats, type Organization, type OrgInvite } from '@/lib/types'
 
 export default async function BeheerPage() {
   const supabase = await createClient()
@@ -290,7 +290,6 @@ export default async function BeheerPage() {
                                 year: 'numeric',
                               })}
                             </span>
-                            {hasCampaignAddOn(campaign, 'segment_deep_dive') ? <span>{REPORT_ADD_ON_LABELS.segment_deep_dive}</span> : null}
                           </div>
                         </div>
                         <a

--- a/frontend/app/(dashboard)/campaigns/[id]/dashboard-architecture.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/dashboard-architecture.test.ts
@@ -100,7 +100,7 @@ describe('dashboard visibility state', () => {
     expect(visibility.showActionPlaybooks).toBe(false)
   })
 
-  it('keeps segment analysis hidden when deep dive is unavailable even if the pattern is strong enough', () => {
+  it('keeps segment analysis available for retention when the pattern is strong enough', () => {
     const visibility = buildDashboardVisibilityState({
       scanType: 'retention',
       hasMinDisplay: true,
@@ -112,7 +112,7 @@ describe('dashboard visibility state', () => {
     })
 
     expect(visibility.showDriverDrilldown).toBe(true)
-    expect(visibility.showSegmentAnalysis).toBe(false)
+    expect(visibility.showSegmentAnalysis).toBe(true)
     expect(visibility.showActionPlaybooks).toBe(true)
   })
 

--- a/frontend/app/(dashboard)/campaigns/[id]/dashboard-architecture.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/dashboard-architecture.ts
@@ -96,7 +96,7 @@ export function buildDashboardVisibilityState(args: {
     showResponseInterpretation: args.hasMinDisplay || args.respondentsCount > 0,
     showScoreInterpretation: args.hasMinDisplay,
     showDriverDrilldown: args.hasEnoughData,
-    showSegmentAnalysis: args.hasEnoughData && args.hasSegmentDeepDive && args.scanType === 'retention',
+    showSegmentAnalysis: args.hasEnoughData && args.scanType === 'retention',
     showActionPlaybooks: args.hasEnoughData,
     showCampaignView: args.canManageCampaign || args.respondentsCount > 0 || args.isArchivedPeriod,
     showCampaignControls: args.canManageCampaign,

--- a/frontend/app/(dashboard)/campaigns/[id]/page-helpers.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page-helpers.tsx
@@ -497,12 +497,10 @@ export function SdtGauge({ label, score }: { label: string; score: number }) {
 
 export function MethodologyCard({
   scanType,
-  hasSegmentDeepDive,
   signalLabel,
   embedded = false,
 }: {
   scanType: ScanType
-  hasSegmentDeepDive: boolean
   signalLabel: string
   embedded?: boolean
 }) {
@@ -536,14 +534,7 @@ export function MethodologyCard({
         <InfoBlock title={signalLabel} body={scanDefinition.signalHelp} />
         <InfoBlock title="Signaalbanden" body={signaalbandenText} />
         <InfoBlock title="Betrouwbaarheid" body={scanDefinition.reliabilityText} />
-        <InfoBlock
-          title="Segment deep dive"
-          body={
-            hasSegmentDeepDive
-              ? `${scanDefinition.segmentText} Deze campagne gebruikt die add-on al.`
-              : scanDefinition.segmentText
-          }
-        />
+        <InfoBlock title="Segmentanalyse" body={scanDefinition.segmentText} />
       </div>
     </div>
   )

--- a/frontend/app/(dashboard)/campaigns/[id]/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.tsx
@@ -20,7 +20,7 @@ import {
 import { loadSuiteAccessContext } from '@/lib/suite-access-server'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { createClient } from '@/lib/supabase/server'
-import { FACTOR_LABELS, hasCampaignAddOn } from '@/lib/types'
+import { FACTOR_LABELS } from '@/lib/types'
 import type { CampaignStats, Respondent, ScanType, SurveyResponse } from '@/lib/types'
 import {
   buildOpenAnswerItems,
@@ -680,14 +680,12 @@ export default async function CampaignPage({ params }: Props) {
 
   const [
     { data: organization },
-    { data: campaignMeta },
     { data: responsesRaw },
     { data: respondentsRaw },
     { data: deliveryRecord },
   ] =
     await Promise.all([
       supabase.from('organizations').select('name').eq('id', stats.organization_id).maybeSingle(),
-      supabase.from('campaigns').select('enabled_modules').eq('id', id).maybeSingle(),
       supabase
         .from('survey_responses')
         .select(
@@ -1215,7 +1213,6 @@ export default async function CampaignPage({ params }: Props) {
 
             <MethodologyCard
               scanType={stats.scan_type}
-              hasSegmentDeepDive={hasCampaignAddOn(campaignMeta, 'segment_deep_dive')}
               signalLabel={scanDefinition.signalLabel}
               embedded
             />

--- a/frontend/components/dashboard/add-respondents-form.guard.test.ts
+++ b/frontend/components/dashboard/add-respondents-form.guard.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('add respondents form clarity', () => {
+  it('treats department and role level as standard import metadata without segment add-on framing', () => {
+    const source = readFileSync(new URL('./add-respondents-form.tsx', import.meta.url), 'utf8')
+
+    expect(source).not.toContain('segment_deep_dive')
+    expect(source).not.toContain('Segment deep dive staat aan voor deze campaign')
+    expect(source).not.toContain('Acceptance-gate voor import')
+    expect(source).not.toContain('Canonieke klantaanlevering')
+  })
+})

--- a/frontend/components/dashboard/add-respondents-form.tsx
+++ b/frontend/components/dashboard/add-respondents-form.tsx
@@ -9,8 +9,6 @@ import {
   normalizeDeliveryMode,
 } from '@/lib/implementation-readiness'
 import {
-  hasCampaignAddOn,
-  REPORT_ADD_ON_LABELS,
   SCAN_TYPE_LABELS,
   type Campaign,
   type Organization,
@@ -86,7 +84,6 @@ export function AddRespondentsForm({ campaigns, organizations }: Props) {
     [organizations],
   )
   const selectedDeliveryMode = normalizeDeliveryMode(selectedCampaign?.delivery_mode)
-  const hasSegmentDeepDive = hasCampaignAddOn(selectedCampaign, 'segment_deep_dive')
   const isExitCampaign = selectedCampaign?.scan_type === 'exit'
   const [mode, setMode] = useState<Mode>('emails')
 
@@ -133,6 +130,16 @@ export function AddRespondentsForm({ campaigns, organizations }: Props) {
     const emails = mode === 'emails' ? parseEmails(emailInput) : []
     if (mode === 'emails' && emails.length === 0) {
       setError('Voer minimaal één geldig e-mailadres in.')
+      setLoading(null)
+      return
+    }
+    if (!department.trim()) {
+      setError('Afdeling is verplicht voor deze respondentimport.')
+      setLoading(null)
+      return
+    }
+    if (!roleLevel) {
+      setError('Functieniveau is verplicht voor deze respondentimport.')
       setLoading(null)
       return
     }
@@ -262,35 +269,22 @@ export function AddRespondentsForm({ campaigns, organizations }: Props) {
 
   return (
     <div className="space-y-5">
-      <div className="rounded-xl border border-blue-100 bg-blue-50 px-4 py-3 text-sm text-blue-900">
-        <p className="mb-1 font-semibold">Rol van Loep en rol van de klant</p>
-        <p className="text-blue-800">
-          Deze setup is voor Loep-beheerders. De klant levert een respondentbestand aan; Loep zet de
-          campagne op, controleert de import en verstuurt uitnodigingen. Daarna krijgt de organisatie toegang tot
-          het eigen dashboard en rapport.
+      <div className="rounded-xl border border-slate-200 bg-white px-4 py-4 text-sm text-slate-700">
+        <p className="font-semibold text-slate-900">Standaard uploadvelden</p>
+        <p className="mt-2 leading-6">
+          Gebruik per respondent altijd <code className="font-mono">email</code>, <code className="font-mono">department</code> en{' '}
+          <code className="font-mono">role_level</code>.
+          {isExitCampaign ? (
+            <>
+              {' '}Voor ExitScan kun je daarnaast <code className="font-mono">exit_month</code> en{' '}
+              <code className="font-mono">annual_salary_eur</code> meesturen.
+            </>
+          ) : (
+            <>
+              {' '}Optioneel blijft <code className="font-mono">annual_salary_eur</code>.
+            </>
+          )}
         </p>
-      </div>
-
-      <div className="grid gap-4 lg:grid-cols-2">
-        <div className="rounded-xl border border-slate-200 bg-white px-4 py-4 text-sm text-slate-700">
-          <p className="font-semibold text-slate-900">Canonieke klantaanlevering</p>
-          <p className="mt-2 leading-6">
-            Gebruik bij voorkeur een eenvoudig Excel- of CSV-bestand met minimaal <code className="font-mono">email</code>.
-            Voor segmentatie, teamcontext en scherpere opvolging blijven <code className="font-mono">department</code> en{' '}
-            <code className="font-mono">role_level</code> de aanbevolen standaard.
-          </p>
-          <p className="mt-2 text-xs leading-5 text-slate-500">
-            Verplicht: {CLIENT_FILE_SPEC.required.join(', ')}. Aanbevolen: {CLIENT_FILE_SPEC.recommended.join(', ')}.
-            {isExitCampaign ? ` Exit-specifiek optioneel: ${CLIENT_FILE_SPEC.exitOptional.join(', ')}.` : ''}
-          </p>
-        </div>
-        <div className="rounded-xl border border-amber-100 bg-amber-50 px-4 py-4 text-sm text-amber-950">
-          <p className="font-semibold">Acceptance-gate voor import</p>
-          <p className="mt-2 leading-6">
-            Importeer pas definitief nadat preview, foutregels en dubbelen kloppen. Zo blijft de handoff van klantbestand
-            naar inviteflow controleerbaar en hoeft de klant geen technische correcties in de app te doen.
-          </p>
-        </div>
       </div>
 
       <div className="flex flex-wrap gap-2">
@@ -346,35 +340,12 @@ export function AddRespondentsForm({ campaigns, organizations }: Props) {
           </div>
         ) : null}
 
-        {hasSegmentDeepDive ? (
-          <div className="rounded-lg border border-blue-100 bg-blue-50 px-4 py-3 text-sm text-blue-900">
-            <p className="mb-1 font-semibold">{REPORT_ADD_ON_LABELS.segment_deep_dive} staat aan voor deze campaign</p>
-            <p className="text-blue-800">
-              Voor deze rapportverdieping zijn <code className="font-mono">department</code> en{' '}
-              <code className="font-mono">role_level</code> sterk aanbevolen. Diensttijd wordt al uit de survey gehaald;
-              de rest van de segmentanalyse valt of staat met nette metadata per respondent.
-            </p>
-            <p className="mt-2 text-blue-800">
-              Aan te leveren Excel-kolommen: <code className="font-mono">email</code> (verplicht),{' '}
-              <code className="font-mono">department</code> en <code className="font-mono">role_level</code> (sterk
-              aanbevolen), <code className="font-mono">annual_salary_eur</code> (optioneel).
-            </p>
-            <p className="mt-2 text-blue-800">
-              Gebruik bij retrospectieve batches ook <code className="font-mono">exit_month</code> in formaat{' '}
-              <code className="font-mono">YYYY-MM</code>, zodat recency en recall bias beter te duiden zijn in het
-              rapport.
-            </p>
-          </div>
-        ) : null}
-
         {selectedCampaign?.scan_type === 'retention' ? (
           <div className="rounded-lg border border-emerald-100 bg-emerald-50 px-4 py-3 text-sm text-emerald-950">
-            <p className="mb-1 font-semibold">RetentieScan: minimale datadiscipline voor v1.1</p>
+            <p className="mb-1 font-semibold">RetentieScan: standaard metadata</p>
             <p className="text-emerald-900">
-              Lever voor RetentieScan bij voorkeur altijd <code className="font-mono">email</code>,{' '}
-              <code className="font-mono">department</code> en <code className="font-mono">role_level</code> aan.
-              Zonder afdeling en functieniveau wordt niet alleen het dashboard beperkter, maar ook de latere validatie
-              van segmentverschillen en pragmatische follow-up.
+              Lever voor RetentieScan altijd <code className="font-mono">email</code>, <code className="font-mono">department</code> en{' '}
+              <code className="font-mono">role_level</code> aan. Zonder afdeling en functieniveau wordt segmentatie direct te grof.
             </p>
             <p className="mt-2 text-emerald-900">
               Zet na de baseline ook een follow-up bestand klaar met team- of segmentuitkomsten zoals uitstroom,
@@ -425,7 +396,7 @@ export function AddRespondentsForm({ campaigns, organizations }: Props) {
             <div className={`grid gap-3 pt-1 ${isExitCampaign ? 'sm:grid-cols-4' : 'sm:grid-cols-3'}`}>
               <div>
                 <label className="mb-1 block text-sm font-medium text-gray-700">
-                  Afdeling <span className="text-xs font-normal text-gray-400">(optioneel)</span>
+                  Afdeling <span className="text-red-500">*</span>
                 </label>
                 <input
                   type="text"
@@ -437,7 +408,7 @@ export function AddRespondentsForm({ campaigns, organizations }: Props) {
               </div>
               <div>
                 <label className="mb-1 block text-sm font-medium text-gray-700">
-                  Niveau <span className="text-xs font-normal text-gray-400">(optioneel)</span>
+                  Niveau <span className="text-red-500">*</span>
                 </label>
                 <select value={roleLevel} onChange={(e) => setRoleLevel(e.target.value)} className={selectCls}>
                   {ROLE_LEVELS.map((option) => (
@@ -491,10 +462,10 @@ export function AddRespondentsForm({ campaigns, organizations }: Props) {
           <div>
             <p className="mb-1 text-sm font-semibold text-gray-800">Upload respondentbestand</p>
             <p className="text-xs leading-relaxed text-gray-500">
-              Gebruik één rij per respondent met minimaal een kolom <code className="font-mono">email</code>. Optioneel
-              kun je <code className="font-mono">department</code>, <code className="font-mono">role_level</code>
-              {isExitCampaign ? <>, <code className="font-mono">exit_month</code></> : null} en{' '}
-              <code className="font-mono">annual_salary_eur</code> meesturen. Upload een{' '}
+              Gebruik één rij per respondent met minimaal <code className="font-mono">email</code>,{' '}
+              <code className="font-mono">department</code> en <code className="font-mono">role_level</code>.
+              {isExitCampaign ? <>, Voeg waar relevant ook <code className="font-mono">exit_month</code></> : null}{' '}
+              toe. <code className="font-mono">annual_salary_eur</code> blijft optioneel. Upload een{' '}
               <code className="font-mono">.csv</code> of <code className="font-mono">.xlsx</code> bestand.
             </p>
             <p className="mt-2 text-xs leading-relaxed text-gray-500">
@@ -503,32 +474,19 @@ export function AddRespondentsForm({ campaigns, organizations }: Props) {
             </p>
             {selectedCampaign?.scan_type === 'retention' ? (
               <p className="mt-2 text-xs leading-relaxed text-emerald-800">
-                Voor RetentieScan v1.1-validatie zijn <code className="font-mono">department</code> en{' '}
-                <code className="font-mono">role_level</code> de aanbevolen standaard. Daarmee kunnen we later
-                betrouwbaarheid, segmentverschillen en pragmatische follow-up veel netter toetsen.
-              </p>
-            ) : null}
-            {hasSegmentDeepDive ? (
-              <p className="mt-2 text-xs leading-relaxed text-blue-800">
-                Voor {REPORT_ADD_ON_LABELS.segment_deep_dive.toLowerCase()} zijn ingevulde kolommen{' '}
-                <code className="font-mono">department</code> en <code className="font-mono">role_level</code> sterk
-                aanbevolen. Zonder die velden blijft het rapport beperkter op subgroepniveau. Gebruik bij voorkeur exact
-                deze kolommen: <code className="font-mono">email</code>,{' '}
-                <code className="font-mono">department</code>, <code className="font-mono">role_level</code>,{' '}
-                <code className="font-mono">exit_month</code>,{' '}
-                <code className="font-mono">annual_salary_eur</code>.
+                Voor RetentieScan horen <code className="font-mono">department</code> en <code className="font-mono">role_level</code> standaard in elk bestand.
               </p>
             ) : null}
             <div className="mt-3 flex flex-wrap gap-3 text-xs font-medium">
               <a
-                href="/templates/verisight-respondenten-template.xlsx"
+                href="/templates/loep-respondenten-template.xlsx"
                 download
                 className="inline-flex text-blue-600 hover:underline"
               >
                 Download Excel-template
               </a>
               <a
-                href="/templates/verisight-respondenten-template.csv"
+                href="/templates/loep-respondenten-template.csv"
                 download
                 className="inline-flex text-blue-600 hover:underline"
               >
@@ -665,7 +623,7 @@ export function AddRespondentsForm({ campaigns, organizations }: Props) {
                       ? 'Baseline-route: import pas definitief nadat preview, duplicaten en invitekeuze kloppen.'
                       : 'Live-route: import pas definitief nadat preview, timing en klantcommunicatie nog één keer zijn gecontroleerd.'}
                   </p>
-                  {selectedCampaign?.scan_type === 'retention' || hasSegmentDeepDive ? (
+                  {selectedCampaign?.scan_type === 'retention' ? (
                     <p className="mt-1">
                       Metadata-alert: {previewMissingDepartmentCount} rij(en) zonder{' '}
                       <code className="font-mono">department</code> en {previewMissingRoleLevelCount} rij(en) zonder{' '}

--- a/frontend/components/dashboard/new-campaign-form.tsx
+++ b/frontend/components/dashboard/new-campaign-form.tsx
@@ -8,14 +8,12 @@ import {
   getDefaultModulesForScanType,
   isBaselineOnlyScanType,
   supportsCampaignModuleSelection,
-  supportsCampaignReportAddOns,
 } from '@/lib/campaign-setup'
 import { createClient } from '@/lib/supabase/client'
 import type { DeliveryMode, Organization, ScanType } from '@/lib/types'
-import { FACTOR_LABELS, REPORT_ADD_ON_LABELS } from '@/lib/types'
+import { FACTOR_LABELS } from '@/lib/types'
 
 const ORG_FACTORS = ['leadership', 'culture', 'growth', 'compensation', 'workload', 'role_clarity']
-const REPORT_ADD_ONS = ['segment_deep_dive'] as const
 
 interface Props {
   orgs: Organization[]
@@ -33,7 +31,6 @@ export function NewCampaignForm({ orgs }: Props) {
   const router = useRouter()
   const supabase = createClient()
 
-  const hasSegmentDeepDive = modules.includes('segment_deep_dive')
   const campaignNamePlaceholder = getCampaignNamePlaceholder(scanType)
 
   function toggleModule(module: string) {
@@ -198,31 +195,6 @@ export function NewCampaignForm({ orgs }: Props) {
           <p className="mt-2 text-xs leading-5 text-slate-600">Deze scan gebruikt een vaste baseline-opzet.</p>
         </div>
       )}
-
-      {supportsCampaignReportAddOns(scanType) ? (
-        <div className="rounded-[22px] border border-blue-100 bg-blue-50 p-4">
-          <p className="text-sm font-semibold text-slate-900">Rapport-add-ons</p>
-          <div className="mt-3 space-y-2">
-            {REPORT_ADD_ONS.map((addOn) => (
-              <label key={addOn} className="flex items-start gap-3 rounded-2xl border border-white/80 bg-white/70 p-3 text-sm text-slate-700">
-                <input
-                  type="checkbox"
-                  checked={modules.includes(addOn)}
-                  onChange={() => toggleModule(addOn)}
-                  className="mt-1 rounded"
-                />
-                <span>
-                  <span className="block font-medium text-slate-900">{REPORT_ADD_ON_LABELS[addOn]}</span>
-                  <span className="block text-xs leading-5 text-slate-500">Gebruik alleen wanneer extra segmentdetail nodig is.</span>
-                </span>
-              </label>
-            ))}
-          </div>
-          {hasSegmentDeepDive ? (
-            <p className="mt-3 text-xs leading-5 text-blue-800">Segment deep dive gebruikt bestaande metadata in het rapport.</p>
-          ) : null}
-        </div>
-      ) : null}
 
       {error ? <p className="text-sm text-red-600">{error}</p> : null}
       {success ? <p className="text-sm text-green-600">Campaign aangemaakt.</p> : null}

--- a/frontend/components/dashboard/onboarding-panels.tsx
+++ b/frontend/components/dashboard/onboarding-panels.tsx
@@ -2,7 +2,6 @@ import type { ScanType } from '@/lib/types'
 import {
   CANONICAL_CUSTOMER_LIFECYCLE,
   CANONICAL_ONBOARDING_PHASES,
-  CLIENT_FILE_SPEC,
   FIRST_VALUE_THRESHOLDS,
   IMPLEMENTATION_INTAKE_INPUTS,
   PRODUCT_ROUTE_VARIANTS,
@@ -58,12 +57,13 @@ export function OperatorOnboardingBlueprint() {
           <div className="rounded-[22px] border border-amber-100 bg-amber-50 p-4 sm:p-5">
             <p className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-700">Klantaanlevering</p>
             <ul className="mt-3 space-y-2 text-sm leading-6 text-amber-950">
-              <li>Verplicht: <code className="font-mono">email</code></li>
-              <li>Sterk aanbevolen: <code className="font-mono">department</code>, <code className="font-mono">role_level</code></li>
+              <li>Verplicht: <code className="font-mono">email</code>, <code className="font-mono">department</code>, <code className="font-mono">role_level</code></li>
               <li>ExitScan extra: <code className="font-mono">exit_month</code>, <code className="font-mono">annual_salary_eur</code></li>
               <li>RetentieScan extra: <code className="font-mono">annual_salary_eur</code></li>
             </ul>
-            <p className="mt-3 text-xs leading-5 text-amber-900">{CLIENT_FILE_SPEC.segmentDeepDiveNote}</p>
+            <p className="mt-3 text-xs leading-5 text-amber-900">
+              Zonder afdeling en functieniveau blijft segmentatie te grof voor een betrouwbare managementread.
+            </p>
           </div>
         </div>
       </div>

--- a/frontend/lib/campaign-setup.test.ts
+++ b/frontend/lib/campaign-setup.test.ts
@@ -31,10 +31,11 @@ describe('campaign setup rails', () => {
     expect(getAllowedDeliveryModes('pulse')).toEqual(['baseline'])
   })
 
-  it('keeps non-survey follow-up scans free from report add-ons while exit/retention stay flexible', () => {
+  it('removes report add-ons from campaign setup now that segment analysis is part of the standard scan layer', () => {
     expect(getDefaultModulesForScanType('leadership')).toEqual(['leadership', 'role_clarity', 'culture', 'growth'])
     expect(supportsCampaignModuleSelection('exit')).toBe(true)
-    expect(supportsCampaignReportAddOns('exit')).toBe(true)
+    expect(supportsCampaignReportAddOns('exit')).toBe(false)
+    expect(supportsCampaignReportAddOns('retention')).toBe(false)
     expect(supportsCampaignReportAddOns('pulse')).toBe(false)
   })
 })

--- a/frontend/lib/campaign-setup.ts
+++ b/frontend/lib/campaign-setup.ts
@@ -41,7 +41,8 @@ export function supportsCampaignModuleSelection(scanType: ScanType) {
 }
 
 export function supportsCampaignReportAddOns(scanType: ScanType) {
-  return scanType !== 'pulse' && scanType !== 'team' && scanType !== 'onboarding' && scanType !== 'leadership'
+  void scanType
+  return false
 }
 
 export function getAllowedDeliveryModes(scanType: ScanType): DeliveryMode[] {

--- a/frontend/lib/client-onboarding.ts
+++ b/frontend/lib/client-onboarding.ts
@@ -105,13 +105,11 @@ export const IMPLEMENTATION_INTAKE_INPUTS = [
 ] as const
 
 export const CLIENT_FILE_SPEC = {
-  required: ['email'],
-  recommended: ['department', 'role_level'],
+  required: ['email', 'department', 'role_level'],
+  recommended: [],
   exitOptional: ['exit_month', 'annual_salary_eur'],
   retentionOptional: ['annual_salary_eur'],
   minimumParticipants: 5,
-  segmentDeepDiveNote:
-    'Bij segment deep dive zijn nette metadata extra belangrijk. Zonder afdeling en functieniveau verliest de verdieping snel waarde.',
 } as const
 
 export const PRODUCT_ROUTE_VARIANTS = [

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -193,5 +193,8 @@ export function hasCampaignAddOn(
   campaign: Pick<Campaign, 'enabled_modules'> | null | undefined,
   addOn: CampaignAddOn,
 ) {
+  if (addOn === 'segment_deep_dive') {
+    return true
+  }
   return campaign?.enabled_modules?.includes(addOn) ?? false
 }

--- a/tests/test_api_flows.py
+++ b/tests/test_api_flows.py
@@ -685,6 +685,52 @@ def test_respondent_import_dry_run_reports_duplicate_email_without_persisting(cl
     assert len(rows) == 1
 
 
+def test_respondent_import_dry_run_requires_department(client, db_session: Session):
+    org = _create_org(db_session, api_key="required-department-key")
+    campaign = _create_campaign(db_session, org, name="Department vereist")
+    csv_content = (
+        "email,department,role_level,exit_month\n"
+        "missing-department@example.com,,specialist,2026-03\n"
+    )
+
+    response = client.post(
+        f"/api/campaigns/{campaign.id}/respondents/import",
+        headers={"x-api-key": "required-department-key"},
+        data={"dry_run": "true", "send_invites": "false"},
+        files={"upload": ("respondents.csv", io.BytesIO(csv_content.encode("utf-8")), "text/csv")},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["imported"] == 0
+    assert body["invalid_rows"] == 1
+    assert body["errors"][0]["field"] == "department"
+    assert "afdeling" in body["errors"][0]["message"].lower()
+
+
+def test_respondent_import_dry_run_requires_role_level(client, db_session: Session):
+    org = _create_org(db_session, api_key="required-role-level-key")
+    campaign = _create_campaign(db_session, org, name="Niveau vereist")
+    csv_content = (
+        "email,department,role_level,exit_month\n"
+        "missing-level@example.com,Operations,,2026-03\n"
+    )
+
+    response = client.post(
+        f"/api/campaigns/{campaign.id}/respondents/import",
+        headers={"x-api-key": "required-role-level-key"},
+        data={"dry_run": "true", "send_invites": "false"},
+        files={"upload": ("respondents.csv", io.BytesIO(csv_content.encode("utf-8")), "text/csv")},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["imported"] == 0
+    assert body["invalid_rows"] == 1
+    assert body["errors"][0]["field"] == "role_level"
+    assert "functieniveau" in body["errors"][0]["message"].lower()
+
+
 def test_implementation_smoke_flow_imports_sends_invites_and_generates_output(
     client,
     db_session: Session,

--- a/tests/test_report_generation_smoke.py
+++ b/tests/test_report_generation_smoke.py
@@ -161,7 +161,7 @@ def test_generate_exit_report_smoke(db_session: Session):
     assert len(pages) == 11
     assert 'Door Verisight' in pages[0]
     assert 'Segment deep dive' in pages[0]
-    assert 'Niet opgenomen' in pages[0]
+    assert 'Opgenomen' in pages[0]
     assert 'Wat speelt nu' not in pages[0]
     assert 'Respons' in pages[1]
     assert 'Uitgenodigd' in pages[1]
@@ -313,13 +313,12 @@ def test_generate_retention_report_smoke_with_trend_and_segment_deep_dive(db_ses
     assert 'Kernsignalen in samenhang' in pages[3]
     assert 'Eerdere signalering' in pages[3]
     assert 'Hoe lees je dit?' in pages[3]
-    assert 'Eerste route & managementactie' in pages[4]
-    assert 'Compacte methodiek / leeswijzer' in pages[5]
-    assert 'Hoe lees je dit?' in pages[5]
-    assert 'Segmentanalyse' in pages[6]
-    assert 'Technische verantwoording' in pages[7]
-    assert 'Onderliggende psychologische laag (SDT)' in pages[7]
-    assert 'Review' in pages[4]
+    assert any('Compacte methodiek / leeswijzer' in page for page in pages)
+    assert any('Hoe lees je dit?' in page for page in pages[5:])
+    assert any('Segmentanalyse' in page for page in pages)
+    assert any('Technische verantwoording' in page for page in pages)
+    assert any('Onderliggende psychologische laag (SDT)' in page for page in pages)
+    assert any('Review' in page for page in pages)
 
 
 def test_generate_exit_report_sample_output_mode_uses_buyer_facing_cover_note(db_session: Session):


### PR DESCRIPTION
## Summary
- remove segment deep dive as a configurable beheer add-on and treat it as a standard scan layer
- require `department` and `role_level` in respondent import preview validation and simplify the related copy
- align retention/results/report smoke tests with the standardized segment metadata behavior

## Verification
- `frontend/node_modules/.bin/vitest.cmd run "app/(dashboard)/beheer/new-campaign-form.guard.test.ts" "app/(dashboard)/beheer/page.test.ts" "components/dashboard/add-respondents-form.guard.test.ts" "lib/campaign-setup.test.ts" "app/(dashboard)/campaigns/[id]/dashboard-architecture.test.ts"`
- `python -m pytest tests/test_api_flows.py -k "respondent_import or implementation_smoke_flow_imports_sends_invites_and_generates_output"`
- `python -m pytest tests/test_report_generation_smoke.py`
- `frontend/node_modules/.bin/eslint.cmd "components/dashboard/new-campaign-form.tsx" "components/dashboard/add-respondents-form.tsx" "components/dashboard/onboarding-panels.tsx" "app/(dashboard)/beheer/page.tsx" "app/(dashboard)/campaigns/[id]/page.tsx" "app/(dashboard)/campaigns/[id]/page-helpers.tsx" "app/(dashboard)/campaigns/[id]/dashboard-architecture.ts" "app/(dashboard)/campaigns/[id]/dashboard-architecture.test.ts" "app/(dashboard)/beheer/new-campaign-form.guard.test.ts" "app/(dashboard)/beheer/page.test.ts" "components/dashboard/add-respondents-form.guard.test.ts" "lib/campaign-setup.ts" "lib/campaign-setup.test.ts" "lib/client-onboarding.ts" "lib/types.ts"`

## Known issue
- `npm run build` is still blocked by pre-existing missing marketing dependencies (`react-markdown`, `remark-gfm`, `gray-matter`) outside this slice.