### PR TITLE
Redesign boardroom results dashboards

### DIFF
--- a/frontend/app/(dashboard)/campaigns/[id]/page-helpers.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/page-helpers.test.ts
@@ -2,11 +2,10 @@ import { describe, expect, it } from 'vitest'
 import {
   buildDecisionPanels,
   buildHeroDescription,
-  clusterRetentionOpenSignals,
   buildNextStepBody,
+  clusterExitOpenSignals,
   computeAverageRiskScore,
   computeRetentionSupplementalAverages,
-  getLargestDistributionSegment,
 } from './page-helpers'
 import { getScanDefinition } from '@/lib/scan-definitions'
 import type { SurveyResponse } from '@/lib/types'
@@ -129,37 +128,44 @@ describe('dashboard page helpers field semantics', () => {
     expect(nextStep).toContain('werkfrictie')
   })
 
-  it('sanitizes retention open-answer samples before they can surface in synthesis cards', () => {
-    const themes = clusterRetentionOpenSignals([
+  it('clusters exit open signals without inventing extra quotes or factor values', () => {
+    const responses: SurveyResponse[] = [
       {
         id: 'resp-1',
         respondent_id: 'r-1',
-        risk_score: 5.2,
+        risk_score: 6.2,
         risk_band: 'MIDDEN',
         preventability: null,
         exit_reason_code: null,
         sdt_scores: {},
         org_scores: {},
-        open_text_raw:
-          'Mijn leidinggevende is slecht bereikbaar. Mail me op jane@example.com of bel +31 6 12345678.',
+        open_text_raw: 'Mijn leidinggevende gaf weinig feedback en de aansturing bleef onduidelijk.',
         full_result: {},
         submitted_at: '2026-04-18T10:00:00Z',
       },
-    ] as SurveyResponse[])
+      {
+        id: 'resp-2',
+        respondent_id: 'r-2',
+        risk_score: 5.9,
+        risk_band: 'MIDDEN',
+        preventability: null,
+        exit_reason_code: null,
+        sdt_scores: {},
+        org_scores: {},
+        open_text_raw: 'Prioriteiten waren niet helder en verantwoordelijkheden bleven diffuus.',
+        full_result: {},
+        submitted_at: '2026-04-18T10:05:00Z',
+      },
+    ]
 
-    expect(themes[0]?.sample).toContain('[verwijderd]')
-    expect(themes[0]?.sample).not.toContain('jane@example.com')
-    expect(themes[0]?.sample).not.toContain('+31 6 12345678')
-  })
+    const themes = clusterExitOpenSignals(responses)
 
-  it('picks the actual largest distribution segment instead of relying on fixed ordering', () => {
-    const largest = getLargestDistributionSegment([
-      { label: 'Werkgerelateerde redenen', value: '20%', percent: 20 },
-      { label: 'Trekfactoren elders', value: '55%', percent: 55 },
-      { label: 'Situationele redenen', value: '25%', percent: 25 },
-    ])
-
-    expect(largest?.label).toBe('Trekfactoren elders')
-    expect(largest?.percent).toBe(55)
+    expect(themes[0]).toMatchObject({
+      key: 'leadership',
+      title: 'Leiderschap en steun',
+      count: 1,
+    })
+    expect(themes.some((theme) => theme.title === 'Rolhelderheid en prioriteiten')).toBe(true)
+    expect(themes).toHaveLength(2)
   })
 })

--- a/frontend/app/(dashboard)/campaigns/[id]/page-helpers.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page-helpers.tsx
@@ -61,24 +61,7 @@ export type RetentionTheme = {
   sample: string
 }
 
