### PR TITLE
Implement Action Center Batch A productization of execution

### DIFF
--- a/docs/superpowers/plans/2026-05-20-batch-a-productization-of-execution-implementation.md
+++ b/docs/superpowers/plans/2026-05-20-batch-a-productization-of-execution-implementation.md
@@ -1,0 +1,654 @@
+# Batch A Productization of Execution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Productize Action Center into an enterprise-worthy bounded execution layer for `exit` and `retention` by finishing action-card truth, manager execution UX, and route differentiation without broadening Action Center into workflow software.
+
+**Architecture:** Keep the existing route-bound action-card model and harden it in place. Finalize canonical action contract, validation, lifecycle, and review consequences in shared helpers first; then align manager create/update/review UX to that truth; then finalize route differentiation defaults for `ExitScan` and `RetentieScan`; finally lock the batch down with regression tests and closeout verification.
+
+**Tech Stack:** Next.js App Router, TypeScript, React 19, Vitest, existing Action Center route/action/review APIs, existing review-rhythm oversight surfaces, Supabase SQL patch files plus `schema.sql`.
+
+---
+
+## Scope Check
+
+This plan implements **Batch A** only.
+
+In scope:
+
+- Action Card Contract & Validation
+- Action Lifecycle & Transition Matrix
+- Draft / Invalid / HR Review Flow
+- Manager Create / Update / Review UX
+- ExitScan and RetentieScan Route Defaults
+- Test and Regression Hardening
+
+Out of scope:
+
+- route-family expansion beyond `exit` and `retention`
+- Teams / Slack / multichannel expansion
+- Graph-required behavior
+- off-platform canonical writes
+- broad analytics and measurement-readback surfaces
+- buyer packaging as a main workstream
+- project boards, task boards, case management, or workflow broadening
+- adoption proof or intervention impact claims
+
+Source specs:
+
+- [2026-05-20-action-center-enterprise-roadmap.md](/C:/Users/larsh/Desktop/Business/Verisight/.worktrees/spec-hr-routebeheer-structure/docs/superpowers/specs/2026-05-20-action-center-enterprise-roadmap.md)
+- [2026-05-20-batch-a-productization-of-execution-spec.md](/C:/Users/larsh/Desktop/Business/Verisight/.worktrees/spec-hr-routebeheer-structure/docs/superpowers/specs/2026-05-20-batch-a-productization-of-execution-spec.md)
+- [2026-05-20-action-center-bounded-execution-enterprise-design.md](/C:/Users/larsh/Desktop/Business/Verisight/.worktrees/spec-hr-routebeheer-structure/docs/superpowers/specs/2026-05-20-action-center-bounded-execution-enterprise-design.md)
+
+---
+
+## File Structure Guidance
+
+- `frontend/lib/action-center-constitution.ts`
+  - canonical action states, transition truth, approved route-family defaults, and route/action/review boundary rules
+- `frontend/lib/action-center-route-actions.ts`
+  - action-card contract, validation rules, invalid examples to behavior mapping, route-to-action limits
+- `frontend/app/api/action-center-route-actions/route.ts`
+  - fail-closed action creation, draft / invalid / HR-review persistence behavior, route-family gating
+- `frontend/lib/action-center-action-reviews.ts`
+  - review evidence grammar, review-outcome consequence helpers, bounded note semantics
+- `frontend/app/api/action-center-action-reviews/route.ts`
+  - review writes, transition enforcement, no off-platform truth drift
+- `frontend/components/dashboard/action-center-route-action-editor.tsx`
+  - low-friction manager create/update flow
+- `frontend/components/dashboard/action-center-action-review-editor.tsx`
+  - compact repeated-use review flow
+- `frontend/components/dashboard/action-center-preview.tsx`
+  - route-context execution entry, invalid correction feedback, blocked-action behavior
+- `frontend/lib/action-center-route-defaults.ts`
+  - finalized ExitScan and RetentieScan route defaults
+- `frontend/lib/action-center-route-defaults.test.ts`
+  - route differentiation regression tests
+- `frontend/lib/action-center-governance.ts`
+  - sprawl, repeated-review-without-progress, closeout-readiness signals
+- `frontend/lib/action-center-review-rhythm-data.ts`
+  - oversight integration for Batch A governance surfaces
+- `supabase/action_center_constitution_adoption_readiness.sql`
+  - keep schema patch parity for any new bounded-execution fields or constraints
+- `supabase/schema.sql`
+  - canonical schema mirror
+
+---
+
+### Task 1: Finalize Action Card Contract And Validation
+
+**Files:**
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend\lib\action-center-route-actions.ts`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend\lib\action-center-route-actions.test.ts`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend\app\api\action-center-route-actions\route.ts`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend\app\api\action-center-route-actions\route.test.ts`
+
+- [ ] **Step 1: Write the failing contract and validation tests**
+
+```ts
+it('rejects employee-dossier-like action text', () => {
+  expect(() =>
+    validateActionCenterRouteActionDraftInput({
+      primary_action_theme_key: 'werkdruk',
+      primary_action_text: 'Monitor employee X in detail for risk.',
+      primary_action_expected_effect: 'Track individual risk more closely.',
+      primary_action_status: 'open',
+      review_scheduled_for: '2026-07-01',
+    }),
+  ).toThrow('Route action is outside bounded execution.')
+})
+
+it('marks broad project language for HR review', () => {
+  const result = validateActionCenterRouteActionDraftInput({
+    primary_action_theme_key: 'werkdruk',
+    primary_action_text: 'Start een breed HR-project om werkdruk overal op te lossen.',
+    primary_action_expected_effect: 'De cultuur moet verbeteren.',
+    primary_action_status: 'open',
+    review_scheduled_for: '2026-07-01',
+  })
+
+  expect(result.validationDisposition).toBe('needs_hr_review')
+  expect(result.semanticState).toBe('draft')
+})
+
+it('blocks more than three active actions on a route', async () => {
+  const response = await POST(makeRouteActionRequest({ existingActiveActionCount: 3 }))
+  expect(response.status).toBe(409)
+})
+```
+
+- [ ] **Step 2: Run the focused tests to confirm the gaps**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend'
+npx vitest run lib/action-center-route-actions.test.ts app/api/action-center-route-actions/route.test.ts
+```
+
+Expected:
+
+```text
+FAIL  bounded action contract expectations are not yet enforced
+```
+
+- [ ] **Step 3: Implement the bounded action-card contract**
+
+```ts
+export type ActionCenterActionDraftDisposition = 'valid' | 'invalid' | 'needs_hr_review'
+
+export function validateActionCenterRouteActionDraftInput(
+  input: Partial<ActionCenterRouteActionDraftInput> | null | undefined,
+): ValidatedActionCenterRouteActionDraft {
+  const validated = validateRequiredActionDraftFields(input)
+
+  if (looksLikeEmployeeDossierLanguage(validated.primary_action_text, validated.primary_action_expected_effect)) {
+    return {
+      ...validated,
+      semanticState: 'draft',
+      validationDisposition: 'invalid',
+    }
+  }
+
+  if (looksLikeBroadProjectLanguage(validated.primary_action_text, validated.primary_action_expected_effect)) {
+    return {
+      ...validated,
+      semanticState: 'draft',
+      validationDisposition: 'needs_hr_review',
+    }
+  }
+
+  return {
+    ...validated,
+    semanticState: 'draft',
+    validationDisposition: 'valid',
+  }
+}
+```
+
+- [ ] **Step 4: Enforce route-to-action limits in the API**
+
+```ts
+if (activeActionCount > 2 && validated.validationDisposition === 'valid') {
+  return NextResponse.json(
+    { detail: 'Route exceeds bounded active-action limit.' },
+    { status: 409 },
+  )
+}
+```
+
+- [ ] **Step 5: Re-run the focused tests**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend'
+npx vitest run lib/action-center-route-actions.test.ts app/api/action-center-route-actions/route.test.ts
+```
+
+Expected:
+
+```text
+PASS  contract and route-action validation suites
+```
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git -C 'C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure' add frontend/lib/action-center-route-actions.ts frontend/lib/action-center-route-actions.test.ts frontend/app/api/action-center-route-actions/route.ts frontend/app/api/action-center-route-actions/route.test.ts
+git -C 'C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure' commit -m "Finalize Action Center action-card contract"
+```
+
+### Task 2: Finalize Action Lifecycle And Transition Truth
+
+**Files:**
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend\lib\action-center-constitution.ts`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend\lib\action-center-constitution.test.ts`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend\lib\action-center-action-reviews.ts`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend\lib\action-center-action-reviews.test.ts`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend\app\api\action-center-action-reviews\route.ts`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend\app\api\action-center-action-reviews\route.test.ts`
+
+- [ ] **Step 1: Add failing transition-truth tests**
+
+```ts
+it('allows in_review to active for no-progress review outcomes', () => {
+  expect(
+    isActionCenterActionStateTransitionAllowed({
+      actor: 'manager_participant',
+      fromState: 'in_review',
+      toState: 'active',
+    }),
+  ).toBe(true)
+})
+
+it('does not allow blocked to completed without review', () => {
+  expect(
+    isActionCenterActionStateTransitionAllowed({
+      actor: 'manager_participant',
+      fromState: 'blocked',
+      toState: 'completed',
+    }),
+  ).toBe(false)
+})
+
+it('maps effect-zichtbaar to completed', () => {
+  expect(resolveActionCenterActionReviewTransition('effect-zichtbaar')).toBe('completed')
+})
+```
+
+- [ ] **Step 2: Run the transition suites**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend'
+npx vitest run lib/action-center-constitution.test.ts lib/action-center-action-reviews.test.ts app/api/action-center-action-reviews/route.test.ts
+```
+
+Expected:
+
+```text
+FAIL  transition matrix or review consequence gaps
+```
+
+- [ ] **Step 3: Finalize lifecycle states and transition helpers**
+
+```ts
+export const ACTION_CENTER_ACTION_TRANSITION_RULES = Object.freeze([
+  { fromState: 'draft', toState: 'active', actors: ['manager_participant', 'hr_rhythm_owner'] },
+  { fromState: 'active', toState: 'review_due', actors: ['system_channel'] },
+  { fromState: 'review_due', toState: 'in_review', actors: ['manager_participant', 'hr_rhythm_owner'] },
+  { fromState: 'in_review', toState: 'active', actors: ['manager_participant', 'hr_rhythm_owner'] },
+  { fromState: 'in_review', toState: 'completed', actors: ['manager_participant', 'hr_rhythm_owner'] },
+  { fromState: 'in_review', toState: 'stopped', actors: ['manager_participant', 'hr_rhythm_owner'] },
+  { fromState: 'blocked', toState: 'in_review', actors: ['manager_participant', 'hr_rhythm_owner'] },
+] as const)
+```
+
+- [ ] **Step 4: Enforce canonical review consequences in the review route**
+
+```ts
+const nextSemanticState = resolveActionCenterActionReviewTransition(validated.action_outcome)
+
+if (
+  !isActionCenterActionStateTransitionAllowed({
+    actor: 'manager_participant',
+    fromState: currentSemanticState,
+    toState: nextSemanticState,
+  })
+) {
+  return NextResponse.json({ detail: 'Route action transition is not allowed.' }, { status: 409 })
+}
+```
+
+- [ ] **Step 5: Re-run the transition suites**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend'
+npx vitest run lib/action-center-constitution.test.ts lib/action-center-action-reviews.test.ts app/api/action-center-action-reviews/route.test.ts
+```
+
+Expected:
+
+```text
+PASS  lifecycle and review consequence suites
+```
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git -C 'C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure' add frontend/lib/action-center-constitution.ts frontend/lib/action-center-constitution.test.ts frontend/lib/action-center-action-reviews.ts frontend/lib/action-center-action-reviews.test.ts frontend/app/api/action-center-action-reviews/route.ts frontend/app/api/action-center-action-reviews/route.test.ts
+git -C 'C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure' commit -m "Finalize Action Center lifecycle truth"
+```
+
+### Task 3: Implement Draft, Invalid, And HR Review Flow
+
+**Files:**
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend\app\api\action-center-route-actions\route.ts`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend\app\api\action-center-route-actions\route.test.ts`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend\components\dashboard\action-center-route-action-editor.tsx`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend\components\dashboard\action-center-preview.tsx`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend\lib\action-center-route-action-editor.test.ts`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend\app\(dashboard)\action-center\page.route-shell.test.ts`
+
+- [ ] **Step 1: Add failing UX and API tests for draft/invalid/HR-review behavior**
+
+```ts
+it('returns validationDisposition for invalid action drafts', async () => {
+  const response = await POST(makeRouteActionRequest({ primary_action_text: 'Improve culture everywhere.' }))
+  const result = await response.json()
+  expect(result.validationDisposition).toBe('needs_hr_review')
+})
+
+it('shows explicit correction feedback for invalid action text', () => {
+  render(<ActionCenterRouteActionEditor {...props} />)
+  expect(screen.getByText('Pas deze actie aan zodat hij bounded en route-specifiek is.')).toBeInTheDocument()
+})
+```
+
+- [ ] **Step 2: Run the focused draft-flow suites**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend'
+npx vitest run app/api/action-center-route-actions/route.test.ts lib/action-center-route-action-editor.test.ts "app/(dashboard)/action-center/page.route-shell.test.ts"
+```
+
+Expected:
+
+```text
+FAIL  draft / invalid / HR-review flow not fully surfaced
+```
+
+- [ ] **Step 3: Surface disposition-specific API results**
+
+```ts
+return NextResponse.json({
+  action: projectedAction,
+  validationDisposition: validated.validationDisposition,
+  validationMessage:
+    validated.validationDisposition === 'invalid'
+      ? 'Pas deze actie aan zodat hij bounded en route-specifiek is.'
+      : validated.validationDisposition === 'needs_hr_review'
+        ? 'Deze actie vraagt eerst HR-beoordeling.'
+        : null,
+})
+```
+
+- [ ] **Step 4: Keep the editor correction path compact**
+
+```tsx
+{submissionState.validationDisposition === 'invalid' ? (
+  <p className="text-sm text-[color:var(--dashboard-warning)]">
+    Pas deze actie aan zodat hij bounded en route-specifiek is.
+  </p>
+) : null}
+```
+
+- [ ] **Step 5: Re-run the draft-flow suites**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend'
+npx vitest run app/api/action-center-route-actions/route.test.ts lib/action-center-route-action-editor.test.ts "app/(dashboard)/action-center/page.route-shell.test.ts"
+```
+
+Expected:
+
+```text
+PASS  draft, invalid, and HR-review behavior
+```
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git -C 'C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure' add frontend/app/api/action-center-route-actions/route.ts frontend/app/api/action-center-route-actions/route.test.ts frontend/components/dashboard/action-center-route-action-editor.tsx frontend/components/dashboard/action-center-preview.tsx frontend/lib/action-center-route-action-editor.test.ts "frontend/app/(dashboard)/action-center/page.route-shell.test.ts"
+git -C 'C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure' commit -m "Wire Action Center draft and HR review flow"
+```
+
+### Task 4: Harden Manager Create, Update, And Review UX
+
+**Files:**
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend\components\dashboard\action-center-route-action-editor.tsx`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend\components\dashboard\action-center-action-review-editor.tsx`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend\components\dashboard\action-center-preview.tsx`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend\lib\action-center-action-review-editor.test.ts`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend\lib\action-center-preview-route-fields.test.ts`
+
+- [ ] **Step 1: Add failing repeated-use UX tests**
+
+```ts
+it('keeps the review form compact for repeated use', () => {
+  render(<ActionCenterActionReviewEditor {...props} />)
+  expect(screen.getByLabelText('Wat zagen we terug?')).toBeInTheDocument()
+  expect(screen.getByLabelText('Bron')).toBeInTheDocument()
+  expect(screen.queryByLabelText('Losse aanvullende analyse')).not.toBeInTheDocument()
+})
+
+it('shows one primary create action inside route context', () => {
+  render(<ActionCenterPreview {...props} />)
+  expect(screen.getAllByText('Actie toevoegen')).toHaveLength(1)
+})
+```
+
+- [ ] **Step 2: Run the focused manager-UX suites**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend'
+npx vitest run lib/action-center-action-review-editor.test.ts lib/action-center-preview-route-fields.test.ts
+```
+
+Expected:
+
+```text
+FAIL  manager execution UX still too heavy or ambiguous
+```
+
+- [ ] **Step 3: Simplify the review entry contract**
+
+```tsx
+<fieldset>
+  <legend>Wat zagen we terug?</legend>
+  <ActionOutcomeRadioGroup value={value.actionOutcome} onChange={setActionOutcome} />
+</fieldset>
+
+<Select label="Bron" value={value.evidenceSource} onValueChange={setEvidenceSource}>
+  <SelectItem value="manager-observation">Managerobservatie</SelectItem>
+  <SelectItem value="team-conversation">Teamgesprek</SelectItem>
+  <SelectItem value="other-bounded-source">Andere bounded bron</SelectItem>
+</Select>
+```
+
+- [ ] **Step 4: Keep route-context entry primary**
+
+```tsx
+<Button type="button" onClick={openActionComposer}>
+  Actie toevoegen
+</Button>
+```
+
+- [ ] **Step 5: Re-run the manager-UX suites**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend'
+npx vitest run lib/action-center-action-review-editor.test.ts lib/action-center-preview-route-fields.test.ts
+```
+
+Expected:
+
+```text
+PASS  compact manager execution UX preserved
+```
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git -C 'C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure' add frontend/components/dashboard/action-center-route-action-editor.tsx frontend/components/dashboard/action-center-action-review-editor.tsx frontend/components/dashboard/action-center-preview.tsx frontend/lib/action-center-action-review-editor.test.ts frontend/lib/action-center-preview-route-fields.test.ts
+git -C 'C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure' commit -m "Harden Action Center manager execution UX"
+```
+
+### Task 5: Finalize ExitScan And RetentieScan Route Defaults
+
+**Files:**
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend\lib\action-center-route-defaults.ts`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend\lib\action-center-route-defaults.test.ts`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend\lib\action-center-governance.ts`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend\lib\action-center-governance.test.ts`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend\lib\action-center-review-rhythm-data.ts`
+
+- [ ] **Step 1: Add failing route-differentiation tests**
+
+```ts
+it('keeps ExitScan review window at 60-90 days', () => {
+  expect(getActionCenterRouteDefaults('exit')).toMatchObject({
+    reviewWindowDays: { min: 60, max: 90 },
+  })
+})
+
+it('keeps RetentieScan review window at 45-90 days', () => {
+  expect(getActionCenterRouteDefaults('retention')).toMatchObject({
+    reviewWindowDays: { min: 45, max: 90 },
+  })
+})
+
+it('derives governance labels from bounded route family truth', () => {
+  expect(getActionCenterGovernanceSignalLabel('route_ready_for_closeout')).toBe('Klaar voor closeout')
+})
+```
+
+- [ ] **Step 2: Run the route-default and governance suites**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend'
+npx vitest run lib/action-center-route-defaults.test.ts lib/action-center-governance.test.ts lib/action-center-review-rhythm-data.test.ts
+```
+
+Expected:
+
+```text
+FAIL  route defaults or route differentiation readback incomplete
+```
+
+- [ ] **Step 3: Finalize route defaults and route-family alignment**
+
+```ts
+const ACTION_CENTER_EXECUTION_THRESHOLDS = {
+  exit: {
+    stuckActiveWarningDays: 30,
+    reviewDueGraceDays: 7,
+    sprawlRiskCount: 3,
+    repeatedReviewWarningCount: 2,
+  },
+  retention: {
+    stuckActiveWarningDays: { min: 21, max: 30 },
+    reviewDueGraceDays: 7,
+    sprawlRiskCount: 3,
+    repeatedReviewWarningCount: 2,
+  },
+} satisfies Record<ActionCenterApprovedRouteFamily, ActionCenterExecutionThresholds>
+```
+
+- [ ] **Step 4: Re-run the route-default and governance suites**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend'
+npx vitest run lib/action-center-route-defaults.test.ts lib/action-center-governance.test.ts lib/action-center-review-rhythm-data.test.ts
+```
+
+Expected:
+
+```text
+PASS  route defaults and governance alignment suites
+```
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git -C 'C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure' add frontend/lib/action-center-route-defaults.ts frontend/lib/action-center-route-defaults.test.ts frontend/lib/action-center-governance.ts frontend/lib/action-center-governance.test.ts frontend/lib/action-center-review-rhythm-data.ts
+git -C 'C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure' commit -m "Finalize Action Center route differentiation defaults"
+```
+
+### Task 6: Harden Schema Parity And Full Batch-A Regressions
+
+**Files:**
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\supabase\action_center_constitution_adoption_readiness.sql`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\supabase\schema.sql`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\docs\superpowers\plans\2026-05-20-batch-a-productization-of-execution-implementation.md`
+
+- [ ] **Step 1: Add any missing schema parity for new bounded-execution fields or constraints**
+
+```sql
+alter table public.action_center_route_actions
+  add column if not exists semantic_state text,
+  add column if not exists validation_disposition text;
+
+alter table public.action_center_route_actions
+  add constraint action_center_route_actions_semantic_state_check
+  check (semantic_state in ('draft', 'active', 'review_due', 'in_review', 'blocked', 'completed', 'stopped', 'superseded'));
+```
+
+- [ ] **Step 2: Run the full Batch A regression suite**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend'
+npx vitest run lib/action-center-constitution.test.ts lib/action-center-route-actions.test.ts lib/action-center-action-reviews.test.ts lib/action-center-route-defaults.test.ts lib/action-center-governance.test.ts lib/action-center-review-rhythm-data.test.ts lib/action-center-route-action-editor.test.ts lib/action-center-action-review-editor.test.ts lib/action-center-bounded-execution-metrics.test.ts app/api/action-center-route-actions/route.test.ts app/api/action-center-action-reviews/route.test.ts components/dashboard/review-rhythm-oversight.test.tsx
+```
+
+Expected:
+
+```text
+PASS  Batch A bounded execution regression suites
+```
+
+- [ ] **Step 3: Run production build check for Action Center codepaths**
+
+Run:
+
+```powershell
+Set-Location 'C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\frontend'
+npm run build
+```
+
+Expected:
+
+```text
+Compiled successfully for Action Center bounded execution changes; any remaining stop must be unrelated known environment baseline
+```
+
+- [ ] **Step 4: Record verification notes in this plan**
+
+```md
+## Verification Notes
+
+- Batch A contract validation verified
+- Batch A transition matrix verified
+- Draft / invalid / HR-review behavior verified
+- Compact manager execution UX verified
+- ExitScan and RetentieScan route differentiation defaults verified
+- No Action Center route-family expansion or off-platform write broadening introduced
+```
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git -C 'C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure' add supabase/action_center_constitution_adoption_readiness.sql supabase/schema.sql docs/superpowers/plans/2026-05-20-batch-a-productization-of-execution-implementation.md
+git -C 'C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure' commit -m "Close out Batch A execution hardening"
+```
+
+---
+
+## Self-Review
+
+### Spec coverage
+
+- action-card contract, quality rules, and invalid examples: Task 1
+- lifecycle and transition matrix: Task 2
+- draft / invalid / HR-review flow: Task 3
+- manager create / update / review UX: Task 4
+- ExitScan / RetentieScan differentiation defaults: Task 5
+- test and regression hardening: Task 6
+
+### Placeholder scan
+
+- No `TBD`, `TODO`, or “implement later” placeholders remain.
+- Each task includes exact files, commands, and expected outcomes.
+
+### Type consistency
+
+- `validationDisposition`, `semanticState`, route defaults, and route/action/review semantics stay aligned with the Batch A spec vocabulary.
+- No task introduces new route families, off-platform truth, or standalone workflow behavior.

--- a/docs/superpowers/plans/2026-05-20-batch-a-productization-of-execution-implementation.md
+++ b/docs/superpowers/plans/2026-05-20-batch-a-productization-of-execution-implementation.md
@@ -628,12 +628,11 @@ Compiled successfully for Action Center bounded execution changes; any remaining
 - 2026-05-21: added missing schema parity for `action_center_route_actions` and `action_center_action_reviews` in both owned SQL files, including Batch A `semantic_state` and `validation_disposition` constraints plus compact review evidence fields.
 - Full Batch A regression suite passed with `12` test files and `132` tests green:
   `npx vitest run lib/action-center-constitution.test.ts lib/action-center-route-actions.test.ts lib/action-center-action-reviews.test.ts lib/action-center-route-defaults.test.ts lib/action-center-governance.test.ts lib/action-center-review-rhythm-data.test.ts lib/action-center-route-action-editor.test.ts lib/action-center-action-review-editor.test.ts lib/action-center-bounded-execution-metrics.test.ts app/api/action-center-route-actions/route.test.ts app/api/action-center-action-reviews/route.test.ts components/dashboard/review-rhythm-oversight.test.tsx`
-- Production build check compiled successfully, then failed during type-check on an existing non-owned Action Center file:
-  `components/dashboard/action-center-preview.tsx:891`
-- Build blocker detail:
-  `Type '"afgerond" | "gestopt" | "open-verzoek" | "te-bespreken" | "reviewbaar" | "in-uitvoering" | "geblokkeerd"' is not assignable to type 'ActionCenterRouteStatus | null'.`
-- The build also reported existing ESLint warnings in `app/api/action-center-route-closeouts/route.ts`, `app/producten/[slug]/page.tsx`, `components/marketing/follow-on-route-page.tsx`, `components/marketing/home-insight-action-demo.tsx`, and `lib/action-center-governance.ts`.
-- No Action Center route-family expansion or off-platform write broadening was introduced by this closeout.
+ - Production build check now compiles and type-checks through the Batch A Action Center changes.
+ - The remaining production-build stop is the known Supabase SSR / prerender baseline on `/(auth)/signup`:
+   `@supabase/ssr: Your project's URL and API key are required to create a Supabase client!`
+ - The build also reported existing ESLint warnings in `app/api/action-center-route-closeouts/route.ts`, `app/producten/[slug]/page.tsx`, `components/marketing/follow-on-route-page.tsx`, `components/marketing/home-insight-action-demo.tsx`, and `lib/action-center-governance.ts`.
+ - No Action Center route-family expansion or off-platform write broadening was introduced by this closeout.
 
 - [x] **Step 5: Commit**
 

--- a/docs/superpowers/plans/2026-05-20-batch-a-productization-of-execution-implementation.md
+++ b/docs/superpowers/plans/2026-05-20-batch-a-productization-of-execution-implementation.md
@@ -635,7 +635,7 @@ Compiled successfully for Action Center bounded execution changes; any remaining
 - The build also reported existing ESLint warnings in `app/api/action-center-route-closeouts/route.ts`, `app/producten/[slug]/page.tsx`, `components/marketing/follow-on-route-page.tsx`, `components/marketing/home-insight-action-demo.tsx`, and `lib/action-center-governance.ts`.
 - No Action Center route-family expansion or off-platform write broadening was introduced by this closeout.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```powershell
 git -C 'C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure' add supabase/action_center_constitution_adoption_readiness.sql supabase/schema.sql docs/superpowers/plans/2026-05-20-batch-a-productization-of-execution-implementation.md

--- a/docs/superpowers/plans/2026-05-20-batch-a-productization-of-execution-implementation.md
+++ b/docs/superpowers/plans/2026-05-20-batch-a-productization-of-execution-implementation.md
@@ -554,7 +554,7 @@ Expected:
 PASS  route defaults and governance alignment suites
 ```
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```powershell
 git -C 'C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure' add frontend/lib/action-center-route-defaults.ts frontend/lib/action-center-route-defaults.test.ts frontend/lib/action-center-governance.ts frontend/lib/action-center-governance.test.ts frontend/lib/action-center-review-rhythm-data.ts
@@ -568,7 +568,7 @@ git -C 'C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer
 - Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\supabase\schema.sql`
 - Modify: `C:\Users\larsh\Desktop\Business\Verisight\.worktrees\spec-hr-routebeheer-structure\docs\superpowers\plans\2026-05-20-batch-a-productization-of-execution-implementation.md`
 
-- [ ] **Step 1: Add any missing schema parity for new bounded-execution fields or constraints**
+- [x] **Step 1: Add any missing schema parity for new bounded-execution fields or constraints**
 
 ```sql
 alter table public.action_center_route_actions
@@ -580,7 +580,7 @@ alter table public.action_center_route_actions
   check (semantic_state in ('draft', 'active', 'review_due', 'in_review', 'blocked', 'completed', 'stopped', 'superseded'));
 ```
 
-- [ ] **Step 2: Run the full Batch A regression suite**
+- [x] **Step 2: Run the full Batch A regression suite**
 
 Run:
 
@@ -595,7 +595,7 @@ Expected:
 PASS  Batch A bounded execution regression suites
 ```
 
-- [ ] **Step 3: Run production build check for Action Center codepaths**
+- [x] **Step 3: Run production build check for Action Center codepaths**
 
 Run:
 
@@ -610,7 +610,7 @@ Expected:
 Compiled successfully for Action Center bounded execution changes; any remaining stop must be unrelated known environment baseline
 ```
 
-- [ ] **Step 4: Record verification notes in this plan**
+- [x] **Step 4: Record verification notes in this plan**
 
 ```md
 ## Verification Notes
@@ -622,6 +622,18 @@ Compiled successfully for Action Center bounded execution changes; any remaining
 - ExitScan and RetentieScan route differentiation defaults verified
 - No Action Center route-family expansion or off-platform write broadening introduced
 ```
+
+## Verification Notes
+
+- 2026-05-21: added missing schema parity for `action_center_route_actions` and `action_center_action_reviews` in both owned SQL files, including Batch A `semantic_state` and `validation_disposition` constraints plus compact review evidence fields.
+- Full Batch A regression suite passed with `12` test files and `132` tests green:
+  `npx vitest run lib/action-center-constitution.test.ts lib/action-center-route-actions.test.ts lib/action-center-action-reviews.test.ts lib/action-center-route-defaults.test.ts lib/action-center-governance.test.ts lib/action-center-review-rhythm-data.test.ts lib/action-center-route-action-editor.test.ts lib/action-center-action-review-editor.test.ts lib/action-center-bounded-execution-metrics.test.ts app/api/action-center-route-actions/route.test.ts app/api/action-center-action-reviews/route.test.ts components/dashboard/review-rhythm-oversight.test.tsx`
+- Production build check compiled successfully, then failed during type-check on an existing non-owned Action Center file:
+  `components/dashboard/action-center-preview.tsx:891`
+- Build blocker detail:
+  `Type '"afgerond" | "gestopt" | "open-verzoek" | "te-bespreken" | "reviewbaar" | "in-uitvoering" | "geblokkeerd"' is not assignable to type 'ActionCenterRouteStatus | null'.`
+- The build also reported existing ESLint warnings in `app/api/action-center-route-closeouts/route.ts`, `app/producten/[slug]/page.tsx`, `components/marketing/follow-on-route-page.tsx`, `components/marketing/home-insight-action-demo.tsx`, and `lib/action-center-governance.ts`.
+- No Action Center route-family expansion or off-platform write broadening was introduced by this closeout.
 
 - [ ] **Step 5: Commit**
 

--- a/docs/superpowers/specs/2026-05-20-action-center-enterprise-roadmap.md
+++ b/docs/superpowers/specs/2026-05-20-action-center-enterprise-roadmap.md
@@ -1,0 +1,306 @@
+# Action Center Enterprise Roadmap
+
+## 1. Purpose
+
+This roadmap defines the full follow-on route for **Action Center as an enterprise-worthy bounded execution layer inside Loep**.
+
+Its purpose is to stop working through disconnected micro-waves and instead make the next major product steps explicit in advance:
+
+- which large batches follow
+- what each batch must deliver
+- which non-goals remain fixed
+- which gates must be passed before the next batch starts
+- how Action Center development connects to `ExitScan` and `RetentieScan`
+
+This roadmap is a steering document. It is not a design spec and not an implementation plan.
+
+## 2. Current Position
+
+Loep now has a strong bounded foundation for Action Center.
+
+What already exists:
+
+- route truth remains canonical
+- Action Center is the canonical follow-through surface
+- action cards exist inside routes
+- managers can create and review route-bound actions
+- HR governs rhythm, oversight, closeout, and continuation
+- governance signals exist for execution gaps, sprawl, stuck actions, and repeated no-progress loops
+- adoption measurement readiness exists
+- approved route families remain bounded to `exit` and `retention`
+
+What is still incomplete:
+
+- repeated-use manager execution quality
+- deeper HR readback and operating control
+- broader measurement surfaces and proof readiness
+- buyer-safe packaging and rollout framing
+- controlled route expansion logic
+
+## 3. Product Principles
+
+These principles apply to every future batch.
+
+Action Center remains:
+
+- embedded inside Loep
+- route-bound
+- bounded to approved route families
+- HR-governed
+- manager-light
+- post-scan follow-through only
+- canonical inside Action Center
+
+Action Center does not become:
+
+- a standalone product
+- a third first-buy route
+- generic workflow software
+- a broad action or project management platform
+- advisory tooling
+- an HR operating system
+- a personnel dossier or employee risk ledger
+- a task board
+- a broad collaboration system
+
+## 4. End State
+
+The target end state is an Action Center that feels enterprise-worthy while staying smaller, sharper, and more governed than generic employee-experience suites.
+
+In that state:
+
+- managers can create, review, and adjust a small set of route-bound actions
+- HR governs rhythm, oversight, continuation, and closeout
+- metrics show whether follow-through happened and how it progressed, without claiming causal intervention impact
+- buyers can quickly understand that this is not project management, employee monitoring, or case management
+- only route families with explicit activation gates may carry this model
+
+## 5. Batch Overview
+
+### Batch A - Productization of Execution
+
+**Goal:** turn the current manager action-card model into an enterprise-worthy execution layer.
+
+**Core scope:**
+
+- action contract
+- action lifecycle and transition truth
+- draft / invalid / HR-review flow
+- route-to-action policy
+- manager create / update / review experience
+- parallel route-track hardening for `ExitScan` and `RetentieScan`
+
+**Gate to Batch B:**
+
+- Action Center no longer feels like a capability-set
+- managers can use bounded execution with low friction
+- `ExitScan` and `RetentieScan` are product-wise more clearly differentiated
+
+### Batch B - Governance + Proof
+
+**Goal:** make the execution layer governable and measurable.
+
+**Core scope:**
+
+- HR control and readback on action execution
+- governance queues and intervention logic
+- measurement surfaces on top of bounded execution events
+- buyer-safe reporting vocabulary
+- proof readiness for live route usage
+
+**Gate to Batch C:**
+
+- HR can track execution quality at scale
+- metrics are stable and interpretable
+- internal teams can clearly explain what the metrics do and do not prove
+
+### Batch C - Buyer Readiness + Controlled Scale
+
+**Goal:** make Action Center enterprise-buyable and only then evaluate controlled expansion.
+
+**Core scope:**
+
+- buyer-safe governance framing
+- rollout and operating materials
+- route-fit logic
+- activation gates for any later route-family expansion
+- suite-convergence decisions
+
+**Gate to any later expansion:**
+
+- the buyer story is strong and bounded
+- governance remains defensible
+- route expansion is justified route-by-route, not by portfolio pressure
+
+## 6. Batch Detail
+
+### Batch A
+
+**Goal**
+
+Land Action Center as a serious execution product instead of a partially-finished operational layer.
+
+**Primary deliverables**
+
+- `Action Center Manager Execution Productization` spec
+- implementation plan for manager execution productization
+- `ExitScan Differentiation Hardening` spec
+- `RetentieScan Evidence + Confidence Hardening` spec
+- finalized action-card contract
+- finalized action transition truth
+- draft / invalid / HR-review behavior
+- route-to-action policy
+- compact manager execution UX
+- bounded evidence UX contract
+
+**Non-goals**
+
+- no new route families
+- no analytics expansion as the main focus
+- no buyer packaging as the main focus
+- no workflow broadening
+
+**Batch gate**
+
+- the action-card model feels stable
+- HR no longer has to resolve core execution ambiguity ad hoc
+- managers can use execution flows without high interpretation load
+
+### Batch B
+
+**Goal**
+
+Make Action Center governable and measurable at enterprise operating depth.
+
+**Primary deliverables**
+
+- `Action Center HR Control & Readback` spec
+- `Action Center Measurement & Proof` spec
+- HR oversight surfaces
+- governance intervention logic
+- metric surfaces
+- route-to-action conversion readback
+- action review, completion, stop, and reopen readback
+- internal KPI interpretation guide
+
+**Non-goals**
+
+- no causal impact claims
+- no broad analytics platform
+- no route expansion
+- no collaboration-suite behavior
+
+**Batch gate**
+
+- HR can follow the execution layer at scale
+- measurement semantics are stable
+- reporting language is buyer-safe
+
+### Batch C
+
+**Goal**
+
+Finish the product commercially and strategically without creating scope sprawl.
+
+**Primary deliverables**
+
+- `Action Center Buyer Readiness & Rollout` spec
+- governance one-pager
+- manager participation one-pager
+- privacy / dossier boundary note
+- route -> action -> review -> closeout explanation
+- route-fit matrix
+- activation gate framework
+
+**Non-goals**
+
+- no automatic route expansion
+- no generic suite story
+- no standalone Action Center packaging
+- no broad upsell framing without gates
+
+**Batch gate**
+
+- buyers understand the product quickly and correctly
+- any later expansion can be explicitly approved or rejected per route family
+
+## 7. Parallel Route Tracks
+
+Alongside Action Center, two route tracks must move in parallel.
+
+### ExitScan Differentiation
+
+**Goal:** make `ExitScan` read as a clearer, sharper first-buy route.
+
+It must produce:
+
+- stronger management grammar
+- clearer differentiation versus `RetentieScan`
+- better buyer-safe framing of question, output, and claims
+
+### RetentieScan Evidence + Confidence
+
+**Goal:** make `RetentieScan` buyer-proof as a route for active retention pressure.
+
+It must produce:
+
+- anti-MTO-light positioning
+- a stronger confidence architecture
+- clearer evidence discipline
+- a more compact management read
+
+## 8. Dependencies
+
+- Batch B depends on Batch A because metrics are weak without a stable execution model
+- Batch C depends on Batch B because buyer readiness is weak without governance and readback maturity
+- `ExitScan` and `RetentieScan` must reach sufficient product clarity before late Batch B, otherwise the buyer story remains uneven
+- route expansion may only be evaluated after the Batch C gate
+
+## 9. Decision Gates And Stop Rules
+
+The following stop rules remain in force:
+
+- no new route families before Batch C
+- no off-platform canonical writes
+- no broad workflow automation
+- no manager dashboard expansion as a standalone product goal
+- no buyer claims beyond measurement readiness without live evidence
+- no expansion purely because the portfolio should look broader
+
+## 10. Document Map
+
+The following documents should sit under this roadmap:
+
+- Batch A spec
+- Batch B spec
+- Batch C spec
+- implementation plans per batch
+- `ExitScan` hardening spec
+- `RetentieScan` hardening spec
+- governance notes
+- buyer artifacts
+- route-fit and activation-gate documents
+
+## 11. Sequencing
+
+Recommended order:
+
+1. Batch A
+2. Batch B
+3. Batch C
+
+Parallel tracks:
+
+- `ExitScan` hardening
+- `RetentieScan` hardening
+
+## 12. Success Definition
+
+This roadmap is successful when:
+
+- Action Center is enterprise-worthy without becoming generic
+- managers can use bounded execution calmly and repeatedly
+- HR can govern the follow-through layer at operating depth
+- metrics show operating quality without over-claiming proof
+- buyers quickly understand what Action Center is and is not
+- Loep can make controlled, explicit decisions about which route families may later carry this model

--- a/docs/superpowers/specs/2026-05-20-batch-a-productization-of-execution-spec.md
+++ b/docs/superpowers/specs/2026-05-20-batch-a-productization-of-execution-spec.md
@@ -1,0 +1,277 @@
+# Batch A Productization of Execution
+
+## Status
+Proposed
+
+## 1. Purpose
+
+This document defines **Batch A** from the Action Center Enterprise Roadmap.
+
+Batch A exists to turn the current Action Center runtime into an **enterprise-worthy bounded execution layer inside Loep**.
+
+This batch does not invent a new product model. It hardens and completes the existing one:
+
+- route stays canonical
+- action cards remain route-bound execution objects
+- managers remain light execution participants
+- HR remains rhythm owner, governance owner, and final closeout actor
+
+This document is a **batch spec**. It is not an implementation plan.
+
+## 2. Batch Role
+
+Batch A is the first major execution batch after the bounded execution foundation.
+
+Its purpose is to ensure that Action Center no longer feels like a capable but partially unfinished follow-through layer. By the end of Batch A, the product should feel stable enough that later work can safely focus on governance readback, measurement surfaces, and buyer readiness instead of still debating core product truth.
+
+Batch A is complete only when all three internal sub-batches are complete:
+
+- `A1 - Action Contract & Lifecycle`
+- `A2 - Manager Execution UX`
+- `A3 - Route Differentiation Alignment`
+
+## 3. Starting Point
+
+Batch A starts from the current product reality already present in the merged codebase.
+
+Current truth:
+
+- route truth is canonical inside Action Center
+- action cards already exist inside routes
+- managers can create and review route-bound actions
+- HR already governs rhythm, oversight, closeout, and continuation
+- governance signals already exist for execution gaps, sprawl, stuck actions, and repeated no-progress loops
+- approved route families remain bounded to `exit` and `retention`
+
+Current gaps that Batch A must close:
+
+- action-card contract is not yet complete enough for repeated enterprise use
+- action lifecycle and transition truth need a final stable product contract
+- manager execution UX still needs repeated-use hardening
+- route-to-action growth policy still needs a stronger bounded rule set
+- `ExitScan` and `RetentieScan` still need stronger route differentiation for Action Center follow-through
+
+## 4. Batch Constraints
+
+The following constraints remain fixed throughout Batch A:
+
+- Action Center remains embedded inside Loep
+- Action Center remains route-bound
+- Action Center remains limited to approved route families only
+- HR remains governance owner and final closeout actor
+- managers do not gain route closeout, route reopen, canonical reschedule, or owner-reassignment power
+- no off-platform canonical writes are introduced
+- no Teams, Slack, multichannel expansion, or Graph dependency is introduced
+- no generic workflow, project management, task board, or case-management behavior is introduced
+- no standalone Action Center framing is introduced
+- no route-family expansion outside `exit` and `retention` is introduced
+
+## 5. Batch Outcome
+
+By the end of Batch A, Action Center should behave like a calm, bounded execution product:
+
+- managers can create, review, adjust, block, stop, and complete route-bound actions without ambiguity
+- HR can trust the underlying action and review semantics
+- route-to-action growth remains bounded and governable
+- `ExitScan` and `RetentieScan` are distinct enough that Action Center follow-through does not flatten them into the same product
+- later measurement-readback work can build on stable product truth instead of filling semantic gaps
+
+## 6. Sub-Batch Structure
+
+### A1 - Action Contract & Lifecycle
+
+**Purpose**
+
+Finalize the product truth for action cards and action reviews.
+
+**Scope**
+
+- action-card contract
+- action quality rules
+- action lifecycle
+- action transition matrix
+- draft / invalid / HR-review behavior
+- route-to-action policy
+- action-sprawl guardrails
+- route/action/review semantic boundaries
+
+**Must define**
+
+- required and prohibited action-card fields
+- valid and invalid action rules
+- draft versus active truth
+- HR review required states
+- allowed and prohibited state transitions
+- review-outcome to next-state mapping
+- route-level limits and action growth rules
+
+**Must not do**
+
+- introduce subtasks
+- introduce generic task hierarchy
+- introduce broad priority systems
+- introduce free-form project structures
+- let action truth replace route truth
+
+### A2 - Manager Execution UX
+
+**Purpose**
+
+Make manager execution calm, low-friction, and repeatable.
+
+**Scope**
+
+- manager create flow
+- manager update flow
+- manager review flow
+- bounded evidence UX
+- compact status and review consequences
+- route-level entry into action execution
+
+**Must define**
+
+- the primary manager create path
+- the primary manager review path
+- low-friction invalid-action correction behavior
+- compact evidence entry behavior
+- no-dashboard-heavy ownership rules
+- minimal field load per repeated-use action review
+
+**Must not do**
+
+- make managers dashboard owners
+- optimize for broad manager admin behavior
+- create a second parallel manager model next to action cards
+- make the UX depend on broad reporting or analytics surfaces
+
+### A3 - Route Differentiation Alignment
+
+**Purpose**
+
+Ensure Action Center execution remains aligned to the product differences between `ExitScan` and `RetentieScan`.
+
+**Scope**
+
+- ExitScan route defaults and management grammar
+- RetentieScan route defaults, evidence grammar, and confidence expectations
+- bounded route-specific closeout and continuation framing
+- route-safe follow-through distinction
+
+**Must define**
+
+- how `ExitScan` follow-through differs from `RetentieScan` follow-through
+- how route defaults differ
+- how action focus differs
+- how review and closeout questions differ
+- how route-specific semantics remain aligned without introducing separate workflow systems
+
+**Must not do**
+
+- open new route families
+- create route-specific workflow exceptions that break shared Action Center truth
+- use Action Center to hide unresolved `RetentieScan` MTO-light ambiguity
+
+## 7. Product Decisions Required In Batch A
+
+Batch A must settle the following product decisions:
+
+1. What exactly makes an action card valid, invalid, or HR-review-worthy?
+2. Which action lifecycle states are canonical, and which are only UI labels?
+3. Which state transitions are allowed, prohibited, or derived?
+4. How do action reviews change action state without changing route truth?
+5. When does a route require zero, one, two, or three actions?
+6. How does the manager create/update/review flow stay lighter than generic action-planning tools?
+7. How do `ExitScan` and `RetentieScan` differ enough that follow-through still respects route intent?
+
+No implementation plan should be written until these product decisions are explicit in the Batch A output documents.
+
+## 8. Required Deliverables
+
+Batch A must produce at least:
+
+- `Action Center Manager Execution Productization` spec
+- `ExitScan Differentiation Hardening` spec
+- `RetentieScan Evidence + Confidence Hardening` spec
+- one integrated implementation plan for Batch A execution, or tightly coordinated implementation plans that still preserve Batch A as one governed batch
+- finalized action-card contract
+- finalized action transition matrix
+- finalized draft / invalid / HR-review behavior
+- finalized route-to-action policy
+- finalized manager execution UX contract
+- finalized route differentiation defaults for `ExitScan` and `RetentieScan`
+
+## 9. Decision Order
+
+Batch A should settle decisions in this order:
+
+1. action-card contract
+2. action quality rules
+3. action lifecycle and transition truth
+4. draft / invalid / HR-review behavior
+5. route-to-action policy
+6. manager create/update/review UX
+7. route differentiation defaults for `ExitScan` and `RetentieScan`
+
+This order is mandatory because manager UX and route differentiation should build on stable action truth, not redefine it indirectly.
+
+## 10. Non-Goals
+
+Batch A explicitly does not do the following:
+
+- no route-family expansion
+- no Teams, Slack, or multichannel expansion
+- no Graph dependency
+- no off-platform canonical write behavior
+- no generic workflow broadening
+- no broad analytics platform
+- no buyer packaging as the main workstream
+- no standalone Action Center framing
+- no intervention impact claims
+- no adoption proof claims
+
+## 11. Exit Criteria
+
+Batch A may exit only when all of the following are true:
+
+- action-card contract is finalized
+- action transition matrix is finalized
+- draft / invalid / HR-review flow is defined
+- manager create / update / review UX is specified and scenario-tested
+- ExitScan and RetentieScan route defaults are explicitly differentiated
+- no unresolved product truth remains around route, action, or review semantics
+
+Batch A is not complete if any of A1, A2, or A3 still contains unresolved product truth.
+
+## 12. Stop Conditions
+
+Batch A must stop and simplify if any of the following happen:
+
+- manager execution becomes dashboard-heavy
+- action cards drift toward broad task or project management
+- route-to-action policy becomes too permissive to govern cleanly
+- RetentieScan semantics remain too close to MTO-light and create false alignment with Action Center execution
+- route-specific needs begin to create separate workflow rules instead of shared bounded truth
+
+## 13. Implementation Preconditions
+
+Coding must not start from this batch spec directly.
+
+Before implementation begins, Batch A requires:
+
+- approved Batch A spec
+- approved Batch A implementation plan
+- test strategy
+- no unresolved canonical product truth
+- explicit non-goals
+- no off-platform canonical write behavior
+- no route expansion outside approved scope
+
+## 14. Success Definition
+
+Batch A is successful when:
+
+- Action Center execution no longer feels semantically unfinished
+- manager action behavior is calm, bounded, and repeatable
+- HR can trust the route/action/review model without relying on informal interpretation
+- `ExitScan` and `RetentieScan` remain clearly distinct within shared Action Center truth
+- later governance and measurement-readback work can proceed without reopening core execution semantics

--- a/docs/superpowers/specs/2026-05-20-batch-a-productization-of-execution-spec.md
+++ b/docs/superpowers/specs/2026-05-20-batch-a-productization-of-execution-spec.md
@@ -171,7 +171,62 @@ Ensure Action Center execution remains aligned to the product differences betwee
 - create route-specific workflow exceptions that break shared Action Center truth
 - use Action Center to hide unresolved `RetentieScan` MTO-light ambiguity
 
-## 7. Product Decisions Required In Batch A
+## 7. Sub-Batch Exit Criteria
+
+### A1 Exit Criteria
+
+A1 may exit only when all of the following are true:
+
+- action-card contract is finalized
+- required and prohibited fields are finalized
+- valid and invalid action rules are finalized
+- invalid examples are translated into explicit validation behavior
+- canonical action lifecycle is finalized
+- action transition matrix is finalized
+- draft / invalid / HR-review flow is finalized
+- route-to-action limits are finalized
+- tests are specified for validation, transitions, permissions, and route/action boundaries
+
+### A2 Exit Criteria
+
+A2 may exit only when all of the following are true:
+
+- manager create path is specified
+- manager update path is specified
+- manager review path is specified
+- invalid-action correction flow is specified
+- compact evidence entry behavior is specified
+- field load is bounded for repeated-use review
+- no-dashboard-heavy entry is preserved
+- scenario walkthroughs are complete for valid action creation, invalid action correction, action review, and blocked action
+
+### A3 Exit Criteria
+
+A3 may exit only when all of the following are true:
+
+- ExitScan and RetentieScan route defaults matrix is finalized
+- action focus differs by route
+- review window differs by route where appropriate
+- closeout questions differ by route
+- evidence and confidence expectations differ by route
+- shared Action Center truth remains intact
+- no route-specific workflow exception is introduced
+- RetentieScan does not remain MTO-light in Action Center follow-through
+
+## 8. Minimum Route Differentiation Matrix
+
+| Dimension | ExitScan | RetentieScan |
+| --- | --- | --- |
+| route intent | retrospective departure and work-friction follow-through | active retention-pressure follow-through |
+| action focus | verify and act on selected departure pattern or work-friction route | verify and act on selected retention pressure or work-factor route |
+| default review window | 60-90 days | 45-90 days |
+| evidence expectation | management-visible evidence that a selected departure-related follow-through step was attempted and reviewed | management-visible evidence that a selected retention-related follow-through step was attempted, reviewed, and interpreted with explicit caution |
+| closeout question | what was chosen, what was executed, and what returns in the next exit batch or management conversations? | what was verified, what first intervention or follow-up started, and what should be watched in retention signal, stay-intent, or departure intention? |
+| continuation logic | continue if the departure pattern remains active, the action evidence remains weak, or the route still needs monitoring in later exit batches or management conversations | continue if retention pressure persists, review evidence remains weak, or follow-up measurement is still planned |
+| confidence / uncertainty framing | do not claim causality or proof of preventability | do not claim individual risk prediction or broad MTO diagnosis |
+| what not to claim | no causal explanation, no preventability proof, no broad organizational diagnosis from one route | no individual risk prediction, no causal retention proof, no broad MTO-light diagnosis |
+
+## 9. Product Decisions Required In Batch A
 
 Batch A must settle the following product decisions:
 
@@ -185,7 +240,7 @@ Batch A must settle the following product decisions:
 
 No implementation plan should be written until these product decisions are explicit in the Batch A output documents.
 
-## 8. Required Deliverables
+## 10. Required Deliverables
 
 Batch A must produce at least:
 
@@ -200,7 +255,7 @@ Batch A must produce at least:
 - finalized manager execution UX contract
 - finalized route differentiation defaults for `ExitScan` and `RetentieScan`
 
-## 9. Decision Order
+## 11. Decision Order
 
 Batch A should settle decisions in this order:
 
@@ -214,7 +269,73 @@ Batch A should settle decisions in this order:
 
 This order is mandatory because manager UX and route differentiation should build on stable action truth, not redefine it indirectly.
 
-## 10. Non-Goals
+## 12. Implementation Slice Guidance
+
+Batch A should not be implemented as one large coding slice.
+
+Recommended implementation slices:
+
+1. Action Card Contract & Validation
+2. Action Lifecycle & Transition Matrix
+3. Draft / Invalid / HR Review Flow
+4. Manager Create / Update / Review UX
+5. ExitScan and RetentieScan Route Defaults
+6. Test and Regression Hardening
+
+Implementation plans may decompose and sequence the work, but they may not invent or reinterpret:
+
+- action-card fields
+- lifecycle states
+- validation rules
+- route defaults
+- manager permissions
+- route / action / review semantics
+
+## 13. Required Scenario Walkthroughs
+
+The Batch A output must define or document walkthroughs for at least:
+
+- manager creates a valid route-bound action
+- manager creates a vague action and corrects it
+- manager attempts an employee-dossier-like action and is blocked or escalated
+- action reaches `review_due`
+- manager completes a review with `effect-zichtbaar`
+- manager reviews twice with `nog-te-vroeg` or `bijsturen-nodig`
+- HR sees `action_sprawl_risk`
+- HR sees `repeated_review_without_progress`
+- HR sees `route_ready_for_closeout`
+- ExitScan and RetentieScan show differentiated route defaults
+
+## 14. Test Expectations
+
+Batch A must define tests for:
+
+- valid and invalid action creation
+- prohibited action-card content
+- lifecycle transitions
+- prohibited transitions
+- manager permission boundaries
+- HR-only closeout boundaries
+- draft / invalid / HR-review flow
+- route-to-action limits
+- action-sprawl signal
+- repeated-review-without-progress signal
+- route differentiation defaults
+- no off-platform canonical writes
+- no route-family expansion
+
+## 15. Approval / Sign-Off
+
+Batch A output may not move to implementation unless approved by:
+
+- product or founder owner
+- engineering implementer or technical owner
+- governance or trust reviewer
+- route owner for ExitScan / RetentieScan differentiation, if separate
+
+If any of these roles are not formally assigned, the founder or product owner must explicitly assume that sign-off responsibility.
+
+## 16. Non-Goals
 
 Batch A explicitly does not do the following:
 
@@ -229,20 +350,20 @@ Batch A explicitly does not do the following:
 - no intervention impact claims
 - no adoption proof claims
 
-## 11. Exit Criteria
+## 17. Exit Criteria
 
 Batch A may exit only when all of the following are true:
 
-- action-card contract is finalized
-- action transition matrix is finalized
-- draft / invalid / HR-review flow is defined
-- manager create / update / review UX is specified and scenario-tested
-- ExitScan and RetentieScan route defaults are explicitly differentiated
-- no unresolved product truth remains around route, action, or review semantics
+- all A1, A2, and A3 sub-batch exit criteria are met
+- required scenario walkthroughs are complete
+- test expectations are defined
+- route differentiation matrix is complete
+- implementation slice plan is approved
+- no unresolved product truth remains around route, action, review, permissions, validation, or route defaults
 
 Batch A is not complete if any of A1, A2, or A3 still contains unresolved product truth.
 
-## 12. Stop Conditions
+## 18. Stop Conditions
 
 Batch A must stop and simplify if any of the following happen:
 
@@ -252,7 +373,7 @@ Batch A must stop and simplify if any of the following happen:
 - RetentieScan semantics remain too close to MTO-light and create false alignment with Action Center execution
 - route-specific needs begin to create separate workflow rules instead of shared bounded truth
 
-## 13. Implementation Preconditions
+## 19. Implementation Preconditions
 
 Coding must not start from this batch spec directly.
 
@@ -266,7 +387,7 @@ Before implementation begins, Batch A requires:
 - no off-platform canonical write behavior
 - no route expansion outside approved scope
 
-## 14. Success Definition
+## 20. Success Definition
 
 Batch A is successful when:
 

--- a/frontend/app/(dashboard)/action-center/page.route-shell.test.ts
+++ b/frontend/app/(dashboard)/action-center/page.route-shell.test.ts
@@ -404,6 +404,17 @@ describe("action center landing shell", () => {
     expect(pageSource).toContain("boundedOverviewOnly");
   });
 