-export function sanitizeOpenAnswerExcerpt(value: string) {
-  return value
-    .replace(/\s+/g, ' ')
-    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, '[verwijderd]')
-    .replace(/https?:\/\/\S+/gi, '[link verwijderd]')
-    .replace(/\+?\d[\d\s().-]{7,}\d/g, '[verwijderd]')
-    .trim()
-}
-
-export function getLargestDistributionSegment<T extends { percent: number }>(segments: T[]) {
-  return segments.reduce<T | null>((largest, segment) => {
-    if (!largest || segment.percent > largest.percent) {
-      return segment
-    }
-
-    return largest
-  }, null)
-}
+export type ExitTheme = RetentionTheme
 
 export type DecisionPanel = {
   eyebrow: string
@@ -497,10 +480,12 @@ export function SdtGauge({ label, score }: { label: string; score: number }) {
 
 export function MethodologyCard({
   scanType,
+  hasSegmentDeepDive,
   signalLabel,
   embedded = false,
 }: {
   scanType: ScanType
+  hasSegmentDeepDive: boolean
   signalLabel: string
   embedded?: boolean
 }) {
@@ -534,7 +519,14 @@ export function MethodologyCard({
         <InfoBlock title={signalLabel} body={scanDefinition.signalHelp} />
         <InfoBlock title="Signaalbanden" body={signaalbandenText} />
         <InfoBlock title="Betrouwbaarheid" body={scanDefinition.reliabilityText} />
-        <InfoBlock title="Segmentanalyse" body={scanDefinition.segmentText} />
+        <InfoBlock
+          title="Segment deep dive"
+          body={
+            hasSegmentDeepDive
+              ? `${scanDefinition.segmentText} Deze campagne gebruikt die add-on al.`
+              : scanDefinition.segmentText
+          }
+        />
       </div>
     </div>
   )
@@ -1103,7 +1095,7 @@ export function clusterRetentionOpenSignals(responses: SurveyResponse[]): Retent
   for (const definition of definitions) counts.set(definition.key, { definition, texts: [] })
 
   for (const response of responses) {
-    const text = sanitizeOpenAnswerExcerpt(response.open_text_raw?.trim() ?? '')
+    const text = response.open_text_raw?.trim()
     if (!text) continue
     const normalized = text.toLowerCase()
     for (const definition of definitions) {
@@ -1117,6 +1109,80 @@ export function clusterRetentionOpenSignals(responses: SurveyResponse[]): Retent
   return Array.from(counts.values())
     .filter((entry) => entry.texts.length > 0)
     .map((entry) => ({ key: entry.definition.key, title: entry.definition.title, count: entry.texts.length, implication: entry.definition.implication, sample: entry.texts[0] }))
+    .sort((left, right) => right.count - left.count)
+    .slice(0, 3)
+}
+
+export function clusterExitOpenSignals(responses: SurveyResponse[]): ExitTheme[] {
+  const definitions = [
+    {
+      key: 'leadership',
+      title: 'Leiderschap en steun',
+      keywords: ['leidinggevende', 'manager', 'feedback', 'aansturing', 'coach', 'steun'],
+      implication:
+        'Dit kleurt vaak hoe veilig signalen besproken werden en of vertrek eerder bestuurlijk zichtbaar had kunnen worden.',
+    },
+    {
+      key: 'workload',
+      title: 'Werkdruk en herstel',
+      keywords: ['werkdruk', 'druk', 'belasting', 'uren', 'drukte', 'overwerk', 'pauze'],
+      implication:
+        'Dit wijst vaak op structurele belasting of te weinig herstel, niet automatisch op een eenduidige vertrekoorzaak.',
+    },
+    {
+      key: 'growth',
+      title: 'Groei en perspectief',
+      keywords: ['groei', 'ontwikkeling', 'loopbaan', 'doorgroei', 'perspectief', 'leren'],
+      implication:
+        'Dit signaal valt vaak samen met ervaren stilstand of te weinig geloofwaardig perspectief in de route.',
+    },
+    {
+      key: 'role_clarity',
+      title: 'Rolhelderheid en prioriteiten',
+      keywords: ['rol', 'duidelijk', 'verwachting', 'prioriteit', 'verantwoordelijkheid', 'taak'],
+      implication:
+        'Dit beeld vraagt meestal eerst toetsing van prioriteiten, eigenaarschap en duidelijkheid in het werk.',
+    },
+    {
+      key: 'culture',
+      title: 'Samenwerking en veiligheid',
+      keywords: ['cultuur', 'veilig', 'samenwerking', 'team', 'vertrouwen', 'uitspreken'],
+      implication:
+        'Dit kan duiden op een bredere contextlaag rond samenwerken, uitspreken en ervaren veiligheid.',
+    },
+    {
+      key: 'compensation',
+      title: 'Beloning en voorwaarden',
+      keywords: ['salaris', 'beloning', 'voorwaarden', 'arbeidsvoorwaarden', 'vergoeding', 'loon'],
+      implication:
+        'Dit komt vaak terug als meelezende context en vraagt verificatie naast werkbeleving en perspectief.',
+    },
+  ] as const
+
+  const counts = new Map<string, { definition: (typeof definitions)[number]; texts: string[] }>()
+  for (const definition of definitions) counts.set(definition.key, { definition, texts: [] })
+
+  for (const response of responses) {
+    const text = response.open_text_raw?.trim()
+    if (!text) continue
+    const normalized = text.toLowerCase()
+    for (const definition of definitions) {
+      if (definition.keywords.some((keyword) => normalized.includes(keyword))) {
+        counts.get(definition.key)?.texts.push(text)
+        break
+      }
+    }
+  }
+
+  return Array.from(counts.values())
+    .filter((entry) => entry.texts.length > 0)
+    .map((entry) => ({
+      key: entry.definition.key,
+      title: entry.definition.title,
+      count: entry.texts.length,
+      implication: entry.definition.implication,
+      sample: entry.texts[0],
+    }))
     .sort((left, right) => right.count - left.count)
     .slice(0, 3)
 }

--- a/frontend/app/(dashboard)/campaigns/[id]/page.route-shell.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.route-shell.test.ts
@@ -2,58 +2,31 @@ import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
 describe('campaign detail route shell', () => {
-  const pageSource = () => readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
-  const openAnswersSource = () =>
-    readFileSync(new URL('./open-antwoorden/page.tsx', import.meta.url), 'utf8')
-
-  it('keeps open answers reachable from the results environment in one click', () => {
-    const source = pageSource()
-
-    expect(source).toContain('/open-antwoorden')
-    expect(source).toContain("blockVisibility.voices === 'visible' && releasedOpenAnswerItems.length > 0")
-  })
-
   it('keeps the manager-only insight boundary intact', () => {
-    const source = pageSource()
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
 
     expect(source).toContain('if (!context.canViewInsights)')
     expect(source).toContain('SuiteAccessDenied')
   })
 
-  it('wires ExitScan through a dedicated analytical component and preserves report + module navigation', () => {
-    const source = pageSource()
+  it('wires ExitScan and RetentieScan through dedicated boardroom components and preserves report + module navigation', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
 
+    expect(source).toContain('ExitProductDashboard')
+    expect(source).toContain('RetentionProductDashboard')
+    expect(source).toContain('primarySignalScoreLabel')
     expect(source).toContain('PdfDownloadButton')
     expect(source).toContain('moduleBackLinkLabel')
-    expect(source).not.toContain('ExitProductDashboard')
-    expect(source).not.toContain('if (stats.scan_type === "exit")')
+    expect(source).toContain('if (stats.scan_type === "exit")')
+    expect(source).toContain('if (stats.scan_type === "retention")')
   })
 
   it('keeps existing module breadcrumbs instead of collapsing to a generic dashboard jump', () => {
-    const source = pageSource()
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
 
     expect(source).toContain('getDashboardModuleHref')
     expect(source).toContain('getDashboardModuleKeyForScanType')
     expect(source).toContain('getDashboardModuleLabel')
     expect(source).toContain('Terug naar alle ExitScans')
-  })
-
-  it('preserves the campaign-detail bridge into Action Center for candidate and active routes', () => {
-    const source = pageSource()
-
-    expect(source).toContain('buildCampaignDetailActionCenterBridge')
-    expect(source).toContain('openActionCenterRoute')
-    expect(source).toContain("buildActionCenterRouteOpenRedirect(id, 'campaign-detail')")
-    expect(source).toContain('Vervolgroute')
-  })
-
-  it('does not query deprecated survey response aliases that are absent from the live schema', () => {
-    const forbiddenColumns = ['signal_score', 'direction_signal_score']
-
-    for (const source of [pageSource(), openAnswersSource()]) {
-      for (const column of forbiddenColumns) {
-        expect(source).not.toContain(column)
-      }
-    }
   })
 })

--- a/frontend/app/(dashboard)/campaigns/[id]/page.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.test.ts
@@ -8,68 +8,17 @@ const componentSource = () =>
   )
 
 describe('exit dashboard analytics guardrails', () => {
-  it('keeps the shared route shell factual and free from the old exit-only branch', () => {
-    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8').toLowerCase()
-    const forbiddenTerms = [
-      'exitproductdashboard',
-      'managementread',
-      'bestuurlijke',
-      'eerste actie',
-      'reviewmoment',
-    ]
-
-    for (const term of forbiddenTerms) {
-      expect(source).not.toContain(term)
-    }
-  })
-
-  it('removes the old hybrid campaign tabs and keeps results-first blocks visible on the route page', () => {
-    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
-
-    expect(source).toContain('Responsbasis')
-    expect(source).toContain('Kernsignaal')
-    expect(source).toContain('Signalen in samenhang')
-    expect(source).toContain('Drivers & prioriteiten')
-    expect(source).toContain('Verdiepingslagen')
-    expect(source).toContain('Survey-stemmen')
-    expect(source).not.toContain('Samenvatting')
-    expect(source).not.toContain('Methodiek')
-    expect(source).not.toContain('Uitvoering')
-  })
-
-  it('does not keep the old tabs as the primary HR results structure', () => {
-    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
-
-    expect(source).not.toContain('DashboardTabs')
-    expect(source).not.toContain("label: 'Overzicht'")
-    expect(source).not.toContain("label: 'Onderbouwing'")
-    expect(source).not.toContain("label: 'Actie'")
-    expect(source).not.toContain("label: 'Campagne'")
-  })
-
-  it('keeps the ExitScan dashboard free from owner, action, review, workflow and setup language', () => {
+  it('keeps the ExitScan dashboard free from causal, predictive and retention wording', () => {
     const source = componentSource().toLowerCase()
     const forbiddenTerms = [
-      'eerste eigenaar',
-      'route-eigenaar',
-      'eigenaar',
-      'eerste actie',
-      'eerste stap',
-      'reviewmoment',
-      'review plannen',
-      'manager toegewezen',
-      'action center',
-      'workflow',
-      'opvolgactie',
-      'start actie',
-      'maak actie',
-      'follow-on',
-      'uitvoerflow',
-      'livegang',
-      'importeren',
-      'uitnodigingen beheren',
-      'reminderactie',
-      'setup',
+      'gedreven door',
+      'oorzakenanalyse',
+      'diagnose',
+      'predictie',
+      'retention flow',
+      'strong editorial confidence',
+      'high impact',
+      'active risk',
     ]
 
     for (const term of forbiddenTerms) {
@@ -77,20 +26,16 @@ describe('exit dashboard analytics guardrails', () => {
     }
   })
 
-  it('renders the agreed ExitScan analytical IA in the expected order', () => {
+  it('renders the agreed ExitScan boardroom IA in the expected order', () => {
     const source = componentSource()
     const orderedHeadings = [
-      'Sterkste signaal',
-      'Waarom dit telt',
-      'Hoofdreden van vertrekbeeld',
-      'Meespelende factoren',
-      'Responscontext',
-      'Topfactoren',
-      'Verdeling van het vertrekbeeld',
-      'Diepere driverlaag',
-      'SDT-laag',
-      'Uitgebreide factorlaag',
-      'Methodische leesgrenzen',
+      'Kernsignaal',
+      'Responsbasis / leessterkte',
+      'Signaalopbouw',
+      'Prioriteitenbeeld',
+      'Basisbehoeften / SDT',
+      'Survey-stemmen',
+      'Bestuurlijke handoff',
     ]
 
     let previousIndex = -1
@@ -112,21 +57,21 @@ describe('exit dashboard analytics guardrails', () => {
     expect(source).toContain('Onvoldoende data')
   })
 
-  it('keeps the visible ExitScan shell free from mojibake and uses a neutral score label', () => {
+  it('keeps the visible ExitScan shell free from mojibake and uses the product score language', () => {
     const source = componentSource()
 
     expect(source).not.toContain('Ã')
     expect(source).not.toContain('Â')
     expect(source).not.toContain('â')
     expect(source).not.toContain('�')
-    expect(source).toContain('Gemiddelde signaalscore')
-    expect(source).not.toContain('Frictiescore')
+    expect(source).toContain('Frictiescore')
+    expect(source).toContain('Leessterkte')
   })
 
   it('renders the SDT layer only when real rows are available', () => {
     const source = componentSource()
 
     expect(source).toContain('sdtRows.length > 0')
-    expect(source).toContain('ExitSdtNeedsChart')
+    expect(source).toContain('SdtTriangleMap')
   })
 })

--- a/frontend/app/(dashboard)/campaigns/[id]/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.tsx
@@ -1,103 +1,241 @@
-import type { ReactNode } from 'react'
-import Link from 'next/link'
-import { notFound, redirect } from 'next/navigation'
-import { isLiveActionCenterScanType } from '@/lib/action-center-live'
-import { SuiteAccessDenied } from '@/components/dashboard/suite-access-denied'
+﻿import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { isLiveActionCenterScanType } from "@/lib/action-center-live";
 import {
   buildActionCenterRouteOpenPatch,
   buildActionCenterRouteOpenRedirect,
   canOpenActionCenterRoute,
   getActionCenterRouteOpenableStages,
   hasOpenedActionCenterRoute,
-} from '@/lib/dashboard/open-action-center-route'
-import { getManagementBandLabel } from '@/lib/management-language'
-import { getScanDefinition } from '@/lib/scan-definitions'
+} from "@/lib/dashboard/open-action-center-route";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
+import { ExitProductDashboard } from "@/components/dashboard/exit-product-dashboard";
+import { RetentionProductDashboard } from "@/components/dashboard/retention-product-dashboard";
+import { CampaignActions } from "./campaign-actions";
+import { PdfDownloadButton } from "./pdf-download-button";
+import {
+  DashboardChartPanel,
+  DashboardChip,
+  DashboardDisclosure,
+  DashboardHero,
+  DashboardKeyValue,
+  DashboardPanel,
+  DashboardRecommendationRail,
+  DashboardSection,
+  DashboardSummaryBar,
+  DashboardTimeline,
+  FocusPanel,
+  InsightStatCard,
+  SignalStatCard,
+} from "@/components/dashboard/dashboard-primitives";
+import { DashboardTabs } from "@/components/dashboard/dashboard-tabs";
+import { FactorTable } from "@/components/dashboard/factor-table";
+import { GuidedSelfServePanel } from "@/components/dashboard/guided-self-serve-panel";
+import { buildLaunchControlState } from "@/lib/launch-controls";
+import { ManagementReadGuide } from "@/components/dashboard/onboarding-panels";
+import {
+  OnboardingAdvancer,
+  OnboardingBalloon,
+} from "@/components/dashboard/onboarding-balloon";
+import { PreflightChecklist } from "@/components/dashboard/preflight-checklist";
+import { RespondentTable } from "@/components/dashboard/respondent-table";
+import { RiskCharts } from "@/components/dashboard/risk-charts";
+import { SuiteAccessDenied } from "@/components/dashboard/suite-access-denied";
+import { getContactRequestsForAdmin } from "@/lib/contact-requests";
+import { deriveGuidedSelfServeDiscipline } from "@/lib/guided-self-serve";
+import {
+  getCampaignCompositionState,
+  isManagementVisibleState,
+} from "@/lib/dashboard/dashboard-state-composition";
+import {
+  ActionPlaybookList,
+  buildCampaignDetailActionCenterBridge,
+  buildDecisionPanels,
+  buildHeroDescription,
+  buildInsightWarnings,
+  buildPulseComparisonState,
+  buildRetentionSegmentPlaybooks,
+  buildRetentionTrendCards,
+  buildRiskHistogram,
+  buildSafeTableResponses,
+  CampaignHealthIndicator,
+  clusterExitOpenSignals,
+  clusterRetentionOpenSignals,
+  computeAverageSignalScore,
+  computePulseSignalAverages,
+  computeAverageSignalVisibility,
+  computeFactorAverages,
+  computeRetentionSignalAverages,
+  computeRetentionSupplementalAverages,
+  computeStrongWorkSignalRate,
+  getDisclosureDefaults,
+  getTopContributingReasonLabel,
+  getTopExitReasonLabel,
+  MethodologyCard,
+  MIN_N_DISPLAY,
+  MIN_N_PATTERNS,
+  PulseTrendSection,
+  RecommendationList,
+  RetentionTrendSection,
+  SegmentPlaybookList,
+  SdtGauge,
+} from "./page-helpers";
+import {
+  buildCampaignReadinessState,
+  getDeliveryModeLabel,
+} from "@/lib/implementation-readiness";
+import { getFirstNextStepGuidance } from "@/lib/client-onboarding";
+import { type CampaignAuditEventRecord } from "@/lib/campaign-audit";
+import { getCustomerActionPermission } from "@/lib/customer-permissions";
+import {
+  buildFactorPresentation,
+  getManagementBandLabel,
+  getRiskBandFromScore,
+} from "@/lib/management-language";
+import type {
+  CampaignDeliveryCheckpoint,
+  CampaignDeliveryRecord,
+} from "@/lib/ops-delivery";
+import {
+  buildTeamLocalReadState,
+  buildTeamPriorityReadState,
+} from "@/lib/products/team";
+import { getProductModule } from "@/lib/products/shared/registry";
+import { buildResponseActivationState } from "@/lib/response-activation";
+import { getScanDefinition } from "@/lib/scan-definitions";
 import {
   getDashboardModuleHref,
   getDashboardModuleKeyForScanType,
   getDashboardModuleLabel,
-} from '@/lib/dashboard/shell-navigation'
-import { loadSuiteAccessContext } from '@/lib/suite-access-server'
-import { createAdminClient } from '@/lib/supabase/admin'
-import { createClient } from '@/lib/supabase/server'
-import { FACTOR_LABELS } from '@/lib/types'
-import type { CampaignStats, Respondent, ScanType, SurveyResponse } from '@/lib/types'
-import {
-  buildOpenAnswerItems,
-  buildOpenAnswersViewModel,
-} from './open-answers-view-model'
-import {
-  buildCampaignDetailActionCenterBridge,
-  MethodologyCard,
-  MIN_N_DISPLAY,
-  MIN_N_PATTERNS,
-  clusterRetentionOpenSignals,
-  computeAverageSignalScore,
-  computeFactorAverages,
-  computeRetentionSupplementalAverages,
-  computeStrongWorkSignalRate,
-  getLargestDistributionSegment,
-  getTopContributingReasonLabel,
-  getTopExitReasonLabel,
-} from './page-helpers'
-import { PdfDownloadButton } from './pdf-download-button'
-import { ResultsLayout } from './results-layout'
-import {
-  buildResultsViewModel,
-  type ResultsBlockVisibility,
-} from './results-view-model'
+} from "@/lib/dashboard/shell-navigation";
+import { loadSuiteAccessContext } from "@/lib/suite-access-server";
+import { FACTOR_LABELS, hasCampaignAddOn } from "@/lib/types";
+import type { CampaignStats, Respondent, SurveyResponse } from "@/lib/types";
 
 interface Props {
-  params: Promise<{ id: string }>
+  params: Promise<{ id: string }>;
 }
 
-type FactorRow = {
-  factor: string
-  score: string
-  scoreValue: number
-  signal: string
-  signalValue: number
-  band: string
-  note: string
+type PresentationMetricKey =
+  | "signal"
+  | "owner"
+  | "next-step"
+  | "review"
+  | "response"
+  | "readiness";
+
+type PresentationMetric = {
+  label: string;
+  value: string;
+  tone: "slate" | "blue" | "emerald" | "amber";
+  accent?: string;
+  helpText?: string;
+};
+
+function buildPresentationMetrics({
+  productExperience,
+  scanDefinition,
+  dashboardViewModel,
+  averageRiskScore,
+  totalCompleted,
+  totalInvited,
+  compositionStateMeta,
+  hasEnoughData,
+}: {
+  productExperience: {
+    summarySignalLabel: string;
+    summaryFocusLabel: string;
+    reviewLabel: string;
+  };
+  scanDefinition: ReturnType<typeof getScanDefinition>;
+  dashboardViewModel: {
+    topSummaryCards: Array<{ title: string; value?: string }>;
+    nextStep: { title: string };
+  };
+  averageRiskScore: number | null;
+  totalCompleted: number;
+  totalInvited: number;
+  compositionStateMeta: {
+    label: string;
+    tone: "slate" | "blue" | "emerald" | "amber";
+  };
+  hasEnoughData: boolean;
+}): Record<PresentationMetricKey, PresentationMetric> {
+  const ownerValue =
+    findPresentationCardValue(dashboardViewModel.topSummaryCards, [
+      "Eerste eigenaar",
+    ]) ?? "Nog niet vrijgegeven";
+  const reviewValue =
+    findPresentationCardValue(dashboardViewModel.topSummaryCards, [
+      "Reviewmoment",
+      "Reviewgrens",
+      "Leesgrens",
+    ]) ?? "Nog indicatief";
+
+  return {
+    signal: {
+      label: productExperience.summarySignalLabel,
+      value:
+        averageRiskScore !== null
+          ? `${averageRiskScore.toFixed(1)}/10`
+          : "Nog geen veilig beeld",
+      tone: averageRiskScore !== null ? "slate" : "amber",
+      helpText: scanDefinition.signalHelp,
+    },
+    owner: {
+      label: "Eerste eigenaar",
+      value: ownerValue,
+      tone: "slate",
+    },
+    "next-step": {
+      label: productExperience.summaryFocusLabel,
+      value: dashboardViewModel.nextStep.title,
+      tone: hasEnoughData ? "slate" : "amber",
+    },
+    review: {
+      label: productExperience.reviewLabel,
+      value: reviewValue,
+      tone: "slate",
+    },
+    response: {
+      label: "Responsstatus",
+      value: `${totalCompleted}/${totalInvited || 0} ingevuld`,
+      tone: hasEnoughData ? "emerald" : "amber",
+    },
+    readiness: {
+      label: "Dashboardstatus",
+      value: compositionStateMeta.label,
+      tone: compositionStateMeta.tone,
+    },
+  };
 }
 
-type SdtRow = {
-  factor: string
-  score: string
-  scoreValue: number
-  signal: string
-  band: string
-  note: string
+function findPresentationCardValue(
+  cards: Array<{ title: string; value?: string }>,
+  titles: string[],
+) {
+  for (const title of titles) {
+    const match = cards.find((card) => card.title === title && card.value);
+    if (match?.value) return match.value;
+  }
+
+  return null;
 }
 
-type MetricItem = {
-  label: string
-  value: string
-  caption: string
+function normalizeInformationalTone(
+  tone: "slate" | "blue" | "emerald" | "amber",
+) {
+  return tone === "blue" ? "slate" : tone;
 }
-
-type SummaryItem = {
-  label: string
-  title: string
-  body: string
-}
-
-const PRIMARY_RESULTS_ORDER = {
-  response: 'Responsbasis',
-  signal: 'Kernsignaal',
-  synthesis: 'Signalen in samenhang',
-  drivers: 'Drivers & prioriteiten',
-  depth: 'Verdiepingslagen',
-  voices: 'Survey-stemmen',
-} as const
 
 function formatRoutePeriodLabel(campaignName: string, createdAt: string) {
   const quarterMatch = campaignName.match(/Q[1-4]\s?\d{4}/i)
-  if (quarterMatch) return quarterMatch[0].replace(/\s+/, ' ')
+  if (quarterMatch) return quarterMatch[0].replace(/\s+/, " ")
 
-  return new Intl.DateTimeFormat('nl-NL', {
-    month: 'long',
-    year: 'numeric',
+  return new Intl.DateTimeFormat("nl-NL", {
+    month: "long",
+    year: "numeric",
   }).format(new Date(createdAt))
 }
 
@@ -106,66 +244,18 @@ function deriveScopeLabel(respondents: Respondent[]) {
     new Set(respondents.map((respondent) => respondent.department).filter(Boolean)),
   ) as string[]
 
-  if (departments.length === 0) return 'Scope binnen deze route'
+  if (departments.length === 0) return "Scope binnen deze route"
   if (departments.length === 1) return departments[0]
   if (departments.length === 2) return `${departments[0]} & ${departments[1]}`
   return `${departments[0]}, ${departments[1]} + ${departments.length - 2} meer`
 }
 
-function getDashboardModuleBackLinkLabel(scanType: CampaignStats['scan_type']) {
-  if (scanType === 'exit') return 'Terug naar alle ExitScans'
-  if (scanType === 'retention') return 'Terug naar alle RetentieScans'
-  if (scanType === 'onboarding') return 'Terug naar alle Onboarding 30-60-90-routes'
-  if (scanType === 'pulse') return 'Terug naar alle Pulse-routes'
-  if (scanType === 'leadership') return 'Terug naar alle Leadership Scans'
-  return 'Terug naar overzicht'
-}
-
-function formatScore(value: number | null) {
-  return value === null ? 'Nog niet beschikbaar' : `${value.toFixed(1)}/10`
-}
-
-function formatPercent(value: number | null) {
-  return value === null ? 'Nog niet beschikbaar' : `${Math.round(value)}%`
-}
-
-function truncateText(value: string, limit = 140) {
-  return value.length > limit ? `${value.slice(0, limit - 3).trimEnd()}...` : value
-}
-
-function getVisualMetricWidth(value: string) {
-  if (value === 'Nog niet beschikbaar') return null
-
-  const percentMatch = value.match(/(-?\d+(?:\.\d+)?)%/)
-  if (percentMatch) {
-    const percent = Number(percentMatch[1])
-    if (!Number.isNaN(percent)) return Math.max(10, Math.min(100, percent))
-  }
-
-  const scoreMatch = value.match(/(-?\d+(?:\.\d+)?)\/10/)
-  if (scoreMatch) {
-    const score = Number(scoreMatch[1])
-    if (!Number.isNaN(score)) return Math.max(10, Math.min(100, score * 10))
-  }
-
-  return null
-}
-
-function getVisualMetricPercent(value: string) {
-  const width = getVisualMetricWidth(value)
-  return width ? Math.round(width) : null
-}
-
 function buildResponseContextNote(totalCompleted: number, completionRate: number) {
   if (totalCompleted >= MIN_N_PATTERNS) {
-    return `${completionRate}% respons en ${totalCompleted} ingevulde responses liggen boven de analysegrens van ${MIN_N_PATTERNS}.`
+    return `Responsbasis van ${completionRate}% is stevig genoeg voor een eerste lezing. Lees verschillen nog steeds in samenhang met scope en context.`
   }
 
-  if (totalCompleted >= MIN_N_DISPLAY) {
-    return `${completionRate}% respons en ${totalCompleted} ingevulde responses liggen boven de weergavegrens van ${MIN_N_DISPLAY}, maar nog onder de analysegrens van ${MIN_N_PATTERNS}.`
-  }
-
-  return `${totalCompleted} ingevulde responses. Detailweergave opent vanaf ${MIN_N_DISPLAY} responses.`
+  return `Eerste read is zichtbaar, maar detail blijft nog begrensd. Gebruik de responsbasis van ${completionRate}% vooral om richting te bepalen, niet om al te ver te concluderen.`
 }
 
 function buildExitPictureDistribution(responses: SurveyResponse[]) {
@@ -178,8 +268,8 @@ function buildExitPictureDistribution(responses: SurveyResponse[]) {
   for (const response of responses) {
     const code = response.exit_reason_code
     if (!code) continue
-    if (code.startsWith('PL')) counts.pull += 1
-    else if (code.startsWith('S')) counts.situational += 1
+    if (code.startsWith("PL")) counts.pull += 1
+    else if (code.startsWith("S")) counts.situational += 1
     else counts.work += 1
   }
 
@@ -188,45 +278,51 @@ function buildExitPictureDistribution(responses: SurveyResponse[]) {
 
   return {
     total,
+    workPercent: toPercent(counts.work),
+    pullPercent: toPercent(counts.pull),
+    situationalPercent: toPercent(counts.situational),
     segments: [
-      {
-        label: 'Werkgerelateerde redenen',
-        value: `${toPercent(counts.work)}%`,
-        percent: toPercent(counts.work),
-      },
-      {
-        label: 'Trekfactoren elders',
-        value: `${toPercent(counts.pull)}%`,
-        percent: toPercent(counts.pull),
-      },
-      {
-        label: 'Situationele redenen',
-        value: `${toPercent(counts.situational)}%`,
-        percent: toPercent(counts.situational),
-      },
+      { label: "Werkfrictie zichtbaar", value: `${toPercent(counts.work)}%`, percent: toPercent(counts.work) },
+      { label: "Andere trekfactoren zichtbaar", value: `${toPercent(counts.pull)}%`, percent: toPercent(counts.pull) },
+      { label: "Situationele context zichtbaar", value: `${toPercent(counts.situational)}%`, percent: toPercent(counts.situational) },
     ],
   }
+}
+
+function getDashboardModuleBackLinkLabel(scanType: CampaignStats["scan_type"]) {
+  if (scanType === "exit") return "Terug naar alle ExitScans"
+  if (scanType === "retention") return "Terug naar alle RetentieScans"
+  if (scanType === "onboarding") return "Terug naar alle Onboarding 30-60-90-routes"
+  if (scanType === "pulse") return "Terug naar alle Pulse-routes"
+  if (scanType === "leadership") return "Terug naar alle Leadership Scans"
+  return "Terug naar overzicht"
 }
 
 function buildFactorPriorityRows(factorAverages: Record<string, number>) {
   return Object.entries(factorAverages)
     .map(([factor, score]) => {
-      const signalValue = 11 - score
+      const signalScore = 11 - score
+      const presentation = buildFactorPresentation({
+        score,
+        signalScore,
+        managementLabel: getManagementBandLabel(signalScore),
+        showSignal: true,
+      })
 
       return {
         factor: FACTOR_LABELS[factor] ?? factor,
-        score: `${score.toFixed(1)}/10`,
+        score: presentation.scoreDisplay,
         scoreValue: score,
-        signal: `${signalValue.toFixed(1)}/10`,
-        signalValue,
-        band: getManagementBandLabel(signalValue),
+        signal: presentation.signalDisplay,
+        band: presentation.managementLabel,
         note:
-          signalValue >= 7
-            ? 'Laagste ervaren score in deze route.'
-            : signalValue >= 4.5
-              ? 'Zichtbaar in het huidige patroon.'
-              : 'Nu minder uitgesproken dan de bovenste factoren.',
-      } satisfies FactorRow
+          signalScore >= 7
+            ? "Vraagt in dit beeld als eerste aandacht."
+            : signalScore >= 4.5
+              ? "Eerst toetsen voordat deze factor zwaarder meeweegt."
+              : "Zichtbaar, maar niet de eerste factor om te openen.",
+        signalValue: signalScore,
+      }
     })
     .sort((left, right) => right.signalValue - left.signalValue)
 }
@@ -237,1224 +333,3181 @@ function buildSdtRows(sdtAverages: {
   relatedness?: number
 }) {
   return [
-    { label: 'Autonomie', value: sdtAverages.autonomy },
-    { label: 'Competentie & groei', value: sdtAverages.competence },
-    { label: 'Verbondenheid', value: sdtAverages.relatedness },
+    { key: "autonomy", label: "Autonomie", value: sdtAverages.autonomy },
+    { key: "competence", label: "Competentie & groei", value: sdtAverages.competence },
+    { key: "relatedness", label: "Verbondenheid", value: sdtAverages.relatedness },
   ]
-    .filter((item) => typeof item.value === 'number')
+    .filter((item) => typeof item.value === "number")
     .map((item) => {
-      const scoreValue = Number(item.value)
-      const signalValue = 11 - scoreValue
-
+      const signalScore = 11 - Number(item.value)
       return {
         factor: item.label,
-        score: `${scoreValue.toFixed(1)}/10`,
-        scoreValue,
-        signal: `${signalValue.toFixed(1)}/10`,
-        band: getManagementBandLabel(signalValue),
+        score: `${Number(item.value).toFixed(1)}/10`,
+        scoreValue: Number(item.value),
+        signal: `${signalScore.toFixed(1)}/10`,
+        band: getManagementBandLabel(signalScore),
         note:
-          signalValue >= 7
-            ? 'Duidelijk zichtbaar in de verdiepingslaag.'
-            : signalValue >= 4.5
-              ? 'Aanwezig als aanvullende context.'
-              : 'Nu minder uitgesproken dan de andere SDT-lagen.',
-      } satisfies SdtRow
+          signalScore >= 7
+            ? "Draagt duidelijk mee aan het vertrekbeeld."
+            : signalScore >= 4.5
+              ? "Relevant als verdiepingslaag naast de organisatiefactoren."
+              : "Ondersteunend, maar niet de eerste driver van dit beeld.",
+      }
     })
 }
 
-function getResultsStatusLabel(readState: ReturnType<typeof buildResultsViewModel>['readState']) {
-  if (readState === 'readable') return 'Leesbaar'
-  if (readState === 'early-read') return 'Eerste read'
-  return 'Nog aan het opbouwen'
-}
-
-function buildSignalHighlights(args: {
-  scanType: ScanType
-  signalLabel: string
-  isVisible: boolean
-  averageSignalScore: number | null
-  topFactorLabel: string | null
-  strongWorkSignalRate: number | null
-  supplemental: ReturnType<typeof computeRetentionSupplementalAverages>
+function buildRetentionSignalSegments(riskDistribution: {
+  HOOG: number
+  MIDDEN: number
+  LAAG: number
 }) {
-  const items: MetricItem[] = [
-    {
-      label: args.signalLabel,
-      value: args.isVisible ? formatScore(args.averageSignalScore) : 'Nog niet beschikbaar',
-      caption: args.isVisible
-        ? 'Gemiddelde score over de leesbare responses.'
-        : `Beschikbaar vanaf ${MIN_N_DISPLAY} responses.`,
-    },
-  ]
-
-  if (args.scanType === 'exit') {
-    items.push(
-      {
-        label: 'Sterkste factor',
-        value: args.isVisible ? (args.topFactorLabel ?? 'Nog niet beschikbaar') : 'Nog niet beschikbaar',
-        caption: 'Factor met de laagste gemiddelde belevingsscore in deze route.',
-      },
-      {
-        label: 'Sterk werksignaal',
-        value: args.isVisible ? formatPercent(args.strongWorkSignalRate) : 'Nog niet beschikbaar',
-        caption: 'Aandeel responses met een sterk werkgerelateerd signaal.',
-      },
-    )
-
-    return items
-  }
-
-  if (args.scanType === 'retention') {
-    items.push(
-      {
-        label: 'Bevlogenheid',
-        value: args.isVisible ? formatScore(args.supplemental.engagement) : 'Nog niet beschikbaar',
-        caption: 'Gemiddelde UWES-score binnen de leesbare responses.',
-      },
-      {
-        label: 'Stay-intent',
-        value: args.isVisible ? formatScore(args.supplemental.stayIntent) : 'Nog niet beschikbaar',
-        caption: 'Gemiddelde richtingsscore op groepsniveau.',
-      },
-    )
-
-    return items
-  }
-
-  items.push(
-    {
-      label: 'Richtingsvraag',
-      value: args.isVisible ? formatScore(args.supplemental.stayIntent) : 'Nog niet beschikbaar',
-      caption: 'Gemiddelde richtingsscore op groepsniveau.',
-    },
-    {
-      label: 'Topfactor',
-      value: args.isVisible ? (args.topFactorLabel ?? 'Nog niet beschikbaar') : 'Nog niet beschikbaar',
-      caption: 'Factor met de laagste gemiddelde belevingsscore in deze route.',
-    },
-  )
-
-  return items
-}
-
-function buildSynthesisItems(args: {
-  scanType: ScanType
-  topFactorLabel: string | null
-  secondFactorLabel: string | null
-  topExitReasonLabel: string | null
-  topContributingReasonLabel: string | null
-  retentionThemes: ReturnType<typeof clusterRetentionOpenSignals>
-  openAnswerThemes: ReturnType<typeof buildOpenAnswersViewModel>['themes']
-  exitDistribution: ReturnType<typeof buildExitPictureDistribution> | null
-}) {
-  const items: SummaryItem[] = []
-
-  if (args.scanType === 'exit') {
-    if (args.topExitReasonLabel) {
-      items.push({
-        label: 'Dominante reden',
-        title: args.topExitReasonLabel,
-        body: 'Meest voorkomende vertrekreden binnen de leesbare exitresponses.',
-      })
-    }
-
-    if (args.topContributingReasonLabel) {
-      items.push({
-        label: 'Meespelende code',
-        title: args.topContributingReasonLabel,
-        body: 'Tweede reden die in dezelfde response-set zichtbaar terugkomt.',
-      })
-    }
-
-    const topSegment = args.exitDistribution
-      ? getLargestDistributionSegment(args.exitDistribution.segments)
-      : null
-    if (topSegment) {
-      items.push({
-        label: 'Verdeling',
-        title: `${topSegment.label} (${topSegment.value})`,
-        body: 'Grootste segment in de huidige verdeling van het vertrekbeeld.',
-      })
-    }
-
-    return items
-  }
-
-  if (args.scanType === 'retention') {
-    for (const theme of args.retentionThemes.slice(0, 2)) {
-      items.push({
-        label: 'Open antwoorden',
-        title: `${theme.title} (${theme.count})`,
-        body: truncateText(theme.sample, 150),
-      })
-    }
-  }
-
-  if (args.topFactorLabel) {
-    items.push({
-      label: 'Topfactor',
-      title: args.topFactorLabel,
-      body: 'Laagste gemiddelde belevingsscore in de huidige route.',
-    })
-  }
-
-  if (args.secondFactorLabel) {
-    items.push({
-      label: 'Tweede factor',
-      title: args.secondFactorLabel,
-      body: 'Volgende factor op basis van de huidige gemiddelde scores.',
-    })
-  }
-
-  if (items.length < 3 && args.openAnswerThemes[0]) {
-    items.push({
-      label: 'Thema in survey-stemmen',
-      title: `${args.openAnswerThemes[0].title} (${args.openAnswerThemes[0].count})`,
-      body: 'Meest voorkomende groep binnen de vrijgegeven open antwoorden.',
-    })
-  }
-
-  return items.slice(0, 3)
-}
-
-function buildDepthNotes(args: {
-  scanDefinition: ReturnType<typeof getScanDefinition>
-  responsesLength: number
-  hasMinDisplay: boolean
-  hasEnoughData: boolean
-}) {
-  const thresholdBody = args.hasEnoughData
-    ? `${args.responsesLength} responses voldoen aan de analysegrens van ${MIN_N_PATTERNS}.`
-    : args.hasMinDisplay
-      ? `${args.responsesLength} responses voldoen aan de weergavegrens van ${MIN_N_DISPLAY}, maar nog niet aan de analysegrens van ${MIN_N_PATTERNS}.`
-      : `${args.responsesLength} responses; detailweergave start bij ${MIN_N_DISPLAY}.`
+  const total = riskDistribution.HOOG + riskDistribution.MIDDEN + riskDistribution.LAAG
+  const toPercent = (value: number) => (total > 0 ? Math.round((value / total) * 100) : 0)
 
   return [
-    {
-      label: 'Wat deze route toont',
-      body: args.scanDefinition.whatItIsText,
-    },
-    {
-      label: 'Wat deze route niet toont',
-      body: args.scanDefinition.whatItIsNotText,
-    },
-    {
-      label: 'Privacygrens',
-      body: args.scanDefinition.privacyBoundaryText,
-    },
-    {
-      label: 'Leesgrens',
-      body: thresholdBody,
-    },
+    { label: "Actief vertrekdenkend", value: `${toPercent(riskDistribution.HOOG)}%`, percent: toPercent(riskDistribution.HOOG) },
+    { label: "Latent risico", value: `${toPercent(riskDistribution.MIDDEN)}%`, percent: toPercent(riskDistribution.MIDDEN) },
+    { label: "Stabiel", value: `${toPercent(riskDistribution.LAAG)}%`, percent: toPercent(riskDistribution.LAAG) },
   ]
 }
 
-function SectionKicker({
-  title,
-  visibility,
-}: {
+type ResultsThemeCard = {
+  key: string
   title: string
-  visibility: ResultsBlockVisibility
-}) {
-  return (
-    <div className="flex flex-wrap items-center justify-between gap-3">
-      <div className="flex items-center gap-3">
-        <span className="h-px w-10 bg-[#C36A29]" />
-        <span className="text-[0.72rem] font-semibold uppercase tracking-[0.28em] text-slate-500">
-          {title}
-        </span>
-      </div>
-      <span
-        className={`inline-flex rounded-full border px-3 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.18em] ${
-          visibility === 'visible'
-            ? 'border-amber-200 bg-amber-50 text-[#8B4A17]'
-            : 'border-slate-200 bg-slate-50 text-slate-500'
-        }`}
-      >
-        {visibility === 'visible' ? 'Zichtbaar' : 'Begrensd'}
-      </span>
-    </div>
-  )
+  count: number
+  implication: string
+  quote?: string | null
+  relationLabel?: string | null
+  evidenceLabel: string
 }
 
-function ResultsBlockCard({
-  title,
-  visibility,
-  summary,
-  body,
-  href,
-  linkLabel,
-  children,
-  className,
-  summaryClassName,
-  bodyClassName,
-  hideSummary,
-}: {
-  title: string
-  visibility: ResultsBlockVisibility
-  summary?: string
-  body: string
-  href?: string
-  linkLabel?: string
-  children?: ReactNode
-  className?: string
-  summaryClassName?: string
-  bodyClassName?: string
-  hideSummary?: boolean
-}) {
-  const toneClasses =
-    visibility === 'visible'
-      ? 'border-slate-200 bg-white shadow-[0_18px_48px_rgba(15,23,42,0.06)]'
-      : 'border-dashed border-slate-200 bg-[color:var(--dashboard-soft)]/36'
-
-  return (
-    <div className={`border px-5 py-5 md:px-7 md:py-7 ${toneClasses} ${className ?? 'rounded-[28px]'}`}>
-      <SectionKicker title={title} visibility={visibility} />
-      {summary && !hideSummary ? (
-        <p
-          className={`mt-5 text-[1.8rem] font-semibold leading-none tracking-[-0.05em] text-[color:var(--dashboard-ink)] md:text-[2.2rem] ${
-            summaryClassName ?? ''
-          }`}
-        >
-          {summary}
-        </p>
-      ) : null}
-      <p className={`mt-3 max-w-3xl text-sm leading-6 text-[color:var(--dashboard-text)] ${bodyClassName ?? ''}`}>
-        {body}
-      </p>
-      {children ? <div className="mt-6">{children}</div> : null}
-      {href && linkLabel ? (
-        <Link
-          href={href}
-          className="mt-6 inline-flex items-center gap-2 rounded-full border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-semibold text-[#8B4A17] transition-colors hover:border-amber-300 hover:bg-amber-100"
-        >
-          {linkLabel}
-        </Link>
-      ) : null}
-    </div>
-  )
-}
-
-function MetricTile({ item }: { item: MetricItem }) {
-  const metricPercent = getVisualMetricPercent(item.value)
-
-  return (
-    <div className="relative overflow-hidden rounded-[24px] border border-slate-200 bg-[linear-gradient(145deg,rgba(255,255,255,0.96),rgba(246,239,229,0.88))] px-4 py-4 shadow-[0_12px_28px_rgba(15,23,42,0.05)]">
-      <div className="absolute inset-x-0 top-0 h-px bg-[linear-gradient(90deg,rgba(195,106,41,0),rgba(195,106,41,0.9),rgba(195,106,41,0))]" />
-      <div className="flex items-start justify-between gap-4">
-        <div className="min-w-0">
-          <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
-            {item.label}
-          </p>
-          <p className="mt-3 text-xl font-semibold tracking-[-0.05em] text-[color:var(--dashboard-ink)]">
-            {item.value}
-          </p>
-        </div>
-        {metricPercent ? (
-          <div
-            className="relative mt-1 size-[4.25rem] shrink-0 rounded-full"
-            style={{
-              background: `conic-gradient(#C36A29 0 ${metricPercent}%, rgba(195,106,41,0.16) ${metricPercent}% 100%)`,
-            }}
-          >
-            <div className="absolute inset-[6px] rounded-full bg-white/90" />
-            <div className="absolute inset-0 flex items-center justify-center text-[0.72rem] font-semibold tracking-[-0.02em] text-[color:var(--dashboard-ink)]">
-              {metricPercent}%
-            </div>
-          </div>
-        ) : null}
-      </div>
-      <p className="mt-3 text-sm leading-6 text-[color:var(--dashboard-text)]">{item.caption}</p>
-    </div>
-  )
-}
-
-function SummaryCard({ item, index }: { item: SummaryItem; index: number }) {
-  const accentClasses = [
-    'from-[#fff7ef] via-white to-[#f6eee4]',
-    'from-[#f6efe4] via-white to-[#f3f6fb]',
-    'from-[#f8f4ee] via-white to-[#fff7ef]',
-  ]
-
-  return (
-    <div
-      className={`relative overflow-hidden rounded-[28px] border border-slate-200 bg-gradient-to-br ${accentClasses[index % accentClasses.length]} px-5 py-5 shadow-[0_18px_40px_rgba(15,23,42,0.05)]`}
-    >
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
-            {item.label}
-          </p>
-          <h3 className="mt-3 text-[1.18rem] font-semibold tracking-[-0.05em] text-[color:var(--dashboard-ink)]">
-            {item.title}
-          </h3>
-        </div>
-        <div className="text-[2.4rem] font-semibold leading-none tracking-[-0.08em] text-[#C36A29]/18">
-          0{index + 1}
-        </div>
-      </div>
-      <p className="mt-4 max-w-md text-sm leading-6 text-[color:var(--dashboard-text)]">{item.body}</p>
-    </div>
-  )
-}
-
-function SignalOrbit({
-  segments,
-  total,
-}: {
-  segments: Array<{ label: string; value: string; percent: number }>
-  total: number
-}) {
-  const [first, second, third] = segments
-  const firstStop = first?.percent ?? 0
-  const secondStop = firstStop + (second?.percent ?? 0)
-  const thirdStop = secondStop + (third?.percent ?? 0)
-
-  return (
-    <div className="rounded-[30px] border border-slate-200 bg-[linear-gradient(145deg,#fffdf9,rgba(246,239,229,0.88))] px-5 py-5 shadow-[0_18px_40px_rgba(15,23,42,0.06)]">
-      <div className="grid gap-6 lg:grid-cols-[auto,minmax(0,1fr)] lg:items-center">
-        <div className="mx-auto">
-          <div
-            className="relative flex size-48 items-center justify-center rounded-full"
-            style={{
-              background: `conic-gradient(#C36A29 0 ${firstStop}%, #D9985D ${firstStop}% ${secondStop}%, #E9D7BE ${secondStop}% ${thirdStop}%, rgba(15,23,42,0.06) ${thirdStop}% 100%)`,
-            }}
-          >
-            <div className="absolute inset-[14px] rounded-full bg-[linear-gradient(180deg,#fffefc,rgba(255,255,255,0.92))]" />
-            <div className="relative z-10 text-center">
-              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.24em] text-slate-500">
-                Responses
-              </p>
-              <p className="mt-3 text-[3rem] font-semibold leading-none tracking-[-0.08em] text-[color:var(--dashboard-ink)]">
-                {total}
-              </p>
-              <p className="mt-2 text-sm text-[color:var(--dashboard-text)]">verdeeld over het vertrekbeeld</p>
-            </div>
-          </div>
-        </div>
-
-        <div className="grid gap-3">
-          {segments.map((segment, index) => (
-            <div
-              key={segment.label}
-              className="rounded-[22px] border border-white/70 bg-white/90 px-4 py-4 shadow-[0_10px_24px_rgba(15,23,42,0.04)]"
-            >
-              <div className="flex items-center justify-between gap-3">
-                <div className="flex items-center gap-3">
-                  <span
-                    className="size-3 rounded-full"
-                    style={{
-                      backgroundColor: index === 0 ? '#C36A29' : index === 1 ? '#D9985D' : '#E9D7BE',
-                    }}
-                  />
-                  <p className="text-sm font-semibold text-[color:var(--dashboard-ink)]">{segment.label}</p>
-                </div>
-                <span className="text-base font-semibold tracking-[-0.04em] text-[color:var(--dashboard-ink)]">
-                  {segment.value}
-                </span>
-              </div>
-              <div className="mt-3 h-2 overflow-hidden rounded-full bg-[rgba(15,23,42,0.05)]">
-                <div
-                  className="h-full rounded-full"
-                  style={{
-                    width: `${Math.max(8, segment.percent)}%`,
-                    backgroundColor: index === 0 ? '#C36A29' : index === 1 ? '#D9985D' : '#E9D7BE',
-                  }}
-                />
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-    </div>
-  )
-}
-
-function PrioritySpotlight({ row, rank }: { row: FactorRow; rank: number }) {
-  const signalPercent = Math.max(10, Math.min(100, row.signalValue * 10))
-
-  return (
-    <div className="relative overflow-hidden rounded-[26px] border border-slate-200 bg-[linear-gradient(145deg,rgba(255,255,255,0.98),rgba(246,239,229,0.85))] px-5 py-5 shadow-[0_16px_36px_rgba(15,23,42,0.06)]">
-      <div className="absolute -right-5 -top-7 text-[5rem] font-semibold tracking-[-0.12em] text-[#C36A29]/10">
-        0{rank}
-      </div>
-      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
-        Prioriteit {rank}
-      </p>
-      <h3 className="mt-3 max-w-[14rem] text-[1.18rem] font-semibold tracking-[-0.05em] text-[color:var(--dashboard-ink)]">
-        {row.factor}
-      </h3>
-      <p className="mt-3 text-sm leading-6 text-[color:var(--dashboard-text)]">{row.note}</p>
-      <div className="mt-5 flex items-end justify-between gap-4">
-        <div>
-          <p className="text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-slate-500">Signaal</p>
-          <p className="mt-2 text-2xl font-semibold tracking-[-0.06em] text-[color:var(--dashboard-ink)]">
-            {row.signal}
-          </p>
-        </div>
-        <div
-          className="relative size-[4.5rem] rounded-full"
-          style={{
-            background: `conic-gradient(#C36A29 0 ${signalPercent}%, rgba(195,106,41,0.15) ${signalPercent}% 100%)`,
-          }}
-        >
-          <div className="absolute inset-[7px] rounded-full bg-white/95" />
-          <div className="absolute inset-0 flex items-center justify-center text-xs font-semibold uppercase tracking-[0.12em] text-slate-600">
-            {row.band}
-          </div>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-function EmptyInlineState({ body }: { body: string }) {
-  return (
-    <div className="border border-dashed border-slate-200 bg-[color:var(--dashboard-soft)]/28 px-5 py-5 text-sm leading-6 text-[color:var(--dashboard-text)]">
-      {body}
-    </div>
-  )
-}
-
-function ResultsShellHeader({
-  moduleHref,
-  moduleLabel,
-  moduleBackLinkLabel,
-  campaignName,
-  organizationName,
-  routePeriodLabel,
-  scopeLabel,
+function buildReadStrengthLabel({
+  hasMinDisplay,
+  hasEnoughData,
   statusLabel,
-  campaignId,
-  scanType,
 }: {
-  moduleHref: string
-  moduleLabel: string
-  moduleBackLinkLabel: string
-  campaignName: string
-  organizationName: string
-  routePeriodLabel: string
-  scopeLabel: string
+  hasMinDisplay: boolean
+  hasEnoughData: boolean
   statusLabel: string
-  campaignId: string
-  scanType: string
 }) {
-  return (
-    <div className="space-y-5 border-b border-slate-200/80 pb-6">
-      <p className="text-[0.78rem] font-medium tracking-[0.01em] text-slate-500">
-        <Link href="/dashboard" className="transition-colors hover:text-slate-700">
-          Overzicht
-        </Link>{' '}
-        /{' '}
-        <Link href={moduleHref} className="transition-colors hover:text-slate-700">
-          {moduleLabel}
-        </Link>{' '}
-        <span aria-hidden> / </span>
-        <span className="text-slate-700">{campaignName}</span>
-      </p>
-      <Link
-        href={moduleHref}
-        className="inline-flex items-center gap-2 text-sm font-medium text-slate-500 transition-colors hover:text-slate-700"
-      >
-        <span aria-hidden="true">&larr;</span> {moduleBackLinkLabel}
-      </Link>
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-        <div className="space-y-3">
-          <div className="flex flex-wrap items-center gap-2.5">
-            <span className="inline-flex rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-[0.72rem] font-semibold uppercase tracking-[0.2em] text-[#8B4A17]">
-              {statusLabel}
-            </span>
-            <span className="text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-slate-400">
-              Resultatenomgeving
-            </span>
-          </div>
-          <h1 className="font-serif text-[2.6rem] leading-[0.96] tracking-[-0.055em] text-[color:var(--dashboard-ink)] sm:text-[3.15rem]">
-            {campaignName}
-          </h1>
-          <p className="text-sm leading-6 text-slate-600">
-            {organizationName} <span aria-hidden="true">&middot;</span> {routePeriodLabel}{' '}
-            <span aria-hidden="true">&middot;</span> {scopeLabel}
-          </p>
-        </div>
-        <PdfDownloadButton
-          campaignId={campaignId}
-          campaignName={campaignName}
-          scanType={scanType}
-          label="Download PDF"
-          loadingLabel="PDF ophalen..."
-          buttonClassName="inline-flex rounded-full border border-slate-950 bg-slate-950 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
-          containerClassName="flex flex-col items-start gap-2 lg:items-end"
-          errorClassName="max-w-56 text-xs text-red-600 lg:text-right"
-        />
-      </div>
-    </div>
-  )
+  if (!hasMinDisplay) return "Nog beperkt"
+  if (!hasEnoughData) return "Begrensd"
+  if (statusLabel.toLowerCase().includes("rapport")) return "Stevig"
+  return "Leesbaar"
+}
+
+function buildTrustNotes() {
+  return [
+    "Gegroepeerde output, geen individueel oordeel.",
+    `Detaillezing opent pas vanaf ${MIN_N_DISPLAY} leesbare responses en wordt steviger vanaf ${MIN_N_PATTERNS}.`,
+    "Segmenten blijven onderdrukt als n-grenzen of suppressieregels dat vragen.",
+    "Open antwoorden worden alleen geanonimiseerd getoond waar de drempel dat toelaat.",
+  ]
+}
+
+function buildEvidenceLabel({
+  count,
+  matchesTopFactor,
+  matchesSecondFactor,
+}: {
+  count: number
+  matchesTopFactor: boolean
+  matchesSecondFactor: boolean
+}) {
+  if (matchesTopFactor) return "Bevestigt"
+  if (matchesSecondFactor) return "Verdiept"
+  return count >= 3 ? "Nuanceert" : "Verkent"
+}
+
+function buildExitSurveyThemeCards(args: {
+  responses: SurveyResponse[]
+  topFactorLabel: string | null
+  secondFactorLabel: string | null
+  hasEnoughData: boolean
+}) {
+  if (!args.hasEnoughData) return [] as ResultsThemeCard[]
+
+  return clusterExitOpenSignals(args.responses).map((theme) => {
+    const mappedFactorLabel = FACTOR_LABELS[theme.key] ?? theme.title
+    const matchesTopFactor = mappedFactorLabel === args.topFactorLabel
+    const matchesSecondFactor = mappedFactorLabel === args.secondFactorLabel
+    return {
+      key: theme.key,
+      title: theme.title,
+      count: theme.count,
+      implication: theme.implication,
+      quote: theme.count >= 3 ? theme.sample : null,
+      relationLabel: matchesTopFactor
+        ? `Valt samen met ${args.topFactorLabel?.toLowerCase()}`
+        : matchesSecondFactor
+          ? `Valt samen met ${args.secondFactorLabel?.toLowerCase()}`
+          : null,
+      evidenceLabel: buildEvidenceLabel({
+        count: theme.count,
+        matchesTopFactor,
+        matchesSecondFactor,
+      }),
+    }
+  })
+}
+
+function buildRetentionSurveyThemeCards(args: {
+  themes: ReturnType<typeof clusterRetentionOpenSignals>
+  topFactorLabel: string | null
+  secondFactorLabel: string | null
+  hasEnoughData: boolean
+}) {
+  if (!args.hasEnoughData) return [] as ResultsThemeCard[]
+
+  return args.themes.map((theme) => {
+    const mappedFactorLabel = FACTOR_LABELS[theme.key] ?? theme.title
+    const matchesTopFactor = mappedFactorLabel === args.topFactorLabel
+    const matchesSecondFactor = mappedFactorLabel === args.secondFactorLabel
+    return {
+      key: theme.key,
+      title: theme.title,
+      count: theme.count,
+      implication: theme.implication,
+      quote: theme.count >= 3 ? theme.sample : null,
+      relationLabel: matchesTopFactor
+        ? `Valt samen met ${args.topFactorLabel?.toLowerCase()}`
+        : matchesSecondFactor
+          ? `Valt samen met ${args.secondFactorLabel?.toLowerCase()}`
+          : null,
+      evidenceLabel: buildEvidenceLabel({
+        count: theme.count,
+        matchesTopFactor,
+        matchesSecondFactor,
+      }),
+    }
+  })
+}
+
+function findFollowThroughCardBody(
+  cards: Array<{ title: string; body: string }>,
+  title: string,
+) {
+  return cards.find((card) => card.title === title)?.body ?? null
 }
 
 export default async function CampaignPage({ params }: Props) {
-  const { id } = await params
-  const supabase = await createClient()
+  const { id } = await params;
+  const supabase = await createClient();
   const {
     data: { user },
-  } = await supabase.auth.getUser()
+  } = await supabase.auth.getUser();
 
   if (!user) {
-    notFound()
+    notFound();
   }
 
-  const { context } = await loadSuiteAccessContext(supabase, user.id)
+  const { context } = await loadSuiteAccessContext(supabase, user.id);
 
   if (!context.canViewInsights) {
     return (
       <SuiteAccessDenied
         title="Je ziet hier geen campagnedetail"
-        description="Jouw login opent alleen Action Center voor toegewezen teams. Surveyresultaten, campagnedetails en rapporten blijven zichtbaar voor HR en Loep."
+        description="Jouw login opent alleen Action Center voor toegewezen teams. Surveyresultaten, campagnedetails en rapporten blijven zichtbaar voor HR en Verisight."
       />
-    )
+    );
   }
 
   const { data: statsRow } = await supabase
-    .from('campaign_stats')
-    .select('*')
-    .eq('campaign_id', id)
-    .single()
+    .from("campaign_stats")
+    .select("*")
+    .eq("campaign_id", id)
+    .single();
 
-  if (!statsRow) notFound()
-  const stats = statsRow as CampaignStats
+  if (!statsRow) notFound();
+  const stats = statsRow as CampaignStats;
+
+  const { data: previousStatsRows } = await supabase
+    .from("campaign_stats")
+    .select("*")
+    .eq("organization_id", stats.organization_id)
+    .eq("scan_type", stats.scan_type)
+    .lt("created_at", stats.created_at)
+    .order("created_at", { ascending: false })
+    .limit(1);
+  const previousStats =
+    (previousStatsRows?.[0] as CampaignStats | undefined) ?? null;
 
   const [
+    { data: profile },
+    { data: membership },
     { data: organization },
-    { data: responsesRaw },
-    { data: respondentsRaw },
-    { data: deliveryRecord },
-  ] =
-    await Promise.all([
-      supabase.from('organizations').select('name').eq('id', stats.organization_id).maybeSingle(),
-      supabase
-        .from('survey_responses')
-        .select(
-          `
-          id,
-          respondent_id,
-          risk_score,
-          risk_band,
-          preventability,
-          stay_intent_score,
-          uwes_score,
-          turnover_intention_score,
-          exit_reason_code,
-          sdt_scores,
-          org_scores,
-          open_text_raw,
-          open_text_analysis,
-          full_result,
-          submitted_at,
-          respondents!inner(id, campaign_id, department, role_level, completed, completed_at, token)
-        `,
-        )
-        .eq('respondents.campaign_id', id),
-      supabase
-        .from('respondents')
-        .select('*')
-        .eq('campaign_id', id)
-        .order('completed_at', { ascending: false, nullsFirst: false }),
-      supabase
-        .from('campaign_delivery_records')
-        .select('id, lifecycle_stage, first_management_use_confirmed_at, updated_at')
-        .eq('campaign_id', id)
-        .maybeSingle(),
-    ])
+    { data: campaignMeta },
+    { count: activeClientAccessCount },
+    { count: pendingClientInviteCount },
+  ] = await Promise.all([
+    user
+      ? supabase
+          .from("profiles")
+          .select("is_verisight_admin")
+          .eq("id", user.id)
+          .maybeSingle()
+      : Promise.resolve({ data: null }),
+    user
+      ? supabase
+          .from("org_members")
+          .select("role")
+          .eq("org_id", stats.organization_id)
+          .eq("user_id", user.id)
+          .maybeSingle()
+      : Promise.resolve({ data: null }),
+    supabase
+      .from("organizations")
+      .select("name")
+      .eq("id", stats.organization_id)
+      .maybeSingle(),
+    supabase
+      .from("campaigns")
+      .select("enabled_modules, delivery_mode")
+      .eq("id", id)
+      .maybeSingle(),
+    supabase
+      .from("org_members")
+      .select("id", { count: "exact", head: true })
+      .eq("org_id", stats.organization_id)
+      .in("role", ["viewer", "member"]),
+    supabase
+      .from("org_invites")
+      .select("id", { count: "exact", head: true })
+      .eq("org_id", stats.organization_id)
+      .is("accepted_at", null),
+  ]);
 
+  const canManageCampaign =
+    profile?.is_verisight_admin === true ||
+    getCustomerActionPermission(membership?.role ?? null, "review_launch");
+  const isVerisightAdmin = profile?.is_verisight_admin === true;
+  const canExecuteCampaign =
+    isVerisightAdmin ||
+    getCustomerActionPermission(
+      membership?.role ?? null,
+      "import_respondents",
+    ) ||
+    getCustomerActionPermission(membership?.role ?? null, "launch_invites") ||
+    getCustomerActionPermission(membership?.role ?? null, "send_reminders");
+  const hasSegmentDeepDive = hasCampaignAddOn(
+    campaignMeta,
+    "segment_deep_dive",
+  );
+  const deliveryAdminClient = canExecuteCampaign ? createAdminClient() : null;
+  const { data: deliveryVisibilityRecord } = deliveryAdminClient
+    ? await deliveryAdminClient
+        .from("campaign_delivery_records")
+        .select("id")
+        .eq("campaign_id", id)
+        .maybeSingle()
+    : { data: null };
+  const { data: importQaCheckpointRaw } =
+    deliveryAdminClient && deliveryVisibilityRecord?.id
+      ? await deliveryAdminClient
+          .from("campaign_delivery_checkpoints")
+          .select("auto_state")
+          .eq("delivery_record_id", deliveryVisibilityRecord.id)
+          .eq("checkpoint_key", "import_qa")
+          .maybeSingle()
+      : { data: null };
+  const importReady = importQaCheckpointRaw?.auto_state === "ready";
+  const { data: deliveryRecordRaw } = await supabase
+    .from("campaign_delivery_records")
+    .select("*")
+    .eq("campaign_id", id)
+    .maybeSingle();
+  const deliveryRecord = (deliveryRecordRaw ??
+    null) as CampaignDeliveryRecord | null;
+  const { data: deliveryCheckpointsRaw } = deliveryRecord
+    ? await supabase
+        .from("campaign_delivery_checkpoints")
+        .select("*")
+        .eq("delivery_record_id", deliveryRecord.id)
+        .order("created_at", { ascending: true })
+    : { data: [] };
+  const deliveryCheckpoints = (deliveryCheckpointsRaw ??
+    []) as CampaignDeliveryCheckpoint[];
+  const guidedSetupDiscipline = deriveGuidedSelfServeDiscipline(
+    deliveryCheckpoints
+      .filter(
+        (
+          checkpoint,
+        ): checkpoint is CampaignDeliveryCheckpoint & {
+          checkpoint_key:
+            | "implementation_intake"
+            | "import_qa"
+            | "invite_readiness";
+        } =>
+          checkpoint.checkpoint_key === "implementation_intake" ||
+          checkpoint.checkpoint_key === "import_qa" ||
+          checkpoint.checkpoint_key === "invite_readiness",
+      )
+      .map((checkpoint) => ({
+        checkpointKey: checkpoint.checkpoint_key,
+        manualState: checkpoint.manual_state,
+      })),
+  );
+  const { data: auditEventsRaw } =
+    isVerisightAdmin || Boolean(membership?.role)
+      ? await supabase
+          .from("campaign_action_audit_events")
+          .select(
+            "id, action_key, outcome, action_label, owner_label, actor_role, actor_label, summary, metadata, created_at",
+          )
+          .eq("campaign_id", id)
+          .order("created_at", { ascending: false })
+          .limit(8)
+      : { data: [] };
+  const auditEvents = (auditEventsRaw ?? []) as CampaignAuditEventRecord[];
+  const {
+    rows: deliveryLeadOptions,
+    configError: deliveryLeadConfigError,
+    loadError: deliveryLeadLoadError,
+  } = isVerisightAdmin
+    ? await getContactRequestsForAdmin(100)
+    : { rows: [], configError: null, loadError: null };
+  const deliveryLeadError = deliveryLeadConfigError ?? deliveryLeadLoadError;
+
+  const { data: responsesRaw } = await supabase
+    .from("survey_responses")
+    .select(
+      `
+      id, respondent_id, risk_score, risk_band, preventability, stay_intent_score, uwes_score, turnover_intention_score,
+      exit_reason_code, sdt_scores, org_scores, open_text_raw, open_text_analysis, full_result,
+      submitted_at,
+      respondents!inner(id, campaign_id, department, role_level, completed, completed_at, token)
+    `,
+    )
+    .eq("respondents.campaign_id", id);
   const responses = (responsesRaw ?? []) as unknown as (SurveyResponse & {
-    respondents: Respondent
-  })[]
-  const respondents = (respondentsRaw ?? []) as Respondent[]
+    respondents: Respondent;
+  })[];
 
-  const hasMinDisplay = responses.length >= MIN_N_DISPLAY
-  const hasEnoughData = responses.length >= MIN_N_PATTERNS
-  const factorData = computeFactorAverages(responses)
-  const factorPriorityRows = buildFactorPriorityRows(factorData.orgAverages)
-  const sdtRows = buildSdtRows(factorData.sdtAverages)
-  const averageSignalScore = computeAverageSignalScore(responses)
-  const supplemental = computeRetentionSupplementalAverages(responses)
-  const releasedOpenAnswerItems = hasMinDisplay ? buildOpenAnswerItems(stats.scan_type, responses) : []
-  const openAnswersViewModel = buildOpenAnswersViewModel(releasedOpenAnswerItems)
-  const strongWorkSignalRate = hasMinDisplay ? computeStrongWorkSignalRate(responses) : null
-  const topExitReasonLabel = hasMinDisplay ? getTopExitReasonLabel(responses) : null
-  const topContributingReasonLabel = hasEnoughData ? getTopContributingReasonLabel(responses) : null
-  const exitDistribution = hasEnoughData ? buildExitPictureDistribution(responses) : null
-  const retentionThemes = stats.scan_type === 'retention' ? clusterRetentionOpenSignals(responses) : []
-  const resultsViewModel = buildResultsViewModel({
-    scanType: stats.scan_type,
-    respondentsCount: respondents.length,
+  let previousResponses: (SurveyResponse & { respondents: Respondent })[] = [];
+  if (
+    (stats.scan_type === "retention" || stats.scan_type === "pulse") &&
+    previousStats
+  ) {
+    const { data: previousResponsesRaw } = await supabase
+      .from("survey_responses")
+      .select(
+        `
+        id, respondent_id, risk_score, risk_band, preventability, stay_intent_score, uwes_score, turnover_intention_score,
+        exit_reason_code, sdt_scores, org_scores, open_text_raw, open_text_analysis, full_result,
+        submitted_at,
+        respondents!inner(id, campaign_id, department, role_level, completed, completed_at, token)
+      `,
+      )
+      .eq("respondents.campaign_id", previousStats.campaign_id);
+
+    previousResponses = (previousResponsesRaw ??
+      []) as unknown as (SurveyResponse & {
+      respondents: Respondent;
+    })[];
+  }
+
+  const { data: allRespondents } = await supabase
+    .from("respondents")
+    .select("*")
+    .eq("campaign_id", id)
+    .order("completed_at", { ascending: false, nullsFirst: false });
+  const respondents = (allRespondents ?? []) as Respondent[];
+  const unsentRespondents = respondents
+    .filter((respondent) => !respondent.sent_at && !respondent.completed)
+    .map((respondent) => ({
+      token: respondent.token,
+      email: respondent.email ?? null,
+    }));
+  const remindableCount = respondents.filter(
+    (respondent) => Boolean(respondent.sent_at) && !respondent.completed,
+  ).length;
+
+  const factorData = computeFactorAverages(responses);
+  const averageRiskScore = computeAverageSignalScore(responses);
+  const strongWorkSignalRate =
+    stats.scan_type === "exit" ? computeStrongWorkSignalRate(responses) : null;
+  const topExitReasonLabel =
+    stats.scan_type === "exit" ? getTopExitReasonLabel(responses) : null;
+  const topContributingReasonLabel =
+    stats.scan_type === "exit"
+      ? getTopContributingReasonLabel(responses)
+      : null;
+  const signalVisibilityAverage =
+    stats.scan_type === "exit"
+      ? computeAverageSignalVisibility(responses)
+      : null;
+  const retentionSupplemental = computeRetentionSupplementalAverages(responses);
+  const currentRetentionSignals =
+    stats.scan_type === "retention"
+      ? { retentionSignal: averageRiskScore, ...retentionSupplemental }
+      : null;
+  const previousRetentionSignals =
+    stats.scan_type === "retention" && previousResponses.length > 0
+      ? computeRetentionSignalAverages(previousResponses)
+      : null;
+  const currentPulseSignals =
+    stats.scan_type === "pulse" ? computePulseSignalAverages(responses) : null;
+  const previousPulseSignals =
+    stats.scan_type === "pulse" && previousResponses.length > 0
+      ? computePulseSignalAverages(previousResponses)
+      : null;
+  const pulseComparison =
+    stats.scan_type === "pulse"
+      ? buildPulseComparisonState({
+          current: currentPulseSignals ?? computePulseSignalAverages([]),
+          previous: previousPulseSignals,
+          currentResponsesLength: responses.length,
+          previousResponsesLength: previousResponses.length,
+        })
+      : null;
+  const teamLocalRead =
+    stats.scan_type === "team" ? buildTeamLocalReadState(responses) : null;
+  const teamPriorityRead =
+    stats.scan_type === "team" && teamLocalRead
+      ? buildTeamPriorityReadState(teamLocalRead)
+      : null;
+
+  const hasEnoughData = responses.length >= MIN_N_PATTERNS;
+  const hasMinDisplay = responses.length >= MIN_N_DISPLAY;
+  const scanDefinition = getScanDefinition(stats.scan_type);
+  const productModule = getProductModule(stats.scan_type);
+  const teamPriorityBand = (signalValue: number) =>
+    signalValue >= 7 ? "HOOG" : signalValue >= 4.5 ? "MIDDEN" : "LAAG";
+  const pendingCount = stats.total_invited - stats.total_completed;
+  const dashboardViewModel = productModule.buildDashboardViewModel({
+    signalLabelLower: scanDefinition.signalLabelLower,
+    averageSignal: averageRiskScore,
+    strongWorkSignalRate,
+    engagement: retentionSupplemental.engagement,
+    turnoverIntention: retentionSupplemental.turnoverIntention,
+    stayIntent: retentionSupplemental.stayIntent,
+    hasEnoughData,
+    hasMinDisplay,
+    pendingCount,
+    factorAverages: factorData.orgAverages,
+    topExitReasonLabel,
+    topContributingReasonLabel,
+    signalVisibilityAverage,
+  });
+
+  const invitesNotSent = respondents.filter(
+    (respondent) => !respondent.sent_at && !respondent.completed,
+  ).length;
+  const incompleteScores = responses.filter(
+    (response) => !response.org_scores || !response.sdt_scores,
+  ).length;
+  const launchControlState = buildLaunchControlState({
+    launchDate: deliveryRecord?.launch_date ?? null,
+    participantCommsConfig: deliveryRecord?.participant_comms_config ?? null,
+    reminderConfig: deliveryRecord?.reminder_config ?? null,
+    launchConfirmedAt: deliveryRecord?.launch_confirmed_at ?? null,
+  });
+  const readinessState = buildCampaignReadinessState({
+    totalInvited: stats.total_invited,
+    totalCompleted: stats.total_completed,
+    invitesNotSent,
+    incompleteScores,
     hasMinDisplay,
     hasEnoughData,
-    hasOpenAnswers: releasedOpenAnswerItems.length > 0,
-  })
-
-  const blockVisibility = Object.fromEntries(
-    resultsViewModel.blocks.map((block) => [block.key, block.visibility]),
-  ) as Record<
-    'response' | 'signal' | 'synthesis' | 'drivers' | 'depth' | 'voices',
-    ResultsBlockVisibility
-  >
-
-  const scanDefinition = getScanDefinition(stats.scan_type)
-  const organizationName = organization?.name ?? 'Organisatie'
-  const routePeriodLabel = formatRoutePeriodLabel(stats.campaign_name, stats.created_at)
-  const scopeLabel = deriveScopeLabel(respondents)
-  const moduleKey =
-    stats.scan_type === 'team' ? null : getDashboardModuleKeyForScanType(stats.scan_type)
-  const moduleLabel = moduleKey ? getDashboardModuleLabel(moduleKey) : scanDefinition.productName
-  const moduleHref = moduleKey ? getDashboardModuleHref(moduleKey) : '/dashboard'
-  const moduleBackLinkLabel = getDashboardModuleBackLinkLabel(stats.scan_type)
-  const topFactorLabel = factorPriorityRows[0]?.factor ?? null
-  const secondFactorLabel = factorPriorityRows[1]?.factor ?? null
+    activeClientAccessCount: activeClientAccessCount ?? 0,
+    pendingClientInviteCount: pendingClientInviteCount ?? 0,
+    importReady,
+    launchControlReady: launchControlState.ready,
+    launchControlBlockers: launchControlState.blockers,
+  });
+  const compositionState = getCampaignCompositionState({
+    isActive: stats.is_active,
+    totalInvited: stats.total_invited,
+    totalCompleted: stats.total_completed,
+    invitesNotSent,
+    incompleteScores,
+    hasMinDisplay,
+    hasEnoughData,
+  });
+  const activationState = buildResponseActivationState(stats.total_completed);
+  const showClientExecutionFlow = compositionState !== "closed";
+  const showManagementOutput = isManagementVisibleState(compositionState);
+  const showDeeperInsights =
+    compositionState === "full" || compositionState === "closed";
+  const showDetailedManagementOutput = showDeeperInsights;
+  const showPartialManagementOutput = compositionState === "partial";
+  const prefersReportFirst = compositionState === "closed";
   const canOpenActionCenterFromDeliveryRecord = deliveryRecord
     ? canOpenActionCenterRoute(deliveryRecord)
-    : false
+    : false;
   const actionCenterBridge = buildCampaignDetailActionCenterBridge({
     campaignId: id,
     routeEntryStage:
       deliveryRecord && hasOpenedActionCenterRoute(deliveryRecord)
-        ? 'active'
+        ? "active"
         : null,
     canOpenRoute:
-      blockVisibility.signal === 'visible' &&
+      showManagementOutput &&
       isLiveActionCenterScanType(stats.scan_type) &&
       canOpenActionCenterFromDeliveryRecord,
     assessedAt: deliveryRecord?.updated_at ?? stats.created_at,
-  })
-  const actionCenterRouteHref = buildActionCenterRouteOpenRedirect(id, 'campaign-detail')
-  const showOpenAnswersRoute =
-    blockVisibility.voices === 'visible' && releasedOpenAnswerItems.length > 0
-  const signalHighlights = buildSignalHighlights({
+  });
+  const actionCenterRouteHref = buildActionCenterRouteOpenRedirect(id, "campaign-detail");
+  const compositionStateMeta = {
+    setup: {
+      label: "Nog niet live",
+      tone: "amber" as const,
+      trust:
+        "Deze campagne blijft in setup. Toon hier nog geen managementlaag of rapport-first gedrag.",
+    },
+    ready_to_launch: {
+      label: "Launch klaar",
+      tone: "amber" as const,
+      trust:
+        "Respondenten staan klaar, maar invites zijn nog niet volledig live. Dashboard en rapport blijven bewust secundair.",
+    },
+    running: {
+      label: "Invites live",
+      tone: "amber" as const,
+      trust:
+        "De inviteflow loopt, maar zonder eerste veilige responslaag hoort dit nog als uitvoerstatus te landen.",
+    },
+    sparse: {
+      label: "Indicatief, nog dun",
+      tone: "amber" as const,
+      trust:
+        "Er zijn eerste responses, maar het beeld is nog te dun voor een veilige dashboardread of aanbevelingslaag.",
+    },
+    partial: {
+      label: "Deels zichtbaar",
+      tone: "amber" as const,
+      trust:
+        "De eerste read is open, maar drivers, aanbevelingen en vervolgblokken blijven deels verborgen door thresholds of scorecompleetheid.",
+    },
+    full: {
+      label: "Duiding gereed",
+      tone: "emerald" as const,
+      trust:
+        "Drivers, aanbevelingen en routeblokken mogen nu zichtbaar worden binnen de bestaande productgrenzen.",
+    },
+    closed: {
+      label: "Rapport eerst",
+      tone: "slate" as const,
+      trust:
+      "Deze campagne is gesloten. Gebruik dashboard en rapport nu voor terugblik, context en bestuurlijke opvolging.",
+    },
+  }[compositionState];
+  const utilitySectionVisible =
+    canExecuteCampaign || respondents.length > 0 || isVerisightAdmin;
+  const riskDistribution = {
+    HOOG: stats.band_high,
+    MIDDEN: stats.band_medium,
+    LAAG: stats.band_low,
+  };
+  const riskHistogram = buildRiskHistogram(responses);
+  const safeTableResponses = buildSafeTableResponses(
+    stats.scan_type,
+    responses,
+  );
+  const retentionTrendCards =
+    stats.scan_type === "retention" &&
+    currentRetentionSignals &&
+    previousRetentionSignals
+      ? buildRetentionTrendCards({
+          current: currentRetentionSignals,
+          previous: previousRetentionSignals,
+        })
+      : [];
+  const retentionSegmentPlaybooks =
+    stats.scan_type === "retention" && hasEnoughData
+      ? buildRetentionSegmentPlaybooks({
+          responses,
+          orgAverageSignal: averageRiskScore,
+          playbooks: productModule.getActionPlaybooks(),
+        })
+      : [];
+  const retentionThemes =
+    stats.scan_type === "retention"
+      ? clusterRetentionOpenSignals(responses)
+      : [];
+  const playbookCalibrationNote =
+    stats.scan_type === "retention"
+      ? (productModule.getActionPlaybookCalibrationNote?.() ?? null)
+      : null;
+  const disclosureDefaults = getDisclosureDefaults({
     scanType: stats.scan_type,
-    signalLabel: scanDefinition.signalLabel,
-    isVisible: blockVisibility.signal === 'visible',
-    averageSignalScore,
-    topFactorLabel,
-    strongWorkSignalRate,
-    supplemental,
-  })
-  const synthesisItems = buildSynthesisItems({
-    scanType: stats.scan_type,
-    topFactorLabel,
-    secondFactorLabel,
-    topExitReasonLabel,
-    topContributingReasonLabel,
-    retentionThemes,
-    openAnswerThemes: openAnswersViewModel.themes,
-    exitDistribution,
-  })
-  const depthNotes = buildDepthNotes({
-    scanDefinition,
-    responsesLength: responses.length,
-    hasMinDisplay,
     hasEnoughData,
-  })
-  const openAnswersHref = `/campaigns/${id}/open-antwoorden`
+    hasMinDisplay,
+    respondentsLength: respondents.length,
+    canManageCampaign,
+  });
+  const { data: learningDossiersRaw } =
+    profile?.is_verisight_admin === true
+      ? await supabase
+          .from("pilot_learning_dossiers")
+          .select(
+            "id, title, triage_status, updated_at, review_moment, next_route, stop_reason, management_action_outcome, adoption_outcome",
+          )
+          .eq("campaign_id", id)
+          .order("updated_at", { ascending: false })
+          .limit(3)
+      : { data: [] };
+  const learningDossiers = (learningDossiersRaw ?? []) as Array<{
+    id: string;
+    title: string;
+    triage_status: string;
+    updated_at: string;
+    review_moment: string | null;
+    next_route: string | null;
+    stop_reason: string | null;
+    management_action_outcome: string | null;
+    adoption_outcome: string | null;
+  }>;
+  const learningCloseoutEvidenceCount = learningDossiers.filter((dossier) =>
+    Boolean(
+      dossier.review_moment ||
+      dossier.next_route ||
+      dossier.stop_reason ||
+      dossier.management_action_outcome ||
+      dossier.adoption_outcome,
+    ),
+  ).length;
+  const firstNextStepGuidance = getFirstNextStepGuidance(stats.scan_type);
+  const primaryTeamPriority =
+    stats.scan_type === "team" && teamPriorityRead?.status === "ready"
+      ? (teamPriorityRead.groups.find((group) => group.isPrimary) ?? null)
+      : null;
+  const primaryTeamQuestions =
+    stats.scan_type === "team" && primaryTeamPriority
+      ? (productModule.getFocusQuestions()[primaryTeamPriority.topFactorKey]?.[
+          teamPriorityBand(primaryTeamPriority.topFactorSignalValue)
+        ] ?? [])
+      : [];
+  const primaryTeamPlaybook =
+    stats.scan_type === "team" && primaryTeamPriority
+      ? (productModule.getActionPlaybooks()[primaryTeamPriority.topFactorKey]?.[
+          teamPriorityBand(primaryTeamPriority.topFactorSignalValue)
+        ] ?? null)
+      : null;
+  const handoffTitle =
+    stats.scan_type === "retention"
+      ? "Eerste vervolgstap"
+      : stats.scan_type === "pulse"
+        ? "Pulse duiding en eerste vervolgactie"
+        : stats.scan_type === "team"
+          ? "Lokale duiding en eerste verificatie"
+          : stats.scan_type === "onboarding"
+            ? "Vroege landingsduiding en eerste vervolgstap"
+            : stats.scan_type === "leadership"
+              ? "Managementcontext en eerste verificatie"
+              : "Vertrekduiding en managementgesprek";
+  const handoffDescription =
+    stats.scan_type === "retention"
+      ? "Deze laag volgt dezelfde lijn als het rapport: waar staat behoud onder druk, waarom telt dat bestuurlijk en wat moet eerst geverifieerd worden."
+      : stats.scan_type === "pulse"
+          ? "Deze laag vertaalt Pulse naar een compacte samenvatting: welke review- of herijkingsvraag vraagt nu direct aandacht, wat moet je als eerste bijsturen en wanneer kijk je opnieuw."
+        : stats.scan_type === "team"
+          ? "Deze laag vertaalt TeamScan naar een bestuurlijk leesbare lokale read: welke afdelingen vallen op, wat moet je eerst toetsen en welke lokale context vraagt nu als eerste aandacht."
+          : stats.scan_type === "onboarding"
+            ? "Deze laag vertaalt onboarding naar een bestuurlijk leesbare landingsduiding: waar stokt de vroege landing, wat telt nu bestuurlijk en welke beperkte correctie hoort hier direct achteraan."
+            : stats.scan_type === "leadership"
+              ? "Deze laag vertaalt Leadership Scan naar een leesbare samenvatting: welke context valt op, wat moet je eerst toetsen en welke managementstap hoort hier direct achteraan."
+              : "Deze laag opent met de Frictiescore als samenvatting: wat keert terug, waar lijkt werkfrictie beinvloedbaar en waar moet management eerst doorvragen.";
+  const readinessLabel = activationState.readinessLabel;
+  const focusBadgeLabel =
+    stats.scan_type === "pulse"
+      ? "Signaal -> bijsturen -> opnieuw meten"
+      : stats.scan_type === "team"
+        ? "Lokaliseren -> verifieren -> begrenzen"
+        : stats.scan_type === "onboarding"
+          ? "Vroege landing -> corrigeren -> opnieuw toetsen"
+          : stats.scan_type === "leadership"
+            ? "Duiden -> verifieren -> begrenzen"
+            : stats.scan_type === "retention"
+              ? "Signaleren -> valideren -> handelen"
+              : "Terugblik -> duiden -> verbeteren";
+  const methodologyBadgeLabel =
+    stats.scan_type === "pulse"
+      ? "Reviewcontext"
+      : stats.scan_type === "team"
+        ? "Lokale context"
+        : stats.scan_type === "onboarding"
+          ? "Vroege landing"
+          : stats.scan_type === "leadership"
+            ? "Managementcontext"
+            : stats.scan_type === "retention"
+              ? "Privacy-first"
+              : "Rapportcontext";
+  const productExperience =
+    stats.scan_type === "retention"
+      ? {
+          familyRoleLabel: "Kernroute",
+          familyRoleTone: "emerald" as const,
+          summaryBarOrder: [
+            "signal",
+            "next-step",
+            "response",
+            "readiness",
+          ] as const,
+          heroAsideOrder: ["signal", "owner", "response", "readiness"] as const,
+          summaryFocusLabel: "Eerste route",
+          reviewLabel: "Reviewmoment",
+          evidenceSectionOrder: "management-first" as const,
+          recommendationOrder: "questions-first" as const,
+          trustNotePlacement: "drivers" as const,
+          trustNoteTitle: "Methodische status",
+          trustNoteBody: scanDefinition.evidenceStatusText,
+          trustNoteTone: "emerald" as const,
+          summaryTone: "slate" as const,
+          summarySignalLabel: "Retentiesignaal",
+          summaryContextLabel: "Groepssignaal · eerst toetsen",
+          summaryContextTone: "slate" as const,
+          summaryLeadTitle: "Eerste bestuurlijke leesrichting",
+          summaryLeadDescription:
+            "Lees RetentieScan eerst als groepssignaal: waar staat behoud onder druk, wat vraagt eerst verificatie en welk managementspoor moet daarna in Wat nu als eerste route worden gekozen.",
+          summaryCardEyebrow: "Behoudsspoor",
+          promotedSummaryCards: 2,
+          driverTitle: "Signaalbeeld en behoudsdruk",
+          driverDescription:
+            "Start bij retentiesignaal, trend en aanvullende signalen. Gebruik factoren en segmenten daarna om te bepalen waarom dit beeld ontstaat en waar behoud eerst nadere toetsing vraagt.",
+          driverIntro:
+            "Begin met het groepssignaal en open pas daarna factoren, trend en aanvullende lagen. Zo blijft RetentieScan een eerst-toetsen managementinstrument in plaats van een losse analysetabel.",
+          driverAsideLabel: hasEnoughData
+            ? "Behoudsdrivers beschikbaar"
+            : "Wacht op meer data",
+          driverAsideTone: hasEnoughData
+            ? ("slate" as const)
+            : ("amber" as const),
+          driverTabOrder: ["signalen", "trend", "factoren", "aanvullend"],
+          signalTabLabel: "Retentiesignaal",
+          signalTabTitle: "Retentiesignaal op groepsniveau",
+          signalTabDescription:
+            "Laat zien hoe breed en hoe scherp behoudsdruk zich over de groep verdeelt, zonder dit als individuele voorspelling te lezen.",
+          factorTabLabel: "Behoudsdrivers",
+          factorTabTitle: "Werkfactoren achter behoudsdruk",
+          factorTabDescription:
+            "Gebruik de laagst scorende werkfactoren als eerste verklarende laag voor managementgesprekken en gerichte verificatie.",
+          supplementalTabLabel: "Aanvullende signalen",
+          supplementalTitle: "Aanvullende signalen en SDT-basis",
+          supplementalDescription:
+            "Deze laag voegt bevlogenheid, open signalen en basisbehoeften toe aan het retentiebeeld, zodat trend en werkbeleving samen gelezen worden.",
+          actionTitle: "Waar behoud eerst aandacht vraagt",
+          focusQuestionTitle: "Prioritaire verificatievragen",
+          focusQuestionDescription:
+            "Start met de factoren en signalen die het eerst verificatie vragen. Gebruik de vragen om te bepalen wat in Wat nu de eerste managementroute wordt.",
+          playbookTitle: "Behoudsplaybooks onder de gekozen route",
+          playbookDescription:
+            "Deze playbooks vormen de uitvoerlaag onder de gekozen managementroute. Ze helpen van verificatie naar uitvoering te gaan zonder nieuwe prioriteiten te openen.",
+          routeTitle: "Van retentiesignaal naar managementroute",
+          routeDescription:
+            "Deze laag bundelt de gekozen route, eerste eigenaar, eerste stap en het logische reviewmoment zonder de executive hoofdlijn te verstoren.",
+          routeBadgeLabel: "Kernroute",
+          afterSessionTitle: "Na de eerste managementsessie",
+          afterSessionDescription:
+            "Gebruik het eerste reviewmoment om bewust te kiezen: blijf je op hetzelfde behoudsspoor, is segmentverdieping logisch of vraagt de volgende stap vooral een gerichte interventie en vervolgmeting?",
+        }
+      : stats.scan_type === "team"
+        ? {
+            familyRoleLabel: "Specialistische vervolgstap",
+            familyRoleTone: "blue" as const,
+            summaryBarOrder: [
+              "signal",
+              "next-step",
+              "response",
+              "readiness",
+            ] as const,
+            heroAsideOrder: [
+              "signal",
+              "next-step",
+              "response",
+              "readiness",
+            ] as const,
+            summaryFocusLabel: "Eerste lokale route",
+            reviewLabel: "Reviewmoment",
+            evidenceSectionOrder: "profile-first" as const,
+            recommendationOrder: "playbooks-first" as const,
+            trustNotePlacement: "handoff" as const,
+            trustNoteTitle: "Leesgrens van deze route",
+            trustNoteBody: scanDefinition.segmentText,
+            trustNoteTone: "amber" as const,
+            summaryTone: "slate" as const,
+            summarySignalLabel: "Teamsignaal",
+            summaryContextLabel: "Lokale context · afdeling eerst",
+            summaryContextTone: "slate" as const,
+            summaryLeadTitle: "Eerste bestuurlijke leesrichting",
+            summaryLeadDescription:
+              "Lees TeamScan eerst als veilige lokale contextlaag: welke afdelingen vallen op, welke factor kleurt dat beeld en welke lokale verificatie hoort nu als eerste.",
+            summaryCardEyebrow: "Lokaal spoor",
+            promotedSummaryCards: 2,
+            driverTitle: "Teamsignaal en lokale context",
+            driverDescription:
+              "Gebruik deze laag om het actuele teamsignaal gecontroleerd te verdiepen zonder TeamScan te verwarren met segment deep dive of manager ranking.",
+            driverIntro:
+              "Start bij de lokale read en gebruik daarna pas factoren, signaalverdeling en basisbehoeften om te bepalen welke afdelingen eerst verificatie vragen.",
+            driverAsideLabel: hasEnoughData
+              ? "Lokale read beschikbaar"
+              : "Wacht op meer data",
+            driverAsideTone: hasEnoughData
+              ? ("slate" as const)
+              : ("amber" as const),
+            driverTabOrder: ["lokaal", "factoren", "signalen", "aanvullend"],
+            signalTabLabel: "Signaalverdeling",
+            signalTabTitle: "Teamsignaal op groepsniveau",
+            signalTabDescription:
+              "Laat zien hoe breed en hoe scherp het teamsignaal zich over de totale groep verdeelt voordat je naar afdelingen kijkt.",
+            factorTabLabel: "Lokale drivers",
+            factorTabTitle: "Werkfactoren achter lokale frictie",
+            factorTabDescription:
+              "Gebruik de scherpste werkfactoren als eerste verklarende laag om te bepalen welke afdelingen lokale verificatie verdienen.",
+            supplementalTabLabel: "SDT-basis",
+            supplementalTitle: "Werkbeleving en SDT-basis",
+            supplementalDescription:
+              "Deze laag laat zien hoe autonomie, competentie en verbondenheid onder het huidige teamsignaal liggen en welke lokale context daardoor meer spanning laat zien.",
+            actionTitle: "Waar eerst lokaal op handelen",
+            focusQuestionTitle: "Prioritaire lokale verificatievragen",
+            focusQuestionDescription:
+              "Start met de factoren die het teamsignaal het scherpst kleuren en gebruik de vragen om te bepalen wat lokaal eerst getoetst moet worden.",
+            playbookTitle: "Lokale playbooks en eerste verificatie",
+            playbookDescription:
+              "Deze playbooks vormen de uitvoerlaag onder de gekozen lokale route. Ze helpen van verificatie naar een begrensde vervolgstap te gaan zonder de vraag breder te maken dan nodig.",
+            routeTitle: "Van TeamScan naar lokale managementroute",
+            routeDescription:
+              "Deze laag bundelt de gekozen lokale route, eerste eigenaar, eerste stap en de bewuste begrenzing van TeamScan zonder de executive hoofdlijn te verstoren.",
+            routeBadgeLabel: "Kleine vervolgstap",
+            afterSessionTitle: "Na de eerste managementsessie",
+            afterSessionDescription:
+              "Gebruik het eerste reviewmoment om bewust te kiezen: blijft een lokale vervolgstap logisch, is bredere duiding weer nodig of vraagt dit signaal juist minder lokalisatie dan gedacht?",
+          }
+        : stats.scan_type === "onboarding"
+          ? {
+              familyRoleLabel: "Begrensde peer-route",
+              familyRoleTone: "blue" as const,
+              summaryBarOrder: [
+                "signal",
+                "owner",
+                "review",
+                "readiness",
+              ] as const,
+              heroAsideOrder: [
+                "signal",
+                "owner",
+                "review",
+                "response",
+              ] as const,
+              summaryFocusLabel: "Eerste checkpoint",
+              reviewLabel: "Reviewmoment",
+              evidenceSectionOrder: "profile-first" as const,
+              recommendationOrder: "playbooks-first" as const,
+              trustNotePlacement: "handoff" as const,
+              trustNoteTitle: "Leesgrens van deze route",
+              trustNoteBody: scanDefinition.evidenceStatusText,
+              trustNoteTone: "amber" as const,
+              summaryTone: "slate" as const,
+              summarySignalLabel: "Onboardingsignaal",
+              summaryContextLabel: "Vroege landing · compacte teamread",
+              summaryContextTone: "slate" as const,
+              summaryLeadTitle: "Eerste bestuurlijke leesrichting",
+              summaryLeadDescription:
+                "Lees onboarding eerst als compacte teamread: waar stokt de vroege landing in de eerste 30-60-90 dagen, welke frictie is nu zichtbaar en welke beperkte correctie hoort daar direct bij.",
+              summaryCardEyebrow: "Landingsspoor",
+              promotedSummaryCards: 1,
+              driverTitle: "Onboardingsignaal en vroege landing",
+              driverDescription:
+                "Gebruik deze laag om het actuele landingsbeeld gecontroleerd te verdiepen zonder onboarding te verwarren met client onboarding of een volledige 30-60-90-journey.",
+              driverIntro:
+                "Start bij de landingsduiding en gebruik daarna pas factoren, signaalverdeling en basisbehoeften om te bepalen welke vroege factor nu eerst aandacht vraagt.",
+              driverAsideLabel: hasEnoughData
+                ? "Landingsduiding beschikbaar"
+                : "Wacht op meer data",
+              driverAsideTone: hasEnoughData
+                ? ("slate" as const)
+                : ("amber" as const),
+              driverTabOrder: ["factoren", "signalen", "aanvullend", "trend"],
+              signalTabLabel: "Landingsbeeld",
+              signalTabTitle: "Onboardingsignaal op groepsniveau",
+              signalTabDescription:
+                "Laat zien hoe breed en hoe scherp het huidige onboardingsignaal zich over de groep verdeelt zonder dit als journey- of retentieclaim te lezen.",
+              factorTabLabel: "Landingsdrivers",
+              factorTabTitle: "Werkfactoren achter vroege frictie",
+              factorTabDescription:
+                "Gebruik de scherpste werkfactoren als eerste managementspoor om te bepalen waar nieuwe instroom nu meer steun, duidelijkheid of inbedding nodig heeft.",
+              supplementalTabLabel: "SDT-basis",
+              supplementalTitle: "Werkbeleving en SDT-basis",
+              supplementalDescription:
+                "Deze laag laat zien hoe autonomie, competentie en verbondenheid onder het huidige onboardingcheckpoint liggen en welke vroege context daardoor meer spanning laat zien.",
+              actionTitle: "Waar eerst op handelen",
+              focusQuestionTitle: "Prioritaire landingsvragen",
+              focusQuestionDescription:
+                "Start met de factoren die de vroege landing het scherpst kleuren en gebruik de vragen om te bepalen wat eerst getoetst moet worden voordat een correctieroute wordt gekozen.",
+              playbookTitle: "Eerste correctie en borging",
+              playbookDescription:
+                "Deze uitvoerlaag helpt van verificatie naar een beperkte eerste correctie en een logisch volgend checkpoint te gaan, zonder de managementhoofdlijn zwaarder te maken dan nodig.",
+              routeTitle: "Van landingsduiding naar eerste managementkeuze",
+              routeDescription:
+                "Deze laag brengt eerste managementgebruik, de gekozen correctie en het logische vervolgmoment samen zonder onboarding te verwarren met een brede lifecycle-suite.",
+              routeBadgeLabel: "Begrensde peer-route",
+              afterSessionTitle: "Na de eerste managementsessie",
+              afterSessionDescription:
+                "Gebruik het eerste reviewmoment om bewust te kiezen: blijft een later checkpoint logisch, vraagt deze instroomfrictie eerst extra verificatie of hoort de vraag thuis in een andere productvorm?",
+            }
+          : stats.scan_type === "leadership"
+            ? {
+                familyRoleLabel: "Begrensde support-route",
+                familyRoleTone: "blue" as const,
+                summaryBarOrder: [
+                  "signal",
+                  "next-step",
+                  "review",
+                  "readiness",
+                ] as const,
+                heroAsideOrder: [
+                  "signal",
+                  "next-step",
+                  "review",
+                  "response",
+                ] as const,
+                summaryFocusLabel: "Eerste check",
+                reviewLabel: "Reviewmoment",
+                evidenceSectionOrder: "profile-first" as const,
+                recommendationOrder: "playbooks-first" as const,
+                trustNotePlacement: "handoff" as const,
+                trustNoteTitle: "Leesgrens van deze route",
+                trustNoteBody: scanDefinition.evidenceStatusText,
+                trustNoteTone: "amber" as const,
+                summaryTone: "slate" as const,
+                summarySignalLabel: "Leadershipsignaal",
+                summaryContextLabel: "Compacte context · groepsniveau",
+                summaryContextTone: "slate" as const,
+                summaryLeadTitle: "Eerste bestuurlijke leesrichting",
+                summaryLeadDescription:
+                  "Lees Leadership Scan eerst als compacte contextread: welke managementcontext kleurt het bestaande people-signaal mee en welke kleine check hoort daar nu logisch bij.",
+                summaryCardEyebrow: "Managementspoor",
+                promotedSummaryCards: 1,
+                driverTitle: "Managementcontext in beeld",
+                driverDescription:
+                  "Gebruik deze laag om het actuele leadershipbeeld gecontroleerd te verdiepen zonder Leadership Scan te verwarren met TeamScan, segment deep dive of een named leader view.",
+                driverIntro:
+                  "Start bij de begrensde read en gebruik daarna pas factoren, signaalverdeling en basisbehoeften om te bepalen welke context eerst een kleine check verdient.",
+                driverAsideLabel: hasEnoughData
+                  ? "Duiding beschikbaar"
+                  : "Wacht op meer data",
+                driverAsideTone: hasEnoughData
+                  ? ("slate" as const)
+                  : ("amber" as const),
+                driverTabOrder: ["factoren", "signalen", "aanvullend", "trend"],
+                signalTabLabel: "Managementbeeld",
+                signalTabTitle: "Leadershipsignaal op groepsniveau",
+                signalTabDescription:
+                  "Laat zien hoe breed en hoe scherp het huidige managementcontextsignaal zich over de groep verdeelt zonder dit te lezen als named leader of performanceclaim.",
+                factorTabLabel: "Managementdrivers",
+                factorTabTitle: "Werkfactoren achter managementfrictie",
+                factorTabDescription:
+                  "Gebruik de scherpste werkfactoren als eerste managementspoor om te bepalen waar de huidige aansturing of prioritering eerst duiding vraagt.",
+                supplementalTabLabel: "SDT-basis",
+                supplementalTitle: "Werkbeleving en SDT-basis",
+                supplementalDescription:
+                  "Deze laag laat zien hoe autonomie, competentie en verbondenheid onder het huidige leadershipsignaal liggen en welke managementcontext daardoor meer spanning laat zien.",
+                actionTitle: "Waar eerst op handelen",
+                focusQuestionTitle: "Prioritaire managementvragen",
+                focusQuestionDescription:
+                  "Start met de factoren die het leadershipbeeld het scherpst kleuren en gebruik de vragen om te bepalen wat eerst getoetst moet worden voordat een begrensde vervolgstap wordt gekozen.",
+                playbookTitle: "Begrensde checks en eerste vervolgstap",
+                playbookDescription:
+                "Deze checks vormen de uitvoerlaag onder de gekozen route. Ze helpen van duiding naar een kleine vervolgstap te gaan zonder named leader output te openen.",
+                routeTitle: "Van leadershipread naar begrensde vervolgstap",
+                routeDescription:
+                  "Deze laag brengt de gekozen check, kleine vervolgstap en het reviewmoment samen zonder Leadership Scan te laten lezen als een quasi-peer route.",
+                routeBadgeLabel: "Kleine vervolgstap",
+                afterSessionTitle: "Na de eerste managementsessie",
+                afterSessionDescription:
+                  "Gebruik het eerste reviewmoment om bewust te kiezen: blijft een kleine check genoeg, vraagt de vraag toch bredere duiding of hoort Leadership Scan hier juist te stoppen?",
+              }
+            : stats.scan_type === "exit"
+              ? {
+                  familyRoleLabel: "Kernroute",
+                  familyRoleTone: "blue" as const,
+                  summaryBarOrder: [
+                    "signal",
+                    "owner",
+                    "response",
+                    "readiness",
+                  ] as const,
+                  heroAsideOrder: [
+                    "signal",
+                    "owner",
+                    "response",
+                    "readiness",
+                  ] as const,
+                  summaryFocusLabel: "Eerste route",
+                  reviewLabel: "Reviewmoment",
+                  evidenceSectionOrder: "management-first" as const,
+                  recommendationOrder: "questions-first" as const,
+                  trustNotePlacement: "drivers" as const,
+                  trustNoteTitle: "Methodische status",
+                  trustNoteBody: scanDefinition.evidenceStatusText,
+                  trustNoteTone: "blue" as const,
+                  summaryTone: "slate" as const,
+                  summarySignalLabel: "Frictiescore",
+                  summaryContextLabel: "Werkfrictie · verklarende laag",
+                  summaryContextTone: "slate" as const,
+                  summaryLeadTitle: "Eerste bestuurlijke leesrichting",
+                  summaryLeadDescription:
+                    "Lees ExitScan eerst via de Frictiescore: wat keert terug, waar lijkt werkfrictie beinvloedbaar en welk managementspoor moet nu als eerste gekozen worden.",
+                  summaryCardEyebrow: "Vertrekspoor",
+                  promotedSummaryCards: 2,
+                  driverTitle: "Kernsignalen en vertrekbeeld",
+                  driverDescription:
+                    "Start bij de scherpste werkfactoren en gebruik daarna pas signaalverdeling en aanvullende lagen om het vertrekbeeld verder te onderbouwen.",
+                  driverIntro:
+                    "Begin met de factoren die het vertrekverhaal het meest kleuren. Gebruik signaalverdeling en SDT daarna om het managementgesprek scherper en concreter te maken.",
+                  driverAsideLabel: hasEnoughData
+                    ? "Vertrekdrivers beschikbaar"
+                    : "Wacht op meer data",
+                  driverAsideTone: hasEnoughData
+                    ? ("slate" as const)
+                    : ("amber" as const),
+                  driverTabOrder: [
+                    "factoren",
+                    "signalen",
+                    "aanvullend",
+                    "trend",
+                  ],
+                  signalTabLabel: "Frictiescore",
+                  signalTabTitle: "Frictiescore op groepsniveau",
+                  signalTabDescription:
+                    "Laat zien hoe breed en hoe scherp de Frictiescore zich over de groep verdeelt, zodat je werkfrictie en vertrekduiding in context kunt lezen.",
+                  factorTabLabel: "Vertrekdrivers",
+                  factorTabTitle: "Laagste scores per werkfactor",
+                  factorTabDescription:
+                    "Deze lijst toont per werkfactor de score en relatieve zwaarte.",
+                  supplementalTabLabel: "SDT-basis",
+                  supplementalTitle: "Werkbeleving en SDT-basis",
+                  supplementalDescription:
+                    "Deze laag laat zien hoe autonomie, competentie en verbondenheid onder het vertrekbeeld liggen en waar vervolgvragen het meeste opleveren.",
+                  actionTitle: "Waar eerst op handelen",
+                  focusQuestionTitle: "Prioritaire focusvragen",
+                  focusQuestionDescription:
+                    "Start met de factoren die het vertrekbeeld het scherpst kleuren en gebruik de vragen om te bepalen wat eerst getoetst moet worden voordat de eerste route wordt gekozen.",
+                  playbookTitle: "Besluit- en eigenaarschapsroutes",
+                  playbookDescription:
+                    "Deze playbooks vormen de uitvoerlaag onder de gekozen managementroute. Ze helpen van vertrekduiding naar uitvoering te gaan zonder nieuwe prioriteiten buiten het gekozen spoor te openen.",
+                  routeTitle: "Van vertrekduiding naar managementroute",
+                  routeDescription:
+                    "Deze laag bundelt de gekozen managementroute, eerste eigenaar, eerste stap en het logische reviewmoment zonder de kernflow bovenin te verstoren.",
+                  routeBadgeLabel: "Kernroute",
+                  afterSessionTitle: "Na de eerste managementsessie",
+                  afterSessionDescription:
+                    "Gebruik het eerste reviewmoment om bewust te kiezen: blijf je op hetzelfde vertrekspoor, vraagt deze scan verdere verdieping of wordt een tweede product logisch op basis van de eerste managementwaarde?",
+                }
+              : {
+                  familyRoleLabel: "Begrensde support-route",
+                  familyRoleTone: "blue" as const,
+                  summaryBarOrder: [
+                    "signal",
+                    "next-step",
+                    "review",
+                    "readiness",
+                  ] as const,
+                  heroAsideOrder: [
+                    "signal",
+                    "next-step",
+                    "review",
+                    "response",
+                  ] as const,
+                  summaryFocusLabel: "Eerste herijking",
+                  reviewLabel: "Reviewmoment",
+                  evidenceSectionOrder: "profile-first" as const,
+                  recommendationOrder: "playbooks-first" as const,
+                  trustNotePlacement: "handoff" as const,
+                  trustNoteTitle: "Leesgrens van deze route",
+                  trustNoteBody: scanDefinition.evidenceStatusText,
+                  trustNoteTone: "amber" as const,
+                  summaryTone: "slate" as const,
+                  summarySignalLabel: "Pulsesignaal",
+                  summaryContextLabel: "Reviewlaag · herhaalritme",
+                  summaryContextTone: "slate" as const,
+                  summaryLeadTitle: "Eerste bestuurlijke leesrichting",
+                  summaryLeadDescription:
+                    "Gebruik deze eerste laag om het primaire managementsignaal en het eerste werkspoor snel scherp te krijgen, voordat een route, eigenaar en hercheckmoment worden gekozen.",
+                  summaryCardEyebrow: "Pulse vervolgstap",
+                  promotedSummaryCards: 2,
+                  driverTitle: "Pulse groepsread en vergelijking",
+                  driverDescription:
+                    "Gebruik deze laag om het actuele Pulse-beeld gecontroleerd te verdiepen zonder de managementhoofdlijn kwijt te raken.",
+                  driverIntro:
+                    "Gebruik de tabs hieronder om tussen groepsread, factoren, aanvullende lagen en vergelijking te wisselen zonder de hoofdlijn van de duiding kwijt te raken.",
+                  driverAsideLabel: hasEnoughData
+                    ? "Pulse read beschikbaar"
+                    : "Wacht op meer data",
+                  driverAsideTone: hasEnoughData
+                    ? ("slate" as const)
+                    : ("amber" as const),
+                  driverTabOrder: [
+                    "factoren",
+                    "trend",
+                    "signalen",
+                    "aanvullend",
+                  ],
+                  signalTabLabel: "Signaalverdeling",
+                  signalTabTitle: "Signaalverdeling",
+                  signalTabDescription:
+                    "Laat zien hoe breed en hoe scherp de signalen zich over de groep verdelen op dit meetmoment.",
+                  factorTabLabel: "Factoren",
+                  factorTabTitle: "Organisatiefactoren",
+                  factorTabDescription:
+                    "De factoren hieronder helpen bepalen waar managementgesprekken en kleine correcties nu het meeste opleveren.",
+                  supplementalTabLabel: "SDT-basis",
+                  supplementalTitle: "SDT basisbehoeften",
+                  supplementalDescription:
+                    "Deze laag laat zien hoe de fundamentele werkbeleving onder de actuele Pulse-signalen mee beweegt.",
+                  actionTitle: "Prioriteiten en route-uitvoer",
+                  focusQuestionTitle: "Prioritaire focusvragen",
+                  focusQuestionDescription:
+                  "Start met de factoren die het scherpst afwijken en gebruik de vragen om te bepalen wat eerst getoetst moet worden voordat een route wordt gekozen.",
+                  playbookTitle: "Pulse playbooks en eerstvolgende correctie",
+                  playbookDescription:
+                  "Deze playbooks vormen de uitvoerlaag onder de gekozen route. Ze helpen van verificatie naar correctie en een logisch hercheckmoment te gaan.",
+                routeTitle: "Van Pulse read naar herhaalritme",
+                  routeDescription:
+                    "Deze laag brengt eerste managementgebruik, de gekozen correctie en het logische volgende meetmoment samen zonder Pulse te verwarren met een bredere kernroute of hoofdrapport.",
+                routeBadgeLabel: "Kleine vervolgstap",
+                  afterSessionTitle: "Na de eerste managementsessie",
+                  afterSessionDescription:
+                  "Gebruik het eerste reviewmoment om bewust te kiezen: doe je nog een compacte Pulse-check, verdiep je eerst de vraag verder of vraagt het thema nu een andere productvorm?",
+                };
+  const presentationMetrics = buildPresentationMetrics({
+    productExperience,
+    scanDefinition,
+    dashboardViewModel,
+    averageRiskScore,
+    totalCompleted: stats.total_completed,
+    totalInvited: stats.total_invited,
+    compositionStateMeta,
+    hasEnoughData,
+  });
+  const summaryItems = productExperience.summaryBarOrder.map(
+    (key) => presentationMetrics[key],
+  );
+  const heroAsideItems = productExperience.heroAsideOrder.map(
+    (key) => presentationMetrics[key],
+  );
+  const sectionAnchors = [
+    { id: "samenvatting", label: "Samenvatting" },
+    ...(showManagementOutput
+      ? [
+          {
+            id: "handoff",
+            label: showPartialManagementOutput
+              ? "Compacte read"
+              : stats.scan_type === "retention"
+                ? "Vervolg"
+                : stats.scan_type === "team"
+                  ? "Lokale read"
+                  : "Vervolg",
+          },
+          ...(showDetailedManagementOutput
+            ? [
+                {
+                  id: "drivers",
+                  label:
+                    stats.scan_type === "retention"
+                      ? "Signalen"
+                      : stats.scan_type === "team"
+                        ? "Lokaal"
+                        : "Drivers",
+                },
+                {
+                  id: "acties",
+                  label:
+                    stats.scan_type === "retention"
+                      ? "Behoudsacties"
+                      : stats.scan_type === "team"
+                        ? "Lokale acties"
+                        : "Acties",
+                },
+                {
+                  id: "route",
+                  label:
+                    stats.scan_type === "retention" ||
+                    stats.scan_type === "exit"
+                      ? "Kernroute"
+                      : stats.scan_type === "team" ||
+                          stats.scan_type === "pulse" ||
+                          stats.scan_type === "onboarding" ||
+                          stats.scan_type === "leadership"
+                        ? "Vervolgroute"
+                        : "Route",
+                },
+              ]
+            : []),
+        ]
+      : []),
+    { id: "methodiek", label: "Methodiek" },
+    ...(utilitySectionVisible
+      ? [
+          {
+            id: showClientExecutionFlow ? "uitvoering" : "operatie",
+            label: showClientExecutionFlow ? "Uitvoering" : "Operatie",
+          },
+        ]
+      : []),
+  ];
+  const promotedSummaryCards =
+    showDetailedManagementOutput && productExperience.promotedSummaryCards > 0
+      ? dashboardViewModel.topSummaryCards.slice(
+          0,
+          productExperience.promotedSummaryCards,
+        )
+      : [];
+  const handoffSummaryCards =
+    showDetailedManagementOutput && productExperience.promotedSummaryCards > 0
+      ? dashboardViewModel.topSummaryCards.slice(
+          productExperience.promotedSummaryCards,
+        )
+      : dashboardViewModel.topSummaryCards;
+  const availableDriverTabs = hasEnoughData
+    ? [
+        ...(stats.scan_type === "team" && teamLocalRead
+          ? [
+              {
+                id: "lokaal",
+                label: "Lokale read",
+                content: (
+                  <div className="space-y-5">
+                    <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4 sm:p-5">
+                      <div className="flex flex-wrap items-center gap-3">
+                        <h3 className="text-sm font-semibold text-slate-950">
+                          {teamLocalRead.summaryTitle}
+                        </h3>
+                        <DashboardChip
+                          label={`${teamLocalRead.coverageCount}/${teamLocalRead.totalResponses} met afdeling`}
+                          tone="slate"
+                        />
+                        <DashboardChip
+                          label={
+                            teamLocalRead.status === "ready"
+                              ? `${teamLocalRead.safeGroupCount} veilige afdelingen`
+                              : "Fallback actief"
+                          }
+                          tone={
+                            teamLocalRead.status === "ready"
+                              ? "emerald"
+                              : "amber"
+                          }
+                        />
+                        <DashboardChip
+                          label={
+                            teamPriorityRead?.status === "ready"
+                              ? `Meenemen in verificatie: ${teamPriorityRead.firstPriorityLabel}`
+                              : teamPriorityRead?.status === "no_hard_order"
+                                ? "Nog geen harde volgorde"
+                                : "Prioriteit nog niet vrijgegeven"
+                          }
+                          tone={
+                            teamPriorityRead?.status === "ready"
+                              ? "amber"
+                              : "slate"
+                          }
+                        />
+                      </div>
+                      <p className="mt-1 text-sm leading-6 text-slate-600">
+                        {teamPriorityRead?.summaryBody ??
+                          teamLocalRead.summaryBody}
+                      </p>
+                      <p className="mt-3 text-xs leading-6 text-slate-500">
+                        {teamPriorityRead?.caution ?? teamLocalRead.caution}
+                      </p>
+                    </div>
 
+                    {teamLocalRead.status === "ready" && teamPriorityRead ? (
+                      <div className="grid gap-4 lg:grid-cols-3">
+                        {teamPriorityRead.groups.map((group) => (
+                          <DashboardPanel
+                            key={group.label}
+                            eyebrow={`${group.priorityTitle} · Afdeling · n = ${group.n}`}
+                            title={group.label}
+                            value={`${group.avgSignal.toFixed(1)}/10`}
+                            body={`${group.summary} ${group.priorityBody} Eerste lokale factor: ${group.topFactorLabel}.`}
+                            tone={group.priorityTone}
+                          />
+                        ))}
+                      </div>
+                    ) : (
+                      <div className="rounded-2xl border border-dashed border-slate-200 bg-white px-4 py-4 text-sm leading-6 text-slate-600">
+                        TeamScan blijft in deze situatie bewust op
+                        organisatieniveau. Zodra genoeg afdelingsmetadata en
+                        veilige groepsgroottes beschikbaar zijn, verschijnt de
+                        lokale read hier.
+                      </div>
+                    )}
+                  </div>
+                ),
+              },
+            ]
+          : []),
+        {
+          id: "signalen",
+          label: productExperience.signalTabLabel,
+          content: (
+            <DashboardChartPanel
+              eyebrow="Signaalbeeld"
+              title={productExperience.signalTabTitle}
+              description={productExperience.signalTabDescription}
+              tone="slate"
+              variant="quiet"
+            >
+              <div className="mt-1">
+                <RiskCharts
+                  distribution={riskDistribution}
+                  histogramBins={riskHistogram}
+                  averageScore={averageRiskScore}
+                  scanType={stats.scan_type}
+                />
+              </div>
+            </DashboardChartPanel>
+          ),
+        },
+        {
+          id: "factoren",
+          label: productExperience.factorTabLabel,
+          content: (
+            <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4 sm:p-5">
+              <h3 className="text-sm font-semibold text-slate-950">
+                {productExperience.factorTabTitle}
+              </h3>
+              <p className="mt-1 text-sm leading-6 text-slate-600">
+                {productExperience.factorTabDescription}
+              </p>
+              <div className="mt-4">
+                <FactorTable
+                  factorAverages={factorData.orgAverages}
+                  scanType={stats.scan_type}
+                />
+              </div>
+            </div>
+          ),
+        },
+        {
+          id: "aanvullend",
+          label: productExperience.supplementalTabLabel,
+          content: (
+            <div className="space-y-5">
+              <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4 sm:p-5">
+                <div className="flex flex-wrap items-center gap-3">
+                  <h3 className="text-sm font-semibold text-slate-950">
+                    {productExperience.supplementalTitle}
+                  </h3>
+                  <DashboardChip
+                    label="Autonomie · Competentie · Verbondenheid"
+                    tone="slate"
+                  />
+                </div>
+                <p className="mt-1 text-sm leading-6 text-slate-600">
+                  {productExperience.supplementalDescription}
+                </p>
+                <div className="mt-4 grid gap-4 sm:grid-cols-3">
+                  {(["autonomy", "competence", "relatedness"] as const).map(
+                    (dimension) => (
+                      <SdtGauge
+                        key={dimension}
+                        label={FACTOR_LABELS[dimension]}
+                        score={factorData.sdtAverages[dimension] ?? 5.5}
+                      />
+                    ),
+                  )}
+                </div>
+              </div>
+
+              {stats.scan_type === "retention" && retentionThemes.length > 0 ? (
+                <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4 sm:p-5">
+                  <h3 className="text-sm font-semibold text-slate-950">
+                    Open signalen op groepsniveau
+                  </h3>
+                  <p className="mt-1 text-sm leading-6 text-slate-600">
+                    Geclusterd zodat open antwoorden als managementsignaal
+                    gelezen kunnen worden, niet als losse klachtenlijst.
+                  </p>
+                  <div className="mt-4 grid gap-4 lg:grid-cols-3">
+                    {retentionThemes.map((theme) => (
+                      <div
+                        key={theme.key}
+                        className="rounded-[20px] border border-white/80 bg-white/80 p-4 shadow-sm"
+                      >
+                        <div className="flex items-center justify-between gap-3">
+                          <p className="text-sm font-semibold text-slate-950">
+                            {theme.title}
+                          </p>
+                          <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-500">
+                            {theme.count}
+                          </span>
+                        </div>
+                        <p className="mt-3 text-sm leading-6 text-slate-700">
+                          {theme.implication}
+                        </p>
+                        <p className="mt-3 text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
+                          Voorbeeldsignaal
+                        </p>
+                        <p className="mt-1 text-sm italic leading-6 text-slate-600">
+                          &quot;{theme.sample}&quot;
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          ),
+        },
+        ...(stats.scan_type === "retention" &&
+        previousStats &&
+        currentRetentionSignals &&
+        previousRetentionSignals
+          ? [
+              {
+                id: "trend",
+                label: "Trend",
+                content: (
+                  <RetentionTrendSection
+                    current={currentRetentionSignals}
+                    previous={previousRetentionSignals}
+                    previousDate={previousStats.created_at}
+                    previousCampaignName={previousStats.campaign_name}
+                    trendCards={retentionTrendCards}
+                  />
+                ),
+              },
+            ]
+          : stats.scan_type === "pulse" &&
+              previousStats &&
+              pulseComparison &&
+              pulseComparison.status !== "no_previous"
+            ? [
+                {
+                  id: "trend",
+                  label: "Vergelijking",
+                  content: (
+                    <PulseTrendSection
+                      comparison={pulseComparison}
+                      previousDate={previousStats.created_at}
+                      previousCampaignName={previousStats.campaign_name}
+                    />
+                  ),
+                },
+              ]
+            : []),
+      ]
+    : [];
+  const driverTabs = hasEnoughData
+    ? productExperience.driverTabOrder.flatMap((tabId) =>
+        availableDriverTabs.filter((tab) => tab.id === tabId),
+      )
+    : [];
+  const trustNote = (
+    <div
+      className={`rounded-[22px] border px-4 py-4 ${
+        productExperience.trustNoteTone === "emerald"
+          ? "border-emerald-200 bg-emerald-50"
+          : productExperience.trustNoteTone === "amber"
+            ? "border-amber-200 bg-amber-50"
+            : "border-slate-200 bg-slate-50"
+      }`}
+    >
+      <p
+        className={`text-xs font-semibold uppercase tracking-[0.18em] ${
+          productExperience.trustNoteTone === "emerald"
+            ? "text-emerald-800"
+            : productExperience.trustNoteTone === "amber"
+              ? "text-amber-900"
+              : "text-slate-600"
+        }`}
+      >
+        {productExperience.trustNoteTitle}
+      </p>
+      <p className="mt-2 text-sm leading-6 text-slate-800">
+        {productExperience.trustNoteBody}
+      </p>
+    </div>
+  );
+  const profileCardsSection =
+    dashboardViewModel.profileCards.length > 0 ? (
+      <div className="grid gap-4 md:grid-cols-2">
+        {dashboardViewModel.profileCards.map((card) => (
+          <DashboardPanel
+            key={`${card.title}-${card.value ?? "profile"}`}
+            eyebrow={card.title}
+            title={card.value || card.title}
+            body={card.body}
+            tone={normalizeInformationalTone(card.tone)}
+          />
+        ))}
+      </div>
+    ) : null;
+  const managementBlocksSection =
+    dashboardViewModel.managementBlocks.length > 0 ? (
+      <div className="grid gap-4 lg:grid-cols-3">
+        {dashboardViewModel.managementBlocks.map((block) => (
+          <div
+            key={block.title}
+            className={`rounded-[22px] border p-4 ${
+              block.tone === "emerald"
+                ? "border-[#d2e6e0] bg-[#eef7f4]"
+                : block.tone === "amber"
+                  ? "border-[#eadfbe] bg-[#faf6ea]"
+                  : "border-slate-200 bg-slate-50"
+            }`}
+          >
+            <p
+              className={`text-xs font-semibold uppercase tracking-[0.2em] ${
+                block.tone === "emerald"
+                  ? "text-[#3C8D8A]"
+                  : block.tone === "amber"
+                    ? "text-[#8C6B1F]"
+                    : "text-slate-600"
+              }`}
+            >
+              {block.title}
+            </p>
+            {block.intro ? (
+              <p className="mt-3 text-sm leading-6 text-slate-700">
+                {block.intro}
+              </p>
+            ) : null}
+            <ul className="mt-3 space-y-2">
+              {block.items.map((item) => (
+                <li
+                  key={item}
+                  className="flex gap-2 text-sm leading-6 text-slate-700"
+                >
+                  <span className="text-slate-400">-</span>
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    ) : null;
+  const focusQuestionsBlock = (
+    <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4 sm:p-5">
+      <h3 className="text-sm font-semibold text-slate-950">
+        {productExperience.focusQuestionTitle}
+      </h3>
+      <p className="mt-1 text-sm leading-6 text-slate-600">
+        {productExperience.focusQuestionDescription}
+      </p>
+      <div className="mt-4">
+        <RecommendationList
+          factorAverages={factorData.orgAverages}
+          scanType={stats.scan_type}
+          bandOverride={
+            stats.scan_type === "onboarding" || stats.scan_type === "leadership"
+              ? dashboardViewModel.managementBandOverride
+              : undefined
+          }
+        />
+      </div>
+    </div>
+  );
+  const playbooksBlock =
+    stats.scan_type === "retention" ||
+    stats.scan_type === "exit" ||
+    stats.scan_type === "pulse" ||
+    stats.scan_type === "team" ||
+    stats.scan_type === "onboarding" ||
+    stats.scan_type === "leadership" ? (
+      <>
+        <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4 sm:p-5">
+          <h3 className="text-sm font-semibold text-slate-950">
+            {productExperience.playbookTitle}
+          </h3>
+          <p className="mt-1 text-sm leading-6 text-slate-600">
+            {productExperience.playbookDescription}
+          </p>
+          {stats.scan_type === "retention" && playbookCalibrationNote ? (
+            <p className="mt-2 text-xs leading-6 text-slate-500">
+              {playbookCalibrationNote}
+            </p>
+          ) : null}
+          <div className="mt-4">
+            <ActionPlaybookList
+              factorAverages={factorData.orgAverages}
+              scanType={stats.scan_type}
+              bandOverride={
+                stats.scan_type === "onboarding" ||
+                stats.scan_type === "leadership"
+                  ? dashboardViewModel.managementBandOverride
+                  : undefined
+              }
+            />
+          </div>
+        </div>
+
+        {stats.scan_type === "retention" && hasSegmentDeepDive ? (
+          <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4 sm:p-5">
+            <h3 className="text-sm font-semibold text-slate-950">
+              Segment-specifieke playbooks
+            </h3>
+            <p className="mt-1 text-sm leading-6 text-slate-600">
+              Alleen zichtbaar als segmentvergelijking voldoende respons en
+              metadata heeft.
+            </p>
+            <div className="mt-4">
+              {retentionSegmentPlaybooks.length > 0 ? (
+                <SegmentPlaybookList segments={retentionSegmentPlaybooks} />
+              ) : (
+                <div className="rounded-2xl border border-dashed border-slate-200 bg-white px-4 py-4 text-sm leading-6 text-slate-600">
+                  Nog geen segmenten met voldoende n en voldoende afwijking om
+                  apart te tonen.
+                </div>
+              )}
+            </div>
+          </div>
+        ) : null}
+      </>
+    ) : null;
+
+  const dominantBand = (["HOOG", "MIDDEN", "LAAG"] as const).reduce(
+    (current, candidate) =>
+      riskDistribution[current] >= riskDistribution[candidate]
+        ? current
+        : candidate,
+  );
+  const totalRiskResponses =
+    riskDistribution.HOOG + riskDistribution.MIDDEN + riskDistribution.LAAG;
+  const dominantPct =
+    totalRiskResponses > 0
+      ? Math.round((riskDistribution[dominantBand] / totalRiskResponses) * 100)
+      : 0;
+  const bandLabels = {
+    HOOG: "Direct prioriteren",
+    MIDDEN: "Eerst toetsen",
+    LAAG: "Volgen",
+  } as const;
+  const focusPanelItems = showManagementOutput
+    ? [
+        {
+          text: dashboardViewModel.primaryQuestion.title,
+          moduleLabel: scanDefinition.productName,
+        },
+        {
+          text: dashboardViewModel.nextStep.title,
+          moduleLabel: scanDefinition.productName,
+        },
+      ]
+    : [];
   async function openActionCenterRoute() {
-    'use server'
+    "use server";
 
-    const admin = createAdminClient()
-    const actionCenterHref = buildActionCenterRouteOpenRedirect(id, 'campaign-detail')
+    const admin = createAdminClient();
+    const actionCenterHref = buildActionCenterRouteOpenRedirect(id, "campaign-detail");
     const { data: currentDeliveryRecord, error: loadError } = await admin
-      .from('campaign_delivery_records')
-      .select('id, lifecycle_stage, first_management_use_confirmed_at')
-      .eq('campaign_id', id)
-      .maybeSingle()
+      .from("campaign_delivery_records")
+      .select("id, lifecycle_stage, first_management_use_confirmed_at")
+      .eq("campaign_id", id)
+      .maybeSingle();
 
     if (loadError || !currentDeliveryRecord) {
-      notFound()
+      redirect(`/campaigns/${id}?bridge=open-unavailable`);
     }
 
     if (hasOpenedActionCenterRoute(currentDeliveryRecord)) {
-      redirect(actionCenterHref)
+      redirect(actionCenterHref);
     }
 
     if (!canOpenActionCenterRoute(currentDeliveryRecord)) {
-      notFound()
+      redirect(`/campaigns/${id}?bridge=open-unavailable`);
     }
 
-    const openedAt = new Date().toISOString()
+    const openedAt = new Date().toISOString();
     const { data: updatedRecord, error } = await admin
-      .from('campaign_delivery_records')
+      .from("campaign_delivery_records")
       .update(buildActionCenterRouteOpenPatch(openedAt))
-      .eq('id', currentDeliveryRecord.id)
-      .is('first_management_use_confirmed_at', null)
-      .in('lifecycle_stage', getActionCenterRouteOpenableStages())
-      .select('id')
-      .maybeSingle()
+      .eq("id", currentDeliveryRecord.id)
+      .is("first_management_use_confirmed_at", null)
+      .in("lifecycle_stage", getActionCenterRouteOpenableStages())
+      .select("id")
+      .maybeSingle();
 
     if (error) {
-      notFound()
+      redirect(`/campaigns/${id}?bridge=open-unavailable`);
     }
 
     if (!updatedRecord) {
       const { data: latestDeliveryRecord } = await admin
-        .from('campaign_delivery_records')
-        .select('id, lifecycle_stage, first_management_use_confirmed_at')
-        .eq('campaign_id', id)
-        .maybeSingle()
+        .from("campaign_delivery_records")
+        .select("id, lifecycle_stage, first_management_use_confirmed_at")
+        .eq("campaign_id", id)
+        .maybeSingle();
 
-      if (!latestDeliveryRecord || !hasOpenedActionCenterRoute(latestDeliveryRecord)) {
-        notFound()
+      if (latestDeliveryRecord && hasOpenedActionCenterRoute(latestDeliveryRecord)) {
+        redirect(actionCenterHref);
       }
+
+      redirect(`/campaigns/${id}?bridge=open-unavailable`);
     }
 
-    redirect(actionCenterHref)
+    redirect(actionCenterHref);
   }
-
-  const actionCenterBridgeCard =
-    actionCenterBridge.presentation.ctaKind === 'open' ? (
-      <div className="rounded-[24px] border border-slate-200 bg-white px-5 py-5 shadow-sm">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-          <div className="space-y-2">
-            <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
-              Vervolgroute
-            </p>
-            <h2 className="text-lg font-semibold tracking-[-0.02em] text-[color:var(--dashboard-ink)]">
-              {actionCenterBridge.presentation.label}
-            </h2>
-            <p className="max-w-3xl text-sm leading-6 text-[color:var(--dashboard-text)]">
-              {actionCenterBridge.presentation.body}
-            </p>
-          </div>
-
-          {actionCenterBridge.bridgeState === 'candidate' ? (
-            <form action={openActionCenterRoute}>
-              <button
-                type="submit"
-                className="inline-flex rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition-colors hover:border-slate-300 hover:bg-slate-50"
-              >
-                {actionCenterBridge.presentation.ctaLabel}
-              </button>
-            </form>
-          ) : (
-            <Link
-              href={actionCenterRouteHref}
-              className="inline-flex rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition-colors hover:border-slate-300 hover:bg-slate-50"
+  const actionCenterRouteAction =
+    actionCenterBridge.presentation.ctaKind === "open" ? (
+      <div className="flex flex-col gap-2">
+        {actionCenterBridge.bridgeState === "candidate" ? (
+          <form action={openActionCenterRoute}>
+            <button
+              type="submit"
+              className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition-colors hover:border-slate-300 hover:bg-slate-50"
             >
               {actionCenterBridge.presentation.ctaLabel}
-            </Link>
-          )}
-        </div>
-      </div>
-    ) : null
-
-  const responseSection = (
-    <ResultsBlockCard
-      title={PRIMARY_RESULTS_ORDER.response}
-      visibility={blockVisibility.response}
-      body={buildResponseContextNote(stats.total_completed, stats.completion_rate_pct ?? 0)}
-      hideSummary
-      className="rounded-[18px] border-0 bg-transparent px-0 py-0"
-      bodyClassName="px-2 text-base md:px-1"
-    >
-      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-        {[
-          { label: 'Uitgenodigd', value: String(stats.total_invited) },
-          { label: 'Ingevuld', value: String(stats.total_completed) },
-          { label: 'Respons', value: `${stats.completion_rate_pct ?? 0}%` },
-          { label: 'Status', value: getResultsStatusLabel(resultsViewModel.readState) },
-        ].map((item) => (
-          <div
-            key={item.label}
-            className="relative overflow-hidden rounded-[24px] border border-slate-200 bg-[linear-gradient(160deg,rgba(255,255,255,0.98),rgba(246,239,229,0.8))] px-5 py-5 shadow-[0_14px_30px_rgba(15,23,42,0.05)]"
+            </button>
+          </form>
+        ) : (
+          <Link
+            href={actionCenterRouteHref}
+            className="inline-flex rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition-colors hover:border-slate-300 hover:bg-slate-50"
           >
-            <div className="absolute inset-x-0 top-0 h-px bg-[linear-gradient(90deg,rgba(195,106,41,0),rgba(195,106,41,0.8),rgba(195,106,41,0))]" />
-            <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
-              {item.label}
-            </p>
-            <p className="mt-4 text-[2rem] font-semibold leading-none tracking-[-0.06em] text-[color:var(--dashboard-ink)]">
-              {item.value}
-            </p>
-          </div>
-        ))}
+            {actionCenterBridge.presentation.ctaLabel}
+          </Link>
+        )}
+        <p className="max-w-sm text-sm leading-6 text-slate-500">
+          {actionCenterBridge.presentation.body}
+        </p>
       </div>
-    </ResultsBlockCard>
-  )
-
-  const signalSection = (
-    <ResultsBlockCard
-      title={PRIMARY_RESULTS_ORDER.signal}
-      visibility={blockVisibility.signal}
-      summary={blockVisibility.signal === 'visible' ? formatScore(averageSignalScore) : 'Nog niet beschikbaar'}
-      body={
-        blockVisibility.signal === 'visible'
-          ? `${scanDefinition.signalLabel} is vrijgegeven voor deze route. Gebruik dit scherm als visueel leesvlak: eerst het kernbeeld, daarna de samenhang en pas daarna de driverlaag.`
-          : `Deze laag opent vanaf ${MIN_N_DISPLAY} leesbare responses.`
-      }
-      className="rounded-[28px]"
-      summaryClassName="text-[3.4rem] md:text-[4.9rem]"
-    >
-      <div className="grid gap-5 xl:grid-cols-[minmax(0,1.18fr),minmax(0,0.82fr)]">
-        <div className="overflow-hidden rounded-[30px] border border-slate-200 bg-[linear-gradient(145deg,#fffdf9,rgba(246,239,229,0.86))] px-5 py-5 shadow-[0_20px_44px_rgba(15,23,42,0.06)] md:px-6 md:py-6">
-          <div className="flex flex-wrap items-end justify-between gap-4 border-b border-slate-200/80 pb-5">
-            <div>
-              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-slate-500">
-                {scanDefinition.signalLabel}
-              </p>
-              <p className="mt-3 text-5xl font-semibold tracking-[-0.08em] text-[color:var(--dashboard-ink)] md:text-[5.75rem]">
-                {blockVisibility.signal === 'visible' ? formatScore(averageSignalScore) : '—'}
-              </p>
-            </div>
-            <div className="max-w-xs text-sm leading-6 text-[color:var(--dashboard-text)]">
-              {blockVisibility.signal === 'visible'
-                ? 'Sterkste visuele ingang tot het groepsbeeld. Lees dit samen met de segmenten en de ondersteunende signalen rechts.'
-                : `Deze laag wordt zichtbaar vanaf ${MIN_N_DISPLAY} leesbare responses.`}
-            </div>
+    ) : null;
+  const summaryActions = (
+    <>
+      {actionCenterRouteAction}
+      {!showManagementOutput ? (
+        <div className="rounded-full border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-900">
+          {activationState.heroActionLabel}
+        </div>
+      ) : showPartialManagementOutput ? (
+        <>
+          <div className="rounded-full border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-900">
+            Aanbevelingen blijven nog begrensd
           </div>
-
-          {exitDistribution ? (
-            <div className="mt-6">
-              <SignalOrbit segments={exitDistribution.segments} total={exitDistribution.total} />
-            </div>
-          ) : (
-            <div className="mt-5 grid gap-4 md:grid-cols-2">
-              {signalHighlights.map((item) => (
-                <MetricTile key={item.label} item={item} />
-              ))}
-            </div>
-          )}
-        </div>
-
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-1">
-          {signalHighlights.map((item) => (
-            <MetricTile key={item.label} item={item} />
-          ))}
-        </div>
-      </div>
-    </ResultsBlockCard>
-  )
-
-  const synthesisSection = (
-    <ResultsBlockCard
-      title={PRIMARY_RESULTS_ORDER.synthesis}
-      visibility={blockVisibility.synthesis}
-      summary={blockVisibility.synthesis === 'visible' ? synthesisItems[0]?.title ?? 'Nog niet beschikbaar' : 'Nog niet beschikbaar'}
-      body={
-        blockVisibility.synthesis === 'visible'
-          ? 'Deze laag maakt het patroon leesbaar door signalen als één compositie te tonen in plaats van als losse bullets.'
-          : `Deze laag opent samen met het kernsignaal vanaf ${MIN_N_DISPLAY} responses.`
-      }
-      className="rounded-[28px]"
-    >
-      {blockVisibility.synthesis === 'visible' && synthesisItems.length > 0 ? (
-        <div className="grid gap-4 xl:grid-cols-3">
-          {synthesisItems.map((item, index) => (
-            <div key={`${item.label}-${item.title}`} className={index === 0 ? 'xl:col-span-2' : undefined}>
-              <SummaryCard item={item} index={index} />
-            </div>
-          ))}
+          <PdfDownloadButton
+            campaignId={id}
+            campaignName={stats.campaign_name}
+            scanType={stats.scan_type}
+          />
+        </>
+      ) : prefersReportFirst ? (
+        <PdfDownloadButton
+          campaignId={id}
+          campaignName={stats.campaign_name}
+          scanType={stats.scan_type}
+        />
+      ) : stats.scan_type === "pulse" ||
+        stats.scan_type === "team" ||
+        stats.scan_type === "onboarding" ||
+        stats.scan_type === "leadership" ? (
+        <div className="rounded-full border border-slate-200 bg-slate-50 px-4 py-2 text-sm font-semibold text-slate-700">
+          {stats.scan_type === "pulse"
+            ? "Pulse: eerste vervolgstap live"
+            : stats.scan_type === "team"
+              ? "TeamScan: lokale read live"
+              : stats.scan_type === "onboarding"
+                ? "Onboarding: checkpoint read live"
+                : "Leadership Scan: management read live"}
         </div>
       ) : (
-        <EmptyInlineState body="Nog geen tweede laag beschikbaar binnen de huidige leesgrens." />
+        <PdfDownloadButton
+          campaignId={id}
+          campaignName={stats.campaign_name}
+          scanType={stats.scan_type}
+        />
       )}
-    </ResultsBlockCard>
+    </>
+  );
+
+  const organizationName = organization?.name ?? "Organisatie"
+  const routePeriodLabel = formatRoutePeriodLabel(stats.campaign_name, stats.created_at)
+  const scopeLabel = deriveScopeLabel(respondents)
+  const moduleKey =
+    stats.scan_type === "team" ? null : getDashboardModuleKeyForScanType(stats.scan_type)
+  const moduleLabel = moduleKey ? getDashboardModuleLabel(moduleKey) : scanDefinition.productName
+  const moduleHref = moduleKey ? getDashboardModuleHref(moduleKey) : "/dashboard"
+  const moduleBackLinkLabel = getDashboardModuleBackLinkLabel(stats.scan_type)
+  const factorPriorityRows = buildFactorPriorityRows(factorData.orgAverages)
+  const sdtRows = buildSdtRows(factorData.sdtAverages)
+  const responseContextNote = buildResponseContextNote(
+    stats.total_completed,
+    stats.completion_rate_pct ?? 0,
   )
+  const readStrengthLabel = buildReadStrengthLabel({
+    hasMinDisplay,
+    hasEnoughData,
+    statusLabel: compositionStateMeta.label,
+  })
+  const trustNotes = buildTrustNotes()
 
-  const driversSection = (
-    <ResultsBlockCard
-      title={PRIMARY_RESULTS_ORDER.drivers}
-      visibility={blockVisibility.drivers}
-      summary={
-        blockVisibility.drivers === 'visible'
-          ? factorPriorityRows
-              .slice(0, 3)
-              .map((row) => row.factor)
-              .join(' / ')
-          : 'Nog niet beschikbaar'
-      }
-      body={
-        blockVisibility.drivers === 'visible'
-          ? 'De driverlaag laat eerst de prioriteiten zien en pas daarna de volledige rangorde. Zo blijft de lezing snel en visueel scherp.'
-          : `Deze laag blijft begrensd tot er minimaal ${MIN_N_PATTERNS} leesbare responses zijn.`
-      }
-      className="rounded-[28px]"
-    >
-      {blockVisibility.drivers === 'visible' && factorPriorityRows.length > 0 ? (
-        <>
-          <div className="grid gap-4 lg:grid-cols-3">
-            {factorPriorityRows.slice(0, 3).map((row, index) => (
-              <PrioritySpotlight key={row.factor} row={row} rank={index + 1} />
-            ))}
-          </div>
+  if (
+    showManagementOutput &&
+    (stats.scan_type === "exit" || stats.scan_type === "retention")
+  ) {
+    const topFactor = factorPriorityRows[0]?.factor ?? null
+    const secondFactor = factorPriorityRows[1]?.factor ?? null
+    const primarySignalScoreLabel =
+      averageRiskScore !== null
+        ? `${averageRiskScore.toFixed(1)}/10`
+        : "Nog niet beschikbaar"
+    const primarySignalBandLabel =
+      averageRiskScore !== null
+        ? getManagementBandLabel(averageRiskScore)
+        : compositionStateMeta.label
+    const headerActions = (
+      <PdfDownloadButton
+        campaignId={id}
+        campaignName={stats.campaign_name}
+        scanType={stats.scan_type}
+      />
+    )
 
-          <div className="hidden overflow-hidden border border-slate-200 md:block">
-            <div className="grid grid-cols-[minmax(0,1.8fr),140px,140px,160px] border-b border-slate-200 bg-[color:var(--dashboard-soft)]/45 px-5 py-3 text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-slate-500">
-              <span>Factor</span>
-              <span>Score</span>
-              <span>Signaal</span>
-              <span>Band</span>
-            </div>
-            {factorPriorityRows.slice(0, 6).map((row) => (
-              <div
-                key={row.factor}
-                className="grid grid-cols-[minmax(0,1.8fr),140px,140px,160px] border-b border-slate-200 px-5 py-4 last:border-b-0"
+    if (stats.scan_type === "exit") {
+      const exitDistribution = buildExitPictureDistribution(responses)
+      const distributionSegments = [
+        {
+          label: "Werkfrictie",
+          value: `${exitDistribution.workPercent}%`,
+          percent: exitDistribution.workPercent,
+        },
+        {
+          label: "Trekfactoren",
+          value: `${exitDistribution.pullPercent}%`,
+          percent: exitDistribution.pullPercent,
+        },
+        {
+          label: "Situationele context",
+          value: `${exitDistribution.situationalPercent}%`,
+          percent: exitDistribution.situationalPercent,
+        },
+      ].filter((segment) => segment.percent > 0)
+      const dominantCategory =
+        [...distributionSegments].sort(
+          (left, right) => right.percent - left.percent,
+        )[0] ?? null
+      const surveyThemes = buildExitSurveyThemeCards({
+        responses,
+        topFactorLabel: topFactor,
+        secondFactorLabel: secondFactor,
+        hasEnoughData,
+      })
+      const ownerRoleLabel =
+        findPresentationCardValue(dashboardViewModel.topSummaryCards, [
+          "Eerste eigenaar",
+        ]) ??
+        findFollowThroughCardBody(
+          dashboardViewModel.followThroughCards,
+          "Eerste eigenaar",
+        ) ??
+        "Nog niet vastgelegd"
+      const firstStepLabel =
+        findFollowThroughCardBody(
+          dashboardViewModel.followThroughCards,
+          "Eerste actie",
+        ) ?? dashboardViewModel.nextStep.body
+      const reviewMomentLabel =
+        findFollowThroughCardBody(
+          dashboardViewModel.followThroughCards,
+          "Reviewmoment",
+        ) ??
+        findPresentationCardValue(dashboardViewModel.topSummaryCards, [
+          "Reviewmoment",
+          "Reviewgrens",
+          "Leesgrens",
+        ]) ??
+        "Nog niet vastgelegd"
+      return (
+        <ExitProductDashboard
+          moduleHref={moduleHref}
+          moduleLabel={moduleLabel}
+          moduleBackLinkLabel={moduleBackLinkLabel}
+          campaignName={stats.campaign_name}
+          organizationName={organizationName}
+          routePeriodLabel={routePeriodLabel}
+          scopeLabel={scopeLabel}
+          statusLabel={compositionStateMeta.label}
+          headerActions={headerActions}
+          primarySignalScoreLabel={primarySignalScoreLabel}
+          primarySignalBandLabel={primarySignalBandLabel}
+          strongestFactorLabel={topFactor ?? "Nog niet beschikbaar"}
+          strongestFactorNote={
+            factorPriorityRows[0]?.note ??
+            "Nog geen scherpe topfactor vrijgegeven."
+          }
+          strongWorkSignalLabel={
+            responses.some((response) => Boolean(response.preventability))
+              ? `${strongWorkSignalRate}%`
+              : "Nog niet beschikbaar"
+          }
+          primaryReasonTitle={
+            topExitReasonLabel ?? dominantCategory?.label ?? "Nog niet beschikbaar"
+          }
+          firstManagementQuestion={dashboardViewModel.primaryQuestion.body}
+          totalInvited={String(stats.total_invited)}
+          totalCompleted={String(stats.total_completed)}
+          responseRate={`${stats.completion_rate_pct}%`}
+          responseContextNote={responseContextNote}
+          readStrengthLabel={readStrengthLabel}
+          trustNotes={trustNotes}
+          compositionSegments={distributionSegments}
+          compositionHighlights={[
+            {
+              label: "Dominante laag",
+              value:
+                topExitReasonLabel ?? dominantCategory?.label ?? "Nog niet beschikbaar",
+              body:
+                topExitReasonLabel !== null
+                  ? "Deze hoofdlaag komt het vaakst terug in de leesbare responses en opent daarom de eerste managementread."
+                  : dominantCategory !== null
+                    ? `${dominantCategory.value} van het patroonbeeld valt in ${dominantCategory.label.toLowerCase()}.`
+                    : "Nog geen veilige dominante laag beschikbaar.",
+            },
+            {
+              label: "Meelezende context",
+              value: topContributingReasonLabel ?? "Nog niet zichtbaar",
+              body:
+                topContributingReasonLabel !== null
+                  ? `${topContributingReasonLabel} valt samen met het vertrekbeeld en vraagt eerste verificatie naast de hoofdlaag.`
+                  : "Nog geen tweede contextlaag vrijgegeven voor deze route.",
+            },
+            {
+              label: "Sterk werksignaal",
+              value:
+                responses.some((response) => Boolean(response.preventability))
+                  ? `${strongWorkSignalRate}%`
+                  : "Nog niet zichtbaar",
+              body:
+                "Laat zien hoeveel responses vooral wijzen op beinvloedbare werkcontext binnen dit groepsbeeld.",
+            },
+          ]}
+          factorRows={factorPriorityRows}
+          sdtRows={sdtRows}
+          surveyThemes={surveyThemes}
+          verificationTrackLabel={
+            topFactor ? `${topFactor} eerst toetsen` : dashboardViewModel.nextStep.title
+          }
+          ownerRoleLabel={ownerRoleLabel}
+          firstStepLabel={firstStepLabel}
+          reviewMomentLabel={reviewMomentLabel}
+        />
+      )
+    }
+
+    if (stats.scan_type === "retention") {
+      const retentionSegments = buildRetentionSignalSegments(riskDistribution)
+      const surveyThemes = buildRetentionSurveyThemeCards({
+        themes: retentionThemes,
+        topFactorLabel: topFactor,
+        secondFactorLabel: secondFactor,
+        hasEnoughData,
+      })
+      const ownerRoleLabel =
+        findPresentationCardValue(dashboardViewModel.topSummaryCards, [
+          "Eerste eigenaar",
+        ]) ??
+        findFollowThroughCardBody(
+          dashboardViewModel.followThroughCards,
+          "Eerste eigenaar",
+        ) ??
+        "Nog niet vastgelegd"
+      const firstStepLabel =
+        findFollowThroughCardBody(
+          dashboardViewModel.followThroughCards,
+          "Eerste actie",
+        ) ?? dashboardViewModel.nextStep.body
+      const reviewMomentLabel =
+        findFollowThroughCardBody(
+          dashboardViewModel.followThroughCards,
+          "Reviewmoment",
+        ) ??
+        findPresentationCardValue(dashboardViewModel.topSummaryCards, [
+          "Reviewmoment",
+          "Reviewgrens",
+          "Leesgrens",
+        ]) ??
+        "Nog niet vastgelegd"
+      return (
+        <RetentionProductDashboard
+          moduleHref={moduleHref}
+          moduleLabel={moduleLabel}
+          moduleBackLinkLabel={moduleBackLinkLabel}
+          campaignName={stats.campaign_name}
+          organizationName={organizationName}
+          routePeriodLabel={routePeriodLabel}
+          scopeLabel={scopeLabel}
+          statusLabel={compositionStateMeta.label}
+          headerActions={headerActions}
+          primarySignalScoreLabel={primarySignalScoreLabel}
+          primarySignalBandLabel={primarySignalBandLabel}
+          strongestFactorLabel={topFactor ?? "Nog niet beschikbaar"}
+          strongestFactorNote={
+            factorPriorityRows[0]?.note ??
+            "Nog geen scherpe topfactor vrijgegeven."
+          }
+          engagementLabel={
+            retentionSupplemental.engagement !== null
+              ? `${retentionSupplemental.engagement.toFixed(1)}/10`
+              : "Nog niet beschikbaar"
+          }
+          turnoverIntentionLabel={
+            retentionSupplemental.turnoverIntention !== null
+              ? `${retentionSupplemental.turnoverIntention.toFixed(1)}/10`
+              : "Nog niet beschikbaar"
+          }
+          stayIntentLabel={
+            retentionSupplemental.stayIntent !== null
+              ? `${retentionSupplemental.stayIntent.toFixed(1)}/10`
+              : "Nog niet beschikbaar"
+          }
+          firstManagementQuestion={dashboardViewModel.primaryQuestion.body}
+          totalInvited={String(stats.total_invited)}
+          totalCompleted={String(stats.total_completed)}
+          responseRate={`${stats.completion_rate_pct}%`}
+          responseContextNote={responseContextNote}
+          readStrengthLabel={readStrengthLabel}
+          trustNotes={trustNotes}
+          compositionSegments={retentionSegments}
+          compositionHighlights={[
+            {
+              label: "Scherpste factor",
+              value: topFactor ?? "Nog niet beschikbaar",
+              body:
+                topFactor !== null
+                  ? `${topFactor} opent nu het eerste behoudsspoor en vraagt daarom de eerste verificatie.`
+                  : "Nog geen scherpe factorlaag vrijgegeven voor deze route.",
+            },
+            {
+              label: "Vertrekintentie",
+              value:
+                retentionSupplemental.turnoverIntention !== null
+                  ? `${retentionSupplemental.turnoverIntention.toFixed(1)}/10`
+                  : "Nog niet zichtbaar",
+              body:
+                "Lees vertrekintentie samen met retentiesignaal en bevlogenheid, niet als individuele voorspelling.",
+            },
+            {
+              label: "Bevlogenheid",
+              value:
+                retentionSupplemental.engagement !== null
+                  ? `${retentionSupplemental.engagement.toFixed(1)}/10`
+                  : "Nog niet zichtbaar",
+              body:
+                "Bevlogenheid verdiept het groepsbeeld en helpt bepalen of behoudsdruk vooral energie, context of perspectief raakt.",
+            },
+          ]}
+          factorRows={factorPriorityRows}
+          sdtRows={sdtRows}
+          surveyThemes={surveyThemes}
+          verificationTrackLabel={
+            topFactor
+              ? `${topFactor} eerst toetsen`
+              : dashboardViewModel.nextStep.title
+          }
+          ownerRoleLabel={ownerRoleLabel}
+          firstStepLabel={firstStepLabel}
+          reviewMomentLabel={reviewMomentLabel}
+        />
+      )
+    }
+  }
+
+  return (
+    <div className="grid gap-8 xl:grid-cols-[minmax(0,1fr),320px] xl:items-start">
+      <div className="min-w-0 space-y-7">
+        <div className="border-b border-slate-200/80 pb-4">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+            <div className="space-y-3">
+              <p className="text-[0.78rem] font-medium tracking-[0.01em] text-slate-500">
+                <Link href="/dashboard" className="transition-colors hover:text-slate-700">
+                  Overzicht
+                </Link>{" "}
+                /{" "}
+                <Link href={moduleHref} className="transition-colors hover:text-slate-700">
+                  {moduleLabel}
+                </Link>{" "}
+                / <span className="text-slate-700">{stats.campaign_name}</span>
+              </p>
+              <Link
+                href={moduleHref}
+                className="inline-flex items-center gap-2 text-sm font-medium text-slate-500 transition-colors hover:text-slate-700"
               >
-                <div className="pr-4">
-                  <p className="text-sm font-semibold text-[color:var(--dashboard-ink)]">{row.factor}</p>
-                  <p className="mt-2 text-sm leading-6 text-[color:var(--dashboard-text)]">{row.note}</p>
+                ← {moduleBackLinkLabel}
+              </Link>
+            </div>
+            <p className="max-w-2xl text-sm leading-6 text-slate-500 lg:text-right">
+              Campagnedetail brengt samenvatting, uitvoering en vervolgstap
+              bij elkaar zonder onnodige omwegen.
+            </p>
+          </div>
+        </div>
+
+        <div id="samenvatting" className="scroll-mt-36 space-y-5">
+          <DashboardHero
+            eyebrow={scanDefinition.productName}
+            title={stats.campaign_name}
+            description={buildHeroDescription({
+              scanType: stats.scan_type,
+              isActive: stats.is_active,
+              completionRate: stats.completion_rate_pct ?? 0,
+              pendingCount,
+              hasEnoughData,
+              averageRiskScore,
+              scanDefinition,
+            })}
+            tone="slate"
+            variant="editorial"
+            meta={
+              <>
+                <DashboardChip
+                  label={stats.is_active ? "Actief" : "Gesloten"}
+                  tone={stats.is_active ? "emerald" : "slate"}
+                />
+                <DashboardChip
+                  label={productExperience.familyRoleLabel}
+                  tone={productExperience.familyRoleTone}
+                />
+                <DashboardChip
+                  label={`${stats.completion_rate_pct ?? 0}% respons`}
+                  tone="slate"
+                />
+                <DashboardChip
+                  label={compositionStateMeta.label}
+                  tone={compositionStateMeta.tone}
+                />
+                <DashboardChip
+                  label={getDeliveryModeLabel(
+                    campaignMeta?.delivery_mode ?? null,
+                    stats.scan_type,
+                  )}
+                  tone="slate"
+                />
+              </>
+            }
+            actions={
+              !showManagementOutput ? (
+                <div className="rounded-full border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-900">
+                  {activationState.heroActionLabel}
                 </div>
-                <div className="text-sm font-semibold text-[color:var(--dashboard-ink)]">{row.score}</div>
-                <div>
-                  <p className="text-sm font-semibold text-[color:var(--dashboard-ink)]">{row.signal}</p>
-                  <div className="mt-3 h-2 overflow-hidden rounded-full bg-[color:var(--dashboard-soft)]">
-                    <div
-                      className="h-full rounded-full bg-[linear-gradient(90deg,#C36A29,#D9985D)]"
-                      style={{ width: `${Math.max(10, Math.min(100, row.signalValue * 10))}%` }}
+              ) : showPartialManagementOutput ? (
+                <>
+                  <div className="rounded-full border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-semibold text-amber-900">
+                    Compacte read zichtbaar, aanbevelingen nog begrensd
+                  </div>
+                  <PdfDownloadButton
+                    campaignId={id}
+                    campaignName={stats.campaign_name}
+                    scanType={stats.scan_type}
+                  />
+                </>
+              ) : prefersReportFirst ? (
+                <>
+                  {!profile?.is_verisight_admin ? (
+                    <OnboardingAdvancer fromStep={1} />
+                  ) : null}
+                  <div className="relative">
+                    {!profile?.is_verisight_admin ? (
+                      <OnboardingBalloon
+                        step={2}
+                        label="Download hier je rapport"
+                        align="left"
+                      />
+                    ) : null}
+                    <PdfDownloadButton
+                      campaignId={id}
+                      campaignName={stats.campaign_name}
+                      scanType={stats.scan_type}
                     />
                   </div>
+                </>
+              ) : stats.scan_type === "pulse" ||
+                stats.scan_type === "team" ||
+                stats.scan_type === "onboarding" ||
+                stats.scan_type === "leadership" ? (
+                <>
+                  {!profile?.is_verisight_admin ? (
+                    <OnboardingAdvancer fromStep={1} />
+                  ) : null}
+                  <div className="rounded-full border border-slate-200 bg-slate-50 px-4 py-2 text-sm font-semibold text-slate-700">
+                    {stats.scan_type === "pulse"
+                      ? "Pulse: eerste vervolgstap live"
+                      : stats.scan_type === "team"
+                        ? "TeamScan: lokale read live"
+                        : stats.scan_type === "onboarding"
+                          ? "Onboarding: checkpoint read live"
+                          : "Leadership Scan: management read live"}
+                  </div>
+                </>
+              ) : (
+                <>
+                  {!profile?.is_verisight_admin ? (
+                    <OnboardingAdvancer fromStep={1} />
+                  ) : null}
+                  <div className="relative">
+                    {!profile?.is_verisight_admin ? (
+                      <OnboardingBalloon
+                        step={2}
+                        label="Download hier je rapport"
+                        align="left"
+                      />
+                    ) : null}
+                    <PdfDownloadButton
+                      campaignId={id}
+                      campaignName={stats.campaign_name}
+                      scanType={stats.scan_type}
+                    />
+                  </div>
+                </>
+              )
+            }
+            aside={
+              <div className="space-y-3">
+                <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
+                  {heroAsideItems.map((item) => (
+                    <DashboardKeyValue
+                      key={item.label}
+                      label={item.label}
+                      value={item.value}
+                      accent={item.accent}
+                      helpText={item.helpText}
+                      variant="quiet"
+                    />
+                  ))}
                 </div>
-                <div>
-                  <span className="inline-flex rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-600">
-                    {row.band}
-                  </span>
+                <div className="border-t border-[color:var(--dashboard-frame-border)] pt-3">
+                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
+                    Campagnestatus
+                  </p>
+                  <p className="mt-2 text-sm leading-6 text-slate-700">
+                    {`${stats.total_completed}/${stats.total_invited || 0} ingevuld`}
+                    .{" "}
+                    {pendingCount > 0
+                      ? `${pendingCount} respondent(en) zijn nog niet afgerond.`
+                      : "Alle uitgenodigde respondenten hebben afgerond."}
+                  </p>
+                  <p className="mt-2 text-xs leading-5 text-slate-500">
+                    State: {compositionStateMeta.label}.{" "}
+                    {compositionStateMeta.trust}
+                  </p>
+                  <p className="mt-2 text-xs leading-5 text-slate-500">
+                    {activationState.statusDetail}
+                  </p>
                 </div>
               </div>
-            ))}
-          </div>
+            }
+          />
 
-          <div className="grid gap-4 md:hidden">
-            {factorPriorityRows.slice(0, 6).map((row) => (
-              <div key={row.factor} className="rounded-[24px] border border-slate-200 bg-[color:var(--dashboard-soft)]/38 px-5 py-4">
-                <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <p className="text-sm font-semibold text-[color:var(--dashboard-ink)]">{row.factor}</p>
-                    <p className="mt-2 text-sm leading-6 text-[color:var(--dashboard-text)]">{row.note}</p>
-                  </div>
-                  <span className="inline-flex rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-600">
-                    {row.band}
-                  </span>
+          {buildInsightWarnings({
+            responsesLength: responses.length,
+            hasMinDisplay,
+            hasEnoughData,
+            scanType: stats.scan_type,
+          }).map((notice) => (
+            <div
+              key={notice.title}
+              className={`rounded-[20px] border px-4 py-3.5 text-sm ${
+                notice.tone === "amber"
+                  ? "border-amber-200 bg-amber-50/85 text-amber-900"
+                  : notice.tone === "red"
+                    ? "border-red-200 bg-red-50/85 text-red-900"
+                    : "border-slate-200 bg-white/80 text-slate-900"
+              }`}
+            >
+              <p className="font-semibold">{notice.title}</p>
+              <p className="mt-1 leading-6">{notice.body}</p>
+            </div>
+          ))}
+
+          {showManagementOutput ? (
+            <div className="grid grid-cols-2 gap-4 xl:grid-cols-4">
+              <SignalStatCard
+                label="Signaal-index"
+                value={
+                  averageRiskScore !== null
+                    ? `${averageRiskScore.toFixed(1)}/10`
+                    : "-"
+                }
+                subline={
+                  averageRiskScore !== null
+                    ? stats.scan_type === "exit"
+                      ? undefined
+                      : bandLabels[getRiskBandFromScore(averageRiskScore)]
+                    : undefined
+                }
+                band={
+                  averageRiskScore !== null
+                    ? stats.scan_type === "exit"
+                      ? "neutral"
+                      : getRiskBandFromScore(averageRiskScore)
+                    : undefined
+                }
+              />
+              <SignalStatCard
+                label="Respons"
+                value={`${stats.completion_rate_pct ?? 0}%`}
+                subline={`${stats.total_completed} van ${stats.total_invited} responsen`}
+                band="neutral"
+              />
+              <SignalStatCard
+                label={stats.scan_type === "exit" ? "Spreiding in beeld" : "Risicoband"}
+                value={`${dominantPct}%`}
+                subline={
+                  stats.scan_type === "exit"
+                    ? "van de responses valt in de grootste zichtbare groep"
+                    : `valt nu in ${bandLabels[dominantBand].toLowerCase()}`
+                }
+                band={stats.scan_type === "exit" ? "neutral" : dominantBand}
+              />
+              <InsightStatCard
+                label="Sterkste factor"
+                value={topExitReasonLabel ?? topContributingReasonLabel ?? "-"}
+                subline="vraagt nu als eerste aandacht"
+              />
+            </div>
+          ) : null}
+        </div>
+
+        <DashboardSummaryBar
+          items={summaryItems}
+          anchors={sectionAnchors}
+          variant="quiet"
+          actions={summaryActions}
+        />
+
+        {showClientExecutionFlow ? (
+          <DashboardSection
+            id="uitvoering"
+            eyebrow="Uitvoering"
+            title="Uitvoering"
+            description="Gebruik dit blok alleen voor uitvoeringsstappen rond uitnodigingen en import."
+            aside={<DashboardChip label="Klantuitvoering" tone="slate" />}
+            variant="quiet"
+          >
+            <div className="mb-4 flex flex-wrap items-center gap-3 rounded-[18px] border border-slate-200 bg-slate-50 px-4 py-3">
+              <p className="text-sm leading-6 text-slate-700">
+                Gebruik Routebeheer voor livegang, respons, output-readiness en blokkades zonder de analytische dashboardlaag te openen.
+              </p>
+              <Link
+                href={`/campaigns/${id}/beheer`}
+                className="inline-flex items-center rounded-full bg-[#2DD4BF] px-4 py-2 text-sm font-semibold text-white transition hover:brightness-95"
+              >
+                Routebeheer openen
+              </Link>
+            </div>
+            <GuidedSelfServePanel
+              campaignId={id}
+              scanType={stats.scan_type}
+              isActive={stats.is_active}
+              deliveryMode={campaignMeta?.delivery_mode ?? null}
+              importReady={importReady}
+              hasSegmentDeepDive={hasSegmentDeepDive}
+              totalInvited={stats.total_invited}
+              totalCompleted={stats.total_completed}
+              invitesNotSent={invitesNotSent}
+              hasMinDisplay={hasMinDisplay}
+              hasEnoughData={hasEnoughData}
+              pendingCount={pendingCount}
+              importQaConfirmed={guidedSetupDiscipline.importQaConfirmed}
+              launchTimingConfirmed={
+                guidedSetupDiscipline.launchTimingConfirmed
+              }
+              communicationReady={guidedSetupDiscipline.communicationReady}
+              remindableCount={remindableCount}
+              unsentRespondents={unsentRespondents}
+              launchDate={deliveryRecord?.launch_date ?? null}
+              launchConfirmedAt={deliveryRecord?.launch_confirmed_at ?? null}
+              participantCommsConfig={
+                deliveryRecord?.participant_comms_config ?? null
+              }
+              reminderConfig={deliveryRecord?.reminder_config ?? null}
+              memberRole={membership?.role ?? null}
+            />
+          </DashboardSection>
+        ) : null}
+
+        {showPartialManagementOutput ? (
+          <DashboardSection
+            id="handoff"
+            eyebrow="Eerste vervolgstap"
+            title="Eerste compacte samenvatting"
+            description="De eerste veilige dashboardlaag is zichtbaar, maar deze campagne blijft nog bewust compact tot meer respons en vollediger scores een rijker beeld dragen."
+            aside={
+              <DashboardChip
+                label={compositionStateMeta.label}
+                tone={compositionStateMeta.tone}
+              />
+            }
+            tone="slate"
+            variant="quiet"
+          >
+            <div className="space-y-5">
+              <DashboardRecommendationRail
+                eyebrow="Trustgrens"
+                title="Aanbevelingen blijven nog begrensd"
+                description="Gebruik nu alleen de compacte read, de eerste managementvraag en het bijbehorende trustsignaal. Drivers, playbooks en vervolgblokken blijven bewust nog deels dicht."
+                tone="amber"
+                variant="quiet"
+              >
+                <div className="grid gap-4 lg:grid-cols-2">
+                  <DashboardPanel
+                    eyebrow="Wat nu wel zichtbaar is"
+                    title="Eerste samenvatting"
+                    body="Gebruik de hero, samenvatting en eerste managementvraag om richting te houden zonder het beeld zwaarder te maken dan de data nu draagt."
+                    tone="slate"
+                  />
+                  <DashboardPanel
+                    eyebrow="Wat bewust nog wacht"
+                    title="Nog geen volle aanbevelingslaag"
+                    body="Drivers, aanbevelingen en de vervolgrichting openen pas zodra minstens 10 complete responses beschikbaar zijn en privacygrenzen niet meer onnodig veel verbergen."
+                    tone="amber"
+                  />
                 </div>
-                <div className="mt-4 grid grid-cols-2 gap-3 text-sm">
-                  <div>
-                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-slate-500">
-                      Score
-                    </p>
-                    <p className="mt-2 font-semibold text-[color:var(--dashboard-ink)]">{row.score}</p>
-                  </div>
-                  <div>
-                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-slate-500">
-                      Signaal
-                    </p>
-                    <p className="mt-2 font-semibold text-[color:var(--dashboard-ink)]">{row.signal}</p>
-                  </div>
+              </DashboardRecommendationRail>
+              <ManagementReadGuide
+                scanType={stats.scan_type}
+                hasMinDisplay={hasMinDisplay}
+                hasEnoughData={hasEnoughData}
+              />
+            </div>
+          </DashboardSection>
+        ) : null}
+
+        {showManagementOutput && promotedSummaryCards.length > 0 ? (
+          <div className="rounded-[28px] border border-[color:var(--border)] bg-[color:var(--bg)] p-4 shadow-[0_12px_32px_rgba(19,32,51,0.05)] sm:p-5">
+            <div className="flex flex-col gap-3 border-b border-[color:var(--border)]/80 pb-4 lg:flex-row lg:items-start lg:justify-between">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--muted)]">
+                  {productExperience.summaryLeadTitle}
+                </p>
+                <p className="mt-2 max-w-3xl text-sm leading-6 text-[color:var(--text)]">
+                  {productExperience.summaryLeadDescription}
+                </p>
+              </div>
+              <DashboardChip
+                label={productExperience.summaryContextLabel}
+                tone={productExperience.summaryContextTone}
+              />
+            </div>
+            <div className="mt-4 grid gap-4 md:grid-cols-2">
+              {promotedSummaryCards.map((card) => (
+                <DashboardPanel
+                  key={`${card.title}-${card.value ?? "summary"}`}
+                  eyebrow={productExperience.summaryCardEyebrow}
+                  title={card.title}
+                  value={card.value}
+                  body={card.body}
+                  tone={normalizeInformationalTone(card.tone)}
+                />
+              ))}
+            </div>
+          </div>
+        ) : null}
+
+        {showDetailedManagementOutput ? (
+          <DashboardSection
+            id="handoff"
+            eyebrow="Eerste vervolgstap"
+            title={handoffTitle}
+            description={handoffDescription}
+            aside={
+              <DashboardChip
+                label={readinessLabel}
+                tone={hasEnoughData ? "emerald" : "amber"}
+              />
+            }
+            tone="slate"
+            variant="quiet"
+          >
+            <div className="space-y-4">
+              <div className="grid gap-4 xl:grid-cols-[minmax(0,1.3fr),minmax(320px,0.7fr)]">
+                <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                  {buildDecisionPanels({
+                    stats,
+                    averageRiskScore,
+                    scanDefinition,
+                    strongWorkSignalRate,
+                    retentionSupplemental,
+                    factorAverages: factorData.orgAverages,
+                    hasEnoughData,
+                    hasMinDisplay,
+                  }).map((panel) => (
+                    <DashboardPanel
+                      key={panel.title}
+                      eyebrow={panel.eyebrow}
+                      title={panel.title}
+                      value={panel.value}
+                      body={panel.body}
+                      tone={panel.tone}
+                    />
+                  ))}
+                  {handoffSummaryCards.map((card) => (
+                    <DashboardPanel
+                      key={`${card.title}-${card.value ?? "card"}`}
+                      eyebrow={productExperience.summaryCardEyebrow}
+                      title={card.title}
+                      value={card.value}
+                      body={card.body}
+                      tone={normalizeInformationalTone(card.tone)}
+                    />
+                  ))}
                 </div>
-                <div className="mt-3 h-2 overflow-hidden rounded-full bg-white">
-                  <div
-                    className="h-full rounded-full bg-[linear-gradient(90deg,#C36A29,#D9985D)]"
-                    style={{ width: `${Math.max(10, Math.min(100, row.signalValue * 10))}%` }}
+
+                <div className="grid gap-4">
+                  <DashboardPanel
+                    eyebrow="Eerste managementvraag"
+                    title={dashboardViewModel.primaryQuestion.title}
+                    body={dashboardViewModel.primaryQuestion.body}
+                    tone={normalizeInformationalTone(
+                      dashboardViewModel.primaryQuestion.tone,
+                    )}
+                  />
+                  <DashboardPanel
+                    eyebrow="Logische vervolgstap"
+                    title={dashboardViewModel.nextStep.title}
+                    body={dashboardViewModel.nextStep.body}
+                    tone={normalizeInformationalTone(
+                      dashboardViewModel.nextStep.tone,
+                    )}
                   />
                 </div>
               </div>
-            ))}
-          </div>
-        </>
-      ) : (
-        <EmptyInlineState body={`Volledige factorprioritering opent vanaf ${MIN_N_PATTERNS} responses.`} />
-      )}
-    </ResultsBlockCard>
-  )
 
-  const depthSection = (
-    <ResultsBlockCard
-      title={PRIMARY_RESULTS_ORDER.depth}
-      visibility={blockVisibility.depth}
-      summary={
-        blockVisibility.depth === 'visible'
-          ? sdtRows.length > 0
-            ? `${sdtRows.length} SDT-lagen zichtbaar`
-            : `${factorPriorityRows.length} factoren berekend`
-          : 'Nog niet beschikbaar'
-      }
-      body={
-        blockVisibility.depth === 'visible'
-          ? 'De verdiepingslaag geeft extra context met een rustiger ritme, zodat verdieping anders voelt dan het hero-signaal erboven.'
-          : `Deze laag opent vanaf ${MIN_N_DISPLAY} leesbare responses.`
-      }
-      className="rounded-[28px]"
-    >
-      <div className="space-y-5">
-        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-          {depthNotes.map((note) => (
-            <div key={note.label} className="rounded-[22px] border border-slate-200 bg-white px-4 py-4 shadow-[0_10px_22px_rgba(15,23,42,0.04)]">
-              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
-                {note.label}
-              </p>
-              <p className="mt-3 text-sm leading-6 text-[color:var(--dashboard-text)]">{note.body}</p>
-            </div>
-          ))}
-        </div>
-
-        <div className="grid gap-4 xl:grid-cols-[minmax(0,0.95fr),minmax(0,1.05fr)]">
-          <div className="space-y-4">
-            {blockVisibility.depth === 'visible' && sdtRows.length > 0 ? (
-              <div className="grid gap-3 md:grid-cols-3 xl:grid-cols-1">
-                {sdtRows.map((row) => (
-                  <div key={row.factor} className="rounded-[24px] border border-slate-200 bg-[linear-gradient(145deg,rgba(255,255,255,0.98),rgba(246,239,229,0.84))] px-5 py-5 shadow-[0_12px_28px_rgba(15,23,42,0.04)]">
-                    <div className="flex items-start justify-between gap-4">
-                      <div>
-                        <p className="text-sm font-semibold text-[color:var(--dashboard-ink)]">{row.factor}</p>
-                        <p className="mt-2 text-sm leading-6 text-[color:var(--dashboard-text)]">{row.note}</p>
-                      </div>
-                      <div
-                        className="relative size-[4.4rem] shrink-0 rounded-full"
-                        style={{
-                          background: `conic-gradient(#C36A29 0 ${Math.max(10, Math.min(100, row.scoreValue * 10))}%, rgba(195,106,41,0.14) ${Math.max(10, Math.min(100, row.scoreValue * 10))}% 100%)`,
-                        }}
-                      >
-                        <div className="absolute inset-[7px] rounded-full bg-white/95" />
-                        <div className="absolute inset-0 flex items-center justify-center text-xs font-semibold tracking-[-0.03em] text-[color:var(--dashboard-ink)]">
-                          {row.score}
-                        </div>
-                      </div>
-                    </div>
-                    <div className="mt-4 h-2 overflow-hidden rounded-full bg-white">
-                      <div
-                        className="h-full rounded-full bg-[linear-gradient(90deg,#C36A29,#D9985D)]"
-                        style={{ width: `${Math.max(10, Math.min(100, row.scoreValue * 10))}%` }}
-                      />
-                    </div>
+              {stats.scan_type === "team" && hasEnoughData ? (
+                <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4 sm:p-5">
+                  <div className="flex flex-wrap items-center gap-3">
+                    <h3 className="text-sm font-semibold text-slate-950">
+                      Lokale vervolgstap
+                    </h3>
+                    <DashboardChip
+                      label={
+                        primaryTeamPriority
+                          ? `Eerst: ${primaryTeamPriority.label}`
+                          : "Kleine vervolgstap"
+                      }
+                      tone={primaryTeamPriority ? "amber" : "slate"}
+                    />
                   </div>
-                ))}
+                  <p className="mt-1 text-sm leading-6 text-slate-600">
+                    {primaryTeamPriority && primaryTeamPlaybook
+                      ? `Gebruik deze TeamScan nu als compacte vervolgstap: ${primaryTeamPriority.label} vraagt eerst verificatie op ${primaryTeamPriority.topFactorLabel.toLowerCase()}, daarna kies je bewust wie de eerste lokale stap trekt en hoe klein de review blijft.`
+                      : "TeamScan geeft al wel lokale richting, maar blijft bewust klein zolang er nog geen eerlijke eerste prioriteit kan worden vrijgegeven."}
+                  </p>
+                  <div className="mt-4 grid gap-4 lg:grid-cols-4">
+                    <DashboardPanel
+                      eyebrow="Afdeling"
+                      title={
+                        primaryTeamPriority?.label ?? "Nog niet vrijgegeven"
+                      }
+                      value={primaryTeamPriority?.priorityTitle}
+                      body={
+                        primaryTeamPriority
+                          ? `${primaryTeamPriority.topFactorLabel} is hier nu het scherpste lokale spoor.`
+                          : "Gebruik meerdere zichtbare afdelingen voorlopig als gespreksinput zonder geforceerde top-1."
+                      }
+                      tone={primaryTeamPriority ? "amber" : "slate"}
+                    />
+                    <DashboardPanel
+                      eyebrow="Eerste eigenaar"
+                      title={
+                        primaryTeamPlaybook?.owner ?? "HR + afdelingsleider"
+                      }
+                      body="Maak expliciet wie het eerste lokale gesprek trekt en wie de vervolgstap terugbrengt in de review."
+                      tone="slate"
+                    />
+                    <DashboardPanel
+                      eyebrow="Begrensde eerste actie"
+                      title={
+                        primaryTeamPlaybook?.actions[0] ??
+                        "Kies eerst een kleine lokale check"
+                      }
+                      body={
+                        primaryTeamPlaybook?.decision ??
+                        "TeamScan blijft hier gericht op een kleine lokale verificatie of correctie, niet op een brede interventie."
+                      }
+                      tone="slate"
+                    />
+                    <DashboardPanel
+                      eyebrow="Reviewmoment"
+                      title={
+                        primaryTeamPlaybook?.review ?? "Lokale hercheck eerst"
+                      }
+                      body="Gebruik het reviewmoment om bewust te kiezen: nog een lokale vervolgstap, terug naar het bredere beeld of juist stoppen."
+                      tone="amber"
+                    />
+                  </div>
+                </div>
+              ) : null}
+
+              {productExperience.trustNotePlacement === "handoff"
+                ? trustNote
+                : null}
+
+              {productExperience.evidenceSectionOrder === "management-first" ? (
+                <>
+                  {managementBlocksSection}
+                  {profileCardsSection}
+                </>
+              ) : (
+                <>
+                  {profileCardsSection}
+                  {managementBlocksSection}
+                </>
+              )}
+            </div>
+          </DashboardSection>
+        ) : null}
+
+        {showDetailedManagementOutput ? (
+          <DashboardSection
+            id="drivers"
+            eyebrow="Wat drijft dit beeld?"
+            title={productExperience.driverTitle}
+            description={productExperience.driverDescription}
+            aside={
+              <DashboardChip
+                label={productExperience.driverAsideLabel}
+                tone={productExperience.driverAsideTone}
+              />
+            }
+            variant="quiet"
+          >
+            {hasEnoughData ? (
+              <div className="space-y-5">
+                {productExperience.trustNotePlacement === "drivers"
+                  ? trustNote
+                  : null}
+                <div className="rounded-[22px] border border-[color:var(--border)] bg-[color:var(--bg)] px-4 py-4 text-sm leading-6 text-[color:var(--text)]">
+                  {productExperience.driverIntro}
+                </div>
+                <DashboardTabs tabs={driverTabs} />
               </div>
             ) : (
-              <EmptyInlineState body="Nog geen extra verdiepingslaag zichtbaar binnen de huidige routegegevens." />
+              <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-4 text-sm leading-6 text-slate-600">
+                Verdiepende analyse wordt zichtbaar vanaf {MIN_N_PATTERNS}{" "}
+                ingevulde responses. Tot die tijd blijft het dashboard bewust
+                compact en voorzichtig.
+              </div>
             )}
-          </div>
+          </DashboardSection>
+        ) : null}
 
-          <div className="space-y-4">
-            {blockVisibility.depth === 'visible' && factorPriorityRows.length > 0 ? (
-              <div className="rounded-[26px] border border-slate-200 bg-white px-5 py-5 shadow-[0_12px_28px_rgba(15,23,42,0.04)]">
-                <div className="border-b border-slate-200 pb-3">
-                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
-                    Organisatiefactoren
-                  </p>
-                  <p className="mt-2 text-sm leading-6 text-[color:var(--dashboard-text)]">
-                    Rangorde van de sterkst zichtbare factoren binnen deze route.
-                  </p>
-                </div>
-                <div className="mt-4 space-y-4">
-                  {factorPriorityRows.slice(0, 5).map((row) => (
-                    <div key={row.factor} className="space-y-2">
-                      <div className="flex items-center justify-between gap-3 text-sm">
-                        <span className="font-medium text-[color:var(--dashboard-ink)]">{row.factor}</span>
-                        <span className="font-semibold text-[color:var(--dashboard-ink)]">{row.signal}</span>
-                      </div>
-                      <div className="h-2 overflow-hidden rounded-full bg-[color:var(--dashboard-soft)]">
-                        <div
-                          className="h-full rounded-full bg-[linear-gradient(90deg,#C36A29,#D9985D)]"
-                          style={{ width: `${Math.max(10, Math.min(100, row.signalValue * 10))}%` }}
+        {showDetailedManagementOutput ? (
+          <DashboardSection
+            id="acties"
+            eyebrow="Waar eerst op handelen"
+            title={productExperience.actionTitle}
+            description={dashboardViewModel.focusSectionIntro}
+            aside={<DashboardChip label={focusBadgeLabel} tone="slate" />}
+            tone="slate"
+            variant="quiet"
+          >
+            {hasEnoughData ? (
+              <div className="space-y-5">
+                {stats.scan_type === "team" && teamPriorityRead ? (
+                  <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4 sm:p-5">
+                    <h3 className="text-sm font-semibold text-slate-950">
+                      {teamPriorityRead.status === "ready"
+                        ? "Eerste lokale verificatie en vervolgstap"
+                        : "Lokale prioriteit blijft compact"}
+                    </h3>
+                    <p className="mt-1 text-sm leading-6 text-slate-600">
+                      {teamPriorityRead.summaryBody}
+                    </p>
+                    {primaryTeamPriority && primaryTeamPlaybook ? (
+                      <div className="mt-4 grid gap-4 lg:grid-cols-2 xl:grid-cols-4">
+                        <DashboardPanel
+                          eyebrow="Afdeling eerst"
+                          title={primaryTeamPriority.label}
+                          value={primaryTeamPriority.priorityTitle}
+                          body={`${primaryTeamPriority.topFactorLabel} is hier nu het scherpste lokale spoor. Gebruik deze afdeling als eerste managementcheck, niet als definitieve eindconclusie.`}
+                          tone="amber"
+                        />
+                        <DashboardPanel
+                          eyebrow="Eerste eigenaar"
+                          title={primaryTeamPlaybook.owner}
+                          body="Deze combinatie trekt de eerste lokale check en bewaakt tegelijk dat TeamScan compact blijft."
+                          tone="slate"
+                        />
+                        <DashboardPanel
+                          eyebrow="Eerste check"
+                          title={primaryTeamPlaybook.validate}
+                          body={
+                            primaryTeamQuestions[0] ??
+                            "Gebruik het eerstvolgende afdelingsgesprek om dit lokale spoor expliciet te verifieren."
+                          }
+                          tone="slate"
+                        />
+                        <DashboardPanel
+                          eyebrow="Reviewmoment"
+                          title={
+                            primaryTeamPlaybook.actions[0] ??
+                            primaryTeamPlaybook.title
+                          }
+                          body={
+                            primaryTeamPlaybook.review ??
+                            "Leg direct vast wanneer deze lokale check opnieuw wordt gelezen en of TeamScan daarna nog een tweede stap nodig heeft."
+                          }
+                          tone="slate"
                         />
                       </div>
-                    </div>
+                    ) : (
+                      <div className="mt-4 rounded-2xl border border-dashed border-slate-200 bg-white px-4 py-4 text-sm leading-6 text-slate-600">
+                        TeamScan toont hier bewust nog geen harde eerste
+                        volgorde. Gebruik de lokale read om meerdere afdelingen
+                        te bespreken, een eigenaar te benoemen en pas na de
+                        eerste check te bepalen of een hardere volgorde
+                        nodig is.
+                      </div>
+                    )}
+                  </div>
+                ) : null}
+
+                {productExperience.recommendationOrder === "playbooks-first" ? (
+                  <>
+                    {playbooksBlock}
+                    {focusQuestionsBlock}
+                  </>
+                ) : (
+                  <>
+                    {focusQuestionsBlock}
+                    {playbooksBlock}
+                  </>
+                )}
+              </div>
+            ) : (
+              <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-4 text-sm leading-6 text-slate-600">
+                Focusvragen en route-uitvoer worden betekenisvoller zodra het
+                dashboard minstens {MIN_N_PATTERNS} responses heeft.
+              </div>
+            )}
+          </DashboardSection>
+        ) : null}
+
+        {showDetailedManagementOutput ? (
+          <DashboardSection
+            id="route"
+            eyebrow="Vervolg na het eerste gesprek"
+            title={productExperience.routeTitle}
+            description={productExperience.routeDescription}
+            aside={
+              <DashboardChip
+                label={productExperience.routeBadgeLabel}
+                tone="slate"
+              />
+            }
+            variant="quiet"
+          >
+            <div className="space-y-5">
+              <ManagementReadGuide
+                scanType={stats.scan_type}
+                hasMinDisplay={hasMinDisplay}
+                hasEnoughData={hasEnoughData}
+              />
+
+              {dashboardViewModel.followThroughCards.length > 0 ? (
+                <DashboardTimeline
+                  title={dashboardViewModel.followThroughTitle}
+                  description={dashboardViewModel.followThroughIntro}
+                  items={dashboardViewModel.followThroughCards}
+                />
+              ) : null}
+
+              <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4 sm:p-5">
+                <h3 className="text-sm font-semibold text-slate-950">
+                  {productExperience.afterSessionTitle}
+                </h3>
+                <p className="mt-1 text-sm leading-6 text-slate-700">
+                  {productExperience.afterSessionDescription}
+                </p>
+                {stats.scan_type === "team" ? (
+                  <div className="mt-4 grid gap-4 lg:grid-cols-3">
+                    <DashboardPanel
+                      eyebrow="Als de lokale check bevestigt"
+                      title="Blijf op dezelfde route"
+                      body="Doe alleen een volgende lokale check als route, lokale actie en reviewmoment uit deze TeamScan al expliciet zijn gemaakt."
+                      tone="slate"
+                    />
+                    <DashboardPanel
+                      eyebrow="Als de vraag breder wordt"
+                        title="Ga terug naar het bredere beeld"
+                      body="Schakel niet door naar extra lokalisatie als de echte vraag weer organisatieniveau, behoudsbeeld of bredere duiding vraagt."
+                      tone="amber"
+                    />
+                    <DashboardPanel
+                      eyebrow="Als de onderbouwing te smal blijft"
+                      title="Stop met verder lokaliseren"
+                      body="Open geen extra TeamScan-verbreding zolang metadata, groepsgrootte of lokale bevestiging daar nog geen eerlijke basis voor geven."
+                      tone="amber"
+                    />
+                  </div>
+                ) : null}
+                {stats.scan_type === "leadership" ? (
+                  <div className="mt-4 grid gap-4 lg:grid-cols-3">
+                    <DashboardPanel
+                      eyebrow="Als de managementcheck bevestigt"
+                      title="Blijf op dezelfde route"
+                      body="Doe alleen een volgende Leadership-check als eigenaar, kleine verificatie of correctie en reviewmoment uit deze samenvatting al expliciet zijn gemaakt."
+                      tone="slate"
+                    />
+                    <DashboardPanel
+                      eyebrow="Als de vraag breder wordt"
+                        title="Ga terug naar het bredere beeld"
+                      body="Schakel niet door naar extra Leadership-verbreding als de echte vraag weer lokale lokalisatie, bredere duiding of een ander productspoor vraagt."
+                      tone="amber"
+                    />
+                    <DashboardPanel
+                      eyebrow="Als de onderbouwing te smal blijft"
+                      title="Open geen named leaders of 360"
+                      body="Maak Leadership Scan niet groter dan deze wave draagt zolang groepsniveau, suppressie en de huidige data nog geen eerlijke basis geven voor named leader of 360-output."
+                      tone="amber"
+                    />
+                  </div>
+                ) : null}
+                <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                  {firstNextStepGuidance.cards.map((card) => (
+                    <DashboardPanel
+                      key={card.key}
+                      eyebrow={
+                        card.key === "insight"
+                          ? "Inzicht"
+                          : card.key === "action"
+                            ? "Eerste actie"
+                            : "Geen standaard vervolg"
+                      }
+                      title={card.title}
+                      body={card.body}
+                      tone="slate"
+                    />
                   ))}
                 </div>
+                <div className="mt-4 rounded-[24px] border border-white/80 bg-white px-4 py-4 shadow-[0_12px_28px_rgba(19,32,51,0.05)]">
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                        Alleen als vervolg echt nodig is
+                      </p>
+                      <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-700">
+                        Gebruik deze routes alleen als de eerste stap al expliciet is gemaakt. Zo blijft vervolg
+                        gericht, in plaats van automatisch groter te worden.
+                      </p>
+                    </div>
+                    <DashboardChip label="Compacte vervolgroutes" tone="slate" />
+                  </div>
+                  <div className="mt-4 grid gap-4 md:grid-cols-2">
+                    {firstNextStepGuidance.followOnSuggestions.map(
+                      (suggestion) => (
+                        <div
+                          key={suggestion.productLabel}
+                          className="rounded-[22px] border border-slate-200 bg-slate-50/88 px-4 py-4"
+                        >
+                          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                            Alleen als
+                          </p>
+                          <p className="mt-2 text-sm font-semibold text-slate-950">
+                            {suggestion.productLabel}
+                          </p>
+                          <p className="mt-2 text-sm leading-6 text-slate-700">
+                            {suggestion.when}
+                          </p>
+                          <p className="mt-3 text-xs leading-5 text-slate-500">
+                            {suggestion.boundary}
+                          </p>
+                        </div>
+                      ),
+                    )}
+                  </div>
+                </div>
               </div>
-            ) : null}
+            </div>
+          </DashboardSection>
+        ) : null}
 
+        <div id="methodiek" className="scroll-mt-36">
+          <DashboardDisclosure
+            defaultOpen={disclosureDefaults.methodologyOpen}
+            title="Methodiek, privacy en leeswijzer"
+            description="Gebruik dit als contextlaag voor interpretatie, privacy en betrouwbaarheid."
+            badge={<DashboardChip label={methodologyBadgeLabel} tone="slate" />}
+          >
             <MethodologyCard
               scanType={stats.scan_type}
+              hasSegmentDeepDive={hasSegmentDeepDive}
               signalLabel={scanDefinition.signalLabel}
               embedded
             />
-          </div>
+          </DashboardDisclosure>
         </div>
-      </div>
-    </ResultsBlockCard>
-  )
 
-  const voicesSection = (
-    <ResultsBlockCard
-      title={PRIMARY_RESULTS_ORDER.voices}
-      visibility={blockVisibility.voices}
-      summary={
-        blockVisibility.voices === 'visible'
-          ? `${releasedOpenAnswerItems.length} antwoorden vrijgegeven`
-          : 'Nog niet beschikbaar'
-      }
-      body={
-        blockVisibility.voices === 'visible'
-          ? 'Survey-stemmen sluiten de kwantitatieve lagen af met geclusterde, geanonimiseerde taal uit dezelfde route.'
-          : hasMinDisplay
-            ? 'Er zijn nog geen vrijgegeven open antwoorden binnen deze route.'
-            : `Open antwoorden openen pas vanaf ${MIN_N_DISPLAY} leesbare responses.`
-      }
-      href={showOpenAnswersRoute ? openAnswersHref : undefined}
-      linkLabel={showOpenAnswersRoute ? 'Bekijk alle open antwoorden' : undefined}
-      className="rounded-[28px]"
-    >
-      {blockVisibility.voices === 'visible' && openAnswersViewModel.groups.length > 0 ? (
-        <div className="space-y-4">
-          <div className="flex flex-wrap gap-2">
-            {openAnswersViewModel.themes.slice(0, 3).map((theme) => (
-              <span
-                key={theme.title}
-                className="rounded-full border border-slate-200 bg-[linear-gradient(145deg,rgba(255,255,255,0.98),rgba(246,239,229,0.84))] px-3 py-1 text-xs font-semibold text-slate-600 shadow-[0_8px_18px_rgba(15,23,42,0.04)]"
-              >
-                {theme.title} · {theme.count}
-              </span>
-            ))}
-          </div>
-          <div className="grid gap-4 xl:grid-cols-3">
-            {openAnswersViewModel.groups
-              .flatMap((group) => group.answers.slice(0, 1).map((answer) => ({ group, answer })))
-              .slice(0, 3)
-              .map(({ group, answer }) => (
-                <div
-                  key={answer.id}
-                  className="relative overflow-hidden rounded-[26px] border border-slate-200 bg-[linear-gradient(145deg,rgba(255,255,255,0.98),rgba(246,239,229,0.82))] px-5 py-5 shadow-[0_16px_34px_rgba(15,23,42,0.05)]"
+        {utilitySectionVisible ? (
+          <DashboardSection
+            id="operatie"
+            eyebrow={showClientExecutionFlow ? "Uitvoering" : "Utilitylaag"}
+            title={
+              showClientExecutionFlow
+                ? "Responsmonitoring en begrensde uitvoerlaag"
+                : "Operatie, respondenten en uitvoering"
+            }
+            description={
+              showClientExecutionFlow
+                ? "Gebruik deze laag om deelnemers, uitnodigingen en respons netjes te volgen. Productsetup, campagne-inrichting en uitvoercontrole blijven bij Verisight."
+                : "Alles onder deze lijn ondersteunt uitvoering en beheer. De managementhoofdlijn blijft hierboven compact en bestuurlijk."
+            }
+            aside={
+              <DashboardChip
+                label={
+                  showClientExecutionFlow
+                    ? "Begeleide uitvoering"
+                : "Beheer en operatie"
+                }
+                tone="slate"
+              />
+            }
+            variant="quiet"
+          >
+            <div className="space-y-4">
+              {canManageCampaign ? (
+                <DashboardDisclosure
+                  defaultOpen={!hasEnoughData}
+                  title="Campagnestatus en uitvoercontrole"
+                  description="Gebruik deze laag voor lifecycle, readiness, vervolgstappen en foutopvang nadat het managementbeeld helder is."
+                  badge={
+                    <DashboardChip
+                      label={
+                        readinessState.launchReady
+                          ? "Uitvoer op orde"
+                          : "Aandacht nodig"
+                      }
+                      tone={readinessState.launchReady ? "emerald" : "amber"}
+                    />
+                  }
                 >
-                  <div className="absolute -left-2 top-2 text-[4.5rem] leading-none tracking-[-0.08em] text-[#C36A29]/10">
-                    ”
+                  <div className="space-y-4">
+                    <CampaignActions
+                      campaignId={id}
+                      isActive={stats.is_active}
+                      pendingCount={pendingCount}
+                      canResendInvites={canExecuteCampaign}
+                      canArchiveCampaign={canManageCampaign}
+                    />
+                    <CampaignHealthIndicator
+                      totalInvited={stats.total_invited}
+                      totalCompleted={stats.total_completed}
+                      invitesNotSent={invitesNotSent}
+                      incompleteScores={incompleteScores}
+                      hasEnoughData={hasEnoughData}
+                      hasMinDisplay={hasMinDisplay}
+                    />
+                    <div
+                      className={`rounded-[24px] border px-4 py-4 ${
+                        readinessState.launchReady
+                          ? "border-emerald-200 bg-emerald-50"
+                          : "border-amber-200 bg-amber-50"
+                      }`}
+                    >
+                      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                        <div>
+                          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                            Implementatiereadiness
+                          </p>
+                          <p className="mt-1 text-base font-semibold text-slate-950">
+                            {readinessState.headline}
+                          </p>
+                        </div>
+                        <span className="rounded-full bg-white/80 px-3 py-1 text-xs font-semibold text-slate-600">
+                          {readinessState.launchReady
+                            ? "Uitvoer op orde"
+                            : "Nog aandacht nodig"}
+                        </span>
+                      </div>
+                      <p className="mt-3 text-sm leading-6 text-slate-700">
+                        {readinessState.detail}
+                      </p>
+                      <p className="mt-3 text-sm font-medium leading-6 text-slate-800">
+                        Volgende stap: {readinessState.nextStep}
+                      </p>
+                    </div>
+                    {stats.is_active ? (
+                      <PreflightChecklist
+                        campaignId={id}
+                        scanType={stats.scan_type}
+                        deliveryMode={campaignMeta?.delivery_mode ?? null}
+                        totalInvited={stats.total_invited}
+                        totalCompleted={stats.total_completed}
+                        invitesNotSent={invitesNotSent}
+                        importReady={importReady}
+                        incompleteScores={incompleteScores}
+                        hasMinDisplay={hasMinDisplay}
+                        hasEnoughData={hasEnoughData}
+                        activeClientAccessCount={activeClientAccessCount ?? 0}
+                        pendingClientInviteCount={pendingClientInviteCount ?? 0}
+                        record={deliveryRecord}
+                        checkpoints={deliveryCheckpoints}
+                        leadOptions={deliveryLeadOptions}
+                        leadLoadError={deliveryLeadError}
+                        linkedLearningDossierCount={learningDossiers.length}
+                        learningCloseoutEvidenceCount={
+                          learningCloseoutEvidenceCount
+                        }
+                        editable={isVerisightAdmin}
+                        auditEvents={auditEvents}
+                      />
+                    ) : (
+                      <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm leading-6 text-slate-700">
+                        Deze campagne is gesloten. Rapportage en dashboard
+                        blijven beschikbaar, maar respondenten kunnen niet meer
+                        invullen.
+                      </div>
+                    )}
                   </div>
-                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--dashboard-muted)]">
-                    {group.title}
-                  </p>
-                  <p className="relative mt-4 text-sm leading-6 text-[color:var(--dashboard-text)]">
-                    {truncateText(answer.text, 180)}
-                  </p>
-                </div>
-              ))}
-          </div>
+                </DashboardDisclosure>
+              ) : null}
+
+              <DashboardDisclosure
+                defaultOpen={disclosureDefaults.respondentsOpen}
+                title="Respondenten en uitnodigingen"
+                description="Operationele detailweergave voor import, responsmonitoring en uitnodigingsbeheer."
+                badge={
+                  <DashboardChip
+                    label={`${respondents.length} respondenten`}
+                    tone="slate"
+                  />
+                }
+              >
+                {respondents.length === 0 ? (
+                  <div className="rounded-[24px] border border-dashed border-slate-200 bg-slate-50 px-4 py-8 text-center">
+                    <p className="text-base font-semibold text-slate-900">
+                      Nog geen respondenten toegevoegd
+                    </p>
+                    <p className="mt-2 text-sm leading-6 text-slate-600">
+                      {showClientExecutionFlow
+                        ? "Gebruik de begeleide uitvoerflow hierboven om eerst het deelnemersbestand aan te leveren. Daarna verschijnen uitnodigingen, responsmonitoring en deze tabel automatisch."
+                        : "Voeg eerst respondenten toe via de setupflow. Daarna komen uitnodigingen, responsmonitoring en deze tabel automatisch beschikbaar."}
+                    </p>
+                    {!showClientExecutionFlow && canManageCampaign ? (
+                      <Link
+                        href="/beheer"
+                        className="mt-4 inline-flex rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition-colors hover:border-slate-300 hover:bg-slate-50"
+                      >
+                        Naar setup
+                      </Link>
+                    ) : null}
+                  </div>
+                ) : (
+                  <RespondentTable
+                    respondents={respondents}
+                    responses={safeTableResponses}
+                    scanType={stats.scan_type}
+                    hasMinDisplay={hasMinDisplay}
+                    canManageCampaign={canManageCampaign}
+                  />
+                )}
+              </DashboardDisclosure>
+
+              {profile?.is_verisight_admin ? (
+                <DashboardDisclosure
+                  defaultOpen={false}
+                  title="Pilot- en early-customer-learning"
+                  description="Gebruik de dossierbron om buyer-signalen, implementatielessen, eerste duiding en de gekozen repeat- of expansionrichting expliciet vast te leggen voor deze campagne."
+                  badge={
+                    <DashboardChip
+                      label={
+                        learningDossiers.length === 0
+                          ? "Nog geen dossier"
+                          : learningCloseoutEvidenceCount > 0
+                            ? `${learningCloseoutEvidenceCount} closeout-signaal`
+                            : `${learningDossiers.length} gekoppeld, closeout open`
+                      }
+                      tone={
+                        learningDossiers.length > 0 &&
+                        learningCloseoutEvidenceCount > 0
+                          ? "emerald"
+                          : "amber"
+                      }
+                    />
+                  }
+                >
+                  <div className="grid gap-4 xl:grid-cols-[minmax(0,1.1fr),minmax(320px,0.9fr)]">
+                    <DashboardPanel
+                      eyebrow="Waarom nu"
+                      title={
+                        learningDossiers.length > 0
+                        ? "Deze campagne is al opgenomen in de learninglus"
+                          : "Koppel deze campagne aan een learningdossier"
+                      }
+                      body={
+                        learningDossiers.length > 0
+                          ? "Gebruik gekoppelde dossiers om implementationfrictie, launchsignalen, managementgebruik en gekozen vervolgroutes expliciet terug te laten landen in product, report, onboarding, sales en operations."
+                          : "Zodra deze campagne leerwaarde geeft, koppel je hem aan een dossier in de dossierbron. Zo blijven echte uitvoerlessen en vervolgkeuzes niet hangen in losse notities."
+                      }
+                      tone={learningDossiers.length > 0 ? "slate" : "amber"}
+                    />
+                    <DashboardPanel
+                      eyebrow="Closeoutdiscipline"
+                      title={
+                        learningCloseoutEvidenceCount > 0
+                          ? "Learning kan naar formele closeout toewerken"
+                          : learningDossiers.length > 0
+                            ? "Learning bestaat, maar closeout-evidence mist nog"
+                            : "Nog geen learning-closeout mogelijk"
+                      }
+                      body={
+                        learningCloseoutEvidenceCount > 0
+                          ? "Er is al minstens één expliciete review-, vervolg- of stopuitkomst vastgelegd. Daarmee kan delivery later eerlijker naar opvolging of learning closeout bewegen."
+                          : learningDossiers.length > 0
+                            ? "Er zijn al gekoppelde dossiers, maar nog geen expliciete review-, vervolg- of stopuitkomst. Houd delivery dus bewust open tot die opvolging echt is vastgelegd."
+                            : "Zonder gekoppeld learningdossier hoort delivery-closeout nog niet als afgerond te voelen."
+                      }
+                      tone={
+                        learningCloseoutEvidenceCount > 0 ? "emerald" : "amber"
+                      }
+                    />
+                    <div className="rounded-[22px] border border-slate-200 bg-slate-50/70 p-4">
+                      <p className="text-sm font-semibold text-slate-950">
+                        Gekoppelde dossiers
+                      </p>
+                      {learningDossiers.length === 0 ? (
+                        <p className="mt-2 text-sm leading-6 text-slate-600">
+                      Er is nog geen dossier gekoppeld aan deze campagne.
+                        </p>
+                      ) : (
+                        <div className="mt-3 space-y-3">
+                          {learningDossiers.map((dossier) => (
+                            <div
+                              key={dossier.id}
+                              className="rounded-2xl border border-white/80 bg-white px-4 py-3"
+                            >
+                              <p className="text-sm font-semibold text-slate-950">
+                                {dossier.title}
+                              </p>
+                              <p className="mt-1 text-xs text-slate-500">
+                                Status: {dossier.triage_status}. Laatst
+                                bijgewerkt:{" "}
+                                {new Intl.DateTimeFormat("nl-NL", {
+                                  dateStyle: "medium",
+                                  timeStyle: "short",
+                                  timeZone: "Europe/Amsterdam",
+                                }).format(new Date(dossier.updated_at))}
+                              </p>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                      <Link
+                        href={`/beheer/klantlearnings?campaign=${id}`}
+                        className="mt-4 inline-flex items-center rounded-full border border-slate-200 bg-white px-4 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:text-slate-900"
+                      >
+                        Open dossierbron
+                      </Link>
+                    </div>
+                  </div>
+                </DashboardDisclosure>
+              ) : null}
+            </div>
+          </DashboardSection>
+        ) : null}
+      </div>
+      {focusPanelItems.length > 0 ? (
+        <div className="xl:pt-[360px]">
+          <FocusPanel items={focusPanelItems} variant="campaign-detail" />
         </div>
-      ) : (
-        <EmptyInlineState body="Er zijn nog geen vrijgegeven open antwoorden om te groeperen." />
-      )}
-    </ResultsBlockCard>
-  )
-
-  return (
-    <div className="space-y-10">
-      <ResultsShellHeader
-        moduleHref={moduleHref}
-        moduleLabel={moduleLabel}
-        moduleBackLinkLabel={moduleBackLinkLabel}
-        campaignName={stats.campaign_name}
-        organizationName={organizationName}
-        routePeriodLabel={routePeriodLabel}
-        scopeLabel={scopeLabel}
-        statusLabel={getResultsStatusLabel(resultsViewModel.readState)}
-        campaignId={id}
-        scanType={stats.scan_type}
-      />
-
-      {actionCenterBridgeCard}
-
-      <ResultsLayout
-        sections={{
-          response: responseSection,
-          signal: signalSection,
-          synthesis: synthesisSection,
-          drivers: driversSection,
-          depth: depthSection,
-          voices: voicesSection,
-        }}
-      />
+      ) : null}
     </div>
-  )
+  );
 }
+
+

--- a/frontend/app/(dashboard)/campaigns/[id]/retention-product-dashboard.guard.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/retention-product-dashboard.guard.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const componentSource = () =>
+  readFileSync(
+    new URL('../../../../components/dashboard/retention-product-dashboard.tsx', import.meta.url),
+    'utf8',
+  )
+
+describe('retention boardroom dashboard guardrails', () => {
+  it('keeps the RetentieScan dashboard free from exit-only and unsafe wording', () => {
+    const source = componentSource().toLowerCase()
+    const forbiddenTerms = [
+      'vertrekbeeld',
+      'exitscan',
+      'oorzakenanalyse',
+      'gedreven door',
+      'diagnose',
+      'predictie',
+      'strong editorial confidence',
+      'retention flow',
+    ]
+
+    for (const term of forbiddenTerms) {
+      expect(source).not.toContain(term)
+    }
+  })
+
+  it('renders the agreed RetentieScan boardroom IA in the expected order', () => {
+    const source = componentSource()
+    const orderedHeadings = [
+      'Kernsignaal',
+      'Responsbasis / leessterkte',
+      'Signaalopbouw',
+      'Prioriteitenbeeld',
+      'Basisbehoeften / SDT',
+      'Survey-stemmen',
+      'Bestuurlijke handoff',
+    ]
+
+    let previousIndex = -1
+    for (const heading of orderedHeadings) {
+      const index = source.indexOf(heading)
+      expect(index, `${heading} ontbreekt`).toBeGreaterThan(-1)
+      expect(index, `${heading} staat buiten volgorde`).toBeGreaterThan(previousIndex)
+      previousIndex = index
+    }
+  })
+})

--- a/frontend/components/dashboard/results-boardroom-primitives.tsx
+++ b/frontend/components/dashboard/results-boardroom-primitives.tsx
@@ -1,0 +1,236 @@
+import type { ReactNode } from 'react'
+import Link from 'next/link'
+
+function joinClasses(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(' ')
+}
+
+export function ResultsBoardroomHeader({
+  moduleHref,
+  moduleLabel,
+  moduleBackLinkLabel,
+  campaignName,
+  organizationName,
+  routePeriodLabel,
+  scopeLabel,
+  productLabel,
+  statusLabel,
+  actions,
+}: {
+  moduleHref: string
+  moduleLabel: string
+  moduleBackLinkLabel: string
+  campaignName: string
+  organizationName: string
+  routePeriodLabel: string
+  scopeLabel: string
+  productLabel: string
+  statusLabel: string
+  actions?: ReactNode
+}) {
+  return (
+    <header className="space-y-5 border-b border-[rgba(13,27,42,0.15)] pb-6">
+      <p className="font-mono text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-[#44505C]">
+        <Link href="/dashboard" className="transition-colors hover:text-[#132033]">
+          Overzicht
+        </Link>{' '}
+        /{' '}
+        <Link href={moduleHref} className="transition-colors hover:text-[#132033]">
+          {moduleLabel}
+        </Link>{' '}
+        / <span className="text-[#132033]">{campaignName}</span>
+      </p>
+      <Link
+        href={moduleHref}
+        className="inline-flex items-center gap-2 text-sm font-medium text-[#44505C] transition-colors hover:text-[#132033]"
+      >
+        <span aria-hidden="true">&larr;</span> {moduleBackLinkLabel}
+      </Link>
+      <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr),auto] xl:items-end">
+        <div className="space-y-4">
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="border border-[rgba(13,27,42,0.15)] bg-[#ffffff] px-3 py-1.5 font-mono text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-[#132033]">
+              {productLabel}
+            </span>
+            <span className="border border-[rgba(13,27,42,0.15)] bg-[#F4F1EA] px-3 py-1.5 font-mono text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-[#44505C]">
+              {statusLabel}
+            </span>
+          </div>
+          <h1 className="font-display text-[clamp(2.7rem,7vw,5rem)] leading-[0.9] tracking-[-0.06em] text-[#132033]">
+            {campaignName}
+          </h1>
+          <p className="text-sm leading-6 text-[#44505C]">
+            {organizationName} <span aria-hidden="true">&middot;</span> {routePeriodLabel}{' '}
+            <span aria-hidden="true">&middot;</span> {scopeLabel}
+          </p>
+        </div>
+        {actions ? <div className="flex flex-wrap items-center gap-3">{actions}</div> : null}
+      </div>
+    </header>
+  )
+}
+
+export function ResultsBoardroomSection({
+  eyebrow,
+  title,
+  description,
+  aside,
+  children,
+  tone = 'white',
+  className,
+}: {
+  eyebrow: string
+  title: string
+  description?: ReactNode
+  aside?: ReactNode
+  children: ReactNode
+  tone?: 'white' | 'chalk' | 'ink'
+  className?: string
+}) {
+  const toneClasses = {
+    white: 'bg-white text-[#132033]',
+    chalk: 'bg-[#F4F1EA] text-[#132033]',
+    ink: 'bg-[#132033] text-white',
+  } as const
+
+  return (
+    <section
+      className={joinClasses(
+        'space-y-5 border border-[rgba(13,27,42,0.15)] p-5 sm:p-6',
+        toneClasses[tone],
+        className,
+      )}
+    >
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr),auto] lg:items-start">
+        <div className="space-y-3">
+          <p
+            className={joinClasses(
+              'font-mono text-[0.72rem] font-semibold uppercase tracking-[0.24em]',
+              tone === 'ink' ? 'text-[#F8D284]' : 'text-[#44505C]',
+            )}
+          >
+            {eyebrow}
+          </p>
+          <h2
+            className={joinClasses(
+              'font-display text-[clamp(2rem,4vw,3rem)] leading-[0.94] tracking-[-0.055em]',
+              tone === 'ink' ? 'text-white' : 'text-[#132033]',
+            )}
+          >
+            {title}
+          </h2>
+          {description ? (
+            <div
+              className={joinClasses(
+                'max-w-4xl text-sm leading-7',
+                tone === 'ink' ? 'text-[#E8EDF2]' : 'text-[#44505C]',
+              )}
+            >
+              {description}
+            </div>
+          ) : null}
+        </div>
+        {aside ? <div className="shrink-0">{aside}</div> : null}
+      </div>
+      {children}
+    </section>
+  )
+}
+
+export function BoardroomMetricTile({
+  label,
+  value,
+  note,
+  tone = 'white',
+  prominent = false,
+}: {
+  label: string
+  value: string
+  note?: string
+  tone?: 'white' | 'chalk' | 'amber' | 'ink'
+  prominent?: boolean
+}) {
+  const toneClasses = {
+    white: 'border-[rgba(13,27,42,0.15)] bg-white text-[#132033]',
+    chalk: 'border-[rgba(13,27,42,0.15)] bg-[#F4F1EA] text-[#132033]',
+    amber: 'border-[#D7A74E] bg-[#FEB234] text-[#132033]',
+    ink: 'border-[#2B3A4E] bg-[#132033] text-white',
+  } as const
+
+  return (
+    <div className={joinClasses('space-y-3 border px-4 py-4', toneClasses[tone])}>
+      <p
+        className={joinClasses(
+          'font-mono text-[0.68rem] font-semibold uppercase tracking-[0.22em]',
+          tone === 'ink' ? 'text-[#F8D284]' : 'text-[#44505C]',
+        )}
+      >
+        {label}
+      </p>
+      <p
+        className={joinClasses(
+          prominent
+            ? 'dash-number text-[clamp(2.2rem,5vw,4rem)] leading-none tracking-[-0.06em]'
+            : 'dash-number text-[1.5rem] leading-none tracking-[-0.05em]',
+        )}
+      >
+        {value}
+      </p>
+      {note ? (
+        <p className={joinClasses('text-sm leading-6', tone === 'ink' ? 'text-[#E8EDF2]' : 'text-[#44505C]')}>
+          {note}
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+export function BoardroomEmptyState({
+  title,
+  body,
+}: {
+  title: string
+  body: string
+}) {
+  return (
+    <div className="border border-dashed border-[rgba(13,27,42,0.18)] bg-[#F4F1EA] px-5 py-5">
+      <p className="font-semibold text-[#132033]">{title}</p>
+      <p className="mt-2 text-sm leading-6 text-[#44505C]">{body}</p>
+    </div>
+  )
+}
+
+export function BoardroomKeyValueList({
+  items,
+  tone = 'white',
+}: {
+  items: Array<{ label: string; value: string }>
+  tone?: 'white' | 'chalk' | 'ink'
+}) {
+  return (
+    <dl className="grid gap-px border border-[rgba(13,27,42,0.15)] bg-[rgba(13,27,42,0.15)] sm:grid-cols-2 xl:grid-cols-4">
+      {items.map((item) => (
+        <div
+          key={item.label}
+          className={joinClasses(
+            'space-y-2 bg-white px-4 py-4',
+            tone === 'chalk' && 'bg-[#F4F1EA]',
+            tone === 'ink' && 'bg-[#132033] text-white',
+          )}
+        >
+          <dt
+            className={joinClasses(
+              'font-mono text-[0.68rem] font-semibold uppercase tracking-[0.22em]',
+              tone === 'ink' ? 'text-[#F8D284]' : 'text-[#44505C]',
+            )}
+          >
+            {item.label}
+          </dt>
+          <dd className="dash-number text-[1.45rem] leading-none tracking-[-0.05em]">
+            {item.value}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  )
+}

--- a/frontend/components/dashboard/results-boardroom-visuals.tsx
+++ b/frontend/components/dashboard/results-boardroom-visuals.tsx
@@ -1,0 +1,273 @@
+'use client'
+
+import {
+  CartesianGrid,
+  Cell,
+  LabelList,
+  ReferenceArea,
+  ReferenceLine,
+  ResponsiveContainer,
+  Scatter,
+  ScatterChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import { getRiskBandFromScore, RISK_COLORS } from '@/lib/management-language'
+
+export type BoardroomFactorRow = {
+  factor: string
+  score: string
+  scoreValue: number
+  signal?: string
+  signalValue: number
+  band: string
+  note: string
+}
+
+export type BoardroomSdtRow = {
+  factor: string
+  score: string
+  scoreValue: number
+  signal: string
+  band: string
+  note: string
+}
+
+export type CompositionSegment = {
+  label: string
+  value: string
+  percent: number
+}
+
+function getBandColor(signalValue: number) {
+  return RISK_COLORS[getRiskBandFromScore(signalValue)]
+}
+
+function formatTooltipValue(value: unknown) {
+  return typeof value === 'number' ? `${value.toFixed(1)}/10` : 'Nog niet beschikbaar'
+}
+
+export function PriorityScatterPlot({
+  rows,
+  xLabel = 'Beleving',
+  yLabel = 'Bestuurlijke aandacht',
+}: {
+  rows: BoardroomFactorRow[]
+  xLabel?: string
+  yLabel?: string
+}) {
+  const data = rows.map((row) => ({
+    ...row,
+    x: Number(row.scoreValue.toFixed(1)),
+    y: Number(row.signalValue.toFixed(1)),
+    fill: getBandColor(row.signalValue),
+  }))
+
+  return (
+    <div className="h-[360px] w-full border border-[rgba(13,27,42,0.15)] bg-white">
+      <ResponsiveContainer width="100%" height="100%">
+        <ScatterChart margin={{ top: 24, right: 24, bottom: 18, left: 12 }}>
+          <CartesianGrid stroke="rgba(13,27,42,0.08)" vertical={false} />
+          <ReferenceArea y1={7} y2={10} fill="rgba(254,178,52,0.12)" />
+          <ReferenceArea x1={1} x2={4.5} fill="rgba(13,27,42,0.04)" />
+          <ReferenceLine x={5.5} stroke="rgba(13,27,42,0.18)" strokeDasharray="4 4" />
+          <ReferenceLine y={4.5} stroke="rgba(13,27,42,0.18)" strokeDasharray="4 4" />
+          <ReferenceLine y={7} stroke="rgba(13,27,42,0.18)" strokeDasharray="4 4" />
+          <XAxis
+            type="number"
+            dataKey="x"
+            domain={[1, 10]}
+            tickCount={10}
+            tick={{ fontSize: 11, fill: '#44505C' }}
+            axisLine={false}
+            tickLine={false}
+            label={{
+              value: xLabel,
+              position: 'insideBottom',
+              offset: -4,
+              fill: '#44505C',
+              fontSize: 11,
+            }}
+          />
+          <YAxis
+            type="number"
+            dataKey="y"
+            domain={[1, 10]}
+            tickCount={10}
+            tick={{ fontSize: 11, fill: '#44505C' }}
+            axisLine={false}
+            tickLine={false}
+            label={{
+              value: yLabel,
+              angle: -90,
+              position: 'insideLeft',
+              fill: '#44505C',
+              fontSize: 11,
+            }}
+          />
+          <Tooltip
+            cursor={{ strokeDasharray: '4 4', stroke: 'rgba(13,27,42,0.24)' }}
+            formatter={(value, _name, item) => {
+              const row = item.payload as (typeof data)[number]
+              return [formatTooltipValue(value), row.factor]
+            }}
+            labelFormatter={(_label, payload) => {
+              const row = payload?.[0]?.payload as (typeof data)[number] | undefined
+              return row ? `${row.factor} — ${row.note}` : ''
+            }}
+            contentStyle={{
+              borderRadius: 0,
+              border: '1px solid rgba(13,27,42,0.15)',
+              boxShadow: 'none',
+              backgroundColor: '#ffffff',
+            }}
+          />
+          <Scatter data={data}>
+            {data.map((entry) => (
+              <Cell
+                key={entry.factor}
+                fill={entry.fill}
+                stroke="#132033"
+                strokeWidth={1.25}
+              />
+            ))}
+            <LabelList
+              dataKey="factor"
+              position="right"
+              offset={8}
+              fontSize={11}
+              fill="#132033"
+            />
+          </Scatter>
+        </ScatterChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+
+export function SignalCompositionRibbon({
+  title,
+  segments,
+  note,
+}: {
+  title: string
+  segments: CompositionSegment[]
+  note?: string
+}) {
+  return (
+    <div className="space-y-4 border border-[rgba(13,27,42,0.15)] bg-white p-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p className="font-mono text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-[#44505C]">
+          {title}
+        </p>
+        {note ? <p className="text-xs leading-5 text-[#44505C]">{note}</p> : null}
+      </div>
+      <div className="flex min-h-12 overflow-hidden border border-[rgba(13,27,42,0.15)] bg-[#F4F1EA]">
+        {segments.length > 0 ? (
+          segments.map((segment, index) => (
+            <div
+              key={`${segment.label}-${index}`}
+              className="flex min-w-0 items-center justify-between gap-2 border-r border-[rgba(13,27,42,0.15)] px-3 py-3 text-[#132033] last:border-r-0"
+              style={{
+                width: `${Math.max(segment.percent, 12)}%`,
+                backgroundColor: index % 2 === 0 ? '#feb234' : '#ffffff',
+              }}
+            >
+              <span className="min-w-0 truncate text-sm font-semibold">{segment.label}</span>
+              <span className="font-mono text-[0.72rem] font-semibold uppercase tracking-[0.2em]">
+                {segment.value}
+              </span>
+            </div>
+          ))
+        ) : (
+          <div className="px-3 py-3 text-sm text-[#44505C]">Nog geen patroonbeeld beschikbaar.</div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function buildTrianglePoint(rows: BoardroomSdtRow[]) {
+  if (rows.length === 0) return { x: 50, y: 56 }
+
+  const byKey = {
+    autonomie: rows.find((row) => row.factor.toLowerCase().includes('autonomie'))?.scoreValue ?? 0,
+    competentie:
+      rows.find((row) => row.factor.toLowerCase().includes('competentie'))?.scoreValue ?? 0,
+    verbondenheid:
+      rows.find((row) => row.factor.toLowerCase().includes('verbondenheid'))?.scoreValue ?? 0,
+  }
+
+  const total = byKey.autonomie + byKey.competentie + byKey.verbondenheid
+  if (total <= 0) return { x: 50, y: 56 }
+
+  const vertices = {
+    autonomie: { x: 50, y: 10 },
+    competentie: { x: 12, y: 82 },
+    verbondenheid: { x: 88, y: 82 },
+  }
+
+  return {
+    x:
+      (byKey.autonomie * vertices.autonomie.x +
+        byKey.competentie * vertices.competentie.x +
+        byKey.verbondenheid * vertices.verbondenheid.x) /
+      total,
+    y:
+      (byKey.autonomie * vertices.autonomie.y +
+        byKey.competentie * vertices.competentie.y +
+        byKey.verbondenheid * vertices.verbondenheid.y) /
+      total,
+  }
+}
+
+export function SdtTriangleMap({ rows }: { rows: BoardroomSdtRow[] }) {
+  const point = buildTrianglePoint(rows)
+
+  return (
+    <div className="grid gap-5 border border-[rgba(13,27,42,0.15)] bg-white p-5 lg:grid-cols-[minmax(0,0.95fr),minmax(260px,0.85fr)]">
+      <div className="border border-[rgba(13,27,42,0.15)] bg-[#F4F1EA] p-4">
+        <svg viewBox="0 0 100 92" className="h-full w-full" role="img" aria-label="SDT driehoekskaart">
+          <path d="M50 10 L12 82 L88 82 Z" fill="#ffffff" stroke="#132033" strokeWidth="1.5" />
+          <path d="M50 10 L50 82" stroke="rgba(13,27,42,0.15)" strokeWidth="1" strokeDasharray="2 2" />
+          <path d="M12 82 L69 46" stroke="rgba(13,27,42,0.15)" strokeWidth="1" strokeDasharray="2 2" />
+          <path d="M88 82 L31 46" stroke="rgba(13,27,42,0.15)" strokeWidth="1" strokeDasharray="2 2" />
+          <circle cx={point.x} cy={point.y} r="4.5" fill="#feb234" stroke="#132033" strokeWidth="1.5" />
+          <text x="50" y="4" textAnchor="middle" className="fill-[#132033] text-[5px] font-semibold">
+            AUTONOMIE
+          </text>
+          <text x="8" y="89" textAnchor="start" className="fill-[#132033] text-[5px] font-semibold">
+            COMPETENTIE
+          </text>
+          <text x="92" y="89" textAnchor="end" className="fill-[#132033] text-[5px] font-semibold">
+            VERBONDENHEID
+          </text>
+        </svg>
+      </div>
+      <div className="space-y-3">
+        <p className="text-sm leading-6 text-[#44505C]">
+          De positie van de punt laat zien waar de basisbehoeften relatief het meest onder druk
+          staan binnen dit groepsbeeld. Lees de drie dimensies altijd samen, niet als losse diagnose.
+        </p>
+        <div className="grid gap-3">
+          {rows.map((row) => (
+            <div
+              key={row.factor}
+              className="grid gap-2 border border-[rgba(13,27,42,0.15)] bg-[#F4F1EA] px-4 py-3 sm:grid-cols-[minmax(0,1fr)_96px_132px]"
+            >
+              <div>
+                <p className="text-sm font-semibold text-[#132033]">{row.factor}</p>
+                <p className="mt-1 text-xs leading-5 text-[#44505C]">{row.note}</p>
+              </div>
+              <p className="dash-number text-[1.2rem] leading-none text-[#132033]">{row.score}</p>
+              <p className="font-mono text-[0.72rem] font-semibold uppercase tracking-[0.2em] text-[#44505C]">
+                {row.band}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/components/dashboard/retention-product-dashboard.tsx
+++ b/frontend/components/dashboard/retention-product-dashboard.tsx
@@ -15,7 +15,7 @@ import {
   SignalCompositionRibbon,
 } from '@/components/dashboard/results-boardroom-visuals'
 
-type ExitThemeCard = {
+type RetentionThemeCard = {
   key: string
   title: string
   count: number
@@ -25,7 +25,7 @@ type ExitThemeCard = {
   evidenceLabel: string
 }
 
-interface ExitProductDashboardProps {
+interface RetentionProductDashboardProps {
   moduleHref: string
   moduleLabel: string
   moduleBackLinkLabel: string
@@ -39,8 +39,9 @@ interface ExitProductDashboardProps {
   primarySignalBandLabel: string
   strongestFactorLabel: string
   strongestFactorNote: string
-  strongWorkSignalLabel: string
-  primaryReasonTitle: string
+  engagementLabel: string
+  turnoverIntentionLabel: string
+  stayIntentLabel: string
   firstManagementQuestion: string
   totalInvited: string
   totalCompleted: string
@@ -52,7 +53,7 @@ interface ExitProductDashboardProps {
   compositionHighlights: Array<{ label: string; value: string; body: string }>
   factorRows: BoardroomFactorRow[]
   sdtRows: BoardroomSdtRow[]
-  surveyThemes: ExitThemeCard[]
+  surveyThemes: RetentionThemeCard[]
   verificationTrackLabel: string
   ownerRoleLabel: string
   firstStepLabel: string
@@ -92,7 +93,7 @@ function RankedFactorTable({ rows }: { rows: BoardroomFactorRow[] }) {
   )
 }
 
-export function ExitProductDashboard({
+export function RetentionProductDashboard({
   moduleHref,
   moduleLabel,
   moduleBackLinkLabel,
@@ -106,8 +107,9 @@ export function ExitProductDashboard({
   primarySignalBandLabel,
   strongestFactorLabel,
   strongestFactorNote,
-  strongWorkSignalLabel,
-  primaryReasonTitle,
+  engagementLabel,
+  turnoverIntentionLabel,
+  stayIntentLabel,
   firstManagementQuestion,
   totalInvited,
   totalCompleted,
@@ -124,7 +126,7 @@ export function ExitProductDashboard({
   ownerRoleLabel,
   firstStepLabel,
   reviewMomentLabel,
-}: ExitProductDashboardProps) {
+}: RetentionProductDashboardProps) {
   const topPriorityRows = factorRows.slice(0, 3)
 
   return (
@@ -137,7 +139,7 @@ export function ExitProductDashboard({
         organizationName={organizationName}
         routePeriodLabel={routePeriodLabel}
         scopeLabel={scopeLabel}
-        productLabel="ExitScan"
+        productLabel="RetentieScan"
         statusLabel={statusLabel}
         actions={headerActions}
       />
@@ -145,7 +147,7 @@ export function ExitProductDashboard({
       <ResultsBoardroomSection
         eyebrow="1. Kernsignaal"
         title="Kernsignaal"
-        description="ExitScan opent het vertrekbeeld als terugkijkende managementread. Lees score, hoofdlaag en factoren samen als groepsbeeld en niet als harde vaststelling."
+        description="RetentieScan opent het groepsbeeld als behoudssignaal. Lees score, aanvullende signalen en factorbeeld samen als eerste verificatiehulp."
         aside={
           <span className="border border-[rgba(13,27,42,0.15)] bg-[#FEB234] px-3 py-2 font-mono text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-[#132033]">
             {primarySignalBandLabel}
@@ -155,23 +157,29 @@ export function ExitProductDashboard({
         <div className="grid gap-px border border-[rgba(13,27,42,0.15)] bg-[rgba(13,27,42,0.15)] xl:grid-cols-[minmax(0,1.15fr),minmax(320px,0.85fr)]">
           <div className="grid gap-px bg-[rgba(13,27,42,0.15)]">
             <BoardroomMetricTile
-              label="Frictiescore"
+              label="Retentiesignaal"
               value={primarySignalScoreLabel}
-              note="De frictiescore toont hoe scherp vertrekfrictie gemiddeld terugkomt in de leesbare responses."
+              note="Het retentiesignaal laat zien hoe scherp behoudsdruk gemiddeld terugkomt in de leesbare responses."
               tone="white"
               prominent
             />
-            <div className="grid gap-px bg-[rgba(13,27,42,0.15)] sm:grid-cols-2">
+            <div className="grid gap-px bg-[rgba(13,27,42,0.15)] sm:grid-cols-3">
               <BoardroomMetricTile
-                label="Scherpste factor"
-                value={strongestFactorLabel}
-                note={strongestFactorNote}
+                label="Bevlogenheid"
+                value={engagementLabel}
+                note="Lees deze waarde samen met behoudsdruk en aanvullende signalen."
                 tone="chalk"
               />
               <BoardroomMetricTile
-                label="Vertrekladder"
-                value={primaryReasonTitle}
-                note="Deze laag kleurt het vertrekbeeld als eerste en vraagt daarom de eerste bestuurlijke verificatie."
+                label="Vertrekintentie"
+                value={turnoverIntentionLabel}
+                note="Laat zien hoe expliciet vertrekdenken nu op groepsniveau terugkomt."
+                tone="chalk"
+              />
+              <BoardroomMetricTile
+                label="Blijfintentie"
+                value={stayIntentLabel}
+                note="Helpt bepalen of twijfel al richting blijven of juist richting vertrek beweegt."
                 tone="chalk"
               />
             </div>
@@ -185,15 +193,15 @@ export function ExitProductDashboard({
             />
             <div className="grid gap-px bg-[rgba(13,27,42,0.15)] sm:grid-cols-2">
               <BoardroomMetricTile
-                label="Sterk werksignaal"
-                value={strongWorkSignalLabel}
-                note="Laat zien hoeveel responses vooral wijzen op beinvloedbare werkcontext."
+                label="Scherpste factor"
+                value={strongestFactorLabel}
+                note={strongestFactorNote}
                 tone="white"
               />
               <BoardroomMetricTile
                 label="Status"
                 value={statusLabel}
-                note="Gebruik de band als leesdiscipline, niet als bewezen causaliteit."
+                note="Gebruik de band als leesdiscipline, niet als individuele voorspelling."
                 tone="white"
               />
             </div>
@@ -204,7 +212,7 @@ export function ExitProductDashboard({
       <ResultsBoardroomSection
         eyebrow="2. Responsbasis / leessterkte"
         title="Responsbasis / leessterkte"
-        description="Deze laag laat zien hoe stevig het gegroepeerde beeld gelezen mag worden en welke grenzen blijven gelden voor segmenten en open tekst."
+        description="Deze laag laat zien hoe stevig het gegroepeerde beeld gelezen mag worden en welke suppressiegrenzen blijven gelden."
         aside={
           <span className="border border-[rgba(13,27,42,0.15)] bg-white px-3 py-2 font-mono text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-[#44505C]">
             Leessterkte — {readStrengthLabel}
@@ -239,10 +247,10 @@ export function ExitProductDashboard({
       <ResultsBoardroomSection
         eyebrow="3. Signaalopbouw"
         title="Signaalopbouw"
-        description="De compositie laat zien welke lagen het vertrekbeeld kleuren. Lees dit als indicatief patroonbeeld en niet als causale verdeling."
+        description="De compositie laat zien hoe de signalen in de groep verdeeld zijn. Lees dit als patroonbeeld en niet als bewezen causaliteit."
       >
         <SignalCompositionRibbon
-          title="Vertrekbeeld in lagen"
+          title="Behoudsbeeld in lagen"
           segments={compositionSegments}
           note="Indicatief patroonbeeld, geen causale verdeling."
         />
@@ -262,7 +270,7 @@ export function ExitProductDashboard({
       <ResultsBoardroomSection
         eyebrow="4. Prioriteitenbeeld"
         title="Prioriteitenbeeld"
-        description="De horizontale as toont beleving, de verticale as bestuurlijke aandacht. Gebruik de topkaarten om het eerste verificatiespoor te kiezen."
+        description="De horizontale as toont beleving, de verticale as bestuurlijke aandacht. Gebruik de topkaarten om het eerste behoudsspoor te kiezen."
       >
         {factorRows.length > 0 ? (
           <div className="space-y-5">
@@ -291,7 +299,7 @@ export function ExitProductDashboard({
       <ResultsBoardroomSection
         eyebrow="5. Basisbehoeften / SDT"
         title="Basisbehoeften / SDT"
-        description="De drie basisbehoeften helpen het vertrekbeeld verdiepen zonder er een losse bewijslaag of harde vaststelling van te maken."
+        description="De basisbehoeften helpen het groepsbeeld verdiepen zonder er losse bewijsvoering van te maken."
       >
         {sdtRows.length > 0 ? (
           <SdtTriangleMap rows={sdtRows} />
@@ -306,7 +314,7 @@ export function ExitProductDashboard({
       <ResultsBoardroomSection
         eyebrow="6. Survey-stemmen"
         title="Survey-stemmen"
-        description="Open signalen verdiepen het beeld waar de anonimiteitsgrens dat toelaat. Quotes blijven geanonimiseerd en worden onderdrukt als de drempel te smal is."
+        description="Open signalen verdiepen het behoudsbeeld waar de anonimiteitsgrens dat toelaat. Quotes blijven geanonimiseerd en worden onderdrukt als de drempel te smal is."
       >
         {surveyThemes.length > 0 ? (
           <div className="grid gap-px border border-[rgba(13,27,42,0.15)] bg-[rgba(13,27,42,0.15)] xl:grid-cols-3">
@@ -354,14 +362,14 @@ export function ExitProductDashboard({
       <ResultsBoardroomSection
         eyebrow="7. Bestuurlijke handoff"
         title="Bestuurlijke handoff"
-        description="Rond de boardroom-read af met een eerste verificatiespoor, een begrensde eigenaar en een reviewmoment. Dit blijft een managementhandoff, geen workflowproduct."
+        description="Rond de boardroom-read af met een eerste verificatiespoor, een begrensde eigenaar en een reviewmoment. Dit blijft een managementhandoff, geen breed workflowproduct."
         tone="ink"
       >
         <div className="grid gap-px border border-[#2B3A4E] bg-[#2B3A4E] lg:grid-cols-2 xl:grid-cols-4">
           <BoardroomMetricTile
             label="Eerste verificatiespoor"
             value={verificationTrackLabel}
-            note="Kies eerst welk spoor bestuurlijk getoetst moet worden voordat bredere actie volgt."
+            note="Kies eerst welk spoor bestuurlijk getoetst moet worden voordat bredere opvolging volgt."
             tone="ink"
           />
           <BoardroomMetricTile


### PR DESCRIPTION
## Summary
- redesign ExitScan and RetentieScan results into a boardroom-first visual architecture
- add shared boardroom primitives and visuals for hero metrics, composition ribbons, scatterplots, and SDT maps
- keep all rendering tied to real product data with safe copy and fallback states

## Verification
- npm test -- "app/(dashboard)/campaigns/[id]/page.route-shell.test.ts" "app/(dashboard)/campaigns/[id]/page.test.ts" "app/(dashboard)/campaigns/[id]/page-helpers.test.ts" "app/(dashboard)/campaigns/[id]/retention-product-dashboard.guard.test.ts"
- npx eslint "app/(dashboard)/campaigns/[id]/page.tsx" "app/(dashboard)/campaigns/[id]/page.test.ts" "app/(dashboard)/campaigns/[id]/page.route-shell.test.ts" "app/(dashboard)/campaigns/[id]/page-helpers.tsx" "app/(dashboard)/campaigns/[id]/page-helpers.test.ts" "app/(dashboard)/campaigns/[id]/retention-product-dashboard.guard.test.ts" "components/dashboard/exit-product-dashboard.tsx" "components/dashboard/retention-product-dashboard.tsx" "components/dashboard/results-boardroom-primitives.tsx" "components/dashboard/results-boardroom-visuals.tsx"
- NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key npm run build