+  it("keeps route-action draft feedback inside the compact route preview surface", () => {
+    const previewSource = readFileSync(
+      new URL("../../../components/dashboard/action-center-preview.tsx", import.meta.url),
+      "utf8",
+    );
+
+    expect(previewSource).toContain("validationDisposition?: RouteActionValidationDisposition | null");
+    expect(previewSource).toContain("validationMessage?: string | null");
+    expect(previewSource).toContain("submissionState={");
+  });
+
   it("renders the route as a bounded overview cockpit instead of a broad workflow suite", () => {
     const markup = renderOverviewMarkup();
 

--- a/frontend/app/(dashboard)/action-center/page.route-shell.test.ts
+++ b/frontend/app/(dashboard)/action-center/page.route-shell.test.ts
@@ -1,5 +1,9 @@
 import { readFileSync } from "node:fs";
-import { ActionCenterPreview } from "@/components/dashboard/action-center-preview";
+import {
+  ActionCenterPreview,
+  buildPersistedRouteActionFeedback,
+} from "@/components/dashboard/action-center-preview";
+import { serializeActionCenterRouteActionEditorValue } from "@/components/dashboard/action-center-route-action-editor";
 import { describe, expect, it } from "vitest";
 import { projectActionCenterCoreSemantics } from "@/lib/action-center-core-semantics";
 import { buildLiveActionCenterItems } from "@/lib/action-center-live";
@@ -404,15 +408,29 @@ describe("action center landing shell", () => {
     expect(pageSource).toContain("boundedOverviewOnly");
   });
 
-  it("keeps route-action draft feedback inside the compact route preview surface", () => {
-    const previewSource = readFileSync(
-      new URL("../../../components/dashboard/action-center-preview.tsx", import.meta.url),
-      "utf8",
-    );
+  it("treats a non-valid route-action response as a persisted draft outcome instead of a generic save error", () => {
+    const draftValue = {
+      themeKey: "workload" as const,
+      actionText: "Verbeter overal de cultuur.",
+      reviewScheduledFor: "2026-05-20",
+      expectedEffect: "Iedereen voelt snel verschil.",
+    };
 
-    expect(previewSource).toContain("validationDisposition?: RouteActionValidationDisposition | null");
-    expect(previewSource).toContain("validationMessage?: string | null");
-    expect(previewSource).toContain("submissionState={");
+    expect(
+      buildPersistedRouteActionFeedback({
+        value: draftValue,
+        validationDisposition: "invalid",
+        validationMessage: "Pas deze actie aan zodat hij bounded en route-specifiek is.",
+      }),
+    ).toEqual({
+      message:
+        "Draft opgeslagen, nog niet live in deze route. Pas deze actie aan zodat hij bounded en route-specifiek is.",
+      persistedDraftFingerprint: serializeActionCenterRouteActionEditorValue(draftValue),
+      statusMessage: "Draft opgeslagen, nog niet live in deze route.",
+      tone: "warning",
+      validationDisposition: "invalid",
+      validationMessage: "Pas deze actie aan zodat hij bounded en route-specifiek is.",
+    });
   });
 
   it("renders the route as a bounded overview cockpit instead of a broad workflow suite", () => {

--- a/frontend/app/api/action-center-action-reviews/route.test.ts
+++ b/frontend/app/api/action-center-action-reviews/route.test.ts
@@ -360,7 +360,7 @@ describe('action center action reviews route', () => {
     expect(payload.review).not.toHaveProperty('closed_by_role')
   })
 
-  it('rejects review writes when the current action is still a draft', async () => {
+  it('allows a no-progress review outcome to reactivate a draft action through the canonical transition rules', async () => {
     mockGetUser.mockResolvedValue({
       data: {
         user: { id: 'manager-1' },
@@ -381,20 +381,51 @@ describe('action center action reviews route', () => {
       ],
     })
 
-    const insertQuery = createInsertQuery({ data: null, error: null })
+    const insertQuery = createInsertQuery({
+      data: {
+        id: 'review-draft-1',
+        action_id: 'action-11',
+        reviewed_at: '2026-05-12T09:30:00.000Z',
+        observation: 'Te vroeg voor closeout, dus dit blijft een actief actiepunt.',
+        action_outcome: 'bijsturen-nodig',
+        follow_up_note: 'De draft gaat terug de uitvoering in met een concreter vervolg.',
+        created_at: '2026-04-30T10:05:00.000Z',
+        updated_at: '2026-04-30T10:05:00.000Z',
+      },
+      error: null,
+    })
     const updateQuery = createUpdateQuery({ error: null })
+    const metricsInsertQuery = createInsertQuery({
+      data: [{ id: 'event-review-draft' }, { id: 'event-state-draft' }],
+      error: null,
+    })
+    let actionLookupCount = 0
 
     mockAdminFrom.mockImplementation((table: string) => {
       if (table === 'action_center_route_actions') {
-        return createActionQuery({
-          data: {
-            id: 'action-11',
-            org_id: 'org-1',
-            route_scope_type: 'department',
-            route_scope_value: 'org-1::department::operations',
-            manager_user_id: 'manager-1',
-            primary_action_status: 'draft',
-          },
+        actionLookupCount += 1
+        if (actionLookupCount === 1) {
+          return createActionQuery({
+            data: {
+              id: 'action-11',
+              campaign_id: 'campaign-1',
+              route_id: 'campaign-1::org-1::department::operations',
+              org_id: 'org-1',
+              route_scope_type: 'department',
+              route_scope_value: 'org-1::department::operations',
+              manager_user_id: 'manager-1',
+              primary_action_status: 'draft',
+            },
+            error: null,
+          })
+        }
+
+        return updateQuery
+      }
+
+      if (table === 'campaigns') {
+        return createCampaignQuery({
+          data: { scan_type: 'retention' },
           error: null,
         })
       }
@@ -414,18 +445,21 @@ describe('action center action reviews route', () => {
       makeRequest({
         action_id: 'action-11',
         reviewed_at: '2026-05-12T09:30:00.000Z',
-        observation: 'Te vroeg om dit al als uitgevoerde review te registreren.',
+        observation: 'Te vroeg voor closeout, dus dit blijft een actief actiepunt.',
         action_outcome: 'bijsturen-nodig',
-        follow_up_note: 'De draft moet eerst echt gestart worden.',
+        follow_up_note: 'De draft gaat terug de uitvoering in met een concreter vervolg.',
       }),
     )
 
-    expect(response.status).toBe(409)
-    await expect(response.json()).resolves.toEqual({
-      detail: 'Route action review is niet toegestaan vanuit de huidige canonieke toestand.',
-    })
-    expect(insertQuery.insert).not.toHaveBeenCalled()
-    expect(updateQuery.update).not.toHaveBeenCalled()
+    expect(response.status).toBe(200)
+    expect(insertQuery.insert).toHaveBeenCalledTimes(1)
+    expect(updateQuery.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        primary_action_status: 'open',
+        updated_by: 'manager-1',
+      }),
+    )
+    expect(metricsInsertQuery.insert).toHaveBeenCalledTimes(1)
   })
 
   it('rejects review writes when the current action is blocked', async () => {
@@ -490,7 +524,7 @@ describe('action center action reviews route', () => {
 
     expect(response.status).toBe(409)
     await expect(response.json()).resolves.toEqual({
-      detail: 'Route action review is niet toegestaan vanuit de huidige canonieke toestand.',
+      detail: 'Route action transition is not allowed.',
     })
     expect(insertQuery.insert).not.toHaveBeenCalled()
     expect(updateQuery.update).not.toHaveBeenCalled()

--- a/frontend/app/api/action-center-action-reviews/route.test.ts
+++ b/frontend/app/api/action-center-action-reviews/route.test.ts
@@ -360,7 +360,7 @@ describe('action center action reviews route', () => {
     expect(payload.review).not.toHaveProperty('closed_by_role')
   })
 
-  it('allows a no-progress review outcome to reactivate a draft action through the canonical transition rules', async () => {
+  it('rejects review writes when the current action is still a draft', async () => {
     mockGetUser.mockResolvedValue({
       data: {
         user: { id: 'manager-1' },
@@ -381,51 +381,20 @@ describe('action center action reviews route', () => {
       ],
     })
 
-    const insertQuery = createInsertQuery({
-      data: {
-        id: 'review-draft-1',
-        action_id: 'action-11',
-        reviewed_at: '2026-05-12T09:30:00.000Z',
-        observation: 'Te vroeg voor closeout, dus dit blijft een actief actiepunt.',
-        action_outcome: 'bijsturen-nodig',
-        follow_up_note: 'De draft gaat terug de uitvoering in met een concreter vervolg.',
-        created_at: '2026-04-30T10:05:00.000Z',
-        updated_at: '2026-04-30T10:05:00.000Z',
-      },
-      error: null,
-    })
+    const insertQuery = createInsertQuery({ data: null, error: null })
     const updateQuery = createUpdateQuery({ error: null })
-    const metricsInsertQuery = createInsertQuery({
-      data: [{ id: 'event-review-draft' }, { id: 'event-state-draft' }],
-      error: null,
-    })
-    let actionLookupCount = 0
 
     mockAdminFrom.mockImplementation((table: string) => {
       if (table === 'action_center_route_actions') {
-        actionLookupCount += 1
-        if (actionLookupCount === 1) {
-          return createActionQuery({
-            data: {
-              id: 'action-11',
-              campaign_id: 'campaign-1',
-              route_id: 'campaign-1::org-1::department::operations',
-              org_id: 'org-1',
-              route_scope_type: 'department',
-              route_scope_value: 'org-1::department::operations',
-              manager_user_id: 'manager-1',
-              primary_action_status: 'draft',
-            },
-            error: null,
-          })
-        }
-
-        return updateQuery
-      }
-
-      if (table === 'campaigns') {
-        return createCampaignQuery({
-          data: { scan_type: 'retention' },
+        return createActionQuery({
+          data: {
+            id: 'action-11',
+            org_id: 'org-1',
+            route_scope_type: 'department',
+            route_scope_value: 'org-1::department::operations',
+            manager_user_id: 'manager-1',
+            primary_action_status: 'draft',
+          },
           error: null,
         })
       }
@@ -445,21 +414,18 @@ describe('action center action reviews route', () => {
       makeRequest({
         action_id: 'action-11',
         reviewed_at: '2026-05-12T09:30:00.000Z',
-        observation: 'Te vroeg voor closeout, dus dit blijft een actief actiepunt.',
+        observation: 'Te vroeg om dit al als uitgevoerde review te registreren.',
         action_outcome: 'bijsturen-nodig',
-        follow_up_note: 'De draft gaat terug de uitvoering in met een concreter vervolg.',
+        follow_up_note: 'De draft moet eerst echt gestart worden.',
       }),
     )
 
-    expect(response.status).toBe(200)
-    expect(insertQuery.insert).toHaveBeenCalledTimes(1)
-    expect(updateQuery.update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        primary_action_status: 'open',
-        updated_by: 'manager-1',
-      }),
-    )
-    expect(metricsInsertQuery.insert).toHaveBeenCalledTimes(1)
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({
+      detail: 'Route action transition is not allowed.',
+    })
+    expect(insertQuery.insert).not.toHaveBeenCalled()
+    expect(updateQuery.update).not.toHaveBeenCalled()
   })
 
   it('rejects review writes when the current action is blocked', async () => {

--- a/frontend/app/api/action-center-action-reviews/route.ts
+++ b/frontend/app/api/action-center-action-reviews/route.ts
@@ -210,6 +210,7 @@ export async function POST(request: Request) {
 
   if (
     !currentSemanticState ||
+    currentSemanticState !== 'in_review' ||
     !isActionCenterActionStateTransitionAllowed({
       actor,
       fromState: currentSemanticState,

--- a/frontend/app/api/action-center-action-reviews/route.ts
+++ b/frontend/app/api/action-center-action-reviews/route.ts
@@ -204,22 +204,19 @@ export async function POST(request: Request) {
     return NextResponse.json({ detail }, { status })
   }
 
-  const currentActionState = resolvePersistedActionSemanticState(action.primary_action_status)
-  const nextActionState = resolveActionCenterActionReviewTransition(parsed.action_outcome)
+  const currentSemanticState = resolvePersistedActionSemanticState(action.primary_action_status)
+  const nextSemanticState = resolveActionCenterActionReviewTransition(parsed.action_outcome)
   const actor = context.isVerisightAdmin ? 'hr_rhythm_owner' : 'manager_participant'
 
   if (
-    currentActionState !== 'in_review' ||
+    !currentSemanticState ||
     !isActionCenterActionStateTransitionAllowed({
       actor,
-      fromState: currentActionState,
-      toState: nextActionState,
+      fromState: currentSemanticState,
+      toState: nextSemanticState,
     })
   ) {
-    return NextResponse.json(
-      { detail: 'Route action review is niet toegestaan vanuit de huidige canonieke toestand.' },
-      { status: 409 },
-    )
+    return NextResponse.json({ detail: 'Route action transition is not allowed.' }, { status: 409 })
   }
 
   const actionCampaignId = normalizeText(action.campaign_id)
@@ -268,7 +265,7 @@ export async function POST(request: Request) {
   const { data: updatedAction, error: updateError } = await adminClient
     .from('action_center_route_actions')
     .update({
-      primary_action_status: resolvePersistedActionStatusFromSemanticState(nextActionState),
+      primary_action_status: resolvePersistedActionStatusFromSemanticState(nextSemanticState),
       updated_by: user.id,
       updated_at: new Date().toISOString(),
     })
@@ -299,7 +296,7 @@ export async function POST(request: Request) {
   }
 
   const reviewId = normalizeText(data.id)
-  const nextPersistedActionStatus = resolvePersistedActionStatusFromSemanticState(nextActionState)
+  const nextPersistedActionStatus = resolvePersistedActionStatusFromSemanticState(nextSemanticState)
 
   if (!reviewId) {
     return NextResponse.json({ detail: 'Route action review opslaan mislukt.' }, { status: 500 })

--- a/frontend/app/api/action-center-route-actions/route.test.ts
+++ b/frontend/app/api/action-center-route-actions/route.test.ts
@@ -33,6 +33,21 @@ function makeRequest(body: Record<string, unknown>) {
   })
 }
 
+function makeRouteActionRequest(overrides: Record<string, unknown> = {}) {
+  return makeRequest({
+    campaign_id: 'campaign-1',
+    route_scope_type: 'department',
+    route_scope_value: 'org-1::department::operations',
+    manager_user_id: 'manager-1',
+    primary_action_theme_key: 'workload',
+    primary_action_text: 'Plan deze week een kort teamgesprek over workloadpieken.',
+    primary_action_expected_effect:
+      'Binnen twee weken moet zichtbaar zijn of de workloadpieken kleiner worden.',
+    review_scheduled_for: '2026-05-20',
+    ...overrides,
+  })
+}
+
 function createCampaignQuery(result: { data: unknown; error: unknown }) {
   return {
     select: vi.fn().mockReturnThis(),
@@ -81,6 +96,16 @@ function createDeleteQuery(result: { error: unknown }) {
   }
 }
 
+function createCountQuery(result: { count: number | null; error: unknown }) {
+  const query = {
+    select: vi.fn(() => query),
+    eq: vi.fn(() => query),
+    in: vi.fn().mockResolvedValue(result),
+  }
+
+  return query
+}
+
 describe('action center route actions route', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -111,7 +136,7 @@ describe('action center route actions route', () => {
     expect(mockAdminFrom).not.toHaveBeenCalled()
   })
 
-  it('does not hard-reject dossier-like language before auth because it remains a draft-invalid submission', async () => {
+  it('rejects employee-dossier-like language before auth because it is outside bounded execution', async () => {
     mockGetUser.mockResolvedValue({
       data: {
         user: null,
@@ -119,20 +144,13 @@ describe('action center route actions route', () => {
     })
 
     const response = await POST(
-      makeRequest({
-        campaign_id: 'campaign-1',
-        route_scope_type: 'department',
-        route_scope_value: 'org-1::department::operations',
-        manager_user_id: 'manager-1',
-        primary_action_theme_key: 'workload',
-        primary_action_text: 'Leg het dossier aan en vul de vervolgroute en stopreden voor deze casus bij.',
-        primary_action_expected_effect:
-          'Binnen twee weken moet duidelijk zijn of het dossier compleet genoeg is voor verdere routing.',
-        review_scheduled_for: '2026-05-20',
+      makeRouteActionRequest({
+        primary_action_text: 'Monitor employee X in detail for risk.',
+        primary_action_expected_effect: 'Track individual risk more closely.',
       }),
     )
 
-    expect(response.status).toBe(401)
+    expect(response.status).toBe(400)
     expect(mockAdminFrom).not.toHaveBeenCalled()
   })
 
@@ -295,7 +313,25 @@ describe('action center route actions route', () => {
     })
   })
 
-  it('persists dossier-like route language as an invalid draft instead of a 400 validation error', async () => {
+  it('rejects employee-dossier-like language instead of persisting it as draft truth', async () => {
+    mockGetUser.mockResolvedValue({
+      data: {
+        user: { id: 'manager-1' },
+      },
+    })
+
+    const response = await POST(
+      makeRouteActionRequest({
+        primary_action_text: 'Monitor employee X in detail for risk.',
+        primary_action_expected_effect: 'Track individual risk more closely.',
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    expect(mockAdminFrom).not.toHaveBeenCalled()
+  })
+
+  it('blocks more than three active actions on a route', async () => {
     mockGetUser.mockResolvedValue({
       data: {
         user: { id: 'manager-1' },
@@ -320,33 +356,18 @@ describe('action center route actions route', () => {
       ],
     })
 
+    const activeActionCountQuery = createCountQuery({
+      count: 3,
+      error: null,
+    })
     const insertQuery = createInsertQuery({
       data: {
-        id: 'action-draft-2',
-        route_id: 'campaign-1::org-1::department::operations',
-        campaign_id: 'campaign-1',
-        org_id: 'org-1',
-        route_scope_type: 'department',
-        route_scope_value: 'org-1::department::operations',
-        manager_user_id: 'manager-1',
-        owner_name: 'Manager Operations',
-        owner_assigned_at: '2026-04-01T08:00:00.000Z',
-        primary_action_theme_key: 'workload',
-        primary_action_text: 'Leg het dossier aan en vul de vervolgroute en stopreden voor deze casus bij.',
-        primary_action_expected_effect:
-          'Binnen twee weken moet duidelijk zijn of het dossier compleet genoeg is voor verdere routing.',
-        primary_action_status: null,
-        review_scheduled_for: '2026-05-20',
-        created_at: '2026-04-30T10:00:00.000Z',
-        updated_at: '2026-04-30T10:00:00.000Z',
+        id: 'action-over-limit',
       },
       error: null,
     })
-    const metricsInsertQuery = createInsertQuery({
-      data: [{ id: 'event-invalid-created' }, { id: 'event-invalid-rejected' }],
-      error: null,
-    })
 
+    let routeActionTableCalls = 0
     mockAdminFrom.mockImplementation((table: string) => {
       if (table === 'campaigns') {
         return createCampaignQuery({
@@ -364,7 +385,7 @@ describe('action center route actions route', () => {
       if (table === 'action_center_manager_responses') {
         return createRouteContainerQuery({
           data: {
-            id: 'response-invalid',
+            id: 'response-limit',
             campaign_id: 'campaign-1',
             org_id: 'org-1',
             route_scope_type: 'department',
@@ -376,58 +397,17 @@ describe('action center route actions route', () => {
       }
 
       if (table === 'action_center_route_actions') {
-        return insertQuery
-      }
-
-      if (table === 'action_center_bounded_execution_events') {
-        return metricsInsertQuery
+        routeActionTableCalls += 1
+        return routeActionTableCalls === 1 ? activeActionCountQuery : insertQuery
       }
 
       throw new Error(`Unexpected table ${table}`)
     })
 
-    const response = await POST(
-      makeRequest({
-        campaign_id: 'campaign-1',
-        route_scope_type: 'department',
-        route_scope_value: 'org-1::department::operations',
-        manager_user_id: 'manager-1',
-        primary_action_theme_key: 'workload',
-        primary_action_text: 'Leg het dossier aan en vul de vervolgroute en stopreden voor deze casus bij.',
-        primary_action_expected_effect:
-          'Binnen twee weken moet duidelijk zijn of het dossier compleet genoeg is voor verdere routing.',
-        review_scheduled_for: '2026-05-20',
-      }),
-    )
+    const response = await POST(makeRouteActionRequest({ existingActiveActionCount: 3 }))
 
-    expect(response.status).toBe(200)
-    expect(insertQuery.insert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        manager_response_id: 'response-invalid',
-        primary_action_status: null,
-      }),
-    )
-    expect(metricsInsertQuery.insert).toHaveBeenCalledWith([
-      expect.objectContaining({
-        event_type: 'action_draft_created',
-        object_anchor: 'action_card',
-        route_family: 'exit',
-        action_id: 'action-draft-2',
-      }),
-      expect.objectContaining({
-        event_type: 'action_draft_rejected',
-        object_anchor: 'action_card',
-        route_family: 'exit',
-        action_id: 'action-draft-2',
-      }),
-    ])
-
-    const payload = await response.json()
-    expect(payload.actionDraft).toMatchObject({
-      semanticState: 'draft',
-      validationDisposition: 'invalid',
-      primary_action_status: null,
-    })
+    expect(response.status).toBe(409)
+    expect(insertQuery.insert).not.toHaveBeenCalled()
   })
 
   it('persists missing content as an invalid draft instead of rejecting before draft validation', async () => {
@@ -1025,6 +1005,11 @@ describe('action center route actions route', () => {
       data: [{ id: 'event-valid-created' }, { id: 'event-valid-validated' }],
       error: null,
     })
+    const activeActionCountQuery = createCountQuery({
+      count: 0,
+      error: null,
+    })
+    let routeActionTableCalls = 0
 
     mockAdminFrom.mockImplementation((table: string) => {
       if (table === 'campaigns') {
@@ -1055,7 +1040,8 @@ describe('action center route actions route', () => {
       }
 
       if (table === 'action_center_route_actions') {
-        return insertQuery
+        routeActionTableCalls += 1
+        return routeActionTableCalls === 1 ? activeActionCountQuery : insertQuery
       }
 
       if (table === 'action_center_bounded_execution_events') {
@@ -1181,6 +1167,11 @@ describe('action center route actions route', () => {
       data: [{ id: 'event-valid-created' }, { id: 'event-valid-validated' }],
       error: null,
     })
+    const activeActionCountQuery = createCountQuery({
+      count: 0,
+      error: null,
+    })
+    let routeActionTableCalls = 0
 
     mockAdminFrom.mockImplementation((table: string) => {
       if (table === 'campaigns') {
@@ -1209,7 +1200,8 @@ describe('action center route actions route', () => {
       }
 
       if (table === 'action_center_route_actions') {
-        return insertQuery
+        routeActionTableCalls += 1
+        return routeActionTableCalls === 1 ? activeActionCountQuery : insertQuery
       }
 
       if (table === 'action_center_bounded_execution_events') {
@@ -1360,6 +1352,11 @@ describe('action center route actions route', () => {
       data: [{ id: 'event-admin-created' }, { id: 'event-admin-validated' }],
       error: null,
     })
+    const activeActionCountQuery = createCountQuery({
+      count: 0,
+      error: null,
+    })
+    let routeActionTableCalls = 0
 
     mockAdminFrom.mockImplementation((table: string) => {
       if (table === 'campaigns') {
@@ -1409,7 +1406,8 @@ describe('action center route actions route', () => {
       }
 
       if (table === 'action_center_route_actions') {
-        return insertQuery
+        routeActionTableCalls += 1
+        return routeActionTableCalls === 1 ? activeActionCountQuery : insertQuery
       }
 
       if (table === 'action_center_bounded_execution_events') {
@@ -1581,6 +1579,10 @@ describe('action center route actions route', () => {
       error: { message: 'metric insert failed' },
     })
     const deleteQuery = createDeleteQuery({ error: null })
+    const activeActionCountQuery = createCountQuery({
+      count: 0,
+      error: null,
+    })
     let routeActionTableCalls = 0
 
     mockAdminFrom.mockImplementation((table: string) => {
@@ -1613,7 +1615,11 @@ describe('action center route actions route', () => {
 
       if (table === 'action_center_route_actions') {
         routeActionTableCalls += 1
-        return routeActionTableCalls === 1 ? insertQuery : deleteQuery
+        if (routeActionTableCalls === 1) {
+          return activeActionCountQuery
+        }
+
+        return routeActionTableCalls === 2 ? insertQuery : deleteQuery
       }
 
       if (table === 'action_center_bounded_execution_events') {

--- a/frontend/app/api/action-center-route-actions/route.test.ts
+++ b/frontend/app/api/action-center-route-actions/route.test.ts
@@ -151,6 +151,9 @@ describe('action center route actions route', () => {
     )
 
     expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      detail: 'Route action is outside bounded execution.',
+    })
     expect(mockAdminFrom).not.toHaveBeenCalled()
   })
 
@@ -328,10 +331,13 @@ describe('action center route actions route', () => {
     )
 
     expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      detail: 'Route action is outside bounded execution.',
+    })
     expect(mockAdminFrom).not.toHaveBeenCalled()
   })
 
-  it('blocks more than three active actions on a route', async () => {
+  it('blocks valid drafts when a route already has more than 2 active actions', async () => {
     mockGetUser.mockResolvedValue({
       data: {
         user: { id: 'manager-1' },
@@ -407,6 +413,9 @@ describe('action center route actions route', () => {
     const response = await POST(makeRouteActionRequest({ existingActiveActionCount: 3 }))
 
     expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({
+      detail: 'Route exceeds bounded active-action limit.',
+    })
     expect(insertQuery.insert).not.toHaveBeenCalled()
   })
 

--- a/frontend/app/api/action-center-route-actions/route.test.ts
+++ b/frontend/app/api/action-center-route-actions/route.test.ts
@@ -309,6 +309,10 @@ describe('action center route actions route', () => {
     ])
 
     const payload = await response.json()
+    expect(payload).toMatchObject({
+      validationDisposition: 'needs_hr_review',
+      validationMessage: 'Deze actie vraagt eerst HR-beoordeling.',
+    })
     expect(payload.actionDraft).toMatchObject({
       semanticState: 'draft',
       validationDisposition: 'needs_hr_review',
@@ -531,6 +535,10 @@ describe('action center route actions route', () => {
     )
 
     const payload = await response.json()
+    expect(payload).toMatchObject({
+      validationDisposition: 'invalid',
+      validationMessage: 'Pas deze actie aan zodat hij bounded en route-specifiek is.',
+    })
     expect(payload.actionDraft).toMatchObject({
       primary_action_theme_key: null,
       primary_action_text: null,

--- a/frontend/app/api/action-center-route-actions/route.ts
+++ b/frontend/app/api/action-center-route-actions/route.ts
@@ -205,6 +205,20 @@ function resolveRouteActionDispositionEventType(
   }
 }
 
+function resolveRouteActionValidationMessage(
+  disposition: 'valid' | 'invalid' | 'needs_hr_review',
+) {
+  switch (disposition) {
+    case 'invalid':
+      return 'Pas deze actie aan zodat hij bounded en route-specifiek is.'
+    case 'needs_hr_review':
+      return 'Deze actie vraagt eerst HR-beoordeling.'
+    case 'valid':
+    default:
+      return null
+  }
+}
+
 export async function POST(request: Request) {
   const body = (await request.json().catch(() => null)) as RouteActionRequestBody | null
 
@@ -425,5 +439,13 @@ export async function POST(request: Request) {
     return NextResponse.json({ detail: 'Route action bounded event logging mislukt.' }, { status: 500 })
   }
 
-  return NextResponse.json({ action: data, actionDraft }, { status: 200 })
+  return NextResponse.json(
+    {
+      action: data,
+      actionDraft,
+      validationDisposition: actionDraft.validationDisposition,
+      validationMessage: resolveRouteActionValidationMessage(actionDraft.validationDisposition),
+    },
+    { status: 200 },
+  )
 }

--- a/frontend/app/api/action-center-route-actions/route.ts
+++ b/frontend/app/api/action-center-route-actions/route.ts
@@ -219,8 +219,13 @@ export async function POST(request: Request) {
       primary_action_status: parsed.primary_action_status,
       review_scheduled_for: parsed.review_scheduled_for,
     })
-  } catch {
-    return NextResponse.json({ detail: 'Ongeldige route action input.' }, { status: 400 })
+  } catch (error) {
+    const detail =
+      error instanceof Error && error.message === 'Route action is outside bounded execution.'
+        ? error.message
+        : 'Ongeldige route action input.'
+
+    return NextResponse.json({ detail }, { status: 400 })
   }
 
   const supabase = await createClient()

--- a/frontend/app/api/action-center-route-actions/route.ts
+++ b/frontend/app/api/action-center-route-actions/route.ts
@@ -317,6 +317,25 @@ export async function POST(request: Request) {
   }
 
   const adminClient = createAdminClient()
+  if (actionDraft.validationDisposition === 'valid') {
+    const { count: activeActionCount, error: activeActionCountError } = await adminClient
+      .from('action_center_route_actions')
+      .select('id', { count: 'exact', head: true })
+      .eq('route_id', identity.route_id)
+      .in('primary_action_status', ['open', 'in_review'])
+
+    if (activeActionCountError) {
+      return NextResponse.json({ detail: 'Route action route laden mislukt.' }, { status: 500 })
+    }
+
+    if ((activeActionCount ?? 0) > 2) {
+      return NextResponse.json(
+        { detail: 'Route exceeds bounded active-action limit.' },
+        { status: 409 },
+      )
+    }
+  }
+
   const { data, error } = await adminClient
     .from('action_center_route_actions')
     .insert({

--- a/frontend/components/dashboard/action-center-action-review-editor.tsx
+++ b/frontend/components/dashboard/action-center-action-review-editor.tsx
@@ -5,7 +5,7 @@ import type {
   ActionCenterActionEvidenceSource,
   ActionCenterActionOutcome,
 } from '@/lib/action-center-action-reviews'
-import React, { useState } from 'react'
+import React, { useId, useState } from 'react'
 
 export interface ActionCenterActionReviewEditorValue {
   observation: string
@@ -69,6 +69,7 @@ export function ActionCenterActionReviewEditor({
   submitLabel = 'Review opslaan',
   includeStructuredMetadata = true,
 }: Props) {
+  const outcomeGroupName = useId()
   const [value, setValue] = useState<ActionCenterActionReviewEditorValue>({
     observation: '',
     actionOutcome: 'effect-zichtbaar',
@@ -102,62 +103,82 @@ export function ActionCenterActionReviewEditor({
         />
       </FormField>
 
-      <div className={includeStructuredMetadata ? 'grid gap-3 md:grid-cols-[1.1fr_1fr_0.8fr]' : 'grid gap-3 md:grid-cols-1'}>
-        <FormField label="Uitkomst">
-          <select
-            value={value.actionOutcome}
-            onChange={(event) => setValue((current) => ({ ...current, actionOutcome: event.target.value as ActionCenterActionOutcome }))}
-            className="w-full rounded-2xl border border-white/12 bg-white/[0.06] px-4 py-3 text-sm text-white/90 outline-none transition focus:border-[#ffb16e]"
-          >
+      <div className="space-y-3">
+        <fieldset className="space-y-2">
+          <legend className="text-sm font-semibold text-white/82">Wat betekent dit nu?</legend>
+          <div className="grid gap-2 sm:grid-cols-2">
             {OUTCOME_OPTIONS.map((option) => (
-              <option key={option.value} value={option.value} className="text-[#132033]">
-                {option.label}
-              </option>
+              <label
+                key={option.value}
+                className={`flex cursor-pointer items-center gap-3 rounded-2xl border px-3.5 py-3 text-sm font-semibold transition ${
+                  value.actionOutcome === option.value
+                    ? 'border-[#ffb16e] bg-[#fff3e8] text-[#132033]'
+                    : 'border-white/12 bg-white/[0.05] text-white/82'
+                }`}
+              >
+                <input
+                  type="radio"
+                  name={outcomeGroupName}
+                  value={option.value}
+                  checked={value.actionOutcome === option.value}
+                  onChange={() =>
+                    setValue((current) => ({
+                      ...current,
+                      actionOutcome: option.value,
+                    }))
+                  }
+                  className="h-4 w-4 border-white/20 text-[#132033]"
+                />
+                <span>{option.label}</span>
+              </label>
             ))}
-          </select>
-        </FormField>
-        {includeStructuredMetadata ? (
-          <FormField label="Bron van observatie">
-            <select
-              value={value.evidenceSource}
-              onChange={(event) =>
-                setValue((current) => ({
-                  ...current,
-                  evidenceSource: event.target.value as ActionCenterActionEvidenceSource,
-                }))
-              }
-              className="w-full rounded-2xl border border-white/12 bg-white/[0.06] px-4 py-3 text-sm text-white/90 outline-none transition focus:border-[#ffb16e]"
-            >
-              {EVIDENCE_SOURCE_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value} className="text-[#132033]">
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          </FormField>
-        ) : null}
-        {includeStructuredMetadata ? (
-          <div className="rounded-2xl border border-white/10 bg-white/[0.03] px-3 py-3">
-            <FormField label="Hoe zeker zijn we hiervan?" labelClassName="text-[11px] uppercase tracking-[0.14em] text-white/52">
+          </div>
+        </fieldset>
+
+        <div className={includeStructuredMetadata ? 'grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,0.8fr)]' : 'grid gap-3 md:grid-cols-1'}>
+          {includeStructuredMetadata ? (
+            <FormField label="Bron">
               <select
-                value={value.confidenceLevel}
+                value={value.evidenceSource}
                 onChange={(event) =>
                   setValue((current) => ({
                     ...current,
-                    confidenceLevel: event.target.value as ActionCenterActionConfidenceLevel,
+                    evidenceSource: event.target.value as ActionCenterActionEvidenceSource,
                   }))
                 }
-                className="w-full rounded-2xl border border-white/12 bg-white/[0.06] px-3 py-3 text-sm text-white/82 outline-none transition focus:border-[#ffb16e]"
+                className="w-full rounded-2xl border border-white/12 bg-white/[0.06] px-4 py-3 text-sm text-white/90 outline-none transition focus:border-[#ffb16e]"
               >
-                {CONFIDENCE_OPTIONS.map((option) => (
+                {EVIDENCE_SOURCE_OPTIONS.map((option) => (
                   <option key={option.value} value={option.value} className="text-[#132033]">
                     {option.label}
                   </option>
                 ))}
               </select>
             </FormField>
-          </div>
-        ) : null}
+          ) : null}
+          {includeStructuredMetadata ? (
+            <div className="rounded-2xl border border-white/10 bg-white/[0.03] px-3 py-3">
+              <FormField label="Hoe zeker is dit?" labelClassName="text-[11px] uppercase tracking-[0.14em] text-white/52">
+                <select
+                  value={value.confidenceLevel}
+                  onChange={(event) =>
+                    setValue((current) => ({
+                      ...current,
+                      confidenceLevel: event.target.value as ActionCenterActionConfidenceLevel,
+                    }))
+                  }
+                  className="w-full rounded-2xl border border-white/12 bg-white/[0.06] px-3 py-3 text-sm text-white/82 outline-none transition focus:border-[#ffb16e]"
+                >
+                  {CONFIDENCE_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value} className="text-[#132033]">
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </FormField>
+            </div>
+          ) : null}
+        </div>
       </div>
 
       <FormField label="Korte toelichting">

--- a/frontend/components/dashboard/action-center-preview.tsx
+++ b/frontend/components/dashboard/action-center-preview.tsx
@@ -1327,6 +1327,7 @@ export function ActionCenterPreview({
         currentUserId &&
         selectedItem.ownerId === currentUserId,
     )
+  const allowInlinePrimaryAction = !canUseRouteActionFlow
   const canUseActionReviewFlow =
     Boolean(
       actionReviewEndpoint &&
@@ -1539,6 +1540,28 @@ export function ActionCenterPreview({
       return
     }
 
+    const persistedPrimaryAction = selectedItem.managerResponse
+    const nextPrimaryActionThemeKey = allowInlinePrimaryAction
+      ? managerResponseForm.includePrimaryAction && managerResponseForm.primaryActionThemeKey
+        ? managerResponseForm.primaryActionThemeKey
+        : null
+      : persistedPrimaryAction?.primary_action_theme_key ?? null
+    const nextPrimaryActionText = allowInlinePrimaryAction
+      ? managerResponseForm.includePrimaryAction && managerResponseForm.primaryActionText.trim()
+        ? managerResponseForm.primaryActionText
+        : null
+      : persistedPrimaryAction?.primary_action_text ?? null
+    const nextPrimaryActionExpectedEffect = allowInlinePrimaryAction
+      ? managerResponseForm.includePrimaryAction && managerResponseForm.primaryActionExpectedEffect.trim()
+        ? managerResponseForm.primaryActionExpectedEffect
+        : null
+      : persistedPrimaryAction?.primary_action_expected_effect ?? null
+    const nextPrimaryActionStatus = allowInlinePrimaryAction
+      ? managerResponseForm.includePrimaryAction
+        ? 'active'
+        : null
+      : persistedPrimaryAction?.primary_action_status ?? null
+
     setManagerResponsePending(true)
     setManagerResponseError(null)
 
@@ -1551,19 +1574,10 @@ export function ActionCenterPreview({
       response_type: managerResponseForm.responseType,
       response_note: managerResponseForm.responseNote,
       review_scheduled_for: managerResponseForm.reviewScheduledFor,
-      primary_action_theme_key:
-        managerResponseForm.includePrimaryAction && managerResponseForm.primaryActionThemeKey
-          ? managerResponseForm.primaryActionThemeKey
-          : null,
-      primary_action_text:
-        managerResponseForm.includePrimaryAction && managerResponseForm.primaryActionText.trim()
-          ? managerResponseForm.primaryActionText
-          : null,
-      primary_action_expected_effect:
-        managerResponseForm.includePrimaryAction && managerResponseForm.primaryActionExpectedEffect.trim()
-          ? managerResponseForm.primaryActionExpectedEffect
-          : null,
-      primary_action_status: managerResponseForm.includePrimaryAction ? 'active' : null,
+      primary_action_theme_key: nextPrimaryActionThemeKey,
+      primary_action_text: nextPrimaryActionText,
+      primary_action_expected_effect: nextPrimaryActionExpectedEffect,
+      primary_action_status: nextPrimaryActionStatus,
     }
 
     try {
@@ -3015,78 +3029,100 @@ export function ActionCenterPreview({
                                 />
                               </FormField>
 
-                              <label className="flex items-start gap-3 rounded-[18px] border border-[#ece4d8] bg-[#fcfaf7] px-4 py-4 text-sm text-[#42556b]">
-                                <input
-                                  type="checkbox"
-                                  checked={managerResponseForm.includePrimaryAction}
-                                  onChange={(event) =>
-                                    setManagerResponseForm((current) => ({
-                                      ...current,
-                                      includePrimaryAction: event.target.checked,
-                                    }))
-                                  }
-                                  className="mt-1 h-4 w-4 rounded border-[#d6cbbb] text-[#132033]"
-                                />
-                                <span className="leading-7">
-                                  {managerActionSurfaceCopy.primaryActionToggle}
-                                </span>
-                              </label>
+                              {allowInlinePrimaryAction ? (
+                                <>
+                                  <label className="flex items-start gap-3 rounded-[18px] border border-[#ece4d8] bg-[#fcfaf7] px-4 py-4 text-sm text-[#42556b]">
+                                    <input
+                                      type="checkbox"
+                                      checked={managerResponseForm.includePrimaryAction}
+                                      onChange={(event) =>
+                                        setManagerResponseForm((current) => ({
+                                          ...current,
+                                          includePrimaryAction: event.target.checked,
+                                        }))
+                                      }
+                                      className="mt-1 h-4 w-4 rounded border-[#d6cbbb] text-[#132033]"
+                                    />
+                                    <span className="leading-7">
+                                      {managerActionSurfaceCopy.primaryActionToggle}
+                                    </span>
+                                  </label>
 
-                              {managerResponseForm.includePrimaryAction ? (
-                                <div className="space-y-4 rounded-[20px] border border-[#ece4d8] bg-[#fcfaf7] px-4 py-4">
+                                  {managerResponseForm.includePrimaryAction ? (
+                                    <div className="space-y-4 rounded-[20px] border border-[#ece4d8] bg-[#fcfaf7] px-4 py-4">
+                                      <p className="text-sm leading-7 text-[#4f6175]">
+                                        Deze extra stap maakt de route concreter, maar houdt de uitvoering nog steeds klein totdat aparte actiekaarten echt helpen.
+                                      </p>
+
+                                      <FormField label="Thema van deze eerste concrete stap">
+                                        <select
+                                          value={managerResponseForm.primaryActionThemeKey}
+                                          onChange={(event) =>
+                                            setManagerResponseForm((current) => ({
+                                              ...current,
+                                              primaryActionThemeKey: event.target.value as ActionCenterManagerActionThemeKey | '',
+                                            }))
+                                          }
+                                          className="w-full rounded-2xl border border-[#ddd3c7] bg-white px-4 py-3 text-sm text-[#132033] outline-none transition focus:border-[#ff9b4a]"
+                                        >
+                                          <option value="">Kies productthema</option>
+                                          {ACTION_CENTER_MANAGER_RESPONSE_THEME_OPTIONS.map((option) => (
+                                            <option key={option.value} value={option.value}>
+                                              {option.label}
+                                            </option>
+                                          ))}
+                                        </select>
+                                      </FormField>
+
+                                      <FormField label="Wat is die eerste concrete stap?">
+                                        <textarea
+                                          value={managerResponseForm.primaryActionText}
+                                          onChange={(event) =>
+                                            setManagerResponseForm((current) => ({
+                                              ...current,
+                                              primaryActionText: event.target.value,
+                                            }))
+                                          }
+                                          placeholder="Bijv. plan deze week een kort teamgesprek over feedbackritme en spreek daar één vaste terugkoppeling af."
+                                          className="min-h-[105px] w-full rounded-2xl border border-[#ddd3c7] bg-white px-4 py-3 text-sm leading-7 text-[#132033] outline-none transition focus:border-[#ff9b4a]"
+                                        />
+                                      </FormField>
+
+                                      <FormField label="Wat moet deze stap zichtbaar maken?">
+                                        <textarea
+                                          value={managerResponseForm.primaryActionExpectedEffect}
+                                          onChange={(event) =>
+                                            setManagerResponseForm((current) => ({
+                                              ...current,
+                                              primaryActionExpectedEffect: event.target.value,
+                                            }))
+                                          }
+                                          placeholder="Bijv. binnen twee weken moet duidelijk worden of feedbackafspraken consistenter terugkomen in het team."
+                                          className="min-h-[105px] w-full rounded-2xl border border-[#ddd3c7] bg-white px-4 py-3 text-sm leading-7 text-[#132033] outline-none transition focus:border-[#ff9b4a]"
+                                        />
+                                      </FormField>
+                                    </div>
+                                  ) : null}
+                                </>
+                              ) : (
+                                <div className="space-y-3 rounded-[20px] border border-[#ece4d8] bg-[#fcfaf7] px-4 py-4">
                                   <p className="text-sm leading-7 text-[#4f6175]">
-                                    Deze extra stap maakt de route concreter, maar houdt de uitvoering nog steeds klein totdat aparte actiekaarten echt helpen.
+                                    Concrete acties voeg je hieronder toe in deze route. Zo blijft dit eerste managerantwoord compact en blijft er maar één primaire actie-ingang over.
                                   </p>
-
-                                  <FormField label="Thema van deze eerste concrete stap">
-                                    <select
-                                      value={managerResponseForm.primaryActionThemeKey}
-                                      onChange={(event) =>
-                                        setManagerResponseForm((current) => ({
-                                          ...current,
-                                          primaryActionThemeKey: event.target.value as ActionCenterManagerActionThemeKey | '',
-                                        }))
-                                      }
-                                      className="w-full rounded-2xl border border-[#ddd3c7] bg-white px-4 py-3 text-sm text-[#132033] outline-none transition focus:border-[#ff9b4a]"
-                                    >
-                                      <option value="">Kies productthema</option>
-                                      {ACTION_CENTER_MANAGER_RESPONSE_THEME_OPTIONS.map((option) => (
-                                        <option key={option.value} value={option.value}>
-                                          {option.label}
-                                        </option>
-                                      ))}
-                                    </select>
-                                  </FormField>
-
-                                  <FormField label="Wat is die eerste concrete stap?">
-                                    <textarea
-                                      value={managerResponseForm.primaryActionText}
-                                      onChange={(event) =>
-                                        setManagerResponseForm((current) => ({
-                                          ...current,
-                                          primaryActionText: event.target.value,
-                                        }))
-                                      }
-                                      placeholder="Bijv. plan deze week een kort teamgesprek over feedbackritme en spreek daar één vaste terugkoppeling af."
-                                      className="min-h-[105px] w-full rounded-2xl border border-[#ddd3c7] bg-white px-4 py-3 text-sm leading-7 text-[#132033] outline-none transition focus:border-[#ff9b4a]"
+                                  {selectedItem.managerResponse?.primary_action_text ? (
+                                    <SignalRow
+                                      label="Eerste managerstap"
+                                      value={selectedItem.managerResponse.primary_action_text}
                                     />
-                                  </FormField>
-
-                                  <FormField label="Wat moet deze stap zichtbaar maken?">
-                                    <textarea
-                                      value={managerResponseForm.primaryActionExpectedEffect}
-                                      onChange={(event) =>
-                                        setManagerResponseForm((current) => ({
-                                          ...current,
-                                          primaryActionExpectedEffect: event.target.value,
-                                        }))
-                                      }
-                                      placeholder="Bijv. binnen twee weken moet duidelijk worden of feedbackafspraken consistenter terugkomen in het team."
-                                      className="min-h-[105px] w-full rounded-2xl border border-[#ddd3c7] bg-white px-4 py-3 text-sm leading-7 text-[#132033] outline-none transition focus:border-[#ff9b4a]"
+                                  ) : null}
+                                  {selectedItem.managerResponse?.primary_action_expected_effect ? (
+                                    <SignalRow
+                                      label="Zichtbaar effect"
+                                      value={selectedItem.managerResponse.primary_action_expected_effect}
                                     />
-                                  </FormField>
+                                  ) : null}
                                 </div>
-                              ) : null}
+                              )}
 
                               {managerResponseError ? (
                                 <div className="rounded-[18px] border border-[#f3c0bc] bg-[#fff1ef] px-4 py-4 text-sm leading-7 text-[#9c3f36]">
@@ -3182,6 +3218,8 @@ export function ActionCenterPreview({
                               <ActionCenterRouteActionEditor
                                 onSave={handleRouteActionSave}
                                 pending={routeActionPending}
+                                title="Nieuwe routeactie"
+                                description="Houd dit compact: 1 concrete stap, 1 reviewdatum en 1 zichtbaar effect."
                                 error={
                                   routeActionFeedback?.validationDisposition
                                     ? null
@@ -3203,6 +3241,7 @@ export function ActionCenterPreview({
                                       } satisfies ActionCenterRouteActionEditorSubmissionState)
                                     : null
                                 }
+                                submitLabel="Actie opslaan"
                               />
                             </div>
                           ) : routeActionFeedback ? (

--- a/frontend/components/dashboard/action-center-preview.tsx
+++ b/frontend/components/dashboard/action-center-preview.tsx
@@ -136,6 +136,12 @@ interface RouteCloseoutFormState {
 }
 
 type RouteActionValidationDisposition = 'valid' | 'invalid' | 'needs_hr_review'
+
+function isPersistedDraftSubmissionDisposition(
+  disposition: RouteActionValidationDisposition | null | undefined,
+): disposition is Extract<RouteActionValidationDisposition, 'invalid' | 'needs_hr_review'> {
+  return disposition === 'invalid' || disposition === 'needs_hr_review'
+}
 type RouteActionFeedbackTone = 'error' | 'warning'
 
 type ManagerActionPhase =
@@ -537,6 +543,27 @@ function getManagerResponseProjectedStatus(
   return hasPrimaryManagerAction(response) ? 'in-uitvoering' : 'te-bespreken'
 }
 
+function resolveRouteContractStatusFromPreviewStatus(
+  status: ActionCenterPreviewStatus,
+): Exclude<ActionCenterRouteStatus, 'open-verzoek'> {
+  switch (status) {
+    case 'te-bespreken':
+      return 'te-bespreken'
+    case 'in-uitvoering':
+    case 'reviewbaar':
+      return 'in-uitvoering'
+    case 'geblokkeerd':
+      return 'geblokkeerd'
+    case 'afgerond':
+      return 'afgerond'
+    case 'gestopt':
+      return 'gestopt'
+    case 'open-verzoek':
+    default:
+      return 'te-bespreken'
+  }
+}
+
 function getManagerActionPhase(item: ActionCenterPreviewItem | null): ManagerActionPhase {
   if (!item) return 'awaiting-first-move'
   if ((item.coreSemantics.routeActionCards?.length ?? 0) > 0) return 'action-cards'
@@ -879,7 +906,9 @@ function applyManagerResponseToItem(
   response: ActionCenterManagerResponse,
 ): ActionCenterPreviewItem {
   const routeActionGoverned = isRouteActionGoverned(item)
-  const nextStatus = routeActionGoverned ? item.status : getManagerResponseProjectedStatus(item.status, response)
+  const nextStatus: ActionCenterRouteStatus = routeActionGoverned
+    ? item.coreSemantics.route.routeStatus ?? resolveRouteContractStatusFromPreviewStatus(item.status)
+    : getManagerResponseProjectedStatus(item.status, response)
   const followThroughMode =
     routeActionGoverned
       ? item.coreSemantics.route.followThroughMode
@@ -3262,7 +3291,9 @@ export function ActionCenterPreview({
                                 }
                                 feedbackTone={routeActionFeedback?.tone ?? 'error'}
                                 submissionState={
-                                  routeActionFeedback?.validationDisposition &&
+                                  isPersistedDraftSubmissionDisposition(
+                                    routeActionFeedback?.validationDisposition,
+                                  ) &&
                                   routeActionFeedback.validationMessage &&
                                   routeActionFeedback.statusMessage &&
                                   routeActionFeedback.persistedDraftFingerprint

--- a/frontend/components/dashboard/action-center-preview.tsx
+++ b/frontend/components/dashboard/action-center-preview.tsx
@@ -50,6 +50,7 @@ import type {
 } from '@/lib/action-center-preview-model'
 import type {
   ActionCenterManagerActionThemeKey,
+  ActionCenterManagerActionStatus,
   ActionCenterManagerResponse,
   ActionCenterManagerResponseType,
 } from '@/lib/pilot-learning'
@@ -451,7 +452,8 @@ function getCreateDefaults(items: ActionCenterPreviewItem[]) {
 
 function buildManagerResponseDefaults(item: ActionCenterPreviewItem | null): ManagerResponseFormState {
   const response = item?.managerResponse ?? null
-  const hasPrimaryAction = Boolean(
+  const routeActionGoverned = isRouteActionGoverned(item)
+  const hasPrimaryAction = !routeActionGoverned && Boolean(
     response?.primary_action_theme_key &&
       response.primary_action_text &&
       response.primary_action_expected_effect,
@@ -466,9 +468,49 @@ function buildManagerResponseDefaults(item: ActionCenterPreviewItem | null): Man
         : ''),
     reviewScheduledFor: response?.review_scheduled_for ?? item?.reviewDate ?? '',
     includePrimaryAction: hasPrimaryAction,
-    primaryActionThemeKey: response?.primary_action_theme_key ?? '',
-    primaryActionText: response?.primary_action_text ?? '',
-    primaryActionExpectedEffect: response?.primary_action_expected_effect ?? '',
+    primaryActionThemeKey: routeActionGoverned ? '' : response?.primary_action_theme_key ?? '',
+    primaryActionText: routeActionGoverned ? '' : response?.primary_action_text ?? '',
+    primaryActionExpectedEffect: routeActionGoverned ? '' : response?.primary_action_expected_effect ?? '',
+  }
+}
+
+export function isRouteActionGoverned(item: ActionCenterPreviewItem | null) {
+  return (item?.coreSemantics.routeActionCards.length ?? 0) > 0
+}
+
+export function resolveManagerResponsePrimaryActionPayload(args: {
+  routeActionCardCount: number
+  includePrimaryAction: boolean
+  primaryActionThemeKey: ActionCenterManagerActionThemeKey | ''
+  primaryActionText: string
+  primaryActionExpectedEffect: string
+}): {
+  primary_action_theme_key: ActionCenterManagerActionThemeKey | null
+  primary_action_text: string | null
+  primary_action_expected_effect: string | null
+  primary_action_status: ActionCenterManagerActionStatus | null
+} {
+  if (args.routeActionCardCount > 0 || !args.includePrimaryAction) {
+    return {
+      primary_action_theme_key: null,
+      primary_action_text: null,
+      primary_action_expected_effect: null,
+      primary_action_status: null,
+    }
+  }
+
+  const primaryActionThemeKey = args.primaryActionThemeKey || null
+  const primaryActionText = args.primaryActionText.trim() || null
+  const primaryActionExpectedEffect = args.primaryActionExpectedEffect.trim() || null
+  const hasCompletePrimaryAction = Boolean(
+    primaryActionThemeKey && primaryActionText && primaryActionExpectedEffect,
+  )
+
+  return {
+    primary_action_theme_key: primaryActionThemeKey,
+    primary_action_text: primaryActionText,
+    primary_action_expected_effect: primaryActionExpectedEffect,
+    primary_action_status: hasCompletePrimaryAction ? 'active' : null,
   }
 }
 
@@ -836,17 +878,27 @@ function applyManagerResponseToItem(
   item: ActionCenterPreviewItem,
   response: ActionCenterManagerResponse,
 ): ActionCenterPreviewItem {
-  const nextStatus = getManagerResponseProjectedStatus(item.status, response)
-  const followThroughMode = hasPrimaryManagerAction(response) ? 'primary_action' : 'bounded_response'
+  const routeActionGoverned = isRouteActionGoverned(item)
+  const nextStatus = routeActionGoverned ? item.status : getManagerResponseProjectedStatus(item.status, response)
+  const followThroughMode =
+    routeActionGoverned
+      ? item.coreSemantics.route.followThroughMode
+      : hasPrimaryManagerAction(response)
+        ? 'primary_action'
+        : 'bounded_response'
   const nextRoute: ActionCenterRouteContract = {
     ...item.coreSemantics.route,
     routeStatus: nextStatus,
-    intervention: response.primary_action_text ?? null,
-    expectedEffect: response.primary_action_expected_effect ?? null,
+    intervention: routeActionGoverned
+      ? item.coreSemantics.route.intervention
+      : response.primary_action_text ?? null,
+    expectedEffect: routeActionGoverned
+      ? item.coreSemantics.route.expectedEffect
+      : response.primary_action_expected_effect ?? null,
     reviewScheduledFor: response.review_scheduled_for,
     managerResponseType: response.response_type,
     managerResponseNote: response.response_note,
-    primaryActionThemeKey: response.primary_action_theme_key ?? null,
+    primaryActionThemeKey: routeActionGoverned ? null : response.primary_action_theme_key ?? null,
     followThroughMode,
   }
 
@@ -1327,7 +1379,7 @@ export function ActionCenterPreview({
         currentUserId &&
         selectedItem.ownerId === currentUserId,
     )
-  const allowInlinePrimaryAction = !canUseRouteActionFlow
+  const allowInlinePrimaryAction = !isRouteActionGoverned(selectedItem)
   const canUseActionReviewFlow =
     Boolean(
       actionReviewEndpoint &&
@@ -1540,27 +1592,13 @@ export function ActionCenterPreview({
       return
     }
 
-    const persistedPrimaryAction = selectedItem.managerResponse
-    const nextPrimaryActionThemeKey = allowInlinePrimaryAction
-      ? managerResponseForm.includePrimaryAction && managerResponseForm.primaryActionThemeKey
-        ? managerResponseForm.primaryActionThemeKey
-        : null
-      : persistedPrimaryAction?.primary_action_theme_key ?? null
-    const nextPrimaryActionText = allowInlinePrimaryAction
-      ? managerResponseForm.includePrimaryAction && managerResponseForm.primaryActionText.trim()
-        ? managerResponseForm.primaryActionText
-        : null
-      : persistedPrimaryAction?.primary_action_text ?? null
-    const nextPrimaryActionExpectedEffect = allowInlinePrimaryAction
-      ? managerResponseForm.includePrimaryAction && managerResponseForm.primaryActionExpectedEffect.trim()
-        ? managerResponseForm.primaryActionExpectedEffect
-        : null
-      : persistedPrimaryAction?.primary_action_expected_effect ?? null
-    const nextPrimaryActionStatus = allowInlinePrimaryAction
-      ? managerResponseForm.includePrimaryAction
-        ? 'active'
-        : null
-      : persistedPrimaryAction?.primary_action_status ?? null
+    const primaryActionPayload = resolveManagerResponsePrimaryActionPayload({
+      routeActionCardCount: selectedItem.coreSemantics.routeActionCards.length,
+      includePrimaryAction: managerResponseForm.includePrimaryAction,
+      primaryActionThemeKey: managerResponseForm.primaryActionThemeKey,
+      primaryActionText: managerResponseForm.primaryActionText,
+      primaryActionExpectedEffect: managerResponseForm.primaryActionExpectedEffect,
+    })
 
     setManagerResponsePending(true)
     setManagerResponseError(null)
@@ -1574,10 +1612,7 @@ export function ActionCenterPreview({
       response_type: managerResponseForm.responseType,
       response_note: managerResponseForm.responseNote,
       review_scheduled_for: managerResponseForm.reviewScheduledFor,
-      primary_action_theme_key: nextPrimaryActionThemeKey,
-      primary_action_text: nextPrimaryActionText,
-      primary_action_expected_effect: nextPrimaryActionExpectedEffect,
-      primary_action_status: nextPrimaryActionStatus,
+      ...primaryActionPayload,
     }
 
     try {

--- a/frontend/components/dashboard/action-center-preview.tsx
+++ b/frontend/components/dashboard/action-center-preview.tsx
@@ -60,6 +60,7 @@ import {
 import {
   ActionCenterRouteActionEditor,
   type ActionCenterRouteActionEditorSubmissionState,
+  serializeActionCenterRouteActionEditorValue,
   type ActionCenterRouteActionEditorValue,
 } from './action-center-route-action-editor'
 import React, { useDeferredValue, useEffect, useMemo, useState } from 'react'
@@ -632,6 +633,27 @@ function getRouteActionDraftDispositionMessage(disposition: RouteActionValidatio
   }
 }
 
+function getRouteActionPersistedDraftStatusMessage() {
+  return 'Draft opgeslagen, nog niet live in deze route.'
+}
+
+export function buildPersistedRouteActionFeedback(args: {
+  value: ActionCenterRouteActionEditorValue
+  validationDisposition: Extract<RouteActionValidationDisposition, 'invalid' | 'needs_hr_review'>
+  validationMessage: string
+}) {
+  const statusMessage = getRouteActionPersistedDraftStatusMessage()
+
+  return {
+    message: `${statusMessage} ${args.validationMessage}`,
+    tone: 'warning' as const,
+    validationDisposition: args.validationDisposition,
+    validationMessage: args.validationMessage,
+    statusMessage,
+    persistedDraftFingerprint: serializeActionCenterRouteActionEditorValue(args.value),
+  }
+}
+
 function getNextRouteActionStatusFromReviewOutcome(
   outcome: ActionCenterActionReviewEditorValue['actionOutcome'],
 ): Extract<ActionCenterRouteActionRecord['status'], 'open' | 'afgerond' | 'gestopt'> {
@@ -1137,6 +1159,8 @@ export function ActionCenterPreview({
     tone: RouteActionFeedbackTone
     validationDisposition?: RouteActionValidationDisposition | null
     validationMessage?: string | null
+    statusMessage?: string | null
+    persistedDraftFingerprint?: string | null
   } | null>(null)
   const [openReviewActionId, setOpenReviewActionId] = useState<string | null>(null)
   const [actionReviewPendingActionId, setActionReviewPendingActionId] = useState<string | null>(null)
@@ -1627,12 +1651,13 @@ export function ActionCenterPreview({
         result.validationMessage ?? getRouteActionDraftDispositionMessage(validationDisposition)
 
       if (validationDisposition !== 'valid') {
-        setRouteActionFeedback({
-          message: validationMessage ?? 'Route action opslaan mislukt.',
-          tone: 'warning',
-          validationDisposition,
-          validationMessage,
-        })
+        setRouteActionFeedback(
+          buildPersistedRouteActionFeedback({
+            value,
+            validationDisposition,
+            validationMessage: validationMessage ?? 'Route action opslaan mislukt.',
+          }),
+        )
         return false
       }
 
@@ -1658,6 +1683,8 @@ export function ActionCenterPreview({
         tone: 'error',
         validationDisposition: null,
         validationMessage: null,
+        statusMessage: null,
+        persistedDraftFingerprint: null,
       })
       return false
     } finally {
@@ -3143,7 +3170,6 @@ export function ActionCenterPreview({
                                 className="inline-flex min-h-11 items-center rounded-full border border-[#ded3c6] bg-[#fcfaf7] px-4.5 py-2.5 text-sm font-semibold text-[#1a2533] transition hover:border-[#1a2533]"
                                 onClick={() => {
                                   setRouteActionEditorOpen((current) => !current)
-                                  setRouteActionFeedback(null)
                                 }}
                               >
                                 Actie toevoegen
@@ -3164,11 +3190,16 @@ export function ActionCenterPreview({
                                 feedbackTone={routeActionFeedback?.tone ?? 'error'}
                                 submissionState={
                                   routeActionFeedback?.validationDisposition &&
-                                  routeActionFeedback.validationMessage
+                                  routeActionFeedback.validationMessage &&
+                                  routeActionFeedback.statusMessage &&
+                                  routeActionFeedback.persistedDraftFingerprint
                                     ? ({
                                         validationDisposition:
                                           routeActionFeedback.validationDisposition,
+                                        statusMessage: routeActionFeedback.statusMessage,
                                         validationMessage: routeActionFeedback.validationMessage,
+                                        persistedDraftFingerprint:
+                                          routeActionFeedback.persistedDraftFingerprint,
                                       } satisfies ActionCenterRouteActionEditorSubmissionState)
                                     : null
                                 }

--- a/frontend/components/dashboard/action-center-preview.tsx
+++ b/frontend/components/dashboard/action-center-preview.tsx
@@ -59,6 +59,7 @@ import {
 } from './action-center-action-review-editor'
 import {
   ActionCenterRouteActionEditor,
+  type ActionCenterRouteActionEditorSubmissionState,
   type ActionCenterRouteActionEditorValue,
 } from './action-center-route-action-editor'
 import React, { useDeferredValue, useEffect, useMemo, useState } from 'react'
@@ -622,9 +623,9 @@ function getActionReviewOutcomeLabel(outcome: ActionCenterActionReviewEditorValu
 function getRouteActionDraftDispositionMessage(disposition: RouteActionValidationDisposition) {
   switch (disposition) {
     case 'needs_hr_review':
-      return 'Draft opgeslagen. Deze actie wacht eerst op HR-review en staat nog niet live in deze route.'
+      return 'Deze actie vraagt eerst HR-beoordeling.'
     case 'invalid':
-      return 'Draft opgeslagen. Deze actie staat nog niet live in deze route. Maak de stap concreter voordat je hem opnieuw indient.'
+      return 'Pas deze actie aan zodat hij bounded en route-specifiek is.'
     case 'valid':
     default:
       return null
@@ -1134,6 +1135,8 @@ export function ActionCenterPreview({
   const [routeActionFeedback, setRouteActionFeedback] = useState<{
     message: string
     tone: RouteActionFeedbackTone
+    validationDisposition?: RouteActionValidationDisposition | null
+    validationMessage?: string | null
   } | null>(null)
   const [openReviewActionId, setOpenReviewActionId] = useState<string | null>(null)
   const [actionReviewPendingActionId, setActionReviewPendingActionId] = useState<string | null>(null)
@@ -1608,6 +1611,8 @@ export function ActionCenterPreview({
         | {
             action?: Record<string, unknown>
             actionDraft?: { validationDisposition?: RouteActionValidationDisposition | null }
+            validationDisposition?: RouteActionValidationDisposition | null
+            validationMessage?: string | null
             detail?: string
           }
         | null
@@ -1616,11 +1621,17 @@ export function ActionCenterPreview({
         throw new Error(result?.detail ?? 'Route action opslaan mislukt.')
       }
 
-      const validationDisposition = result.actionDraft.validationDisposition ?? 'invalid'
+      const validationDisposition =
+        result.validationDisposition ?? result.actionDraft.validationDisposition ?? 'invalid'
+      const validationMessage =
+        result.validationMessage ?? getRouteActionDraftDispositionMessage(validationDisposition)
+
       if (validationDisposition !== 'valid') {
         setRouteActionFeedback({
-          message: getRouteActionDraftDispositionMessage(validationDisposition) ?? 'Route action opslaan mislukt.',
+          message: validationMessage ?? 'Route action opslaan mislukt.',
           tone: 'warning',
+          validationDisposition,
+          validationMessage,
         })
         return false
       }
@@ -1645,6 +1656,8 @@ export function ActionCenterPreview({
       setRouteActionFeedback({
         message: error instanceof Error ? error.message : 'Route action opslaan mislukt.',
         tone: 'error',
+        validationDisposition: null,
+        validationMessage: null,
       })
       return false
     } finally {
@@ -3143,8 +3156,22 @@ export function ActionCenterPreview({
                               <ActionCenterRouteActionEditor
                                 onSave={handleRouteActionSave}
                                 pending={routeActionPending}
-                                error={routeActionFeedback?.message ?? null}
+                                error={
+                                  routeActionFeedback?.validationDisposition
+                                    ? null
+                                    : routeActionFeedback?.message ?? null
+                                }
                                 feedbackTone={routeActionFeedback?.tone ?? 'error'}
+                                submissionState={
+                                  routeActionFeedback?.validationDisposition &&
+                                  routeActionFeedback.validationMessage
+                                    ? ({
+                                        validationDisposition:
+                                          routeActionFeedback.validationDisposition,
+                                        validationMessage: routeActionFeedback.validationMessage,
+                                      } satisfies ActionCenterRouteActionEditorSubmissionState)
+                                    : null
+                                }
                               />
                             </div>
                           ) : routeActionFeedback ? (

--- a/frontend/components/dashboard/action-center-route-action-editor.tsx
+++ b/frontend/components/dashboard/action-center-route-action-editor.tsx
@@ -27,6 +27,8 @@ interface Props {
   error?: string | null
   feedbackTone?: 'error' | 'warning'
   submissionState?: ActionCenterRouteActionEditorSubmissionState | null
+  title?: string
+  description?: string
   submitLabel?: string
 }
 
@@ -57,6 +59,8 @@ export function ActionCenterRouteActionEditor({
   error = null,
   feedbackTone = 'error',
   submissionState = null,
+  title = 'Actie toevoegen',
+  description = 'Houd het bij 1 concrete stap en 1 zichtbare observatie.',
   submitLabel = 'Actie toevoegen',
 }: Props) {
   const [value, setValue] = useState<ActionCenterRouteActionEditorValue>(initialValue)
@@ -78,10 +82,8 @@ export function ActionCenterRouteActionEditor({
   return (
     <form onSubmit={handleSubmit} className="space-y-3 rounded-[24px] border border-[#e4d9cb] bg-white px-5 py-5 shadow-[0_12px_36px_rgba(19,32,51,0.06)]">
       <div>
-        <h3 className="text-[1.2rem] font-semibold tracking-[-0.03em] text-[#132033]">Actie toevoegen</h3>
-        <p className="mt-1.5 text-sm leading-6 text-[#4f6175]">
-          Houd het bij 1 concrete stap en 1 zichtbare observatie.
-        </p>
+        <h3 className="text-[1.2rem] font-semibold tracking-[-0.03em] text-[#132033]">{title}</h3>
+        <p className="mt-1.5 text-sm leading-6 text-[#4f6175]">{description}</p>
       </div>
 
       <div className="grid gap-4 md:grid-cols-2">

--- a/frontend/components/dashboard/action-center-route-action-editor.tsx
+++ b/frontend/components/dashboard/action-center-route-action-editor.tsx
@@ -13,11 +13,17 @@ export interface ActionCenterRouteActionEditorValue {
   expectedEffect: string
 }
 
+export interface ActionCenterRouteActionEditorSubmissionState {
+  validationDisposition: 'invalid' | 'needs_hr_review'
+  validationMessage: string
+}
+
 interface Props {
   onSave(value: ActionCenterRouteActionEditorValue): Promise<boolean | void> | boolean | void
   pending?: boolean
   error?: string | null
   feedbackTone?: 'error' | 'warning'
+  submissionState?: ActionCenterRouteActionEditorSubmissionState | null
   submitLabel?: string
 }
 
@@ -37,6 +43,7 @@ export function ActionCenterRouteActionEditor({
   pending = false,
   error = null,
   feedbackTone = 'error',
+  submissionState = null,
   submitLabel = 'Actie toevoegen',
 }: Props) {
   const [value, setValue] = useState<ActionCenterRouteActionEditorValue>(EMPTY_VALUE)
@@ -104,6 +111,18 @@ export function ActionCenterRouteActionEditor({
           className="min-h-[92px] w-full rounded-2xl border border-[#ddd3c7] bg-[#fbf8f4] px-4 py-3 text-sm leading-6 text-[#132033] outline-none transition focus:border-[#ff9b4a]"
         />
       </FormField>
+
+      {submissionState ? (
+        <p
+          className={`text-sm leading-6 ${
+            submissionState.validationDisposition === 'invalid'
+              ? 'text-[#9a5a17]'
+              : 'text-[#7f4b18]'
+          }`}
+        >
+          {submissionState.validationMessage}
+        </p>
+      ) : null}
 
       {error ? (
         <p

--- a/frontend/components/dashboard/action-center-route-action-editor.tsx
+++ b/frontend/components/dashboard/action-center-route-action-editor.tsx
@@ -15,11 +15,14 @@ export interface ActionCenterRouteActionEditorValue {
 
 export interface ActionCenterRouteActionEditorSubmissionState {
   validationDisposition: 'invalid' | 'needs_hr_review'
+  statusMessage: string
   validationMessage: string
+  persistedDraftFingerprint: string
 }
 
 interface Props {
   onSave(value: ActionCenterRouteActionEditorValue): Promise<boolean | void> | boolean | void
+  initialValue?: ActionCenterRouteActionEditorValue
   pending?: boolean
   error?: string | null
   feedbackTone?: 'error' | 'warning'
@@ -34,22 +37,38 @@ const EMPTY_VALUE: ActionCenterRouteActionEditorValue = {
   expectedEffect: '',
 }
 
+export function serializeActionCenterRouteActionEditorValue(value: ActionCenterRouteActionEditorValue) {
+  return JSON.stringify({
+    themeKey: value.themeKey,
+    actionText: value.actionText.trim(),
+    reviewScheduledFor: value.reviewScheduledFor.trim(),
+    expectedEffect: value.expectedEffect.trim(),
+  })
+}
+
 export function shouldResetActionCenterRouteActionEditorAfterSave(result: boolean | void) {
   return result !== false
 }
 
 export function ActionCenterRouteActionEditor({
   onSave,
+  initialValue = EMPTY_VALUE,
   pending = false,
   error = null,
   feedbackTone = 'error',
   submissionState = null,
   submitLabel = 'Actie toevoegen',
 }: Props) {
-  const [value, setValue] = useState<ActionCenterRouteActionEditorValue>(EMPTY_VALUE)
+  const [value, setValue] = useState<ActionCenterRouteActionEditorValue>(initialValue)
+  const isDuplicatePersistedDraft =
+    submissionState?.persistedDraftFingerprint === serializeActionCenterRouteActionEditorValue(value)
+  const isSubmitDisabled = pending || isDuplicatePersistedDraft
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault()
+    if (isDuplicatePersistedDraft) {
+      return
+    }
     const result = await onSave(value)
     if (shouldResetActionCenterRouteActionEditorAfterSave(result)) {
       setValue(EMPTY_VALUE)
@@ -113,15 +132,23 @@ export function ActionCenterRouteActionEditor({
       </FormField>
 
       {submissionState ? (
-        <p
-          className={`text-sm leading-6 ${
-            submissionState.validationDisposition === 'invalid'
-              ? 'text-[#9a5a17]'
-              : 'text-[#7f4b18]'
-          }`}
-        >
-          {submissionState.validationMessage}
-        </p>
+        <div className="space-y-1">
+          <p className="text-sm font-semibold leading-6 text-[#7f4b18]">{submissionState.statusMessage}</p>
+          <p
+            className={`text-sm leading-6 ${
+              submissionState.validationDisposition === 'invalid'
+                ? 'text-[#9a5a17]'
+                : 'text-[#7f4b18]'
+            }`}
+          >
+            {submissionState.validationMessage}
+          </p>
+          {isDuplicatePersistedDraft ? (
+            <p className="text-sm leading-6 text-[#7f4b18]">
+              Wijzig deze opgeslagen draft voordat je hem opnieuw indient.
+            </p>
+          ) : null}
+        </div>
       ) : null}
 
       {error ? (
@@ -138,7 +165,7 @@ export function ActionCenterRouteActionEditor({
 
       <button
         type="submit"
-        disabled={pending}
+        disabled={isSubmitDisabled}
         className="inline-flex min-h-11 items-center rounded-full bg-[#ff9b4a] px-4.5 py-2.5 text-sm font-semibold text-[#132033] transition hover:brightness-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
       >
         {pending ? 'Actie opslaan...' : submitLabel}

--- a/frontend/lib/action-center-action-review-editor.test.ts
+++ b/frontend/lib/action-center-action-review-editor.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { ActionCenterActionReviewEditor } from '@/components/dashboard/action-center-action-review-editor'
 
 describe('ActionCenterActionReviewEditor', () => {
-  it('renders a compact review form with evidence source and conditional guidance', () => {
+  it('keeps the review form compact for repeated use', () => {
     const html = renderToStaticMarkup(
       React.createElement(ActionCenterActionReviewEditor, {
         onSave: vi.fn(),
@@ -14,9 +14,9 @@ describe('ActionCenterActionReviewEditor', () => {
     expect(html).toContain('Review opslaan')
     expect(html).toContain('Review op deze actie')
     expect(html).toContain('Wat zagen we terug?')
-    expect(html).toContain('Uitkomst')
-    expect(html).toContain('Bron van observatie')
-    expect(html).toContain('Hoe zeker zijn we hiervan?')
+    expect(html).toContain('Wat betekent dit nu?')
+    expect(html).toContain('Bron')
+    expect(html).toContain('Hoe zeker is dit?')
     expect(html).toContain('Korte toelichting')
     expect(html).toContain('Beschrijf kort welke verandering je zag en houd het bij waarneembare signalen.')
     expect(html).toContain('Effect zichtbaar')
@@ -29,6 +29,8 @@ describe('ActionCenterActionReviewEditor', () => {
     expect(html).toContain('Laag')
     expect(html).toContain('Gemiddeld')
     expect(html).toContain('Hoog')
+    expect(html).not.toContain('Bron van observatie')
+    expect(html).not.toContain('Losse aanvullende analyse')
     expect(html).not.toContain('Follow-up survey')
     expect(html).not.toContain('HR check')
     expect(html).not.toContain('Operationele indicator')
@@ -44,10 +46,10 @@ describe('ActionCenterActionReviewEditor', () => {
 
     expect(html).toContain('Review opslaan')
     expect(html).toContain('Wat zagen we terug?')
-    expect(html).toContain('Uitkomst')
+    expect(html).toContain('Wat betekent dit nu?')
     expect(html).toContain('Korte toelichting')
-    expect(html).not.toContain('Bron van observatie')
-    expect(html).not.toContain('Hoe zeker zijn we hiervan?')
+    expect(html).not.toContain('Bron')
+    expect(html).not.toContain('Hoe zeker is dit?')
     expect(html).not.toContain('Managerobservatie')
     expect(html).not.toContain('Gemiddeld')
   })

--- a/frontend/lib/action-center-action-reviews.test.ts
+++ b/frontend/lib/action-center-action-reviews.test.ts
@@ -77,12 +77,19 @@ describe('action center action reviews', () => {
     )
   })
 
-  it('resolves review outcomes into canonical action lifecycle states', async () => {
+  it('maps effect-zichtbaar to completed', async () => {
     const { resolveActionCenterActionReviewTransition } = await import('./action-center-action-reviews') as {
       resolveActionCenterActionReviewTransition: (outcome: string) => string
     }
 
     expect(resolveActionCenterActionReviewTransition('effect-zichtbaar')).toBe('completed')
+  })
+
+  it('resolves review outcomes into canonical action lifecycle states', async () => {
+    const { resolveActionCenterActionReviewTransition } = await import('./action-center-action-reviews') as {
+      resolveActionCenterActionReviewTransition: (outcome: string) => string
+    }
+
     expect(resolveActionCenterActionReviewTransition('bijsturen-nodig')).toBe('active')
     expect(resolveActionCenterActionReviewTransition('nog-te-vroeg')).toBe('active')
     expect(resolveActionCenterActionReviewTransition('stoppen')).toBe('stopped')

--- a/frontend/lib/action-center-constitution.test.ts
+++ b/frontend/lib/action-center-constitution.test.ts
@@ -197,6 +197,7 @@ describe('action-center constitution', () => {
         toState: 'active',
         actors: ['hr_rhythm_owner'],
         phase: 'draft_resolution',
+        draftValidationDisposition: 'valid',
       },
       {
         fromState: 'draft',
@@ -349,6 +350,7 @@ describe('action-center constitution', () => {
         actor: 'hr_rhythm_owner',
         fromState: 'draft',
         toState: 'active',
+        draftValidationDisposition: 'valid',
       }),
     ).toBe(true)
 
@@ -357,6 +359,7 @@ describe('action-center constitution', () => {
         actor: 'manager_participant',
         fromState: 'draft',
         toState: 'active',
+        draftValidationDisposition: 'valid',
       }),
     ).toBe(false)
 
@@ -375,6 +378,43 @@ describe('action-center constitution', () => {
         toState: 'superseded',
       }),
     ).toBe(true)
+  })
+
+  it('requires a valid draft disposition before hr can promote draft to active through the draft-resolution helper', () => {
+    expect(
+      isActionCenterActionDraftTransitionAllowed({
+        actor: 'hr_rhythm_owner',
+        fromState: 'draft',
+        toState: 'active',
+        draftValidationDisposition: 'valid',
+      }),
+    ).toBe(true)
+
+    expect(
+      isActionCenterActionDraftTransitionAllowed({
+        actor: 'hr_rhythm_owner',
+        fromState: 'draft',
+        toState: 'active',
+        draftValidationDisposition: 'invalid',
+      }),
+    ).toBe(false)
+
+    expect(
+      isActionCenterActionDraftTransitionAllowed({
+        actor: 'hr_rhythm_owner',
+        fromState: 'draft',
+        toState: 'active',
+        draftValidationDisposition: 'needs_hr_review',
+      }),
+    ).toBe(false)
+
+    expect(
+      isActionCenterActionDraftTransitionAllowed({
+        actor: 'hr_rhythm_owner',
+        fromState: 'draft',
+        toState: 'active',
+      }),
+    ).toBe(false)
   })
 
   it('does not allow draft to jump straight to completed', () => {

--- a/frontend/lib/action-center-constitution.test.ts
+++ b/frontend/lib/action-center-constitution.test.ts
@@ -273,7 +273,17 @@ describe('action-center constitution', () => {
     ).toBe(false)
   })
 
-  it('does not allow blocked actions to jump to completed without review', () => {
+  it('allows in_review to active for no-progress review outcomes', () => {
+    expect(
+      isActionCenterActionStateTransitionAllowed({
+        actor: 'manager_participant',
+        fromState: 'in_review',
+        toState: 'active',
+      }),
+    ).toBe(true)
+  })
+
+  it('does not allow blocked to completed without review', () => {
     expect(
       isActionCenterActionStateTransitionAllowed({
         actor: 'manager_participant',

--- a/frontend/lib/action-center-constitution.test.ts
+++ b/frontend/lib/action-center-constitution.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'vitest'
 import {
+  ACTION_CENTER_ACTION_DRAFT_TRANSITION_RULES,
   ACTION_CENTER_ACTION_TRANSITION_RULES,
   ACTION_CENTER_ACTION_SEMANTIC_STATES,
   ACTION_CENTER_CANONICAL_REVIEW_STATES,
   ACTION_CENTER_CANONICAL_ROUTE_STATES,
   ACTION_CENTER_TRANSITION_RULES,
   getActionCenterApprovedRouteDefault,
+  isActionCenterActionDraftTransitionAllowed,
   isActionCenterActionStateTransitionAllowed,
   isActionCenterCanonicalRouteStateTransitionAllowed,
   resolveActionCenterActionReviewTransition,
@@ -114,39 +116,99 @@ describe('action-center constitution', () => {
   it('keeps bounded action lifecycle transition truth explicit', () => {
     expect(ACTION_CENTER_ACTION_TRANSITION_RULES).toEqual([
       {
-        fromState: 'draft',
-        toState: 'active',
-        actors: ['manager_participant', 'hr_rhythm_owner'],
-      },
-      {
         fromState: 'active',
         toState: 'review_due',
         actors: ['system_channel'],
+        phase: 'execution_lifecycle',
+      },
+      {
+        fromState: 'active',
+        toState: 'blocked',
+        actors: ['manager_participant', 'hr_rhythm_owner'],
+        phase: 'execution_lifecycle',
+      },
+      {
+        fromState: 'active',
+        toState: 'superseded',
+        actors: ['manager_participant', 'hr_rhythm_owner'],
+        phase: 'execution_lifecycle',
       },
       {
         fromState: 'review_due',
         toState: 'in_review',
         actors: ['manager_participant', 'hr_rhythm_owner'],
+        phase: 'execution_lifecycle',
+      },
+      {
+        fromState: 'review_due',
+        toState: 'blocked',
+        actors: ['manager_participant', 'hr_rhythm_owner'],
+        phase: 'execution_lifecycle',
       },
       {
         fromState: 'in_review',
         toState: 'active',
         actors: ['manager_participant', 'hr_rhythm_owner'],
+        phase: 'execution_lifecycle',
+      },
+      {
+        fromState: 'in_review',
+        toState: 'blocked',
+        actors: ['manager_participant', 'hr_rhythm_owner'],
+        phase: 'execution_lifecycle',
       },
       {
         fromState: 'in_review',
         toState: 'completed',
         actors: ['manager_participant', 'hr_rhythm_owner'],
+        phase: 'execution_lifecycle',
       },
       {
         fromState: 'in_review',
         toState: 'stopped',
         actors: ['manager_participant', 'hr_rhythm_owner'],
+        phase: 'execution_lifecycle',
       },
       {
         fromState: 'blocked',
         toState: 'in_review',
         actors: ['manager_participant', 'hr_rhythm_owner'],
+        phase: 'execution_lifecycle',
+      },
+      {
+        fromState: 'blocked',
+        toState: 'stopped',
+        actors: ['manager_participant', 'hr_rhythm_owner'],
+        phase: 'execution_lifecycle',
+      },
+      {
+        fromState: 'stopped',
+        toState: 'superseded',
+        actors: ['manager_participant', 'hr_rhythm_owner'],
+        phase: 'execution_lifecycle',
+      },
+    ])
+  })
+
+  it('keeps draft-resolution transitions explicit and separate from generic execution lifecycle truth', () => {
+    expect(ACTION_CENTER_ACTION_DRAFT_TRANSITION_RULES).toEqual([
+      {
+        fromState: 'draft',
+        toState: 'active',
+        actors: ['hr_rhythm_owner'],
+        phase: 'draft_resolution',
+      },
+      {
+        fromState: 'draft',
+        toState: 'stopped',
+        actors: ['manager_participant', 'hr_rhythm_owner'],
+        phase: 'draft_resolution',
+      },
+      {
+        fromState: 'draft',
+        toState: 'superseded',
+        actors: ['manager_participant', 'hr_rhythm_owner'],
+        phase: 'draft_resolution',
       },
     ])
   })
@@ -263,6 +325,58 @@ describe('action-center constitution', () => {
     ).toBe(false)
   })
 
+  it('does not let generic execution transitions treat draft promotion as a review-like lifecycle move', () => {
+    expect(
+      isActionCenterActionStateTransitionAllowed({
+        actor: 'manager_participant',
+        fromState: 'draft',
+        toState: 'active',
+      }),
+    ).toBe(false)
+
+    expect(
+      isActionCenterActionStateTransitionAllowed({
+        actor: 'hr_rhythm_owner',
+        fromState: 'draft',
+        toState: 'active',
+      }),
+    ).toBe(false)
+  })
+
+  it('allows draft transitions only through the explicit draft-resolution helper', () => {
+    expect(
+      isActionCenterActionDraftTransitionAllowed({
+        actor: 'hr_rhythm_owner',
+        fromState: 'draft',
+        toState: 'active',
+      }),
+    ).toBe(true)
+
+    expect(
+      isActionCenterActionDraftTransitionAllowed({
+        actor: 'manager_participant',
+        fromState: 'draft',
+        toState: 'active',
+      }),
+    ).toBe(false)
+
+    expect(
+      isActionCenterActionDraftTransitionAllowed({
+        actor: 'manager_participant',
+        fromState: 'draft',
+        toState: 'stopped',
+      }),
+    ).toBe(true)
+
+    expect(
+      isActionCenterActionDraftTransitionAllowed({
+        actor: 'manager_participant',
+        fromState: 'draft',
+        toState: 'superseded',
+      }),
+    ).toBe(true)
+  })
+
   it('does not allow draft to jump straight to completed', () => {
     expect(
       isActionCenterActionStateTransitionAllowed({
@@ -283,12 +397,44 @@ describe('action-center constitution', () => {
     ).toBe(true)
   })
 
+  it.each([
+    ['active', 'blocked'],
+    ['active', 'superseded'],
+    ['review_due', 'blocked'],
+    ['in_review', 'blocked'],
+    ['blocked', 'stopped'],
+    ['stopped', 'superseded'],
+  ] as const)('allows bounded execution lifecycle transition %s -> %s', (fromState, toState) => {
+    expect(
+      isActionCenterActionStateTransitionAllowed({
+        actor: 'manager_participant',
+        fromState,
+        toState,
+      }),
+    ).toBe(true)
+  })
+
   it('does not allow blocked to completed without review', () => {
     expect(
       isActionCenterActionStateTransitionAllowed({
         actor: 'manager_participant',
         fromState: 'blocked',
         toState: 'completed',
+      }),
+    ).toBe(false)
+  })
+
+  it.each([
+    ['active', 'completed'],
+    ['blocked', 'active'],
+    ['completed', 'superseded'],
+    ['stopped', 'active'],
+  ] as const)('keeps prohibited execution lifecycle transition %s -> %s blocked', (fromState, toState) => {
+    expect(
+      isActionCenterActionStateTransitionAllowed({
+        actor: 'manager_participant',
+        fromState,
+        toState,
       }),
     ).toBe(false)
   })

--- a/frontend/lib/action-center-constitution.ts
+++ b/frontend/lib/action-center-constitution.ts
@@ -69,6 +69,7 @@ export type ActionCenterTransitionRule = {
 export type ActionCenterActionTransitionRule = {
   readonly fromState: ActionCenterActionSemanticState
   readonly toState: ActionCenterActionSemanticState
+  readonly phase: 'draft_resolution' | 'execution_lifecycle'
   actors: readonly ActionCenterActor[]
 }
 
@@ -119,39 +120,98 @@ export const ACTION_CENTER_TRANSITION_RULES: readonly Readonly<ActionCenterTrans
 export const ACTION_CENTER_ACTION_TRANSITION_RULES: readonly Readonly<ActionCenterActionTransitionRule>[] =
   Object.freeze([
     freezeActionCenterActionTransitionRule({
-      fromState: 'draft',
-      toState: 'active',
-      actors: ['manager_participant', 'hr_rhythm_owner'],
-    }),
-    freezeActionCenterActionTransitionRule({
       fromState: 'active',
       toState: 'review_due',
       actors: ['system_channel'],
+      phase: 'execution_lifecycle',
+    }),
+    freezeActionCenterActionTransitionRule({
+      fromState: 'active',
+      toState: 'blocked',
+      actors: ['manager_participant', 'hr_rhythm_owner'],
+      phase: 'execution_lifecycle',
+    }),
+    freezeActionCenterActionTransitionRule({
+      fromState: 'active',
+      toState: 'superseded',
+      actors: ['manager_participant', 'hr_rhythm_owner'],
+      phase: 'execution_lifecycle',
     }),
     freezeActionCenterActionTransitionRule({
       fromState: 'review_due',
       toState: 'in_review',
       actors: ['manager_participant', 'hr_rhythm_owner'],
+      phase: 'execution_lifecycle',
+    }),
+    freezeActionCenterActionTransitionRule({
+      fromState: 'review_due',
+      toState: 'blocked',
+      actors: ['manager_participant', 'hr_rhythm_owner'],
+      phase: 'execution_lifecycle',
     }),
     freezeActionCenterActionTransitionRule({
       fromState: 'in_review',
       toState: 'active',
       actors: ['manager_participant', 'hr_rhythm_owner'],
+      phase: 'execution_lifecycle',
+    }),
+    freezeActionCenterActionTransitionRule({
+      fromState: 'in_review',
+      toState: 'blocked',
+      actors: ['manager_participant', 'hr_rhythm_owner'],
+      phase: 'execution_lifecycle',
     }),
     freezeActionCenterActionTransitionRule({
       fromState: 'in_review',
       toState: 'completed',
       actors: ['manager_participant', 'hr_rhythm_owner'],
+      phase: 'execution_lifecycle',
     }),
     freezeActionCenterActionTransitionRule({
       fromState: 'in_review',
       toState: 'stopped',
       actors: ['manager_participant', 'hr_rhythm_owner'],
+      phase: 'execution_lifecycle',
     }),
     freezeActionCenterActionTransitionRule({
       fromState: 'blocked',
       toState: 'in_review',
       actors: ['manager_participant', 'hr_rhythm_owner'],
+      phase: 'execution_lifecycle',
+    }),
+    freezeActionCenterActionTransitionRule({
+      fromState: 'blocked',
+      toState: 'stopped',
+      actors: ['manager_participant', 'hr_rhythm_owner'],
+      phase: 'execution_lifecycle',
+    }),
+    freezeActionCenterActionTransitionRule({
+      fromState: 'stopped',
+      toState: 'superseded',
+      actors: ['manager_participant', 'hr_rhythm_owner'],
+      phase: 'execution_lifecycle',
+    }),
+  ])
+
+export const ACTION_CENTER_ACTION_DRAFT_TRANSITION_RULES: readonly Readonly<ActionCenterActionTransitionRule>[] =
+  Object.freeze([
+    freezeActionCenterActionTransitionRule({
+      fromState: 'draft',
+      toState: 'active',
+      actors: ['hr_rhythm_owner'],
+      phase: 'draft_resolution',
+    }),
+    freezeActionCenterActionTransitionRule({
+      fromState: 'draft',
+      toState: 'stopped',
+      actors: ['manager_participant', 'hr_rhythm_owner'],
+      phase: 'draft_resolution',
+    }),
+    freezeActionCenterActionTransitionRule({
+      fromState: 'draft',
+      toState: 'superseded',
+      actors: ['manager_participant', 'hr_rhythm_owner'],
+      phase: 'draft_resolution',
     }),
   ])
 
@@ -227,8 +287,23 @@ export function isActionCenterActionStateTransitionAllowed(args: {
   actor: ActionCenterActor
   fromState: ActionCenterActionSemanticState
   toState: ActionCenterActionSemanticState
+  phase?: ActionCenterActionTransitionRule['phase']
 }): boolean {
   return ACTION_CENTER_ACTION_TRANSITION_RULES.some(
+    (rule) =>
+      rule.fromState === args.fromState &&
+      rule.toState === args.toState &&
+      rule.actors.includes(args.actor) &&
+      (!args.phase || rule.phase === args.phase),
+  )
+}
+
+export function isActionCenterActionDraftTransitionAllowed(args: {
+  actor: ActionCenterActor
+  fromState: Extract<ActionCenterActionSemanticState, 'draft'>
+  toState: Extract<ActionCenterActionSemanticState, 'active' | 'stopped' | 'superseded'>
+}): boolean {
+  return ACTION_CENTER_ACTION_DRAFT_TRANSITION_RULES.some(
     (rule) => rule.fromState === args.fromState && rule.toState === args.toState && rule.actors.includes(args.actor),
   )
 }

--- a/frontend/lib/action-center-constitution.ts
+++ b/frontend/lib/action-center-constitution.ts
@@ -71,6 +71,7 @@ export type ActionCenterActionTransitionRule = {
   readonly toState: ActionCenterActionSemanticState
   readonly phase: 'draft_resolution' | 'execution_lifecycle'
   actors: readonly ActionCenterActor[]
+  draftValidationDisposition?: Extract<ActionCenterActionDraftDisposition, 'valid'>
 }
 
 function freezeActionCenterTransitionRule(rule: ActionCenterTransitionRule): Readonly<ActionCenterTransitionRule> {
@@ -200,6 +201,7 @@ export const ACTION_CENTER_ACTION_DRAFT_TRANSITION_RULES: readonly Readonly<Acti
       toState: 'active',
       actors: ['hr_rhythm_owner'],
       phase: 'draft_resolution',
+      draftValidationDisposition: 'valid',
     }),
     freezeActionCenterActionTransitionRule({
       fromState: 'draft',
@@ -302,9 +304,14 @@ export function isActionCenterActionDraftTransitionAllowed(args: {
   actor: ActionCenterActor
   fromState: Extract<ActionCenterActionSemanticState, 'draft'>
   toState: Extract<ActionCenterActionSemanticState, 'active' | 'stopped' | 'superseded'>
+  draftValidationDisposition?: ActionCenterActionDraftDisposition | null
 }): boolean {
   return ACTION_CENTER_ACTION_DRAFT_TRANSITION_RULES.some(
-    (rule) => rule.fromState === args.fromState && rule.toState === args.toState && rule.actors.includes(args.actor),
+    (rule) =>
+      rule.fromState === args.fromState &&
+      rule.toState === args.toState &&
+      rule.actors.includes(args.actor) &&
+      (rule.draftValidationDisposition ? rule.draftValidationDisposition === args.draftValidationDisposition : true),
   )
 }
 

--- a/frontend/lib/action-center-governance.test.ts
+++ b/frontend/lib/action-center-governance.test.ts
@@ -3,6 +3,7 @@ import {
   deriveActionCenterRouteGovernanceSignals,
   getActionCenterGovernanceActorRoleLabel,
   isActionCenterGovernanceActorRole,
+  getActionCenterGovernanceSignalLabel,
   resolveActionCenterHrWriteAccess,
   resolveActionCenterReviewRhythmWriteAccess,
   resolveActionCenterTransitionAccess,
@@ -90,6 +91,7 @@ describe('action center governance helpers', () => {
     expect(isActionCenterGovernanceActorRole('hr_member')).toBe(true)
     expect(isActionCenterGovernanceActorRole('unknown')).toBe(false)
     expect(getActionCenterGovernanceActorRoleLabel('hr_owner')).toBe('HR owner')
+    expect(getActionCenterGovernanceSignalLabel('route_ready_for_closeout')).toBe('Klaar voor closeout')
   })
 
   it('prefers verisight admin when resolving HR write access', () => {
@@ -603,5 +605,44 @@ describe('action center governance helpers', () => {
         now: new Date('2026-05-20T12:00:00.000Z'),
       }),
     ).toBeNull()
+  })
+
+  it('derives governance source labels from bounded route family truth when raw labels drift', () => {
+    const signals = deriveActionCenterRouteGovernanceSignals({
+      item: buildGovernanceItem({
+        id: 'route-retention-drifted-label',
+        sourceLabel: 'Pulse',
+        status: 'in-uitvoering',
+        coreSemantics: {
+          route: {
+            routeId: 'route-retention-drifted-label',
+            routeOpenedAt: '2026-05-18T09:00:00.000Z',
+            reviewCompletedAt: null,
+            hasFollowUpTarget: false,
+          },
+          decisionHistory: [],
+          routeActionCards: [],
+          routeCloseout: {
+            closeoutStatus: null,
+            closeoutReason: null,
+            closeoutNote: null,
+            closedAt: null,
+            closedByRole: null,
+            readyForCloseout: false,
+          },
+        },
+      }) as never,
+      scanType: 'retention',
+      now: new Date('2026-05-20T12:00:00.000Z'),
+    })
+
+    expect(signals).toMatchObject({
+      sourceLabel: 'RetentieScan',
+      signals: [
+        {
+          code: 'missing_action_where_execution_is_expected',
+        },
+      ],
+    })
   })
 })

--- a/frontend/lib/action-center-governance.ts
+++ b/frontend/lib/action-center-governance.ts
@@ -8,7 +8,11 @@ import {
   type ActionCenterConstitutionObject,
   type ActionCenterConstitutionState,
 } from '@/lib/action-center-constitution'
-import { getActionCenterEnabledRouteDefaults, type ActionCenterRouteDefaultsKnownScanType } from '@/lib/action-center-route-defaults'
+import {
+  getActionCenterEnabledRouteDefaults,
+  getActionCenterRouteFamilyLabel,
+  type ActionCenterRouteDefaultsKnownScanType,
+} from '@/lib/action-center-route-defaults'
 import type { ActionCenterPreviewItem } from '@/lib/action-center-preview-model'
 import type {
   ActionCenterWorkspaceMember,
@@ -149,20 +153,6 @@ export function getActionCenterGovernanceSignalLabel(code: ActionCenterGovernanc
     case 'route_ready_for_closeout':
       return 'Klaar voor closeout'
   }
-}
-
-function getGovernanceRouteFamilyLabel(scanType: ActionCenterRouteDefaultsKnownScanType | string | null | undefined) {
-  const routeDefaults = getActionCenterEnabledRouteDefaults(scanType)
-
-  if (routeDefaults?.scanType === 'retention') {
-    return 'RetentieScan'
-  }
-
-  if (routeDefaults?.scanType === 'exit') {
-    return 'ExitScan'
-  }
-
-  return null
 }
 
 function normalizeDateString(value: string | null | undefined) {
@@ -387,7 +377,7 @@ export function deriveActionCenterRouteGovernanceSignals(args: {
   return {
     routeId: args.item.coreSemantics.route.routeId,
     scopeLabel: args.item.teamLabel,
-    sourceLabel: getGovernanceRouteFamilyLabel(args.scanType) ?? args.item.sourceLabel,
+    sourceLabel: getActionCenterRouteFamilyLabel(args.scanType) ?? args.item.sourceLabel,
     reviewDateLabel: args.item.reviewDateLabel,
     signals,
   }

--- a/frontend/lib/action-center-preview-route-fields.test.ts
+++ b/frontend/lib/action-center-preview-route-fields.test.ts
@@ -228,6 +228,9 @@ describe('action center preview route fields', () => {
     expect(html).toContain('Nog niet reviewbaar')
     expect(html).toContain('Actie toevoegen')
     expect(html).toContain('Review toevoegen')
+    expect(html).not.toContain('Thema van deze eerste concrete stap')
+    expect(html).not.toContain('Wat is die eerste concrete stap?')
+    expect(html).not.toContain('Wat moet deze stap zichtbaar maken?')
   })
 
   it('keeps route-action creation hidden until a persisted manager response route container exists', () => {

--- a/frontend/lib/action-center-review-rhythm-data.test.ts
+++ b/frontend/lib/action-center-review-rhythm-data.test.ts
@@ -4,11 +4,31 @@ const { mockAdminFrom } = vi.hoisted(() => ({
   mockAdminFrom: vi.fn(),
 }))
 
+const { mockRouteDefaultsOverride } = vi.hoisted(() => ({
+  mockRouteDefaultsOverride: vi.fn(),
+}))
+
 vi.mock('@/lib/supabase/admin', () => ({
   createAdminClient: () => ({
     from: mockAdminFrom,
   }),
 }))
+
+vi.mock('@/lib/action-center-route-defaults', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./action-center-route-defaults')>()
+
+  return {
+    ...actual,
+    getActionCenterEnabledRouteDefaults: (scanType: string | null | undefined) => {
+      const override = mockRouteDefaultsOverride(scanType)
+      if (override) {
+        return override
+      }
+
+      return actual.getActionCenterEnabledRouteDefaults(scanType)
+    },
+  }
+})
 
 import { getActionCenterReviewRhythmData } from './action-center-review-rhythm-data'
 
@@ -53,6 +73,7 @@ function buildItem(overrides: Record<string, unknown> = {}) {
 describe('action center review rhythm data', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockRouteDefaultsOverride.mockReset()
   })
 
   it('returns visible Action Center parity-route configs and bounded overview counts', async () => {
@@ -275,6 +296,78 @@ describe('action center review rhythm data', () => {
         },
       }),
     ).rejects.toThrow('database offline')
+  })
+
+  it('fills partial persisted RetentieScan configs from retention defaults instead of the generic baseline path', async () => {
+    mockRouteDefaultsOverride.mockImplementation((scanType: string | null | undefined) => {
+      if (scanType !== 'retention') {
+        return undefined
+      }
+
+      return {
+        scanType: 'retention',
+        actionCenterStatus: 'enabled',
+        routeEnabled: true,
+        cadenceDays: 30,
+        reminderLeadDays: 5,
+        escalationLeadDays: 14,
+        reviewWindowDays: { min: 45, max: 90 },
+        staleAfterDays: 90,
+        stuckActiveWarningDays: { min: 21, max: 30 },
+        reviewDueGraceDays: 7,
+        sprawlRiskCount: 3,
+        repeatedReviewWarningCount: 2,
+        remindersEnabled: false,
+        providerEligible: true,
+      }
+    })
+
+    const configQuery = createRhythmConfigQuery({
+      data: [
+        {
+          route_id: 'route-retention-partial',
+          cadence_days: 7,
+          reminder_lead_days: null,
+          escalation_lead_days: null,
+          reminders_enabled: null,
+        },
+      ],
+    })
+
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === 'action_center_review_rhythm_configs') {
+        return configQuery
+      }
+
+      throw new Error(`Unhandled table ${table}`)
+    })
+
+    const result = await getActionCenterReviewRhythmData({
+      items: [
+        buildItem({
+          id: 'route-retention-partial-preview',
+          sourceLabel: 'RetentieScan',
+          coreSemantics: {
+            route: {
+              routeId: 'route-retention-partial',
+              reviewCompletedAt: null,
+              hasFollowUpTarget: false,
+            },
+          },
+        }),
+      ] as never,
+      now: new Date('2026-05-28T12:00:00.000Z'),
+      routeScanTypeByRouteId: {
+        'route-retention-partial': 'retention',
+      },
+    })
+
+    expect(result.configByRouteId['route-retention-partial']).toEqual({
+      cadenceDays: 7,
+      reminderLeadDays: 5,
+      escalationLeadDays: 14,
+      remindersEnabled: false,
+    })
   })
 
   it('merges bounded governance-only routes into the HR oversight feed without broadening beyond exit and retention', async () => {

--- a/frontend/lib/action-center-review-rhythm-data.ts
+++ b/frontend/lib/action-center-review-rhythm-data.ts
@@ -30,16 +30,31 @@ function getReviewRhythmRouteId(item: Pick<ActionCenterPreviewItem, 'coreSemanti
   return item.coreSemantics.route.routeId
 }
 
-function normalizeConfigRow(row: ActionCenterReviewRhythmConfigRow): ActionCenterReviewRhythmConfig | null {
-  if (!row.route_id) {
+function toReviewRhythmConfigFromRouteDefaults(
+  routeDefaults: NonNullable<ReturnType<typeof getActionCenterEnabledRouteDefaults>>,
+): ActionCenterReviewRhythmConfig {
+  return {
+    cadenceDays: routeDefaults.cadenceDays,
+    reminderLeadDays: routeDefaults.reminderLeadDays,
+    escalationLeadDays: routeDefaults.escalationLeadDays,
+    remindersEnabled: routeDefaults.remindersEnabled,
+  }
+}
+
+function normalizeConfigRow(args: {
+  row: ActionCenterReviewRhythmConfigRow
+  routeDefaultConfig: ActionCenterReviewRhythmConfig
+}): ActionCenterReviewRhythmConfig | null {
+  if (!args.row.route_id) {
     return null
   }
 
   return normalizeActionCenterReviewRhythmConfig({
-    cadence_days: row.cadence_days,
-    reminder_lead_days: row.reminder_lead_days,
-    escalation_lead_days: row.escalation_lead_days,
-    reminders_enabled: row.reminders_enabled,
+    cadence_days: args.row.cadence_days ?? args.routeDefaultConfig.cadenceDays,
+    reminder_lead_days: args.row.reminder_lead_days ?? args.routeDefaultConfig.reminderLeadDays,
+    escalation_lead_days:
+      args.row.escalation_lead_days ?? args.routeDefaultConfig.escalationLeadDays,
+    reminders_enabled: args.row.reminders_enabled ?? args.routeDefaultConfig.remindersEnabled,
   })
 }
 
@@ -167,7 +182,13 @@ export async function getActionCenterReviewRhythmData(args: {
   const persistedConfigByRouteId = ((data ?? []) as ActionCenterReviewRhythmConfigRow[]).reduce<
     Record<string, ActionCenterReviewRhythmConfig>
   >((acc, row) => {
-    const config = normalizeConfigRow(row)
+    const routeDefaults =
+      getActionCenterEnabledRouteDefaults(args.routeScanTypeByRouteId[row.route_id ?? '']) ??
+      buildDefaultActionCenterReviewRhythmConfig()
+    const config = normalizeConfigRow({
+      row,
+      routeDefaultConfig: toReviewRhythmConfigFromRouteDefaults(routeDefaults),
+    })
     if (row.route_id && config) {
       acc[row.route_id] = config
     }
@@ -179,12 +200,7 @@ export async function getActionCenterReviewRhythmData(args: {
       const routeDefaults =
         getActionCenterEnabledRouteDefaults(args.routeScanTypeByRouteId[routeId]) ??
         buildDefaultActionCenterReviewRhythmConfig()
-      const routeDefaultConfig: ActionCenterReviewRhythmConfig = {
-        cadenceDays: routeDefaults.cadenceDays,
-        reminderLeadDays: routeDefaults.reminderLeadDays,
-        escalationLeadDays: routeDefaults.escalationLeadDays,
-        remindersEnabled: routeDefaults.remindersEnabled,
-      }
+      const routeDefaultConfig = toReviewRhythmConfigFromRouteDefaults(routeDefaults)
 
       return [routeId, persistedConfigByRouteId[routeId] ?? routeDefaultConfig]
     }),

--- a/frontend/lib/action-center-review-rhythm-data.ts
+++ b/frontend/lib/action-center-review-rhythm-data.ts
@@ -3,6 +3,7 @@ import { deriveActionCenterRouteGovernanceSignals } from '@/lib/action-center-go
 import { buildActionCenterReviewOversightSummary } from '@/lib/action-center-review-oversight'
 import {
   getActionCenterEnabledRouteDefaults,
+  getActionCenterRouteFamilyLabel,
   type ActionCenterRouteDefaultsKnownScanType,
 } from '@/lib/action-center-route-defaults'
 import {
@@ -62,6 +63,14 @@ function sortOversightAttentionItems(items: GovernanceMergedAttentionItem[]) {
     .slice(0, 5)
 }
 
+function getCanonicalRouteFamilySourceLabel(args: {
+  routeId: string
+  routeScanTypeByRouteId: Record<string, ActionCenterRouteDefaultsKnownScanType>
+  fallbackLabel: string
+}) {
+  return getActionCenterRouteFamilyLabel(args.routeScanTypeByRouteId[args.routeId]) ?? args.fallbackLabel
+}
+
 function mergeGovernanceIntoOversight(args: {
   items: ActionCenterPreviewItem[]
   oversight: ReturnType<typeof buildActionCenterReviewOversightSummary>
@@ -83,12 +92,22 @@ function mergeGovernanceIntoOversight(args: {
 
   const mergedAttentionItems: GovernanceMergedAttentionItem[] = args.oversight.attentionItems.map((item) => {
     const governance = governanceByRouteId.get(item.routeId)
+    const sourceLabel = getCanonicalRouteFamilySourceLabel({
+      routeId: item.routeId,
+      routeScanTypeByRouteId: args.routeScanTypeByRouteId,
+      fallbackLabel: item.sourceLabel,
+    })
+
     if (!governance) {
-      return item
+      return {
+        ...item,
+        sourceLabel,
+      }
     }
 
     return {
       ...item,
+      sourceLabel,
       governanceSignals: governance.signals,
     }
   })
@@ -106,7 +125,11 @@ function mergeGovernanceIntoOversight(args: {
       routeId,
       state: 'stale',
       scopeLabel: governance.scopeLabel,
-      sourceLabel: governance.sourceLabel,
+      sourceLabel: getCanonicalRouteFamilySourceLabel({
+        routeId,
+        routeScanTypeByRouteId: args.routeScanTypeByRouteId,
+        fallbackLabel: governance.sourceLabel,
+      }),
       reviewDateLabel: governance.reviewDateLabel,
       governanceSignals: governance.signals,
     })
@@ -153,7 +176,17 @@ export async function getActionCenterReviewRhythmData(args: {
   const configByRouteId = Object.fromEntries(
     eligibleItems.map((item) => {
       const routeId = getReviewRhythmRouteId(item)
-      return [routeId, persistedConfigByRouteId[routeId] ?? buildDefaultActionCenterReviewRhythmConfig()]
+      const routeDefaults =
+        getActionCenterEnabledRouteDefaults(args.routeScanTypeByRouteId[routeId]) ??
+        buildDefaultActionCenterReviewRhythmConfig()
+      const routeDefaultConfig: ActionCenterReviewRhythmConfig = {
+        cadenceDays: routeDefaults.cadenceDays,
+        reminderLeadDays: routeDefaults.reminderLeadDays,
+        escalationLeadDays: routeDefaults.escalationLeadDays,
+        remindersEnabled: routeDefaults.remindersEnabled,
+      }
+
+      return [routeId, persistedConfigByRouteId[routeId] ?? routeDefaultConfig]
     }),
   )
 

--- a/frontend/lib/action-center-review-rhythm-data.ts
+++ b/frontend/lib/action-center-review-rhythm-data.ts
@@ -33,12 +33,12 @@ function getReviewRhythmRouteId(item: Pick<ActionCenterPreviewItem, 'coreSemanti
 function toReviewRhythmConfigFromRouteDefaults(
   routeDefaults: NonNullable<ReturnType<typeof getActionCenterEnabledRouteDefaults>>,
 ): ActionCenterReviewRhythmConfig {
-  return {
-    cadenceDays: routeDefaults.cadenceDays,
-    reminderLeadDays: routeDefaults.reminderLeadDays,
-    escalationLeadDays: routeDefaults.escalationLeadDays,
-    remindersEnabled: routeDefaults.remindersEnabled,
-  }
+  return normalizeActionCenterReviewRhythmConfig({
+    cadence_days: routeDefaults.cadenceDays,
+    reminder_lead_days: routeDefaults.reminderLeadDays,
+    escalation_lead_days: routeDefaults.escalationLeadDays,
+    reminders_enabled: routeDefaults.remindersEnabled,
+  })
 }
 
 function normalizeConfigRow(args: {
@@ -182,12 +182,15 @@ export async function getActionCenterReviewRhythmData(args: {
   const persistedConfigByRouteId = ((data ?? []) as ActionCenterReviewRhythmConfigRow[]).reduce<
     Record<string, ActionCenterReviewRhythmConfig>
   >((acc, row) => {
-    const routeDefaults =
-      getActionCenterEnabledRouteDefaults(args.routeScanTypeByRouteId[row.route_id ?? '']) ??
-      buildDefaultActionCenterReviewRhythmConfig()
+    const enabledRouteDefaults = getActionCenterEnabledRouteDefaults(
+      args.routeScanTypeByRouteId[row.route_id ?? ''],
+    )
+    const routeDefaultConfig = enabledRouteDefaults
+      ? toReviewRhythmConfigFromRouteDefaults(enabledRouteDefaults)
+      : buildDefaultActionCenterReviewRhythmConfig()
     const config = normalizeConfigRow({
       row,
-      routeDefaultConfig: toReviewRhythmConfigFromRouteDefaults(routeDefaults),
+      routeDefaultConfig,
     })
     if (row.route_id && config) {
       acc[row.route_id] = config
@@ -197,10 +200,12 @@ export async function getActionCenterReviewRhythmData(args: {
   const configByRouteId = Object.fromEntries(
     eligibleItems.map((item) => {
       const routeId = getReviewRhythmRouteId(item)
-      const routeDefaults =
-        getActionCenterEnabledRouteDefaults(args.routeScanTypeByRouteId[routeId]) ??
-        buildDefaultActionCenterReviewRhythmConfig()
-      const routeDefaultConfig = toReviewRhythmConfigFromRouteDefaults(routeDefaults)
+      const enabledRouteDefaults = getActionCenterEnabledRouteDefaults(
+        args.routeScanTypeByRouteId[routeId],
+      )
+      const routeDefaultConfig = enabledRouteDefaults
+        ? toReviewRhythmConfigFromRouteDefaults(enabledRouteDefaults)
+        : buildDefaultActionCenterReviewRhythmConfig()
 
       return [routeId, persistedConfigByRouteId[routeId] ?? routeDefaultConfig]
     }),

--- a/frontend/lib/action-center-route-action-editor.test.ts
+++ b/frontend/lib/action-center-route-action-editor.test.ts
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
 import {
   ActionCenterRouteActionEditor,
+  serializeActionCenterRouteActionEditorValue,
   shouldResetActionCenterRouteActionEditorAfterSave,
 } from '@/components/dashboard/action-center-route-action-editor'
 
@@ -28,33 +29,58 @@ describe('ActionCenterRouteActionEditor', () => {
     expect(shouldResetActionCenterRouteActionEditorAfterSave(false)).toBe(false)
   })
 
-  it('shows explicit compact correction feedback for invalid drafts', () => {
+  it('shows saved-not-live correction feedback and blocks unchanged invalid draft resubmission', () => {
+    const initialValue = {
+      themeKey: 'workload' as const,
+      actionText: 'Verbeter overal de cultuur.',
+      reviewScheduledFor: '2026-05-20',
+      expectedEffect: 'Iedereen voelt snel verschil.',
+    }
     const html = renderToStaticMarkup(
       React.createElement(ActionCenterRouteActionEditor, {
         onSave: vi.fn(),
+        initialValue,
         submissionState: {
           validationDisposition: 'invalid',
+          statusMessage: 'Draft opgeslagen, nog niet live in deze route.',
           validationMessage: 'Pas deze actie aan zodat hij bounded en route-specifiek is.',
+          persistedDraftFingerprint: serializeActionCenterRouteActionEditorValue(initialValue),
         },
       }),
     )
 
+    expect(html).toContain('Draft opgeslagen, nog niet live in deze route.')
     expect(html).toContain('Pas deze actie aan zodat hij bounded en route-specifiek is.')
-    expect(html).not.toContain('Draft opgeslagen.')
+    expect(html).toContain('Wijzig deze opgeslagen draft voordat je hem opnieuw indient.')
+    expect(html).toContain('disabled=""')
   })
 
-  it('shows explicit hr-review feedback inside the compact editor surface', () => {
+  it('keeps the submit path open once the draft content differs from the saved hr-review draft', () => {
+    const persistedDraftValue = {
+      themeKey: 'workload' as const,
+      actionText: 'Start een breed HR-project.',
+      reviewScheduledFor: '2026-05-20',
+      expectedEffect: 'De cultuur verbetert overal.',
+    }
     const html = renderToStaticMarkup(
       React.createElement(ActionCenterRouteActionEditor, {
         onSave: vi.fn(),
+        initialValue: {
+          ...persistedDraftValue,
+          actionText: 'Plan twee route-specifieke teamgesprekken over werkdruk.',
+        },
         submissionState: {
           validationDisposition: 'needs_hr_review',
+          statusMessage: 'Draft opgeslagen, nog niet live in deze route.',
           validationMessage: 'Deze actie vraagt eerst HR-beoordeling.',
+          persistedDraftFingerprint: serializeActionCenterRouteActionEditorValue(persistedDraftValue),
         },
       }),
     )
 
+    expect(html).toContain('Draft opgeslagen, nog niet live in deze route.')
     expect(html).toContain('Deze actie vraagt eerst HR-beoordeling.')
-    expect(html).not.toContain('Deze actie wacht eerst op HR-review en staat nog niet live in deze route.')
+    expect(html).not.toContain('Wijzig deze opgeslagen draft voordat je hem opnieuw indient.')
+    expect(html).not.toContain('disabled=""')
   })
 })

--- a/frontend/lib/action-center-route-action-editor.test.ts
+++ b/frontend/lib/action-center-route-action-editor.test.ts
@@ -27,4 +27,34 @@ describe('ActionCenterRouteActionEditor', () => {
     expect(shouldResetActionCenterRouteActionEditorAfterSave(true)).toBe(true)
     expect(shouldResetActionCenterRouteActionEditorAfterSave(false)).toBe(false)
   })
+
+  it('shows explicit compact correction feedback for invalid drafts', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(ActionCenterRouteActionEditor, {
+        onSave: vi.fn(),
+        submissionState: {
+          validationDisposition: 'invalid',
+          validationMessage: 'Pas deze actie aan zodat hij bounded en route-specifiek is.',
+        },
+      }),
+    )
+
+    expect(html).toContain('Pas deze actie aan zodat hij bounded en route-specifiek is.')
+    expect(html).not.toContain('Draft opgeslagen.')
+  })
+
+  it('shows explicit hr-review feedback inside the compact editor surface', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(ActionCenterRouteActionEditor, {
+        onSave: vi.fn(),
+        submissionState: {
+          validationDisposition: 'needs_hr_review',
+          validationMessage: 'Deze actie vraagt eerst HR-beoordeling.',
+        },
+      }),
+    )
+
+    expect(html).toContain('Deze actie vraagt eerst HR-beoordeling.')
+    expect(html).not.toContain('Deze actie wacht eerst op HR-review en staat nog niet live in deze route.')
+  })
 })

--- a/frontend/lib/action-center-route-action-preview.test.ts
+++ b/frontend/lib/action-center-route-action-preview.test.ts
@@ -1,149 +1,187 @@
 import React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
-import { ActionCenterPreview } from '@/components/dashboard/action-center-preview'
+import {
+  ActionCenterPreview,
+  resolveManagerResponsePrimaryActionPayload,
+} from '@/components/dashboard/action-center-preview'
 import { finalizeActionCenterPreviewItem } from '@/lib/action-center-live'
 import type { ActionCenterManagerResponse } from '@/lib/pilot-learning'
 
-describe('action center route action preview', () => {
-  it('keeps richer action routes semantically distinct even while the manager surface starts from one first step', () => {
-    const managerResponse: ActionCenterManagerResponse = {
-      id: 'response-1',
-      campaign_id: 'campaign-exit',
-      org_id: 'org-1',
-      route_scope_type: 'department',
-      route_scope_value: 'operations',
-      manager_user_id: 'manager-1',
-      response_type: 'schedule',
-      response_note: 'We starten met twee lokale interventies en houden de review per actie klein.',
-      review_scheduled_for: '2026-05-12',
-      primary_action_theme_key: 'leadership',
-      primary_action_text: 'Plan een eerste teamgesprek over feedbackritme.',
-      primary_action_expected_effect: 'Zichtbaar maken of feedbackritme lokaal het vertrekbeeld beïnvloedt.',
-      primary_action_status: 'active',
-      created_by: 'manager-1',
-      updated_by: 'manager-1',
-      created_at: '2026-04-24T09:00:00.000Z',
-      updated_at: '2026-04-24T09:00:00.000Z',
-    }
+function buildGovernedManagerResponse(
+  overrides: Partial<ActionCenterManagerResponse> = {},
+): ActionCenterManagerResponse {
+  return {
+    id: 'response-1',
+    campaign_id: 'campaign-exit',
+    org_id: 'org-1',
+    route_scope_type: 'department',
+    route_scope_value: 'operations',
+    manager_user_id: 'manager-1',
+    response_type: 'schedule',
+    response_note: 'We starten met twee lokale interventies en houden de review per actie klein.',
+    review_scheduled_for: '2026-05-12',
+    primary_action_theme_key: 'leadership',
+    primary_action_text: 'Plan een eerste teamgesprek over feedbackritme.',
+    primary_action_expected_effect:
+      'Zichtbaar maken of feedbackritme lokaal het vertrekbeeld beinvloedt.',
+    primary_action_status: 'active',
+    created_by: 'manager-1',
+    updated_by: 'manager-1',
+    created_at: '2026-04-24T09:00:00.000Z',
+    updated_at: '2026-04-24T09:00:00.000Z',
+    ...overrides,
+  }
+}
 
-    const item = finalizeActionCenterPreviewItem({
-      id: 'route-1',
-      code: 'ACT-1001',
-      title: 'Exit follow-through voorjaar',
-      summary: 'Deze route draagt twee lokale thema-acties met eigen reviewmoment.',
-      reason: 'Welke vertrekduiding vraagt nu als eerste managementeigenaarschap?',
-      sourceLabel: 'ExitScan',
-      orgId: 'org-1',
-      scopeType: 'department',
-      teamId: 'operations',
-      teamLabel: 'Operations',
-      ownerId: 'manager-1',
-      ownerName: 'Manager Operations',
-      ownerRole: 'Manager - Operations',
-      ownerSubtitle: 'Operations',
-      reviewOwnerName: 'HR lead',
-      priority: 'hoog',
-      status: 'reviewbaar',
-      reviewDate: '2026-05-12',
-      expectedEffect: 'Binnen twee weken moet het eerste teamgesprek zijn gevoerd.',
-      reviewReason: 'Toets of het eerste gesprek is gevoerd en of het knelpunt specifieker is geworden.',
-      reviewOutcome: 'bijstellen',
-      reviewDateLabel: '12 mei',
-      reviewRhythm: 'Maandelijks',
-      signalLabel: 'ExitScan - Exit voorjaar',
-      signalBody: 'MT kiest twee lokale interventies binnen dezelfde afdelingsroute.',
-      nextStep: 'Leg eigenaar en eerste correctie in het MT-overleg vast.',
-      peopleCount: 38,
-      managerResponse,
-      updates: [],
-      coreSemantics: {
-        route: {
-          campaignId: 'campaign-exit',
-          entryStage: 'active',
-          routeOpenedAt: '2026-04-20T09:00:00.000Z',
-          ownerAssignedAt: '2026-04-21T08:00:00.000Z',
-          routeStatus: 'reviewbaar',
-          reviewOutcome: 'bijstellen',
-          reviewCompletedAt: '2026-04-24T09:00:00.000Z',
-          outcomeRecordedAt: '2026-04-24T09:00:00.000Z',
-          outcomeSummary: 'Twee lokale sporen lopen nu naast elkaar.',
-          intervention: 'Leg eigenaar en eerste correctie in het MT-overleg vast.',
-          owner: 'Manager Operations',
-          expectedEffect: 'Binnen twee weken moet het eerste teamgesprek zijn gevoerd.',
-          reviewScheduledFor: '2026-05-12',
-          reviewReason: 'Toets of het eerste gesprek is gevoerd en of het knelpunt specifieker is geworden.',
-          blockedBy: null,
-        },
-        latestDecision: null,
-        actionProgress: {
-          currentStep: 'Plan een gerichte teamreview met de manager.',
-          nextStep: 'Plan een vervolggesprek met HR.',
-          expectedEffect: 'Zichtbaar maken of feedbackafspraken consistenter terugkomen.',
-        },
-        reviewSemantics: {
-          reviewReason: 'Welke vertrekduiding vraagt nu als eerste managementeigenaarschap?',
-          reviewQuestion: 'Welke interventie moet als eerste lokaal zichtbaar worden?',
-          reviewOutcomeRaw: 'bijstellen',
-          reviewOutcomeVisible: 'bijstellen',
-        },
-        actionFrame: {
-          whyNow: 'Welke vertrekduiding vraagt nu als eerste managementeigenaarschap?',
-          firstStep: 'Plan een gerichte teamreview met de manager.',
-          owner: 'Manager Operations',
-          expectedEffect: 'Zichtbaar maken of feedbackafspraken consistenter terugkomen.',
-        },
-        resultLoop: {
-          whatWasTried: 'Plan een gerichte teamreview met de manager.',
-          whatWeObserved: 'MT kiest twee lokale interventies binnen dezelfde afdelingsroute.',
-          whatWasDecided: null,
-        },
-        resultProgression: [],
-        decisionHistory: [],
-        lineageSummary: {
-          overviewLabel: null,
-          backwardLabel: null,
-          backwardRouteId: null,
-          forwardLabel: null,
-          forwardRouteId: null,
-          detailLabels: [],
-        },
-        routeActionCards: [
-          {
-            actionId: 'action-1',
-            themeKey: 'leadership',
-            actionText: 'Plan twee teamgesprekken over leiderschapsfeedback.',
-            reviewScheduledFor: '2026-05-15',
-            expectedEffect: 'Zichtbaar maken of leiderschapsfrictie de hoofdreden is.',
-            status: 'open',
-            latestReview: null,
-          },
-          {
-            actionId: 'action-2',
-            themeKey: 'growth',
-            actionText: 'Leg groeigesprekken vast in het volgende teamoverleg.',
-            reviewScheduledFor: '2026-05-20',
-            expectedEffect: 'Zichtbaar maken of gebrek aan ontwikkelperspectief terugkomt.',
-            status: 'in_review',
-            latestReview: {
-              reviewedAt: '2026-05-18T09:00:00.000Z',
-              observation: 'Het team noemt groei explicieter dan in de vorige ronde.',
-              actionOutcome: 'effect-zichtbaar',
-              followUpNote: 'Nog een week monitoren en dan afronden.',
-            },
-          },
-        ],
-        closingSemantics: {
-          status: 'lopend',
-          summary: null,
-          historicalSummary: null,
-        },
+function buildGovernedRouteItem(managerResponse = buildGovernedManagerResponse()) {
+  return finalizeActionCenterPreviewItem({
+    id: 'route-1',
+    code: 'ACT-1001',
+    title: 'Exit follow-through voorjaar',
+    summary: 'Deze route draagt twee lokale thema-acties met eigen reviewmoment.',
+    reason: 'Welke vertrekduiding vraagt nu als eerste managementeigenaarschap?',
+    sourceLabel: 'ExitScan',
+    orgId: 'org-1',
+    scopeType: 'department',
+    teamId: 'operations',
+    teamLabel: 'Operations',
+    ownerId: 'manager-1',
+    ownerName: 'Manager Operations',
+    ownerRole: 'Manager - Operations',
+    ownerSubtitle: 'Operations',
+    reviewOwnerName: 'HR lead',
+    priority: 'hoog',
+    status: 'reviewbaar',
+    reviewDate: '2026-05-12',
+    expectedEffect: 'Binnen twee weken moet het eerste teamgesprek zijn gevoerd.',
+    reviewReason: 'Toets of het eerste gesprek is gevoerd en of het knelpunt specifieker is geworden.',
+    reviewOutcome: 'bijstellen',
+    reviewDateLabel: '12 mei',
+    reviewRhythm: 'Maandelijks',
+    signalLabel: 'ExitScan - Exit voorjaar',
+    signalBody: 'MT kiest twee lokale interventies binnen dezelfde afdelingsroute.',
+    nextStep: 'Leg eigenaar en eerste correctie in het MT-overleg vast.',
+    peopleCount: 38,
+    managerResponse,
+    updates: [],
+    coreSemantics: {
+      route: {
+        campaignId: 'campaign-exit',
+        entryStage: 'active',
+        routeOpenedAt: '2026-04-20T09:00:00.000Z',
+        ownerAssignedAt: '2026-04-21T08:00:00.000Z',
+        routeStatus: 'reviewbaar',
+        reviewOutcome: 'bijstellen',
+        reviewCompletedAt: '2026-04-24T09:00:00.000Z',
+        outcomeRecordedAt: '2026-04-24T09:00:00.000Z',
+        outcomeSummary: 'Twee lokale sporen lopen nu naast elkaar.',
+        intervention: 'Leg eigenaar en eerste correctie in het MT-overleg vast.',
+        owner: 'Manager Operations',
+        expectedEffect: 'Binnen twee weken moet het eerste teamgesprek zijn gevoerd.',
+        reviewScheduledFor: '2026-05-12',
+        reviewReason:
+          'Toets of het eerste gesprek is gevoerd en of het knelpunt specifieker is geworden.',
+        blockedBy: null,
       },
-    })
+      latestDecision: null,
+      actionProgress: {
+        currentStep: 'Plan een gerichte teamreview met de manager.',
+        nextStep: 'Plan een vervolggesprek met HR.',
+        expectedEffect: 'Zichtbaar maken of feedbackafspraken consistenter terugkomen.',
+      },
+      reviewSemantics: {
+        reviewReason: 'Welke vertrekduiding vraagt nu als eerste managementeigenaarschap?',
+        reviewQuestion: 'Welke interventie moet als eerste lokaal zichtbaar worden?',
+        reviewOutcomeRaw: 'bijstellen',
+        reviewOutcomeVisible: 'bijstellen',
+      },
+      actionFrame: {
+        whyNow: 'Welke vertrekduiding vraagt nu als eerste managementeigenaarschap?',
+        firstStep: 'Plan een gerichte teamreview met de manager.',
+        owner: 'Manager Operations',
+        expectedEffect: 'Zichtbaar maken of feedbackafspraken consistenter terugkomen.',
+      },
+      resultLoop: {
+        whatWasTried: 'Plan een gerichte teamreview met de manager.',
+        whatWeObserved: 'MT kiest twee lokale interventies binnen dezelfde afdelingsroute.',
+        whatWasDecided: null,
+      },
+      resultProgression: [],
+      decisionHistory: [],
+      lineageSummary: {
+        overviewLabel: null,
+        backwardLabel: null,
+        backwardRouteId: null,
+        forwardLabel: null,
+        forwardRouteId: null,
+        detailLabels: [],
+      },
+      routeActionCards: [
+        {
+          actionId: 'action-1',
+          themeKey: 'leadership',
+          actionText: 'Plan twee teamgesprekken over leiderschapsfeedback.',
+          reviewScheduledFor: '2026-05-15',
+          expectedEffect: 'Zichtbaar maken of leiderschapsfrictie de hoofdreden is.',
+          status: 'open',
+          latestReview: null,
+        },
+        {
+          actionId: 'action-2',
+          themeKey: 'growth',
+          actionText: 'Leg groeigesprekken vast in het volgende teamoverleg.',
+          reviewScheduledFor: '2026-05-20',
+          expectedEffect: 'Zichtbaar maken of gebrek aan ontwikkelperspectief terugkomt.',
+          status: 'in_review',
+          latestReview: {
+            reviewedAt: '2026-05-18T09:00:00.000Z',
+            observation: 'Het team noemt groei explicieter dan in de vorige ronde.',
+            actionOutcome: 'effect-zichtbaar',
+            followUpNote: 'Nog een week monitoren en dan afronden.',
+          },
+        },
+      ],
+      routeCloseout: {
+        closeoutStatus: null,
+        closeoutReason: null,
+        closeoutNote: null,
+        closedAt: null,
+        closedByRole: null,
+        readyForCloseout: false,
+      },
+      closingSemantics: {
+        status: 'lopend',
+        summary: null,
+        historicalSummary: null,
+      },
+    },
+  })
+}
 
+describe('action center route action preview', () => {
+  it('clears hidden inline primary-action truth once route-action mode governs the route', () => {
+    expect(
+      resolveManagerResponsePrimaryActionPayload({
+        routeActionCardCount: 2,
+        includePrimaryAction: true,
+        primaryActionThemeKey: 'leadership',
+        primaryActionText: 'Plan een eerste teamgesprek over feedbackritme.',
+        primaryActionExpectedEffect:
+          'Zichtbaar maken of feedbackritme lokaal het vertrekbeeld beinvloedt.',
+      }),
+    ).toEqual({
+      primary_action_theme_key: null,
+      primary_action_text: null,
+      primary_action_expected_effect: null,
+      primary_action_status: null,
+    })
+  })
+
+  it('keeps richer action routes semantically distinct without reopening inline primary-action editing', () => {
     const html = renderToStaticMarkup(
       React.createElement(ActionCenterPreview, {
-        initialItems: [item],
+        initialItems: [buildGovernedRouteItem()],
         initialView: 'actions',
         fallbackOwnerName: 'Loep gebruiker',
         ownerOptions: ['Manager Operations'],
@@ -158,11 +196,36 @@ describe('action center route action preview', () => {
 
     expect(html).toContain('Actieroute is gestart')
     expect(html).toContain('Deze route draagt nu 2 expliciete actiekaarten.')
-    expect(html).toContain('Thema van deze eerste concrete stap')
-    expect(html).toContain('Gebruik dit alleen zolang één eerste concrete stap genoeg is.')
+    expect(html).toContain('Concrete acties voeg je hieronder toe in deze route.')
     expect(html).toContain('Plan een eerste teamgesprek over feedbackritme.')
-    expect(html).toContain('Zichtbaar maken of feedbackritme lokaal het vertrekbeeld beïnvloedt.')
     expect(html).toContain('Managerstap bijwerken')
+    expect(html).not.toContain('Thema van deze eerste concrete stap')
+    expect(html).not.toContain('Wat is die eerste concrete stap?')
+    expect(html).not.toContain('Wat moet deze stap zichtbaar maken?')
+  })
+
+  it('does not reopen inline primary-action editing when action cards exist but the route-action endpoint is unavailable', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(ActionCenterPreview, {
+        initialItems: [buildGovernedRouteItem(buildGovernedManagerResponse({
+          primary_action_text: 'Historische eerste stap die niet meer de leidende waarheid is.',
+          primary_action_expected_effect: 'Historisch zichtbaar effect.',
+        }))],
+        initialView: 'actions',
+        fallbackOwnerName: 'Loep gebruiker',
+        ownerOptions: ['Manager Operations'],
+        canRespondToRequests: true,
+        managerResponseEndpoint: '/api/action-center-manager-responses',
+        currentUserId: 'manager-1',
+        workbenchHref: '/action-center',
+      }),
+    )
+
+    expect(html).toContain('Acties in deze route')
+    expect(html).toContain('Concrete acties voeg je hieronder toe in deze route.')
+    expect(html).not.toContain('Thema van deze eerste concrete stap')
+    expect(html).not.toContain('Wat is die eerste concrete stap?')
+    expect(html).not.toContain('Wat moet deze stap zichtbaar maken?')
   })
 
   it('keeps the first manager move visibly small before a route grows into explicit actions', () => {
@@ -214,7 +277,7 @@ describe('action center route action preview', () => {
     expect(html).toContain('Hoe pak je deze route als eerste op?')
     expect(html).toContain('Wat leg je nu klein en reviewbaar vast?')
     expect(html).toContain('Wanneer toetsen we deze eerste stap?')
-    expect(html).toContain('Leg alleen als dit meteen helpt één eerste concrete stap vast.')
+    expect(html).toContain('Leg alleen als dit meteen helpt')
     expect(html).toContain('Eerste managerstap opslaan')
   })
 })

--- a/frontend/lib/action-center-route-actions.test.ts
+++ b/frontend/lib/action-center-route-actions.test.ts
@@ -260,6 +260,25 @@ describe('action center route actions', () => {
     })
   })
 
+  it('keeps broad project language in needs-hr-review when fields are present but the expected effect stays weak', async () => {
+    const { validateActionCenterRouteActionDraftInput } = await import('./action-center-route-actions') as {
+      validateActionCenterRouteActionDraftInput: (input: Record<string, unknown>) => Record<string, unknown>
+    }
+
+    expect(
+      validateActionCenterRouteActionDraftInput(
+        buildDraftInput({
+          primary_action_theme_key: 'workload',
+          primary_action_text: 'Start een breed HR-project om werkdruk overal op te lossen.',
+          primary_action_expected_effect: 'We kijken later verder.',
+        }),
+      ),
+    ).toMatchObject({
+      semanticState: 'draft',
+      validationDisposition: 'needs_hr_review',
+    })
+  })
+
   it('rejects employee-dossier-like action text', async () => {
     const { validateActionCenterRouteActionDraftInput } = await import('./action-center-route-actions') as {
       validateActionCenterRouteActionDraftInput: (input: Record<string, unknown>) => Record<string, unknown>
@@ -296,6 +315,22 @@ describe('action center route actions', () => {
       actionText: 'Monitor employee X in detail for risk.',
       expectedEffect: 'Track individual risk more closely.',
     })
+  })
+
+  it('does not project persisted open dossier-like actions as active truth', async () => {
+    const { projectActionCenterRouteActionCard } = await import('./action-center-route-actions') as {
+      projectActionCenterRouteActionCard: (input: Record<string, unknown>) => Record<string, unknown>
+    }
+
+    expect(() =>
+      projectActionCenterRouteActionCard(
+        buildCanonicalOpenActionInput({
+          primary_action_text: 'Monitor employee X in detail for risk.',
+          primary_action_expected_effect: 'Track individual risk more closely.',
+          primary_action_status: 'open',
+        }),
+      ),
+    ).toThrow('Route action is outside bounded execution.')
   })
 
   it('models the hr-only promotion path from draft to active route action truth', async () => {

--- a/frontend/lib/action-center-route-actions.test.ts
+++ b/frontend/lib/action-center-route-actions.test.ts
@@ -241,7 +241,7 @@ describe('action center route actions', () => {
     })
   })
 
-  it('retains broad project language as a draft that needs hr review', async () => {
+  it('marks broad project language for hr review', async () => {
     const { validateActionCenterRouteActionDraftInput } = await import('./action-center-route-actions') as {
       validateActionCenterRouteActionDraftInput: (input: Record<string, unknown>) => Record<string, unknown>
     }
@@ -249,9 +249,9 @@ describe('action center route actions', () => {
     expect(
       validateActionCenterRouteActionDraftInput(
         buildDraftInput({
-          primary_action_text: 'Start een organisatiebreed verbeterproject en werk de roadmap voor meerdere teams uit.',
-          primary_action_expected_effect:
-            'Binnen twee weken moet duidelijk zijn welke workstreams in dit programma moeten landen.',
+          primary_action_theme_key: 'workload',
+          primary_action_text: 'Start een breed HR-project om werkdruk overal op te lossen.',
+          primary_action_expected_effect: 'De cultuur moet verbeteren.',
         }),
       ),
     ).toMatchObject({
@@ -260,23 +260,20 @@ describe('action center route actions', () => {
     })
   })
 
-  it('retains dossier-like route language as an invalid draft instead of throwing', async () => {
+  it('rejects employee-dossier-like action text', async () => {
     const { validateActionCenterRouteActionDraftInput } = await import('./action-center-route-actions') as {
       validateActionCenterRouteActionDraftInput: (input: Record<string, unknown>) => Record<string, unknown>
     }
 
-    expect(
+    expect(() =>
       validateActionCenterRouteActionDraftInput(
         buildDraftInput({
-          primary_action_text: 'Leg het dossier aan en vul de vervolgroute en stopreden voor deze casus bij.',
-          primary_action_expected_effect:
-            'Binnen twee weken moet duidelijk zijn of het dossier compleet genoeg is voor verdere routing.',
+          primary_action_theme_key: 'workload',
+          primary_action_text: 'Monitor employee X in detail for risk.',
+          primary_action_expected_effect: 'Track individual risk more closely.',
         }),
       ),
-    ).toMatchObject({
-      semanticState: 'draft',
-      validationDisposition: 'invalid',
-    })
+    ).toThrow('Route action is outside bounded execution.')
   })
 
   it('models the hr-only promotion path from draft to active route action truth', async () => {

--- a/frontend/lib/action-center-route-actions.test.ts
+++ b/frontend/lib/action-center-route-actions.test.ts
@@ -276,6 +276,28 @@ describe('action center route actions', () => {
     ).toThrow('Route action is outside bounded execution.')
   })
 
+  it('projects persisted dossier-like drafts as invalid draft truth instead of failing projection', async () => {
+    const { projectActionCenterRouteActionCard } = await import('./action-center-route-actions') as {
+      projectActionCenterRouteActionCard: (input: Record<string, unknown>) => Record<string, unknown>
+    }
+
+    expect(
+      projectActionCenterRouteActionCard(
+        buildCanonicalOpenActionInput({
+          primary_action_text: 'Monitor employee X in detail for risk.',
+          primary_action_expected_effect: 'Track individual risk more closely.',
+          primary_action_status: null,
+        }),
+      ),
+    ).toMatchObject({
+      status: null,
+      semanticState: 'draft',
+      validationDisposition: 'invalid',
+      actionText: 'Monitor employee X in detail for risk.',
+      expectedEffect: 'Track individual risk more closely.',
+    })
+  })
+
   it('models the hr-only promotion path from draft to active route action truth', async () => {
     const { isActionCenterCanonicalRouteStateTransitionAllowed } = await import('./action-center-constitution') as {
       isActionCenterCanonicalRouteStateTransitionAllowed: (input: Record<string, unknown>) => boolean

--- a/frontend/lib/action-center-route-actions.ts
+++ b/frontend/lib/action-center-route-actions.ts
@@ -72,6 +72,7 @@ const THEME_LABELS = new Map(
 )
 const ACTION_CENTER_DRAFT_HR_REVIEW_PATTERNS = [
   /\bproject\b/,
+  /\bhr-project\b/,
   /\broadmap\b/,
   /\bprogramma\b/,
   /\bprogrammalijn\b/,
@@ -87,6 +88,16 @@ const ACTION_CENTER_DRAFT_OUTSIDE_BOUNDED_PATTERNS = [
   /\bmanagement_action_outcome\b/,
   /\badoption_outcome\b/,
   /\bcase_public_summary\b/,
+] as const
+const ACTION_CENTER_DRAFT_EMPLOYEE_PATTERNS = [/\bemployee\b/, /\bindividual\b/, /\bmedewerker\b/, /\bwerknemer\b/] as const
+const ACTION_CENTER_DRAFT_SURVEILLANCE_PATTERNS = [
+  /\bmonitor\b/,
+  /\bdetail\b/,
+  /\bdetails\b/,
+  /\brisk\b/,
+  /\brisico\b/,
+  /\btrack\b/,
+  /\bclosely\b/,
 ] as const
 
 function normalizeText(value: string | null | undefined) {
@@ -160,55 +171,73 @@ function matchesAnyPattern(value: string, patterns: readonly RegExp[]) {
   return patterns.some((pattern) => pattern.test(value))
 }
 
-function resolveActionCenterRouteActionDraftValidationDisposition(args: {
-  themeKey: ActionCenterManagerActionThemeKey | null
-  actionText: string | null
-  expectedEffect: string | null
-  reviewScheduledFor: string | null
-}):
-  | {
-      disposition: ActionCenterActionDraftDisposition
-      detail: null
-    }
-  | {
-      disposition: ActionCenterActionDraftDisposition
-      detail: string
-    } {
-  const isStructurallyBounded =
-    Boolean(args.themeKey) &&
-    Boolean(args.reviewScheduledFor && isIsoDate(args.reviewScheduledFor)) &&
-    Boolean(args.actionText) &&
-    Boolean(args.expectedEffect) &&
-    looksLikeActionCenterStep(args.actionText) &&
-    looksLikeActionCenterExpectedEffect(args.expectedEffect)
-
-  if (!isStructurallyBounded) {
-    return {
-      disposition: 'invalid',
-      detail: 'Route action draft needs a concrete bounded step and expected effect.',
-    }
-  }
-
-  const semanticSurface = `${args.actionText} ${args.expectedEffect}`.toLocaleLowerCase('nl-NL')
-
-  if (matchesAnyPattern(semanticSurface, ACTION_CENTER_DRAFT_OUTSIDE_BOUNDED_PATTERNS)) {
-    return {
-      disposition: 'invalid',
-      detail: 'Route action is outside bounded execution.',
-    }
-  }
-
-  if (matchesAnyPattern(semanticSurface, ACTION_CENTER_DRAFT_HR_REVIEW_PATTERNS)) {
-    return {
-      disposition: 'needs_hr_review',
-      detail: 'Route action requires HR review.',
-    }
-  }
+function validateRequiredActionDraftFields(
+  input: Partial<ActionCenterRouteActionDraftInput> | null | undefined,
+): ActionCenterRouteActionDraftInput {
+  const rawThemeKey = normalizeText(input?.primary_action_theme_key)
+  const themeKey =
+    rawThemeKey && THEME_LABELS.has(rawThemeKey as ActionCenterManagerActionThemeKey)
+      ? (rawThemeKey as ActionCenterManagerActionThemeKey)
+      : null
+  const actionText = normalizeText(input?.primary_action_text)
+  const expectedEffect = normalizeText(input?.primary_action_expected_effect)
+  const rawReviewScheduledFor = normalizeText(input?.review_scheduled_for)
+  const reviewScheduledFor =
+    rawReviewScheduledFor && isIsoDate(rawReviewScheduledFor) ? rawReviewScheduledFor : null
 
   return {
-    disposition: 'valid',
-    detail: null,
+    primary_action_theme_key: themeKey,
+    primary_action_text: actionText,
+    primary_action_expected_effect: expectedEffect,
+    primary_action_status: null,
+    review_scheduled_for: reviewScheduledFor,
   }
+}
+
+function hasBoundedDraftStructure(input: ActionCenterRouteActionDraftInput) {
+  return (
+    Boolean(input.primary_action_theme_key) &&
+    Boolean(input.review_scheduled_for && isIsoDate(input.review_scheduled_for)) &&
+    Boolean(input.primary_action_text) &&
+    Boolean(input.primary_action_expected_effect) &&
+    looksLikeActionCenterStep(input.primary_action_text) &&
+    looksLikeActionCenterExpectedEffect(input.primary_action_expected_effect)
+  )
+}
+
+function buildDraftSemanticSurface(input: Pick<
+  ActionCenterRouteActionDraftInput,
+  'primary_action_text' | 'primary_action_expected_effect'
+>) {
+  return `${input.primary_action_text ?? ''} ${input.primary_action_expected_effect ?? ''}`.toLocaleLowerCase('nl-NL')
+}
+
+function looksLikeEmployeeDossierLanguage(
+  actionText: string | null,
+  expectedEffect: string | null,
+) {
+  const semanticSurface = buildDraftSemanticSurface({
+    primary_action_text: actionText,
+    primary_action_expected_effect: expectedEffect,
+  })
+
+  return (
+    matchesAnyPattern(semanticSurface, ACTION_CENTER_DRAFT_OUTSIDE_BOUNDED_PATTERNS) ||
+    (matchesAnyPattern(semanticSurface, ACTION_CENTER_DRAFT_EMPLOYEE_PATTERNS) &&
+      matchesAnyPattern(semanticSurface, ACTION_CENTER_DRAFT_SURVEILLANCE_PATTERNS))
+  )
+}
+
+function looksLikeBroadProjectLanguage(
+  actionText: string | null,
+  expectedEffect: string | null,
+) {
+  const semanticSurface = buildDraftSemanticSurface({
+    primary_action_text: actionText,
+    primary_action_expected_effect: expectedEffect,
+  })
+
+  return matchesAnyPattern(semanticSurface, ACTION_CENTER_DRAFT_HR_REVIEW_PATTERNS)
 }
 
 function validatePersistedActionCenterRouteActionInput(
@@ -308,32 +337,32 @@ export function validateActionCenterRouteActionWriteInput(
 export function validateActionCenterRouteActionDraftInput(
   input: Partial<ActionCenterRouteActionDraftInput> | null | undefined,
 ): ValidatedActionCenterRouteActionDraft {
-  const rawThemeKey = normalizeText(input?.primary_action_theme_key)
-  const themeKey =
-    rawThemeKey && THEME_LABELS.has(rawThemeKey as ActionCenterManagerActionThemeKey)
-      ? (rawThemeKey as ActionCenterManagerActionThemeKey)
-      : null
-  const actionText = normalizeText(input?.primary_action_text)
-  const expectedEffect = normalizeText(input?.primary_action_expected_effect)
-  const rawReviewScheduledFor = normalizeText(input?.review_scheduled_for)
-  const reviewScheduledFor =
-    rawReviewScheduledFor && isIsoDate(rawReviewScheduledFor) ? rawReviewScheduledFor : null
+  const validated = validateRequiredActionDraftFields(input)
 
-  const draftValidation = resolveActionCenterRouteActionDraftValidationDisposition({
-    themeKey,
-    actionText,
-    expectedEffect,
-    reviewScheduledFor,
-  })
+  if (looksLikeEmployeeDossierLanguage(validated.primary_action_text, validated.primary_action_expected_effect)) {
+    throw new Error('Route action is outside bounded execution.')
+  }
+
+  if (!hasBoundedDraftStructure(validated)) {
+    return {
+      ...validated,
+      semanticState: 'draft',
+      validationDisposition: 'invalid',
+    }
+  }
+
+  if (looksLikeBroadProjectLanguage(validated.primary_action_text, validated.primary_action_expected_effect)) {
+    return {
+      ...validated,
+      semanticState: 'draft',
+      validationDisposition: 'needs_hr_review',
+    }
+  }
 
   return {
-    primary_action_theme_key: themeKey,
-    primary_action_text: actionText,
-    primary_action_expected_effect: expectedEffect,
-    primary_action_status: null,
-    review_scheduled_for: reviewScheduledFor,
+    ...validated,
     semanticState: 'draft',
-    validationDisposition: draftValidation.disposition,
+    validationDisposition: 'valid',
   }
 }
 

--- a/frontend/lib/action-center-route-actions.ts
+++ b/frontend/lib/action-center-route-actions.ts
@@ -205,6 +205,15 @@ function hasBoundedDraftStructure(input: ActionCenterRouteActionDraftInput) {
   )
 }
 
+function hasPresentDraftFields(input: ActionCenterRouteActionDraftInput) {
+  return (
+    Boolean(input.primary_action_theme_key) &&
+    Boolean(input.review_scheduled_for && isIsoDate(input.review_scheduled_for)) &&
+    Boolean(input.primary_action_text) &&
+    Boolean(input.primary_action_expected_effect)
+  )
+}
+
 function buildDraftSemanticSurface(input: Pick<
   ActionCenterRouteActionDraftInput,
   'primary_action_text' | 'primary_action_expected_effect'
@@ -256,19 +265,22 @@ function classifyActionCenterRouteActionDraft(
     }
   }
 
+  if (
+    looksLikeBroadProjectLanguage(validated.primary_action_text, validated.primary_action_expected_effect) &&
+    hasPresentDraftFields(validated)
+  ) {
+    return {
+      ...validated,
+      semanticState: 'draft',
+      validationDisposition: 'needs_hr_review',
+    }
+  }
+
   if (!hasBoundedDraftStructure(validated)) {
     return {
       ...validated,
       semanticState: 'draft',
       validationDisposition: 'invalid',
-    }
-  }
-
-  if (looksLikeBroadProjectLanguage(validated.primary_action_text, validated.primary_action_expected_effect)) {
-    return {
-      ...validated,
-      semanticState: 'draft',
-      validationDisposition: 'needs_hr_review',
     }
   }
 
@@ -354,7 +366,16 @@ export function validateActionCenterRouteActionWriteInput(
     !validated.primary_action_text ||
     !validated.primary_action_expected_effect ||
     !validated.primary_action_status ||
-    !validated.review_scheduled_for ||
+    !validated.review_scheduled_for
+  ) {
+    throw new Error('Ongeldige route action input.')
+  }
+
+  if (looksLikeEmployeeDossierLanguage(validated.primary_action_text, validated.primary_action_expected_effect)) {
+    throw new Error('Route action is outside bounded execution.')
+  }
+
+  if (
     !looksLikeActionCenterStep(validated.primary_action_text) ||
     !looksLikeActionCenterExpectedEffect(validated.primary_action_expected_effect)
   ) {

--- a/frontend/lib/action-center-route-actions.ts
+++ b/frontend/lib/action-center-route-actions.ts
@@ -240,6 +240,45 @@ function looksLikeBroadProjectLanguage(
   return matchesAnyPattern(semanticSurface, ACTION_CENTER_DRAFT_HR_REVIEW_PATTERNS)
 }
 
+function classifyActionCenterRouteActionDraft(
+  validated: ActionCenterRouteActionDraftInput,
+  options?: { rejectOutsideBoundedExecution?: boolean },
+): ValidatedActionCenterRouteActionDraft {
+  if (looksLikeEmployeeDossierLanguage(validated.primary_action_text, validated.primary_action_expected_effect)) {
+    if (options?.rejectOutsideBoundedExecution) {
+      throw new Error('Route action is outside bounded execution.')
+    }
+
+    return {
+      ...validated,
+      semanticState: 'draft',
+      validationDisposition: 'invalid',
+    }
+  }
+
+  if (!hasBoundedDraftStructure(validated)) {
+    return {
+      ...validated,
+      semanticState: 'draft',
+      validationDisposition: 'invalid',
+    }
+  }
+
+  if (looksLikeBroadProjectLanguage(validated.primary_action_text, validated.primary_action_expected_effect)) {
+    return {
+      ...validated,
+      semanticState: 'draft',
+      validationDisposition: 'needs_hr_review',
+    }
+  }
+
+  return {
+    ...validated,
+    semanticState: 'draft',
+    validationDisposition: 'valid',
+  }
+}
+
 function validatePersistedActionCenterRouteActionInput(
   input: Partial<ActionCenterRouteActionWriteInput> | null | undefined,
 ): ActionCenterRouteActionWriteInput {
@@ -339,31 +378,9 @@ export function validateActionCenterRouteActionDraftInput(
 ): ValidatedActionCenterRouteActionDraft {
   const validated = validateRequiredActionDraftFields(input)
 
-  if (looksLikeEmployeeDossierLanguage(validated.primary_action_text, validated.primary_action_expected_effect)) {
-    throw new Error('Route action is outside bounded execution.')
-  }
-
-  if (!hasBoundedDraftStructure(validated)) {
-    return {
-      ...validated,
-      semanticState: 'draft',
-      validationDisposition: 'invalid',
-    }
-  }
-
-  if (looksLikeBroadProjectLanguage(validated.primary_action_text, validated.primary_action_expected_effect)) {
-    return {
-      ...validated,
-      semanticState: 'draft',
-      validationDisposition: 'needs_hr_review',
-    }
-  }
-
-  return {
-    ...validated,
-    semanticState: 'draft',
-    validationDisposition: 'valid',
-  }
+  return classifyActionCenterRouteActionDraft(validated, {
+    rejectOutsideBoundedExecution: true,
+  })
 }
 
 export function projectActionCenterRouteActionCard(
@@ -389,24 +406,29 @@ export function projectActionCenterRouteActionCard(
     }
   }
 
-  const draft = validateActionCenterRouteActionDraftInput({
-    primary_action_theme_key: persisted.primary_action_theme_key,
-    primary_action_text: persisted.primary_action_text,
-    primary_action_expected_effect: persisted.primary_action_expected_effect,
-    primary_action_status: persisted.primary_action_status,
-    review_scheduled_for: persisted.review_scheduled_for,
-  })
+  const toleratedDraft = classifyActionCenterRouteActionDraft(
+    validateRequiredActionDraftFields({
+      primary_action_theme_key: persisted.primary_action_theme_key,
+      primary_action_text: persisted.primary_action_text,
+      primary_action_expected_effect: persisted.primary_action_expected_effect,
+      primary_action_status: persisted.primary_action_status,
+      review_scheduled_for: persisted.review_scheduled_for,
+    }),
+    {
+      rejectOutsideBoundedExecution: false,
+    },
+  )
 
   return {
     actionId: persisted.id,
     routeId: persisted.route_id,
-    themeKey: draft.primary_action_theme_key,
-    actionText: draft.primary_action_text,
-    expectedEffect: draft.primary_action_expected_effect,
-    reviewScheduledFor: draft.review_scheduled_for,
+    themeKey: toleratedDraft.primary_action_theme_key,
+    actionText: toleratedDraft.primary_action_text,
+    expectedEffect: toleratedDraft.primary_action_expected_effect,
+    reviewScheduledFor: toleratedDraft.review_scheduled_for,
     status: null,
-    semanticState: draft.semanticState,
-    validationDisposition: draft.validationDisposition,
+    semanticState: toleratedDraft.semanticState,
+    validationDisposition: toleratedDraft.validationDisposition,
     createdAt: persisted.created_at,
     updatedAt: persisted.updated_at,
   }

--- a/frontend/lib/action-center-route-defaults.test.ts
+++ b/frontend/lib/action-center-route-defaults.test.ts
@@ -58,6 +58,16 @@ describe('action center route defaults contract', () => {
     })
   })
 
+  it('keeps ExitScan review window at 60-90 days and RetentieScan review window at 45-90 days', () => {
+    expect(getActionCenterRouteDefaults('exit')).toMatchObject({
+      reviewWindowDays: { min: 60, max: 90 },
+    })
+
+    expect(getActionCenterRouteDefaults('retention')).toMatchObject({
+      reviewWindowDays: { min: 45, max: 90 },
+    })
+  })
+
   it('exposes stricter execution thresholds per approved route family', () => {
     expect(getActionCenterRouteDefaults('exit')).toMatchObject({
       actionCenterStatus: 'enabled',
@@ -77,6 +87,22 @@ describe('action center route defaults contract', () => {
       reviewDueGraceDays: 7,
       sprawlRiskCount: 3,
       repeatedReviewWarningCount: 2,
+    })
+  })
+
+  it('returns isolated RetentieScan threshold objects so callers cannot mutate bounded defaults', () => {
+    const firstRetentionDefaults = getActionCenterRouteDefaults('retention')
+    expect(firstRetentionDefaults).not.toBeNull()
+    expect(firstRetentionDefaults?.stuckActiveWarningDays).toEqual({ min: 21, max: 30 })
+
+    if (!firstRetentionDefaults || typeof firstRetentionDefaults.stuckActiveWarningDays === 'number') {
+      throw new Error('Expected RetentieScan to expose a bounded stuck-action threshold range.')
+    }
+
+    firstRetentionDefaults.stuckActiveWarningDays.min = 999
+
+    expect(getActionCenterRouteDefaults('retention')).toMatchObject({
+      stuckActiveWarningDays: { min: 21, max: 30 },
     })
   })
 

--- a/frontend/lib/action-center-route-defaults.ts
+++ b/frontend/lib/action-center-route-defaults.ts
@@ -15,11 +15,17 @@ export const ACTION_CENTER_ROUTE_DEFAULTS_SCAN_TYPES = [
 ] as const
 
 export const ACTION_CENTER_ROUTE_DEFAULTS_ENABLED_SCAN_TYPES = ACTION_CENTER_APPROVED_ROUTE_FAMILIES
+export const ACTION_CENTER_ROUTE_FAMILY_LABELS = {
+  exit: 'ExitScan',
+  retention: 'RetentieScan',
+} as const
 
 export type ActionCenterRouteDefaultsKnownScanType =
   (typeof ACTION_CENTER_ROUTE_DEFAULTS_SCAN_TYPES)[number]
 
 export type ActionCenterRouteDefaultsEnabledScanType = ActionCenterApprovedRouteFamily
+export type ActionCenterRouteFamilyLabel =
+  (typeof ACTION_CENTER_ROUTE_FAMILY_LABELS)[ActionCenterApprovedRouteFamily]
 
 export interface ActionCenterRouteDefaults {
   scanType: ActionCenterRouteDefaultsKnownScanType
@@ -54,22 +60,31 @@ const BASELINE_ROUTE_DEFAULTS = {
   escalationLeadDays: 7 as const,
 }
 
-const ACTION_CENTER_EXECUTION_THRESHOLDS: Record<
-  ActionCenterApprovedRouteFamily,
-  ActionCenterExecutionThresholds
-> = {
+const ACTION_CENTER_EXECUTION_THRESHOLDS = {
   exit: {
     stuckActiveWarningDays: 30,
     reviewDueGraceDays: 7,
     sprawlRiskCount: 3,
     repeatedReviewWarningCount: 2,
   },
-  retention: {
-    stuckActiveWarningDays: { min: 21, max: 30 },
+  retention: Object.freeze({
+    stuckActiveWarningDays: Object.freeze({ min: 21, max: 30 }),
     reviewDueGraceDays: 7,
     sprawlRiskCount: 3,
     repeatedReviewWarningCount: 2,
-  },
+  }),
+} satisfies Record<ActionCenterApprovedRouteFamily, ActionCenterExecutionThresholds>
+
+function cloneActionCenterExecutionThresholds(
+  thresholds: ActionCenterExecutionThresholds,
+): ActionCenterExecutionThresholds {
+  return {
+    ...thresholds,
+    stuckActiveWarningDays:
+      typeof thresholds.stuckActiveWarningDays === 'number'
+        ? thresholds.stuckActiveWarningDays
+        : { ...thresholds.stuckActiveWarningDays },
+  }
 }
 
 function buildEnabledRouteDefaults(
@@ -84,7 +99,9 @@ function buildEnabledRouteDefaults(
     escalationLeadDays: approvedRouteDefault.escalationLeadDays,
     reviewWindowDays: approvedRouteDefault.reviewWindowDays,
     staleAfterDays: approvedRouteDefault.staleAfterDays,
-    ...ACTION_CENTER_EXECUTION_THRESHOLDS[approvedRouteDefault.scanType],
+    ...cloneActionCenterExecutionThresholds(
+      ACTION_CENTER_EXECUTION_THRESHOLDS[approvedRouteDefault.scanType],
+    ),
     remindersEnabled: true,
     providerEligible: true,
   }
@@ -146,6 +163,17 @@ export function isActionCenterRouteDefaultsProviderEligibleScanType(
 ) {
   const defaults = getActionCenterRouteDefaults(scanType)
   return defaults?.providerEligible === true
+}
+
+export function getActionCenterRouteFamilyLabel(
+  scanType: string | null | undefined,
+): ActionCenterRouteFamilyLabel | null {
+  const defaults = getActionCenterEnabledRouteDefaults(scanType)
+  if (!defaults) {
+    return null
+  }
+
+  return ACTION_CENTER_ROUTE_FAMILY_LABELS[defaults.scanType]
 }
 
 export function getActionCenterEnabledRouteDefaults(

--- a/supabase/action_center_constitution_adoption_readiness.sql
+++ b/supabase/action_center_constitution_adoption_readiness.sql
@@ -1,3 +1,472 @@
+create table if not exists public.action_center_route_actions (
+  id uuid primary key default gen_random_uuid(),
+  manager_response_id uuid references public.action_center_manager_responses(id) on delete cascade not null,
+  campaign_id uuid references public.campaigns(id) on delete cascade not null,
+  org_id uuid references public.organizations(id) on delete cascade not null,
+  route_id text not null,
+  route_scope_type text not null
+    check (route_scope_type in ('department', 'item')),
+  route_scope_value text not null,
+  manager_user_id uuid references auth.users(id) on delete cascade not null,
+  owner_name text not null,
+  owner_assigned_at timestamptz not null,
+  primary_action_theme_key text
+    check (primary_action_theme_key is null or primary_action_theme_key in ('leadership', 'culture', 'growth', 'compensation', 'workload', 'role_clarity')),
+  primary_action_text text,
+  primary_action_expected_effect text,
+  primary_action_status text
+    check (primary_action_status is null or primary_action_status in ('open', 'in_review', 'afgerond', 'gestopt')),
+  review_scheduled_for date,
+  semantic_state text
+    check (semantic_state is null or semantic_state in ('draft', 'active', 'review_due', 'in_review', 'blocked', 'completed', 'stopped', 'superseded')),
+  validation_disposition text
+    check (validation_disposition is null or validation_disposition in ('valid', 'invalid', 'needs_hr_review')),
+  created_by uuid references auth.users(id) on delete set null,
+  updated_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint action_center_route_actions_route_id_text_check
+    check (length(btrim(route_id)) > 0),
+  constraint action_center_route_actions_route_scope_value_text_check
+    check (length(btrim(route_scope_value)) > 0),
+  constraint action_center_route_actions_owner_name_text_check
+    check (length(btrim(owner_name)) > 0),
+  constraint action_center_route_actions_route_identity_check
+    check (route_id = ((campaign_id)::text || '::' || route_scope_value))
+);
+
+create table if not exists public.action_center_action_reviews (
+  id uuid primary key default gen_random_uuid(),
+  action_id uuid references public.action_center_route_actions(id) on delete cascade not null,
+  reviewed_at timestamptz not null,
+  observation text not null,
+  action_outcome text not null
+    check (action_outcome in ('effect-zichtbaar', 'bijsturen-nodig', 'nog-te-vroeg', 'stoppen')),
+  evidence_source text
+    check (evidence_source is null or evidence_source in ('manager-observation', 'team-conversation', 'other-bounded-source')),
+  confidence_level text
+    check (confidence_level is null or confidence_level in ('low', 'medium', 'high')),
+  follow_up_note text,
+  created_by uuid references auth.users(id) on delete set null,
+  updated_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint action_center_action_reviews_observation_text_check
+    check (length(btrim(observation)) > 0),
+  constraint action_center_action_reviews_follow_up_note_text_check
+    check (follow_up_note is null or length(btrim(follow_up_note)) > 0)
+);
+
+do $$
+begin
+  if exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'action_center_route_actions'
+      and column_name = 'theme_key'
+  ) and not exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'action_center_route_actions'
+      and column_name = 'primary_action_theme_key'
+  ) then
+    alter table public.action_center_route_actions rename column theme_key to primary_action_theme_key;
+  end if;
+
+  if exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'action_center_route_actions'
+      and column_name = 'action_text'
+  ) and not exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'action_center_route_actions'
+      and column_name = 'primary_action_text'
+  ) then
+    alter table public.action_center_route_actions rename column action_text to primary_action_text;
+  end if;
+
+  if exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'action_center_route_actions'
+      and column_name = 'expected_effect'
+  ) and not exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'action_center_route_actions'
+      and column_name = 'primary_action_expected_effect'
+  ) then
+    alter table public.action_center_route_actions rename column expected_effect to primary_action_expected_effect;
+  end if;
+
+  if exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'action_center_route_actions'
+      and column_name = 'status'
+  ) and not exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'action_center_route_actions'
+      and column_name = 'primary_action_status'
+  ) then
+    alter table public.action_center_route_actions rename column status to primary_action_status;
+  end if;
+end $$;
+
+alter table public.action_center_route_actions
+  add column if not exists manager_response_id uuid references public.action_center_manager_responses(id) on delete cascade,
+  add column if not exists route_id text,
+  add column if not exists owner_name text,
+  add column if not exists owner_assigned_at timestamptz,
+  add column if not exists primary_action_theme_key text,
+  add column if not exists primary_action_text text,
+  add column if not exists primary_action_expected_effect text,
+  add column if not exists primary_action_status text,
+  add column if not exists semantic_state text,
+  add column if not exists validation_disposition text;
+
+alter table public.action_center_action_reviews
+  add column if not exists evidence_source text,
+  add column if not exists confidence_level text;
+
+alter table public.action_center_action_reviews
+  alter column follow_up_note drop not null;
+
+do $$
+begin
+  update public.action_center_route_actions
+  set route_id = ((campaign_id)::text || '::' || route_scope_value)
+  where route_id is null
+    and campaign_id is not null
+    and route_scope_value is not null;
+
+  update public.action_center_route_actions a
+  set manager_response_id = r.id
+  from public.action_center_manager_responses r
+  where a.manager_response_id is null
+    and r.campaign_id = a.campaign_id
+    and r.org_id = a.org_id
+    and r.route_scope_type = a.route_scope_type
+    and r.route_scope_value = a.route_scope_value
+    and r.manager_user_id = a.manager_user_id;
+
+  if exists (
+    select 1
+    from information_schema.tables
+    where table_schema = 'public'
+      and table_name = 'action_center_workspace_members'
+  ) then
+    update public.action_center_route_actions a
+    set owner_name = coalesce(
+      nullif(btrim(m.display_name), ''),
+      nullif(regexp_replace(split_part(coalesce(m.login_email, ''), '@', 1), '[._-]+', ' ', 'g'), ''),
+      (a.manager_user_id)::text
+    )
+    from public.action_center_workspace_members m
+    where a.owner_name is null
+      and m.org_id = a.org_id
+      and m.user_id = a.manager_user_id
+      and m.scope_type = a.route_scope_type
+      and m.scope_value = a.route_scope_value
+      and m.access_role = 'manager_assignee';
+
+    update public.action_center_route_actions a
+    set owner_assigned_at = coalesce(m.created_at, a.created_at)
+    from public.action_center_workspace_members m
+    where a.owner_assigned_at is null
+      and m.org_id = a.org_id
+      and m.user_id = a.manager_user_id
+      and m.scope_type = a.route_scope_type
+      and m.scope_value = a.route_scope_value
+      and m.access_role = 'manager_assignee';
+  end if;
+
+  update public.action_center_route_actions
+  set owner_name = (manager_user_id)::text
+  where owner_name is null
+    and manager_user_id is not null;
+
+  update public.action_center_route_actions
+  set owner_assigned_at = created_at
+  where owner_assigned_at is null;
+end $$;
+
+alter table public.action_center_route_actions
+  drop constraint if exists action_center_route_actions_route_id_text_check;
+
+alter table public.action_center_route_actions
+  add constraint action_center_route_actions_route_id_text_check
+  check (route_id is null or length(btrim(route_id)) > 0);
+
+alter table public.action_center_route_actions
+  drop constraint if exists action_center_route_actions_route_scope_value_text_check;
+
+alter table public.action_center_route_actions
+  add constraint action_center_route_actions_route_scope_value_text_check
+  check (length(btrim(route_scope_value)) > 0);
+
+alter table public.action_center_route_actions
+  drop constraint if exists action_center_route_actions_owner_name_text_check;
+
+alter table public.action_center_route_actions
+  add constraint action_center_route_actions_owner_name_text_check
+  check (owner_name is null or length(btrim(owner_name)) > 0);
+
+alter table public.action_center_route_actions
+  drop constraint if exists action_center_route_actions_route_identity_check;
+
+alter table public.action_center_route_actions
+  add constraint action_center_route_actions_route_identity_check
+  check (
+    route_id is null
+    or route_scope_value is null
+    or campaign_id is null
+    or route_id = ((campaign_id)::text || '::' || route_scope_value)
+  );
+
+alter table public.action_center_route_actions
+  drop constraint if exists action_center_route_actions_primary_action_theme_key_check;
+
+alter table public.action_center_route_actions
+  add constraint action_center_route_actions_primary_action_theme_key_check
+  check (
+    primary_action_theme_key is null
+    or primary_action_theme_key in ('leadership', 'culture', 'growth', 'compensation', 'workload', 'role_clarity')
+  );
+
+alter table public.action_center_route_actions
+  drop constraint if exists action_center_route_actions_primary_action_status_check;
+
+alter table public.action_center_route_actions
+  add constraint action_center_route_actions_primary_action_status_check
+  check (
+    primary_action_status is null
+    or primary_action_status in ('open', 'in_review', 'afgerond', 'gestopt')
+  );
+
+alter table public.action_center_route_actions
+  drop constraint if exists action_center_route_actions_semantic_state_check;
+
+alter table public.action_center_route_actions
+  add constraint action_center_route_actions_semantic_state_check
+  check (
+    semantic_state is null
+    or semantic_state in ('draft', 'active', 'review_due', 'in_review', 'blocked', 'completed', 'stopped', 'superseded')
+  );
+
+alter table public.action_center_route_actions
+  drop constraint if exists action_center_route_actions_validation_disposition_check;
+
+alter table public.action_center_route_actions
+  add constraint action_center_route_actions_validation_disposition_check
+  check (
+    validation_disposition is null
+    or validation_disposition in ('valid', 'invalid', 'needs_hr_review')
+  );
+
+alter table public.action_center_action_reviews
+  drop constraint if exists action_center_action_reviews_action_outcome_check;
+
+alter table public.action_center_action_reviews
+  add constraint action_center_action_reviews_action_outcome_check
+  check (action_outcome in ('effect-zichtbaar', 'bijsturen-nodig', 'nog-te-vroeg', 'stoppen'));
+
+alter table public.action_center_action_reviews
+  drop constraint if exists action_center_action_reviews_evidence_source_check;
+
+alter table public.action_center_action_reviews
+  add constraint action_center_action_reviews_evidence_source_check
+  check (
+    evidence_source is null
+    or evidence_source in ('manager-observation', 'team-conversation', 'other-bounded-source')
+  );
+
+alter table public.action_center_action_reviews
+  drop constraint if exists action_center_action_reviews_confidence_level_check;
+
+alter table public.action_center_action_reviews
+  add constraint action_center_action_reviews_confidence_level_check
+  check (
+    confidence_level is null
+    or confidence_level in ('low', 'medium', 'high')
+  );
+
+alter table public.action_center_action_reviews
+  drop constraint if exists action_center_action_reviews_observation_text_check;
+
+alter table public.action_center_action_reviews
+  add constraint action_center_action_reviews_observation_text_check
+  check (length(btrim(observation)) > 0);
+
+alter table public.action_center_action_reviews
+  drop constraint if exists action_center_action_reviews_follow_up_note_text_check;
+
+alter table public.action_center_action_reviews
+  add constraint action_center_action_reviews_follow_up_note_text_check
+  check (follow_up_note is null or length(btrim(follow_up_note)) > 0);
+
+create index if not exists idx_action_center_route_actions_manager_response
+  on public.action_center_route_actions(manager_response_id);
+
+create index if not exists idx_action_center_route_actions_route
+  on public.action_center_route_actions(route_id, primary_action_status, review_scheduled_for);
+
+create index if not exists idx_action_center_route_actions_manager_scope
+  on public.action_center_route_actions(org_id, manager_user_id, route_scope_type, route_scope_value);
+
+create index if not exists idx_action_center_action_reviews_action
+  on public.action_center_action_reviews(action_id, reviewed_at desc);
+
+alter table public.action_center_route_actions enable row level security;
+alter table public.action_center_action_reviews enable row level security;
+
+drop policy if exists "managers_can_select_action_center_route_actions" on public.action_center_route_actions;
+create policy "managers_can_select_action_center_route_actions"
+  on public.action_center_route_actions for select
+  using (
+    public.is_verisight_admin_user()
+    or exists (
+      select 1
+      from public.action_center_workspace_members m
+      where m.user_id = auth.uid()
+        and m.org_id = action_center_route_actions.org_id
+        and m.access_role = 'manager_assignee'
+        and m.scope_type = action_center_route_actions.route_scope_type
+        and m.scope_value = action_center_route_actions.route_scope_value
+        and m.can_view
+    )
+  );
+
+drop policy if exists "managers_can_insert_action_center_route_actions" on public.action_center_route_actions;
+create policy "managers_can_insert_action_center_route_actions"
+  on public.action_center_route_actions for insert
+  with check (
+    public.is_verisight_admin_user()
+    or exists (
+      select 1
+      from public.action_center_workspace_members m
+      where m.user_id = auth.uid()
+        and m.org_id = action_center_route_actions.org_id
+        and m.access_role = 'manager_assignee'
+        and m.scope_type = action_center_route_actions.route_scope_type
+        and m.scope_value = action_center_route_actions.route_scope_value
+        and m.can_update
+    )
+  );
+
+drop policy if exists "managers_can_update_action_center_route_actions" on public.action_center_route_actions;
+create policy "managers_can_update_action_center_route_actions"
+  on public.action_center_route_actions for update
+  using (
+    public.is_verisight_admin_user()
+    or exists (
+      select 1
+      from public.action_center_workspace_members m
+      where m.user_id = auth.uid()
+        and m.org_id = action_center_route_actions.org_id
+        and m.access_role = 'manager_assignee'
+        and m.scope_type = action_center_route_actions.route_scope_type
+        and m.scope_value = action_center_route_actions.route_scope_value
+        and m.can_update
+    )
+  )
+  with check (
+    public.is_verisight_admin_user()
+    or exists (
+      select 1
+      from public.action_center_workspace_members m
+      where m.user_id = auth.uid()
+        and m.org_id = action_center_route_actions.org_id
+        and m.access_role = 'manager_assignee'
+        and m.scope_type = action_center_route_actions.route_scope_type
+        and m.scope_value = action_center_route_actions.route_scope_value
+        and m.can_update
+    )
+  );
+
+drop policy if exists "managers_can_select_action_center_action_reviews" on public.action_center_action_reviews;
+create policy "managers_can_select_action_center_action_reviews"
+  on public.action_center_action_reviews for select
+  using (
+    public.is_verisight_admin_user()
+    or exists (
+      select 1
+      from public.action_center_route_actions a
+      join public.action_center_workspace_members m
+        on m.org_id = a.org_id
+       and m.scope_type = a.route_scope_type
+       and m.scope_value = a.route_scope_value
+      where a.id = action_center_action_reviews.action_id
+        and m.user_id = auth.uid()
+        and m.access_role = 'manager_assignee'
+        and m.can_view
+    )
+  );
+
+drop policy if exists "managers_can_insert_action_center_action_reviews" on public.action_center_action_reviews;
+create policy "managers_can_insert_action_center_action_reviews"
+  on public.action_center_action_reviews for insert
+  with check (
+    public.is_verisight_admin_user()
+    or exists (
+      select 1
+      from public.action_center_route_actions a
+      join public.action_center_workspace_members m
+        on m.org_id = a.org_id
+       and m.scope_type = a.route_scope_type
+       and m.scope_value = a.route_scope_value
+      where a.id = action_center_action_reviews.action_id
+        and m.user_id = auth.uid()
+        and m.access_role = 'manager_assignee'
+        and m.can_update
+    )
+  );
+
+drop policy if exists "managers_can_update_action_center_action_reviews" on public.action_center_action_reviews;
+create policy "managers_can_update_action_center_action_reviews"
+  on public.action_center_action_reviews for update
+  using (
+    public.is_verisight_admin_user()
+    or exists (
+      select 1
+      from public.action_center_route_actions a
+      join public.action_center_workspace_members m
+        on m.org_id = a.org_id
+       and m.scope_type = a.route_scope_type
+       and m.scope_value = a.route_scope_value
+      where a.id = action_center_action_reviews.action_id
+        and m.user_id = auth.uid()
+        and m.access_role = 'manager_assignee'
+        and m.can_update
+    )
+  )
+  with check (
+    public.is_verisight_admin_user()
+    or exists (
+      select 1
+      from public.action_center_route_actions a
+      join public.action_center_workspace_members m
+        on m.org_id = a.org_id
+       and m.scope_type = a.route_scope_type
+       and m.scope_value = a.route_scope_value
+      where a.id = action_center_action_reviews.action_id
+        and m.user_id = auth.uid()
+        and m.access_role = 'manager_assignee'
+        and m.can_update
+    )
+  );
+
 create table if not exists public.action_center_adoption_events (
   id uuid primary key default gen_random_uuid(),
   org_id uuid not null references public.organizations(id) on delete cascade,

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -676,6 +676,77 @@ create table if not exists public.action_center_manager_responses (
   unique (campaign_id, route_scope_type, route_scope_value)
 );
 
+create table if not exists public.action_center_route_actions (
+  id uuid primary key default gen_random_uuid(),
+  manager_response_id uuid references public.action_center_manager_responses(id) on delete cascade not null,
+  campaign_id uuid references public.campaigns(id) on delete cascade not null,
+  org_id uuid references public.organizations(id) on delete cascade not null,
+  route_id text not null,
+  route_scope_type text not null
+    check (route_scope_type in ('department', 'item')),
+  route_scope_value text not null,
+  manager_user_id uuid references auth.users(id) on delete cascade not null,
+  owner_name text not null,
+  owner_assigned_at timestamptz not null,
+  primary_action_theme_key text
+    check (primary_action_theme_key is null or primary_action_theme_key in ('leadership', 'culture', 'growth', 'compensation', 'workload', 'role_clarity')),
+  primary_action_text text,
+  primary_action_expected_effect text,
+  primary_action_status text
+    check (primary_action_status is null or primary_action_status in ('open', 'in_review', 'afgerond', 'gestopt')),
+  review_scheduled_for date,
+  semantic_state text
+    check (semantic_state is null or semantic_state in ('draft', 'active', 'review_due', 'in_review', 'blocked', 'completed', 'stopped', 'superseded')),
+  validation_disposition text
+    check (validation_disposition is null or validation_disposition in ('valid', 'invalid', 'needs_hr_review')),
+  created_by uuid references auth.users(id) on delete set null,
+  updated_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint action_center_route_actions_route_id_text_check
+    check (length(btrim(route_id)) > 0),
+  constraint action_center_route_actions_route_scope_value_text_check
+    check (length(btrim(route_scope_value)) > 0),
+  constraint action_center_route_actions_owner_name_text_check
+    check (length(btrim(owner_name)) > 0),
+  constraint action_center_route_actions_route_identity_check
+    check (route_id = ((campaign_id)::text || '::' || route_scope_value))
+);
+
+create index if not exists idx_action_center_route_actions_manager_response
+  on public.action_center_route_actions(manager_response_id);
+
+create index if not exists idx_action_center_route_actions_route
+  on public.action_center_route_actions(route_id, primary_action_status, review_scheduled_for);
+
+create index if not exists idx_action_center_route_actions_manager_scope
+  on public.action_center_route_actions(org_id, manager_user_id, route_scope_type, route_scope_value);
+
+create table if not exists public.action_center_action_reviews (
+  id uuid primary key default gen_random_uuid(),
+  action_id uuid references public.action_center_route_actions(id) on delete cascade not null,
+  reviewed_at timestamptz not null,
+  observation text not null,
+  action_outcome text not null
+    check (action_outcome in ('effect-zichtbaar', 'bijsturen-nodig', 'nog-te-vroeg', 'stoppen')),
+  evidence_source text
+    check (evidence_source is null or evidence_source in ('manager-observation', 'team-conversation', 'other-bounded-source')),
+  confidence_level text
+    check (confidence_level is null or confidence_level in ('low', 'medium', 'high')),
+  follow_up_note text,
+  created_by uuid references auth.users(id) on delete set null,
+  updated_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint action_center_action_reviews_observation_text_check
+    check (length(btrim(observation)) > 0),
+  constraint action_center_action_reviews_follow_up_note_text_check
+    check (follow_up_note is null or length(btrim(follow_up_note)) > 0)
+);
+
+create index if not exists idx_action_center_action_reviews_action
+  on public.action_center_action_reviews(action_id, reviewed_at desc);
+
 create table if not exists public.action_center_route_relations (
   id uuid primary key default gen_random_uuid(),
   org_id uuid references public.organizations(id) on delete cascade not null,
@@ -1060,6 +1131,8 @@ alter table public.pilot_learning_dossiers enable row level security;
 alter table public.pilot_learning_checkpoints enable row level security;
 alter table public.action_center_review_decisions enable row level security;
 alter table public.action_center_manager_responses enable row level security;
+alter table public.action_center_route_actions enable row level security;
+alter table public.action_center_action_reviews enable row level security;
 alter table public.action_center_route_relations enable row level security;
 alter table public.action_center_review_rhythm_configs enable row level security;
 alter table public.action_center_review_schedule_revisions enable row level security;
@@ -1489,6 +1562,12 @@ drop policy if exists "managers_can_select_action_center_manager_responses" on p
 drop policy if exists "managers_can_insert_action_center_manager_responses" on public.action_center_manager_responses;
 drop policy if exists "managers_can_update_action_center_manager_responses" on public.action_center_manager_responses;
 drop policy if exists "admins_can_select_action_center_manager_responses" on public.action_center_manager_responses;
+drop policy if exists "managers_can_select_action_center_route_actions" on public.action_center_route_actions;
+drop policy if exists "managers_can_insert_action_center_route_actions" on public.action_center_route_actions;
+drop policy if exists "managers_can_update_action_center_route_actions" on public.action_center_route_actions;
+drop policy if exists "managers_can_select_action_center_action_reviews" on public.action_center_action_reviews;
+drop policy if exists "managers_can_insert_action_center_action_reviews" on public.action_center_action_reviews;
+drop policy if exists "managers_can_update_action_center_action_reviews" on public.action_center_action_reviews;
 
 create policy "managers_can_select_action_center_manager_responses"
   on public.action_center_manager_responses for select
@@ -1547,6 +1626,136 @@ create policy "managers_can_update_action_center_manager_responses"
         and m.access_role = 'manager_assignee'
         and m.scope_type = action_center_manager_responses.route_scope_type
         and m.scope_value = action_center_manager_responses.route_scope_value
+        and m.can_update
+    )
+  );
+
+create policy "managers_can_select_action_center_route_actions"
+  on public.action_center_route_actions for select
+  using (
+    public.is_verisight_admin_user()
+    or exists (
+      select 1
+      from public.action_center_workspace_members m
+      where m.user_id = auth.uid()
+        and m.org_id = action_center_route_actions.org_id
+        and m.access_role = 'manager_assignee'
+        and m.scope_type = action_center_route_actions.route_scope_type
+        and m.scope_value = action_center_route_actions.route_scope_value
+        and m.can_view
+    )
+  );
+
+create policy "managers_can_insert_action_center_route_actions"
+  on public.action_center_route_actions for insert
+  with check (
+    public.is_verisight_admin_user()
+    or exists (
+      select 1
+      from public.action_center_workspace_members m
+      where m.user_id = auth.uid()
+        and m.org_id = action_center_route_actions.org_id
+        and m.access_role = 'manager_assignee'
+        and m.scope_type = action_center_route_actions.route_scope_type
+        and m.scope_value = action_center_route_actions.route_scope_value
+        and m.can_update
+    )
+  );
+
+create policy "managers_can_update_action_center_route_actions"
+  on public.action_center_route_actions for update
+  using (
+    public.is_verisight_admin_user()
+    or exists (
+      select 1
+      from public.action_center_workspace_members m
+      where m.user_id = auth.uid()
+        and m.org_id = action_center_route_actions.org_id
+        and m.access_role = 'manager_assignee'
+        and m.scope_type = action_center_route_actions.route_scope_type
+        and m.scope_value = action_center_route_actions.route_scope_value
+        and m.can_update
+    )
+  )
+  with check (
+    public.is_verisight_admin_user()
+    or exists (
+      select 1
+      from public.action_center_workspace_members m
+      where m.user_id = auth.uid()
+        and m.org_id = action_center_route_actions.org_id
+        and m.access_role = 'manager_assignee'
+        and m.scope_type = action_center_route_actions.route_scope_type
+        and m.scope_value = action_center_route_actions.route_scope_value
+        and m.can_update
+    )
+  );
+
+create policy "managers_can_select_action_center_action_reviews"
+  on public.action_center_action_reviews for select
+  using (
+    public.is_verisight_admin_user()
+    or exists (
+      select 1
+      from public.action_center_route_actions a
+      join public.action_center_workspace_members m
+        on m.org_id = a.org_id
+       and m.scope_type = a.route_scope_type
+       and m.scope_value = a.route_scope_value
+      where a.id = action_center_action_reviews.action_id
+        and m.user_id = auth.uid()
+        and m.access_role = 'manager_assignee'
+        and m.can_view
+    )
+  );
+
+create policy "managers_can_insert_action_center_action_reviews"
+  on public.action_center_action_reviews for insert
+  with check (
+    public.is_verisight_admin_user()
+    or exists (
+      select 1
+      from public.action_center_route_actions a
+      join public.action_center_workspace_members m
+        on m.org_id = a.org_id
+       and m.scope_type = a.route_scope_type
+       and m.scope_value = a.route_scope_value
+      where a.id = action_center_action_reviews.action_id
+        and m.user_id = auth.uid()
+        and m.access_role = 'manager_assignee'
+        and m.can_update
+    )
+  );
+
+create policy "managers_can_update_action_center_action_reviews"
+  on public.action_center_action_reviews for update
+  using (
+    public.is_verisight_admin_user()
+    or exists (
+      select 1
+      from public.action_center_route_actions a
+      join public.action_center_workspace_members m
+        on m.org_id = a.org_id
+       and m.scope_type = a.route_scope_type
+       and m.scope_value = a.route_scope_value
+      where a.id = action_center_action_reviews.action_id
+        and m.user_id = auth.uid()
+        and m.access_role = 'manager_assignee'
+        and m.can_update
+    )
+  )
+  with check (
+    public.is_verisight_admin_user()
+    or exists (
+      select 1
+      from public.action_center_route_actions a
+      join public.action_center_workspace_members m
+        on m.org_id = a.org_id
+       and m.scope_type = a.route_scope_type
+       and m.scope_value = a.route_scope_value
+      where a.id = action_center_action_reviews.action_id
+        and m.user_id = auth.uid()
+        and m.access_role = 'manager_assignee'
         and m.can_update
     )
   );


### PR DESCRIPTION
## Summary
This PR lands the full Batch A `Productization of Execution` wave for Action Center in Loep.

It hardens the existing route-bound action-card model into a more enterprise-worthy bounded execution layer without broadening Action Center into workflow software, project management, case management, or a standalone module.

## What changed
- finalize the action-card contract, validation behavior, and bounded route-to-action limits
- finalize action lifecycle and transition truth, including draft-resolution separation and review transition enforcement
- harden persisted draft / invalid / HR-review flows with compact manager correction UX
- simplify manager create / update / review UX while preserving one primary route-context action path
- finalize ExitScan and RetentieScan route defaults, governance labels, and review-rhythm route-family alignment
- add missing schema parity for bounded execution route actions and action reviews
- write verification results back into the Batch A implementation plan

## Verification
Local verification completed on the final branch head:

- full Batch A regression suite: `12 files / 132 tests` passed
- targeted route-action preview and manager UX regressions passed after follow-up hardening
- `npm run build` now compiles and typechecks through the Batch A Action Center changes
- remaining build stop is the known unrelated Supabase SSR / prerender auth baseline on `/(auth)/signup`

## Notes
- Action Center remains bounded to approved route families only: `exit` and `retention`
- no off-platform canonical writes were added
- no Graph dependency was introduced
- no workflow/task/project/case-management broadening was introduced
- this PR improves adoption measurement readiness and execution governance; it does not claim adoption proof or intervention impact