### PR TITLE
Refine boardroom ExitScan results experience

### DIFF
--- a/frontend/app/(dashboard)/campaigns/[id]/page-helpers.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/page-helpers.test.ts
@@ -103,7 +103,7 @@ describe('dashboard page helpers field semantics', () => {
     expect(panels[2]?.body).toContain('aanvullende signalen')
   })
 
-  it('keeps exit helper openings centered on average signal language with werkfrictie as duiding', () => {
+  it('keeps exit helper openings centered on vertrekduiding with claim-safe werkfrictie language', () => {
     const hero = buildHeroDescription({
       scanType: 'exit',
       isActive: false,
@@ -122,10 +122,11 @@ describe('dashboard page helpers field semantics', () => {
       topFactor: 'Leiderschap',
     })
 
-    expect(hero).toContain('gemiddelde signaalscore')
+    expect(hero).toContain('terugkijkende vertrekduiding')
     expect(hero).toContain('werkfrictie')
-    expect(nextStep).toContain('gemiddelde signaalscore')
+    expect(nextStep).toContain('Frictiescore')
     expect(nextStep).toContain('werkfrictie')
+    expect(nextStep).not.toContain('oorzaak')
   })
 
   it('clusters exit open signals without inventing extra quotes or factor values', () => {

--- a/frontend/app/(dashboard)/campaigns/[id]/page-helpers.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page-helpers.tsx
@@ -185,7 +185,7 @@ export function buildHeroDescription({
   }
 
   if (scanType === 'exit') {
-    return 'Deze ExitScan laat een bestuurlijke read zien van terugkerende werkfrictie. Gebruik Frictiescore als openingssignaal en lees daarna welke werkfactoren en verschillen het vertrekbeeld nu het sterkst kleuren.'
+    return 'Deze ExitScan laat een terugkijkende vertrekduiding zien van terugkerende werkfrictie. Gebruik Frictiescore als openingssignaal en lees daarna welke werkfactoren en verschillen het vertrekbeeld nu het sterkst kleuren.'
   }
 
   return `Bekijk eerst welke factoren het laagst scoren en waar de grootste verschillen zichtbaar zijn.`
@@ -1214,7 +1214,7 @@ export function clusterExitOpenSignals(responses: SurveyResponse[]): ExitTheme[]
       title: 'Beloning en voorwaarden',
       keywords: ['salaris', 'beloning', 'voorwaarden', 'arbeidsvoorwaarden', 'vergoeding', 'loon'],
       implication:
-        'Dit komt vaak terug als meelezende context en vraagt verificatie naast werkbeleving en perspectief.',
+        'Dit komt vaak terug als aanvullende context en vraagt verificatie naast werkbeleving en perspectief.',
     },
   ] as const
 

--- a/frontend/app/(dashboard)/campaigns/[id]/page.route-shell.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.route-shell.test.ts
@@ -21,6 +21,16 @@ describe('campaign detail route shell', () => {
     expect(source).toContain('if (stats.scan_type === "retention")')
   })
 
+  it('keeps Action Center outside the primary ExitScan and RetentieScan result shells', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+
+    expect(source).toContain('const actionCenterBridgeCard =')
+    expect(source).toMatch(/if \(stats\.scan_type === ['"]exit['"]\)/)
+    expect(source).toMatch(/if \(stats\.scan_type === ['"]retention['"]\)/)
+    expect(source).toContain('{actionCenterBridgeCard}')
+    expect(source).toContain('ResultsLayout')
+  })
+
   it('keeps existing module breadcrumbs instead of collapsing to a generic dashboard jump', () => {
     const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
 

--- a/frontend/app/(dashboard)/campaigns/[id]/page.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.test.ts
@@ -102,13 +102,13 @@ describe('exit dashboard analytics guardrails', () => {
   it('renders the agreed ExitScan boardroom IA in the expected order', () => {
     const source = exitDashboardSource()
     const orderedHeadings = [
-      'Kernsignaal',
-      'Responsbasis / leessterkte',
-      'Signaalopbouw',
-      'Prioriteitenbeeld',
-      'Basisbehoeften / SDT',
-      'Survey-stemmen',
-      'Bestuurlijke handoff',
+      'eyebrow="1. Kernsignaal"',
+      'eyebrow="2. Responsbasis / leessterkte"',
+      'eyebrow="3. Signaalopbouw"',
+      'eyebrow="4. Prioriteitenbeeld"',
+      'eyebrow="5. Basisbehoeften / SDT"',
+      'eyebrow="6. Survey-stemmen"',
+      'eyebrow="7. Bestuurlijke handoff"',
     ]
 
     let previousIndex = -1
@@ -133,10 +133,10 @@ describe('exit dashboard analytics guardrails', () => {
   it('keeps the visible ExitScan shell free from mojibake and uses the product score language', () => {
     const source = exitDashboardSource()
 
-    expect(source).not.toContain('Ãƒ')
-    expect(source).not.toContain('Ã‚')
-    expect(source).not.toContain('Ã¢')
-    expect(source).not.toContain('ï¿½')
+    expect(source).not.toContain('ÃƒÆ’')
+    expect(source).not.toContain('Ãƒâ€š')
+    expect(source).not.toContain('ÃƒÂ¢')
+    expect(source).not.toContain('Ã¯Â¿Â½')
     expect(source).toContain('Frictiescore')
     expect(source).toContain('Leessterkte')
   })
@@ -146,5 +146,33 @@ describe('exit dashboard analytics guardrails', () => {
 
     expect(source).toContain('sdtRows.length > 0')
     expect(source).toContain('SdtTriangleMap')
+  })
+
+  it('surfaces a compact executive strip and safer customer-facing labels', () => {
+    const source = exitDashboardSource()
+
+    expect(source).toContain('Dominant thema')
+    expect(source).toContain('Scherpste factor')
+    expect(source).toContain('Responsbasis')
+    expect(source).toContain('Bestuurlijke vraag')
+    expect(source).toContain('Resultaten beschikbaar')
+    expect(source).toContain('terugkijkende vertrekduiding')
+    expect(source).not.toContain('Vertrekladder')
+    expect(source).not.toContain('Sterk werksignaal')
+    expect(source).not.toContain('managementread')
+    expect(source).not.toContain('workflowproduct')
+    expect(source).not.toContain('leesdiscipline')
+  })
+
+  it('keeps trust copy bounded and the handoff in customer language', () => {
+    const source = exitDashboardSource()
+
+    expect(source).toContain('Indicatief patroonbeeld, geen causale verdeling.')
+    expect(source).toContain('Detailinzichten worden alleen getoond bij voldoende respons.')
+    expect(source).toContain('anonimiteit te beschermen')
+    expect(source).toContain('Sluit af met één eerste verificatiespoor, een eigenaar en een concreet reviewmoment.')
+    expect(source).toContain('eerst toetsen vóór bredere actie')
+    expect(source).not.toContain('suppressieregels')
+    expect(source).not.toContain('geen workflowproduct')
   })
 })

--- a/frontend/app/(dashboard)/campaigns/[id]/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.tsx
@@ -27,6 +27,10 @@ import { createAdminClient } from '@/lib/supabase/admin'
 import { createClient } from '@/lib/supabase/server'
 import { FACTOR_LABELS, hasCampaignAddOn } from '@/lib/types'
 import type { Campaign, CampaignStats, MemberRole, Respondent, ScanType, SurveyResponse } from '@/lib/types'
+import { buildExitDashboardViewModel } from '@/lib/products/exit/dashboard'
+import { buildRetentionDashboardViewModel } from '@/lib/products/retention/dashboard'
+import { ExitProductDashboard } from '@/components/dashboard/exit-product-dashboard'
+import { RetentionProductDashboard } from '@/components/dashboard/retention-product-dashboard'
 import {
   buildOpenAnswerItems,
   buildOpenAnswersViewModel,
@@ -36,8 +40,10 @@ import {
   MethodologyCard,
   MIN_N_DISPLAY,
   MIN_N_PATTERNS,
+  clusterExitOpenSignals,
   clusterRetentionOpenSignals,
   computeAverageSignalScore,
+  computeAverageSignalVisibility,
   computeFactorAverages,
   computeRetentionSupplementalAverages,
   computeStrongWorkSignalRate,
@@ -64,6 +70,7 @@ type FactorRow = {
   signalValue: number
   band: string
   note: string
+  question?: string
 }
 
 type SdtRow = {
@@ -214,9 +221,40 @@ function buildExitPictureDistribution(responses: SurveyResponse[]) {
 }
 
 function buildFactorPriorityRows(factorAverages: Record<string, number>) {
+  const factorGuidance: Record<string, { note: string; question: string }> = {
+    growth: {
+      note: 'Toets of gebrek aan perspectief of ontwikkeling structureel meespeelt in het vertrekbeeld.',
+      question: 'Komt gebrek aan perspectief of doorgroei structureel terug in gesprekken en open signalen?',
+    },
+    leadership: {
+      note: 'Toets of begeleiding, feedback of vertrouwen terugkerend genoemd worden.',
+      question: 'Welke rol spelen begeleiding, feedback of vertrouwen in het huidige vertrekbeeld?',
+    },
+    workload: {
+      note: 'Toets of druk incidenteel of structureel is en waar herstel wegvalt.',
+      question: 'Is werkdruk vooral piekbelasting of terugkerende structurele belasting?',
+    },
+    role_clarity: {
+      note: 'Toets of verwachtingen, prioriteiten en eigenaarschap voldoende helder waren.',
+      question: 'Waar bleven prioriteiten of rolverwachtingen voor vertrekkers te diffuus?',
+    },
+    culture: {
+      note: 'Toets of samenwerking, veiligheid of uitspreken het vertrekbeeld mee kleuren.',
+      question: 'Waar voelt samenwerken of uitspreken nog onvoldoende veilig of consistent?',
+    },
+    compensation: {
+      note: 'Toets of voorwaarden vooral aanvullende context vormen of echt structureel mee kleuren.',
+      question: 'Is beloning vooral aanvullende context, of speelt dit structureel mee in vertrekgesprekken?',
+    },
+  }
+
   return Object.entries(factorAverages)
     .map(([factor, score]) => {
       const signalValue = 11 - score
+      const guidance = factorGuidance[factor] ?? {
+        note: 'Toets of deze factor structureel terugkomt voordat je hier een bredere managementactie aan koppelt.',
+        question: 'Komt deze factor structureel terug, of vraagt het beeld eerst nog extra verificatie?',
+      }
 
       return {
         factor: FACTOR_LABELS[factor] ?? factor,
@@ -225,12 +263,8 @@ function buildFactorPriorityRows(factorAverages: Record<string, number>) {
         signal: `${signalValue.toFixed(1)}/10`,
         signalValue,
         band: getManagementBandLabel(signalValue),
-        note:
-          signalValue >= 7
-            ? 'Laagste ervaren score in deze route.'
-            : signalValue >= 4.5
-              ? 'Zichtbaar in het huidige patroon.'
-              : 'Nu minder uitgesproken dan de bovenste factoren.',
+        note: guidance.note,
+        question: guidance.question,
       } satisfies FactorRow
     })
     .sort((left, right) => right.signalValue - left.signalValue)
@@ -259,10 +293,10 @@ function buildSdtRows(sdtAverages: {
         band: getManagementBandLabel(signalValue),
         note:
           signalValue >= 7
-            ? 'Duidelijk zichtbaar in de verdiepingslaag.'
+            ? 'Deze basisbehoefte vraagt zichtbare verdieping in het vertrekbeeld.'
             : signalValue >= 4.5
-              ? 'Aanwezig als aanvullende context.'
-              : 'Nu minder uitgesproken dan de andere SDT-lagen.',
+              ? 'Aanwezig als aanvullende context op het kernsignaal.'
+              : 'Nu minder uitgesproken dan de andere basisbehoeften.',
       } satisfies SdtRow
     })
 }
@@ -271,6 +305,25 @@ function getResultsStatusLabel(readState: ReturnType<typeof buildResultsViewMode
   if (readState === 'readable') return 'Leesbaar'
   if (readState === 'early-read') return 'Eerste read'
   return 'Nog aan het opbouwen'
+}
+
+function getCustomerResultsStatusLabel(readState: ReturnType<typeof buildResultsViewModel>['readState']) {
+  if (readState === 'readable') return 'Resultaten beschikbaar'
+  if (readState === 'early-read') return 'Eerste resultaten beschikbaar'
+  return 'Nog aan het opbouwen'
+}
+
+function getReadStrengthLabel(readState: ReturnType<typeof buildResultsViewModel>['readState']) {
+  if (readState === 'readable') return 'Stevig leesbaar'
+  if (readState === 'early-read') return 'Voorzichtig leesbaar'
+  return 'Nog in opbouw'
+}
+
+function getFollowThroughCardBody(
+  cards: Array<{ title: string; body: string }>,
+  title: string,
+) {
+  return cards.find((card) => card.title === title)?.body ?? null
 }
 
 function buildSignalHighlights(args: {
@@ -988,6 +1041,67 @@ export default async function CampaignPage({ params }: Props) {
     openAnswerThemes: openAnswersViewModel.themes,
     exitDistribution,
   })
+  const responseContextNote = buildResponseContextNote(
+    stats.total_completed,
+    stats.completion_rate_pct ?? 0,
+  )
+  const customerStatusLabel = getCustomerResultsStatusLabel(resultsViewModel.readState)
+  const readStrengthLabel = getReadStrengthLabel(resultsViewModel.readState)
+  const signalVisibilityAverage =
+    stats.scan_type === 'exit' && hasEnoughData ? computeAverageSignalVisibility(responses) : null
+  const exitThemes =
+    stats.scan_type === 'exit' && hasMinDisplay ? clusterExitOpenSignals(responses) : []
+  const exitDashboardViewModel =
+    stats.scan_type === 'exit'
+      ? buildExitDashboardViewModel({
+          signalLabelLower: scanDefinition.signalLabelLower,
+          averageSignal: averageSignalScore,
+          strongWorkSignalRate,
+          engagement: supplemental.engagement,
+          turnoverIntention: supplemental.turnoverIntention,
+          stayIntent: supplemental.stayIntent,
+          hasEnoughData,
+          hasMinDisplay,
+          pendingCount: Math.max(stats.total_invited - stats.total_completed, 0),
+          factorAverages: factorData.orgAverages,
+          topExitReasonLabel,
+          topContributingReasonLabel,
+          signalVisibilityAverage,
+        })
+      : null
+  const retentionDashboardViewModel =
+    stats.scan_type === 'retention'
+      ? buildRetentionDashboardViewModel({
+          signalLabelLower: scanDefinition.signalLabelLower,
+          averageSignal: averageSignalScore,
+          strongWorkSignalRate,
+          engagement: supplemental.engagement,
+          turnoverIntention: supplemental.turnoverIntention,
+          stayIntent: supplemental.stayIntent,
+          hasEnoughData,
+          hasMinDisplay,
+          pendingCount: Math.max(stats.total_invited - stats.total_completed, 0),
+          factorAverages: factorData.orgAverages,
+        })
+      : null
+  const trustNotes = [
+    'Detailinzichten worden alleen getoond bij voldoende respons.',
+    'Kleine groepen blijven verborgen om anonimiteit te beschermen.',
+    'Open antwoorden blijven geanonimiseerd en worden onderdrukt bij te lage n.',
+    'Gebruik dit vertrekbeeld als vertrekduiding op groepsniveau, niet als individuele beoordeling.',
+  ]
+  const defaultHeaderActions = (
+    <PdfDownloadButton
+      campaignId={id}
+      campaignName={stats.campaign_name}
+      scanType={stats.scan_type}
+      label="Download PDF"
+      loadingLabel="PDF ophalen..."
+      buttonClassName="inline-flex rounded-full border border-slate-950 bg-slate-950 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
+      containerClassName="flex flex-col items-start gap-2 lg:items-end"
+      errorClassName="max-w-56 text-xs text-red-600 lg:text-right"
+    />
+  )
   const depthNotes = buildDepthNotes({
     scanDefinition,
     responsesLength: responses.length,
@@ -1084,6 +1198,233 @@ export default async function CampaignPage({ params }: Props) {
         </div>
       </div>
     ) : null
+
+  if (stats.scan_type === "exit") {
+    const dominantThemeLabel = topExitReasonLabel ?? 'Nog niet beschikbaar'
+    const dominantThemeNote = topContributingReasonLabel
+      ? `${topContributingReasonLabel} valt geregeld samen met dit vertrekbeeld en vraagt aanvullende verificatie.`
+      : 'Meest terugkerende vertreklaag binnen de huidige batch.'
+    const strongestFactorNote =
+      factorPriorityRows[0]?.note ?? 'Nog geen veilige factorlezing beschikbaar.'
+    const executiveSummary =
+      topFactorLabel && secondFactorLabel
+        ? `${topFactorLabel} komt het sterkst terug. ${topFactorLabel} en ${secondFactorLabel.toLowerCase()} vragen eerst verificatie.`
+        : topFactorLabel
+          ? `${topFactorLabel} komt het sterkst terug en kleurt het vertrekbeeld op dit moment het duidelijkst.`
+          : 'De eerste managementsamenvatting wordt zichtbaar zodra voldoende bruikbare responses beschikbaar zijn.'
+    const compositionHighlights = [
+      {
+        label: 'Dominant thema',
+        value: dominantThemeLabel,
+        body: 'Wat het vertrekbeeld nu het duidelijkst kleurt op groepsniveau.',
+      },
+      {
+        label: 'Aanvullende context',
+        value: topContributingReasonLabel ?? 'Nog niet zichtbaar',
+        body: 'Extra laag die geregeld samenvalt met het hoofdbeeld en dus eerst verificatie vraagt.',
+      },
+      {
+        label: 'Beïnvloedbaar werksignaal',
+        value: hasMinDisplay ? formatPercent(strongWorkSignalRate) : 'Nog niet beschikbaar',
+        body: 'Aandeel responses waarin vooral beïnvloedbare werkcontext terugkomt.',
+      },
+    ]
+    const surveyThemes = exitThemes.map((theme, index) => {
+      const relationLabel =
+        theme.key === 'leadership'
+          ? 'Verdiept leiderschapssignaal'
+          : theme.key === 'growth' || theme.key === 'workload'
+            ? 'Bevestigt topfactor'
+            : 'Nuanceert hoofdbeeld'
+      const evidenceLabel =
+        index === 0 ? 'Bevestigt topfactor' : index === 1 ? 'Nuanceert hoofdbeeld' : 'Aanvullende context'
+
+      return {
+        key: theme.key,
+        title: theme.title,
+        count: theme.count,
+        implication: theme.implication,
+        quote: theme.count >= 3 ? theme.sample : null,
+        relationLabel,
+        evidenceLabel,
+      }
+    })
+    const exitFollowThroughCards = exitDashboardViewModel?.followThroughCards ?? []
+
+    return (
+      <ExitProductDashboard
+        moduleHref={moduleHref}
+        moduleLabel={moduleLabel}
+        moduleBackLinkLabel={moduleBackLinkLabel}
+        campaignName={stats.campaign_name}
+        organizationName={organizationName}
+        routePeriodLabel={routePeriodLabel}
+        scopeLabel={scopeLabel}
+        statusLabel={customerStatusLabel}
+        headerActions={defaultHeaderActions}
+        primarySignalScoreLabel={formatScore(averageSignalScore)}
+        primarySignalBandLabel={
+          averageSignalScore !== null ? getManagementBandLabel(averageSignalScore) : 'Nog niet beschikbaar'
+        }
+        strongestFactorLabel={topFactorLabel ?? 'Nog niet beschikbaar'}
+        strongestFactorNote={strongestFactorNote}
+        dominantThemeLabel={dominantThemeLabel}
+        dominantThemeNote={dominantThemeNote}
+        executiveSummary={executiveSummary}
+        firstManagementQuestion={
+          exitDashboardViewModel?.primaryQuestion.body ??
+          'Welke factor of vertreklaag vraagt als eerste bestuurlijke verificatie?'
+        }
+        totalInvited={String(stats.total_invited)}
+        totalCompleted={String(stats.total_completed)}
+        responseRate={`${stats.completion_rate_pct ?? 0}%`}
+        responseContextNote={responseContextNote}
+        readStrengthLabel={readStrengthLabel}
+        trustNotes={trustNotes}
+        compositionSegments={exitDistribution?.segments ?? []}
+        compositionHighlights={compositionHighlights}
+        factorRows={factorPriorityRows}
+        sdtRows={sdtRows}
+        surveyThemes={surveyThemes}
+        verificationTrackLabel={topFactorLabel ?? 'Nog niet beschikbaar'}
+        ownerRoleLabel={
+          getFollowThroughCardBody(exitFollowThroughCards, 'Eerste eigenaar') ??
+          'HR / verantwoordelijke MT-eigenaar'
+        }
+        firstStepLabel={
+          getFollowThroughCardBody(exitFollowThroughCards, 'Eerste actie') ??
+          exitDashboardViewModel?.nextStep.body ??
+          'Bepaal eerst welke gerichte verificatie of verbeteractie volgt.'
+        }
+        reviewMomentLabel={
+          getFollowThroughCardBody(exitFollowThroughCards, 'Reviewmoment') ??
+          'Leg direct een eerste reviewmoment vast zodra het verificatiespoor gekozen is.'
+        }
+      />
+    )
+  }
+
+  if (stats.scan_type === "retention") {
+    const retentionFollowThroughCards = retentionDashboardViewModel?.followThroughCards ?? []
+
+    return (
+      <RetentionProductDashboard
+        moduleHref={moduleHref}
+        moduleLabel={moduleLabel}
+        moduleBackLinkLabel={moduleBackLinkLabel}
+        campaignName={stats.campaign_name}
+        organizationName={organizationName}
+        routePeriodLabel={routePeriodLabel}
+        scopeLabel={scopeLabel}
+        statusLabel={customerStatusLabel}
+        headerActions={defaultHeaderActions}
+        primarySignalScoreLabel={formatScore(averageSignalScore)}
+        primarySignalBandLabel={
+          averageSignalScore !== null ? getManagementBandLabel(averageSignalScore) : 'Nog niet beschikbaar'
+        }
+        strongestFactorLabel={topFactorLabel ?? 'Nog niet beschikbaar'}
+        strongestFactorNote={
+          factorPriorityRows[0]?.note ?? 'Nog geen veilige factorlezing beschikbaar.'
+        }
+        engagementLabel={formatScore(supplemental.engagement)}
+        turnoverIntentionLabel={formatScore(supplemental.turnoverIntention)}
+        stayIntentLabel={formatScore(supplemental.stayIntent)}
+        firstManagementQuestion={
+          retentionDashboardViewModel?.primaryQuestion.body ??
+          'Welk behoudssignaal vraagt nu als eerste managementtoetsing?'
+        }
+        totalInvited={String(stats.total_invited)}
+        totalCompleted={String(stats.total_completed)}
+        responseRate={`${stats.completion_rate_pct ?? 0}%`}
+        responseContextNote={responseContextNote}
+        readStrengthLabel={readStrengthLabel}
+        trustNotes={[
+          'Detailinzichten worden alleen getoond bij voldoende respons.',
+          'Kleine groepen blijven verborgen om anonimiteit te beschermen.',
+          'Open antwoorden blijven geanonimiseerd en worden onderdrukt bij te lage n.',
+        ]}
+        compositionSegments={
+          [
+            {
+              label: 'Direct prioriteren',
+              value: `${factorPriorityRows.filter((row) => row.band === 'Direct prioriteren').length}`,
+              percent: factorPriorityRows.length
+                ? Math.round(
+                    (factorPriorityRows.filter((row) => row.band === 'Direct prioriteren').length /
+                      factorPriorityRows.length) *
+                      100,
+                  )
+                : 0,
+            },
+            {
+              label: 'Eerst toetsen',
+              value: `${factorPriorityRows.filter((row) => row.band === 'Eerst toetsen').length}`,
+              percent: factorPriorityRows.length
+                ? Math.round(
+                    (factorPriorityRows.filter((row) => row.band === 'Eerst toetsen').length /
+                      factorPriorityRows.length) *
+                      100,
+                  )
+                : 0,
+            },
+            {
+              label: 'Volgen',
+              value: `${factorPriorityRows.filter((row) => row.band === 'Volgen').length}`,
+              percent: factorPriorityRows.length
+                ? Math.round(
+                    (factorPriorityRows.filter((row) => row.band === 'Volgen').length /
+                      factorPriorityRows.length) *
+                      100,
+                  )
+                : 0,
+            },
+          ].filter((segment) => segment.percent > 0)
+        }
+        compositionHighlights={[
+          {
+            label: 'Scherpste factor',
+            value: topFactorLabel ?? 'Nog niet beschikbaar',
+            body: 'Factor die het behoudsbeeld nu het duidelijkst kleurt.',
+          },
+          {
+            label: 'Open signaal',
+            value: retentionThemes[0]?.title ?? 'Nog niet zichtbaar',
+            body: 'Thema dat in de open antwoorden het meest terugkomt.',
+          },
+          {
+            label: 'Bevlogenheid',
+            value: formatScore(supplemental.engagement),
+            body: 'Aanvullende laag om het behoudssignaal beter te duiden.',
+          },
+        ]}
+        factorRows={factorPriorityRows}
+        sdtRows={sdtRows}
+        surveyThemes={retentionThemes.map((theme, index) => ({
+          key: theme.key,
+          title: theme.title,
+          count: theme.count,
+          implication: theme.implication,
+          quote: theme.count >= 3 ? theme.sample : null,
+          relationLabel: index === 0 ? 'Bevestigt topfactor' : 'Nuanceert hoofdbeeld',
+          evidenceLabel: index === 0 ? 'Bevestigt topfactor' : 'Aanvullende context',
+        }))}
+        verificationTrackLabel={topFactorLabel ?? 'Nog niet beschikbaar'}
+        ownerRoleLabel={
+          getFollowThroughCardBody(retentionFollowThroughCards, 'Eerste eigenaar') ??
+          'HR / verantwoordelijke MT-eigenaar'
+        }
+        firstStepLabel={
+          getFollowThroughCardBody(retentionFollowThroughCards, 'Eerste actie') ??
+          retentionDashboardViewModel?.nextStep.body ??
+          'Bepaal eerst welke gerichte verificatie of verbeteractie volgt.'
+        }
+        reviewMomentLabel={
+          getFollowThroughCardBody(retentionFollowThroughCards, 'Reviewmoment') ??
+          'Leg direct een eerste reviewmoment vast zodra het verificatiespoor gekozen is.'
+        }
+      />
+    )
+  }
 
   if (stats.scan_type === 'culture_assessment') {
     const hiddenReasonEntitlement = getCultureAssessmentGovernedEntitlement(

--- a/frontend/components/dashboard/exit-product-dashboard.tsx
+++ b/frontend/components/dashboard/exit-product-dashboard.tsx
@@ -39,8 +39,9 @@ interface ExitProductDashboardProps {
   primarySignalBandLabel: string
   strongestFactorLabel: string
   strongestFactorNote: string
-  strongWorkSignalLabel: string
-  primaryReasonTitle: string
+  dominantThemeLabel: string
+  dominantThemeNote: string
+  executiveSummary: string
   firstManagementQuestion: string
   totalInvited: string
   totalCompleted: string
@@ -62,33 +63,69 @@ interface ExitProductDashboardProps {
 function RankedFactorTable({ rows }: { rows: BoardroomFactorRow[] }) {
   return (
     <div className="overflow-hidden border border-[rgba(13,27,42,0.15)]">
-      <div className="hidden bg-[#F4F1EA] px-4 py-3 font-mono text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-[#44505C] lg:grid lg:grid-cols-[72px_minmax(0,1.3fr)_120px_160px_minmax(0,1.4fr)]">
+      <div className="hidden bg-[#F4F1EA] px-4 py-3 font-mono text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-[#44505C] lg:grid lg:grid-cols-[72px_minmax(0,1.2fr)_120px_160px_minmax(0,1.2fr)]">
         <span>Rang</span>
         <span>Factor</span>
         <span>Score</span>
-        <span>Band</span>
+        <span>Status</span>
         <span>Leesnotitie</span>
       </div>
       {rows.map((row, index) => (
         <div
           key={`${row.factor}-${index}`}
-          className="grid gap-3 border-t border-[rgba(13,27,42,0.15)] bg-white px-4 py-4 first:border-t-0 lg:grid-cols-[72px_minmax(0,1.3fr)_120px_160px_minmax(0,1.4fr)] lg:items-start"
+          className="grid gap-3 border-t border-[rgba(13,27,42,0.15)] bg-white px-4 py-4 first:border-t-0 lg:grid-cols-[72px_minmax(0,1.2fr)_120px_160px_minmax(0,1.2fr)] lg:items-start"
         >
           <span className="font-mono text-[0.72rem] font-semibold uppercase tracking-[0.2em] text-[#44505C]">
             {(index + 1).toString().padStart(2, '0')}
           </span>
-          <div>
+          <div className="space-y-2">
             <p className="text-sm font-semibold text-[#132033]">{row.factor}</p>
-            <p className="mt-1 text-xs leading-5 text-[#44505C] lg:hidden">{row.note}</p>
+            {row.question ? (
+              <p className="text-xs leading-5 text-[#A06D11] lg:hidden">{row.question}</p>
+            ) : null}
+            <p className="text-xs leading-5 text-[#44505C] lg:hidden">{row.note}</p>
           </div>
           <p className="dash-number text-[1.2rem] leading-none text-[#132033]">{row.score}</p>
           <p className="font-mono text-[0.72rem] font-semibold uppercase tracking-[0.2em] text-[#44505C]">
             {row.band}
           </p>
-          <p className="hidden text-sm leading-6 text-[#44505C] lg:block">{row.note}</p>
+          <div className="hidden space-y-2 lg:block">
+            <p className="text-sm leading-6 text-[#44505C]">{row.note}</p>
+            {row.question ? (
+              <p className="text-sm leading-6 text-[#A06D11]">Eerste toetsvraag: {row.question}</p>
+            ) : null}
+          </div>
         </div>
       ))}
     </div>
+  )
+}
+
+function SectionMiniNav() {
+  const items = [
+    ['kernsignaal', 'Kernsignaal'],
+    ['responsbasis', 'Responsbasis'],
+    ['signaalopbouw', 'Signaalopbouw'],
+    ['prioriteiten', 'Prioriteiten'],
+    ['survey-stemmen', 'Survey-stemmen'],
+    ['handoff', 'Handoff'],
+  ] as const
+
+  return (
+    <nav className="sticky top-3 z-10 border border-[rgba(13,27,42,0.15)] bg-[#F7F4EE]/95 px-3 py-3 backdrop-blur">
+      <ul className="flex flex-wrap gap-2">
+        {items.map(([href, label]) => (
+          <li key={href}>
+            <a
+              href={`#${href}`}
+              className="inline-flex border border-[rgba(13,27,42,0.15)] bg-white px-3 py-1.5 font-mono text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[#44505C] transition-colors hover:text-[#132033]"
+            >
+              {label}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
   )
 }
 
@@ -106,8 +143,9 @@ export function ExitProductDashboard({
   primarySignalBandLabel,
   strongestFactorLabel,
   strongestFactorNote,
-  strongWorkSignalLabel,
-  primaryReasonTitle,
+  dominantThemeLabel,
+  dominantThemeNote,
+  executiveSummary,
   firstManagementQuestion,
   totalInvited,
   totalCompleted,
@@ -126,9 +164,10 @@ export function ExitProductDashboard({
   reviewMomentLabel,
 }: ExitProductDashboardProps) {
   const topPriorityRows = factorRows.slice(0, 3)
+  const responseBasisLabel = `${totalCompleted} ingevuld · ${responseRate}`
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-5">
       <ResultsBoardroomHeader
         moduleHref={moduleHref}
         moduleLabel={moduleLabel}
@@ -142,156 +181,186 @@ export function ExitProductDashboard({
         actions={headerActions}
       />
 
-      <ResultsBoardroomSection
-        eyebrow="1. Kernsignaal"
-        title="Kernsignaal"
-        description="ExitScan opent het vertrekbeeld als terugkijkende managementread. Lees score, hoofdlaag en factoren samen als groepsbeeld en niet als harde vaststelling."
-        aside={
-          <span className="border border-[rgba(13,27,42,0.15)] bg-[#FEB234] px-3 py-2 font-mono text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-[#132033]">
-            {primarySignalBandLabel}
-          </span>
-        }
-      >
-        <div className="grid gap-px border border-[rgba(13,27,42,0.15)] bg-[rgba(13,27,42,0.15)] xl:grid-cols-[minmax(0,1.15fr),minmax(320px,0.85fr)]">
-          <div className="grid gap-px bg-[rgba(13,27,42,0.15)]">
-            <BoardroomMetricTile
-              label="Frictiescore"
-              value={primarySignalScoreLabel}
-              note="De frictiescore toont hoe scherp vertrekfrictie gemiddeld terugkomt in de leesbare responses."
-              tone="white"
-              prominent
-            />
-            <div className="grid gap-px bg-[rgba(13,27,42,0.15)] sm:grid-cols-2">
-              <BoardroomMetricTile
-                label="Scherpste factor"
-                value={strongestFactorLabel}
-                note={strongestFactorNote}
-                tone="chalk"
-              />
-              <BoardroomMetricTile
-                label="Vertrekladder"
-                value={primaryReasonTitle}
-                note="Deze laag kleurt het vertrekbeeld als eerste en vraagt daarom de eerste bestuurlijke verificatie."
-                tone="chalk"
-              />
-            </div>
-          </div>
-          <div className="grid gap-px bg-[rgba(13,27,42,0.15)]">
-            <BoardroomMetricTile
-              label="Bestuurlijke vraag"
-              value="Eerst toetsen"
-              note={firstManagementQuestion}
-              tone="ink"
-            />
-            <div className="grid gap-px bg-[rgba(13,27,42,0.15)] sm:grid-cols-2">
-              <BoardroomMetricTile
-                label="Sterk werksignaal"
-                value={strongWorkSignalLabel}
-                note="Laat zien hoeveel responses vooral wijzen op beinvloedbare werkcontext."
-                tone="white"
-              />
-              <BoardroomMetricTile
-                label="Status"
-                value={statusLabel}
-                note="Gebruik de band als leesdiscipline, niet als bewezen causaliteit."
-                tone="white"
-              />
-            </div>
-          </div>
-        </div>
-      </ResultsBoardroomSection>
+      <SectionMiniNav />
 
-      <ResultsBoardroomSection
-        eyebrow="2. Responsbasis / leessterkte"
-        title="Responsbasis / leessterkte"
-        description="Deze laag laat zien hoe stevig het gegroepeerde beeld gelezen mag worden en welke grenzen blijven gelden voor segmenten en open tekst."
-        aside={
-          <span className="border border-[rgba(13,27,42,0.15)] bg-white px-3 py-2 font-mono text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-[#44505C]">
-            Leessterkte — {readStrengthLabel}
-          </span>
-        }
+      <section
+        aria-label="Executive result strip"
+        className="grid gap-px border border-[rgba(13,27,42,0.15)] bg-[rgba(13,27,42,0.15)] xl:grid-cols-6"
       >
-        <BoardroomKeyValueList
-          items={[
-            { label: 'Uitgenodigd', value: totalInvited },
-            { label: 'Ingevuld', value: totalCompleted },
-            { label: 'Respons', value: responseRate },
-            { label: 'Leessterkte', value: readStrengthLabel },
-          ]}
-        />
-        <div className="grid gap-4 xl:grid-cols-[minmax(0,1.1fr),minmax(280px,0.9fr)]">
-          <div className="border border-[rgba(13,27,42,0.15)] bg-[#F4F1EA] px-4 py-4 text-sm leading-6 text-[#44505C]">
-            {responseContextNote}
-          </div>
-          <div className="border border-[rgba(13,27,42,0.15)] bg-white px-4 py-4">
-            <p className="font-mono text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-[#44505C]">
-              Leesgrenzen
-            </p>
-            <ul className="mt-3 space-y-2 text-sm leading-6 text-[#44505C]">
-              {trustNotes.map((note) => (
-                <li key={note}>{note}</li>
-              ))}
-            </ul>
-          </div>
-        </div>
-      </ResultsBoardroomSection>
-
-      <ResultsBoardroomSection
-        eyebrow="3. Signaalopbouw"
-        title="Signaalopbouw"
-        description="De compositie laat zien welke lagen het vertrekbeeld kleuren. Lees dit als indicatief patroonbeeld en niet als causale verdeling."
-      >
-        <SignalCompositionRibbon
-          title="Vertrekbeeld in lagen"
-          segments={compositionSegments}
-          note="Indicatief patroonbeeld, geen causale verdeling."
-        />
-        <div className="grid gap-px border border-[rgba(13,27,42,0.15)] bg-[rgba(13,27,42,0.15)] lg:grid-cols-3">
-          {compositionHighlights.map((item) => (
-            <BoardroomMetricTile
-              key={item.label}
-              label={item.label}
-              value={item.value}
-              note={item.body}
-              tone="white"
-            />
-          ))}
-        </div>
-      </ResultsBoardroomSection>
-
-      <ResultsBoardroomSection
-        eyebrow="4. Prioriteitenbeeld"
-        title="Prioriteitenbeeld"
-        description="De horizontale as toont beleving, de verticale as bestuurlijke aandacht. Gebruik de topkaarten om het eerste verificatiespoor te kiezen."
-      >
-        {factorRows.length > 0 ? (
-          <div className="space-y-5">
-            <PriorityScatterPlot rows={factorRows} xLabel="Beleving" yLabel="Bestuurlijke aandacht" />
-            <div className="grid gap-px border border-[rgba(13,27,42,0.15)] bg-[rgba(13,27,42,0.15)] lg:grid-cols-3">
-              {topPriorityRows.map((row, index) => (
-                <BoardroomMetricTile
-                  key={row.factor}
-                  label={`Topprioriteit 0${index + 1}`}
-                  value={row.factor}
-                  note={`${row.band} — ${row.note}`}
-                  tone={index === 0 ? 'amber' : 'white'}
-                />
-              ))}
-            </div>
-            <RankedFactorTable rows={factorRows} />
-          </div>
-        ) : (
-          <BoardroomEmptyState
-            title="Onvoldoende data"
-            body="Nog geen veilige prioriteitenkaart beschikbaar voor organisatiefactoren."
+        {[
+          { label: 'Frictiescore', value: primarySignalScoreLabel, note: 'Primaire groepsscore' },
+          { label: 'Band / status', value: primarySignalBandLabel, note: 'Managementsamenvatting' },
+          { label: 'Dominant thema', value: dominantThemeLabel, note: 'Wat het vertrekbeeld nu kleurt' },
+          { label: 'Scherpste factor', value: strongestFactorLabel, note: 'Eerste factor om te toetsen' },
+          { label: 'Responsbasis', value: responseBasisLabel, note: `${totalInvited} uitgenodigd` },
+          { label: 'Bestuurlijke vraag', value: 'Eerst toetsen', note: firstManagementQuestion },
+        ].map((item, index) => (
+          <BoardroomMetricTile
+            key={item.label}
+            label={item.label}
+            value={item.value}
+            note={item.note}
+            tone={index === 0 ? 'amber' : 'white'}
           />
-        )}
-      </ResultsBoardroomSection>
+        ))}
+      </section>
+
+      <div id="kernsignaal">
+        <ResultsBoardroomSection
+          eyebrow="1. Kernsignaal"
+          title="Kernsignaal"
+          description="Gebruik deze terugkijkende vertrekduiding als managementsamenvatting van wat nu het sterkst terugkomt. Lees het beeld als groepsinterpretatie, niet als harde oorzaakverklaring."
+          aside={
+            <span className="border border-[rgba(13,27,42,0.15)] bg-[#FEB234] px-3 py-2 font-mono text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-[#132033]">
+              {primarySignalBandLabel}
+            </span>
+          }
+        >
+          <div className="grid gap-px border border-[rgba(13,27,42,0.15)] bg-[rgba(13,27,42,0.15)] xl:grid-cols-[minmax(0,1.2fr),minmax(320px,0.8fr)]">
+            <div className="space-y-5 bg-white px-5 py-5 sm:px-6 sm:py-6">
+              <p className="font-mono text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-[#44505C]">
+                Frictiescore
+              </p>
+              <p className="dash-number text-[clamp(3.2rem,9vw,6.5rem)] leading-none tracking-[-0.08em] text-[#132033]">
+                {primarySignalScoreLabel}
+              </p>
+              <p className="max-w-3xl text-base leading-8 text-[#132033]">{executiveSummary}</p>
+              <div className="grid gap-px border border-[rgba(13,27,42,0.15)] bg-[rgba(13,27,42,0.15)] sm:grid-cols-3">
+                <BoardroomMetricTile
+                  label="Dominant thema"
+                  value={dominantThemeLabel}
+                  note={dominantThemeNote}
+                  tone="chalk"
+                />
+                <BoardroomMetricTile
+                  label="Scherpste factor"
+                  value={strongestFactorLabel}
+                  note={strongestFactorNote}
+                  tone="chalk"
+                />
+                <BoardroomMetricTile
+                  label="Resultaten beschikbaar"
+                  value={statusLabel}
+                  note="Gebruik dit als eerste managementsamenvatting; geen harde oorzaakverklaring."
+                  tone="chalk"
+                />
+              </div>
+            </div>
+            <div className="grid gap-px bg-[rgba(13,27,42,0.15)]">
+              <BoardroomMetricTile
+                label="Bestuurlijke vraag"
+                value="Eerst toetsen"
+                note={firstManagementQuestion}
+                tone="ink"
+              />
+              <BoardroomMetricTile
+                label="Interpretatiegrens"
+                value="Resultaten beschikbaar"
+                note="Lees dit vertrekbeeld als vertrekduiding op groepsniveau. Wat samenvalt vraagt verificatie; het bewijst geen oorzaak."
+                tone="white"
+              />
+            </div>
+          </div>
+        </ResultsBoardroomSection>
+      </div>
+
+      <div id="responsbasis">
+        <ResultsBoardroomSection
+          eyebrow="2. Responsbasis / leessterkte"
+          title="Responsbasis / leessterkte"
+          description="Detailinzichten worden alleen getoond bij voldoende respons. Kleine groepen blijven verborgen om anonimiteit te beschermen."
+          aside={
+            <span className="border border-[rgba(13,27,42,0.15)] bg-white px-3 py-2 font-mono text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-[#44505C]">
+              Leessterkte — {readStrengthLabel}
+            </span>
+          }
+        >
+          <BoardroomKeyValueList
+            items={[
+              { label: 'Uitgenodigd', value: totalInvited },
+              { label: 'Ingevuld', value: totalCompleted },
+              { label: 'Respons', value: responseRate },
+              { label: 'Leessterkte', value: readStrengthLabel },
+            ]}
+          />
+          <div className="grid gap-4 xl:grid-cols-[minmax(0,1.1fr),minmax(280px,0.9fr)]">
+            <div className="border border-[rgba(13,27,42,0.15)] bg-[#F4F1EA] px-4 py-4 text-sm leading-6 text-[#44505C]">
+              {responseContextNote}
+            </div>
+            <div className="border border-[rgba(13,27,42,0.15)] bg-white px-4 py-4">
+              <p className="font-mono text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-[#44505C]">
+                Interpretatiegrens
+              </p>
+              <ul className="mt-3 space-y-2 text-sm leading-6 text-[#44505C]">
+                {trustNotes.map((note) => (
+                  <li key={note}>{note}</li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </ResultsBoardroomSection>
+      </div>
+
+      <div id="signaalopbouw">
+        <ResultsBoardroomSection
+          eyebrow="3. Signaalopbouw"
+          title="Welke lagen kleuren het vertrekbeeld?"
+          description="De compositie laat zien welke lagen nu het sterkst terugkomen. Lees dit als indicatief patroonbeeld, geen causale verdeling."
+        >
+          <SignalCompositionRibbon
+            title="Vertrekbeeld in lagen"
+            segments={compositionSegments}
+            note="Indicatief patroonbeeld, geen causale verdeling."
+          />
+          <div className="grid gap-px border border-[rgba(13,27,42,0.15)] bg-[rgba(13,27,42,0.15)] lg:grid-cols-3">
+            {compositionHighlights.map((item) => (
+              <BoardroomMetricTile
+                key={item.label}
+                label={item.label}
+                value={item.value}
+                note={item.body}
+                tone="white"
+              />
+            ))}
+          </div>
+        </ResultsBoardroomSection>
+      </div>
+
+      <div id="prioriteiten">
+        <ResultsBoardroomSection
+          eyebrow="4. Prioriteitenbeeld"
+          title="Prioriteitenbeeld"
+          description="De horizontale as toont beleving; de verticale as laat zien welke factoren bestuurlijk eerst aandacht vragen. Gebruik dit voor verificatie en prioritering."
+        >
+          {factorRows.length > 0 ? (
+            <div className="space-y-5">
+              <PriorityScatterPlot rows={factorRows} xLabel="Beleving" yLabel="Bestuurlijke aandacht" />
+              <div className="grid gap-px border border-[rgba(13,27,42,0.15)] bg-[rgba(13,27,42,0.15)] lg:grid-cols-3">
+                {topPriorityRows.map((row, index) => (
+                  <BoardroomMetricTile
+                    key={row.factor}
+                    label={`Topprioriteit 0${index + 1}`}
+                    value={`${row.factor} · ${row.score}`}
+                    note={`${row.band}. ${row.note}${row.question ? ` Eerste toetsvraag: ${row.question}` : ''}`}
+                    tone={index === 0 ? 'amber' : 'white'}
+                  />
+                ))}
+              </div>
+              <RankedFactorTable rows={factorRows} />
+            </div>
+          ) : (
+            <BoardroomEmptyState
+              title="Onvoldoende data"
+              body="Nog geen veilige prioriteitenkaart beschikbaar voor organisatiefactoren."
+            />
+          )}
+        </ResultsBoardroomSection>
+      </div>
 
       <ResultsBoardroomSection
         eyebrow="5. Basisbehoeften / SDT"
         title="Basisbehoeften / SDT"
-        description="De drie basisbehoeften helpen het vertrekbeeld verdiepen zonder er een losse bewijslaag of harde vaststelling van te maken."
+        description="Gebruik deze laag als verdieping op het vertrekbeeld. De positie van de punt laat zien welke basisbehoeften relatief meer onder druk staan."
       >
         {sdtRows.length > 0 ? (
           <SdtTriangleMap rows={sdtRows} />
@@ -303,87 +372,91 @@ export function ExitProductDashboard({
         )}
       </ResultsBoardroomSection>
 
-      <ResultsBoardroomSection
-        eyebrow="6. Survey-stemmen"
-        title="Survey-stemmen"
-        description="Open signalen verdiepen het beeld waar de anonimiteitsgrens dat toelaat. Quotes blijven geanonimiseerd en worden onderdrukt als de drempel te smal is."
-      >
-        {surveyThemes.length > 0 ? (
-          <div className="grid gap-px border border-[rgba(13,27,42,0.15)] bg-[rgba(13,27,42,0.15)] xl:grid-cols-3">
-            {surveyThemes.map((theme) => (
-              <div key={theme.key} className="space-y-4 bg-white px-4 py-4">
-                <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <p className="font-mono text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-[#44505C]">
-                      {theme.evidenceLabel}
-                    </p>
-                    <h3 className="mt-2 text-[1.05rem] font-semibold tracking-[-0.03em] text-[#132033]">
-                      {theme.title}
-                    </h3>
+      <div id="survey-stemmen">
+        <ResultsBoardroomSection
+          eyebrow="6. Survey-stemmen"
+          title="Survey-stemmen"
+          description="Open signalen verdiepen het beeld waar de anonimiteitsgrens dat toelaat. Quotes blijven geanonimiseerd en onderdrukt bij te lage n."
+        >
+          {surveyThemes.length > 0 ? (
+            <div className="grid gap-px border border-[rgba(13,27,42,0.15)] bg-[rgba(13,27,42,0.15)] xl:grid-cols-3">
+              {surveyThemes.map((theme) => (
+                <div key={theme.key} className="space-y-4 bg-white px-4 py-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="font-mono text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-[#44505C]">
+                        {theme.evidenceLabel}
+                      </p>
+                      <h3 className="mt-2 text-[1.05rem] font-semibold tracking-[-0.03em] text-[#132033]">
+                        {theme.title}
+                      </h3>
+                    </div>
+                    <span className="border border-[rgba(13,27,42,0.15)] bg-[#F4F1EA] px-2 py-1 font-mono text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[#44505C]">
+                      n={theme.count}
+                    </span>
                   </div>
-                  <span className="border border-[rgba(13,27,42,0.15)] bg-[#F4F1EA] px-2 py-1 font-mono text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[#44505C]">
-                    {theme.count}
-                  </span>
+                  {theme.relationLabel ? (
+                    <p className="font-mono text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[#A06D11]">
+                      {theme.relationLabel}
+                    </p>
+                  ) : null}
+                  <p className="text-sm leading-6 text-[#44505C]">{theme.implication}</p>
+                  {theme.quote ? (
+                    <blockquote className="border-l border-[#FEB234] pl-3 text-sm italic leading-6 text-[#132033]">
+                      &quot;{theme.quote}&quot;
+                    </blockquote>
+                  ) : (
+                    <p className="text-xs leading-5 text-[#44505C]">
+                      Quote onderdrukt zolang de anonimiteitsgrens voor dit thema te smal blijft.
+                    </p>
+                  )}
                 </div>
-                {theme.relationLabel ? (
-                  <p className="font-mono text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[#A06D11]">
-                    {theme.relationLabel}
-                  </p>
-                ) : null}
-                <p className="text-sm leading-6 text-[#44505C]">{theme.implication}</p>
-                {theme.quote ? (
-                  <blockquote className="border-l border-[#FEB234] pl-3 text-sm italic leading-6 text-[#132033]">
-                    &quot;{theme.quote}&quot;
-                  </blockquote>
-                ) : (
-                  <p className="text-xs leading-5 text-[#44505C]">
-                    Quote onderdrukt zolang de anonimiteitsgrens voor dit thema te smal blijft.
-                  </p>
-                )}
-              </div>
-            ))}
-          </div>
-        ) : (
-          <BoardroomEmptyState
-            title="Nog geen open signaallaag"
-            body="Er zijn nog geen bruikbare open antwoorden of themaclusters die veilig op groepsniveau getoond kunnen worden."
-          />
-        )}
-      </ResultsBoardroomSection>
+              ))}
+            </div>
+          ) : (
+            <BoardroomEmptyState
+              title="Nog geen open signaallaag"
+              body="Er zijn nog geen bruikbare open antwoorden of themaclusters die veilig op groepsniveau getoond kunnen worden."
+            />
+          )}
+        </ResultsBoardroomSection>
+      </div>
 
-      <ResultsBoardroomSection
-        eyebrow="7. Bestuurlijke handoff"
-        title="Bestuurlijke handoff"
-        description="Rond de boardroom-read af met een eerste verificatiespoor, een begrensde eigenaar en een reviewmoment. Dit blijft een managementhandoff, geen workflowproduct."
-        tone="ink"
-      >
-        <div className="grid gap-px border border-[#2B3A4E] bg-[#2B3A4E] lg:grid-cols-2 xl:grid-cols-4">
-          <BoardroomMetricTile
-            label="Eerste verificatiespoor"
-            value={verificationTrackLabel}
-            note="Kies eerst welk spoor bestuurlijk getoetst moet worden voordat bredere actie volgt."
-            tone="ink"
-          />
-          <BoardroomMetricTile
-            label="Bestuurlijke vraag"
-            value="Eerst verifiëren"
-            note={firstManagementQuestion}
-            tone="ink"
-          />
-          <BoardroomMetricTile
-            label="Eerste eigenaar"
-            value={ownerRoleLabel}
-            note={firstStepLabel}
-            tone="ink"
-          />
-          <BoardroomMetricTile
-            label="Reviewmoment"
-            value="Vastleggen"
-            note={reviewMomentLabel}
-            tone="ink"
-          />
-        </div>
-      </ResultsBoardroomSection>
+      <div id="handoff">
+        <ResultsBoardroomSection
+          eyebrow="7. Bestuurlijke handoff"
+          title="Bestuurlijke handoff"
+          description="Sluit af met één eerste verificatiespoor, een eigenaar en een concreet reviewmoment. Gebruik dit als bounded managementsamenvatting: eerst toetsen vóór bredere actie."
+          tone="ink"
+        >
+          <div className="grid gap-px border border-[#2B3A4E] bg-[#2B3A4E] lg:grid-cols-2 xl:grid-cols-4">
+            <BoardroomMetricTile
+              label="Eerste verificatiespoor"
+              value={verificationTrackLabel}
+              note="Kies eerst welk spoor bestuurlijk getoetst moet worden."
+              tone="ink"
+            />
+            <BoardroomMetricTile
+              label="Bestuurlijke vraag"
+              value="Eerst toetsen"
+              note={firstManagementQuestion}
+              tone="ink"
+            />
+            <BoardroomMetricTile
+              label="Eerste eigenaar"
+              value={ownerRoleLabel}
+              note={firstStepLabel}
+              tone="ink"
+            />
+            <BoardroomMetricTile
+              label="Reviewmoment"
+              value="Vastleggen"
+              note={reviewMomentLabel}
+              tone="ink"
+            />
+          </div>
+        </ResultsBoardroomSection>
+      </div>
     </div>
   )
 }

--- a/frontend/components/dashboard/results-boardroom-visuals.tsx
+++ b/frontend/components/dashboard/results-boardroom-visuals.tsx
@@ -23,6 +23,7 @@ export type BoardroomFactorRow = {
   signalValue: number
   band: string
   note: string
+  question?: string
 }
 
 export type BoardroomSdtRow = {
@@ -57,91 +58,119 @@ export function PriorityScatterPlot({
   xLabel?: string
   yLabel?: string
 }) {
-  const data = rows.map((row) => ({
+  const data = rows.map((row, index) => ({
     ...row,
     x: Number(row.scoreValue.toFixed(1)),
     y: Number(row.signalValue.toFixed(1)),
     fill: getBandColor(row.signalValue),
+    displayLabel: index < 3 ? row.factor : '',
   }))
 
   return (
-    <div className="h-[360px] w-full border border-[rgba(13,27,42,0.15)] bg-white">
-      <ResponsiveContainer width="100%" height="100%">
-        <ScatterChart margin={{ top: 24, right: 24, bottom: 18, left: 12 }}>
-          <CartesianGrid stroke="rgba(13,27,42,0.08)" vertical={false} />
-          <ReferenceArea y1={7} y2={10} fill="rgba(254,178,52,0.12)" />
-          <ReferenceArea x1={1} x2={4.5} fill="rgba(13,27,42,0.04)" />
-          <ReferenceLine x={5.5} stroke="rgba(13,27,42,0.18)" strokeDasharray="4 4" />
-          <ReferenceLine y={4.5} stroke="rgba(13,27,42,0.18)" strokeDasharray="4 4" />
-          <ReferenceLine y={7} stroke="rgba(13,27,42,0.18)" strokeDasharray="4 4" />
-          <XAxis
-            type="number"
-            dataKey="x"
-            domain={[1, 10]}
-            tickCount={10}
-            tick={{ fontSize: 11, fill: '#44505C' }}
-            axisLine={false}
-            tickLine={false}
-            label={{
-              value: xLabel,
-              position: 'insideBottom',
-              offset: -4,
-              fill: '#44505C',
-              fontSize: 11,
-            }}
-          />
-          <YAxis
-            type="number"
-            dataKey="y"
-            domain={[1, 10]}
-            tickCount={10}
-            tick={{ fontSize: 11, fill: '#44505C' }}
-            axisLine={false}
-            tickLine={false}
-            label={{
-              value: yLabel,
-              angle: -90,
-              position: 'insideLeft',
-              fill: '#44505C',
-              fontSize: 11,
-            }}
-          />
-          <Tooltip
-            cursor={{ strokeDasharray: '4 4', stroke: 'rgba(13,27,42,0.24)' }}
-            formatter={(value, _name, item) => {
-              const row = item.payload as (typeof data)[number]
-              return [formatTooltipValue(value), row.factor]
-            }}
-            labelFormatter={(_label, payload) => {
-              const row = payload?.[0]?.payload as (typeof data)[number] | undefined
-              return row ? `${row.factor} — ${row.note}` : ''
-            }}
-            contentStyle={{
-              borderRadius: 0,
-              border: '1px solid rgba(13,27,42,0.15)',
-              boxShadow: 'none',
-              backgroundColor: '#ffffff',
-            }}
-          />
-          <Scatter data={data}>
-            {data.map((entry) => (
-              <Cell
-                key={entry.factor}
-                fill={entry.fill}
-                stroke="#132033"
-                strokeWidth={1.25}
-              />
-            ))}
-            <LabelList
-              dataKey="factor"
-              position="right"
-              offset={8}
-              fontSize={11}
-              fill="#132033"
+    <div className="space-y-4 border border-[rgba(13,27,42,0.15)] bg-white p-4 sm:p-5">
+      <div className="grid gap-px border border-[rgba(13,27,42,0.15)] bg-[rgba(13,27,42,0.15)] sm:grid-cols-3">
+        {[
+          {
+            title: 'Volgen',
+            body: 'Linksonder: signalen blijven zichtbaar, maar vragen nu nog geen eerste MT-prioriteit.',
+          },
+          {
+            title: 'Eerst toetsen',
+            body: 'Middengebied: eerst verifiëren of het beeld structureel terugkomt.',
+          },
+          {
+            title: 'Direct prioriteren',
+            body: 'Rechtsboven: lage beleving en hoge bestuurlijke aandacht vragen eerst MT-aandacht.',
+          },
+        ].map((zone) => (
+          <div key={zone.title} className="space-y-2 bg-[#F4F1EA] px-4 py-3">
+            <p className="font-mono text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-[#44505C]">
+              {zone.title}
+            </p>
+            <p className="text-sm leading-6 text-[#44505C]">{zone.body}</p>
+          </div>
+        ))}
+      </div>
+
+      <div className="h-[330px] w-full border border-[rgba(13,27,42,0.15)] bg-white">
+        <ResponsiveContainer width="100%" height="100%">
+          <ScatterChart margin={{ top: 24, right: 30, bottom: 22, left: 18 }}>
+            <CartesianGrid stroke="rgba(13,27,42,0.08)" vertical={false} />
+            <ReferenceArea x1={1} x2={4.5} y1={1} y2={4.5} fill="rgba(19,32,51,0.04)" />
+            <ReferenceArea x1={4.5} x2={7} y1={4.5} y2={7} fill="rgba(244,241,234,0.9)" />
+            <ReferenceArea x1={7} x2={10} y1={7} y2={10} fill="rgba(254,178,52,0.14)" />
+            <ReferenceLine x={5.5} stroke="rgba(13,27,42,0.18)" strokeDasharray="4 4" />
+            <ReferenceLine y={4.5} stroke="rgba(13,27,42,0.18)" strokeDasharray="4 4" />
+            <ReferenceLine y={7} stroke="rgba(13,27,42,0.18)" strokeDasharray="4 4" />
+            <XAxis
+              type="number"
+              dataKey="x"
+              domain={[1, 10]}
+              tickCount={10}
+              tick={{ fontSize: 11, fill: '#44505C' }}
+              axisLine={false}
+              tickLine={false}
+              label={{
+                value: xLabel,
+                position: 'insideBottom',
+                offset: -4,
+                fill: '#44505C',
+                fontSize: 11,
+              }}
             />
-          </Scatter>
-        </ScatterChart>
-      </ResponsiveContainer>
+            <YAxis
+              type="number"
+              dataKey="y"
+              domain={[1, 10]}
+              tickCount={10}
+              tick={{ fontSize: 11, fill: '#44505C' }}
+              axisLine={false}
+              tickLine={false}
+              label={{
+                value: yLabel,
+                angle: -90,
+                position: 'insideLeft',
+                fill: '#44505C',
+                fontSize: 11,
+              }}
+            />
+            <Tooltip
+              cursor={{ strokeDasharray: '4 4', stroke: 'rgba(13,27,42,0.24)' }}
+              formatter={(value, _name, item) => {
+                const row = item.payload as (typeof data)[number]
+                return [formatTooltipValue(value), row.factor]
+              }}
+              labelFormatter={(_label, payload) => {
+                const row = payload?.[0]?.payload as (typeof data)[number] | undefined
+                return row ? `${row.factor} — ${row.note}` : ''
+              }}
+              contentStyle={{
+                borderRadius: 0,
+                border: '1px solid rgba(13,27,42,0.15)',
+                boxShadow: 'none',
+                backgroundColor: '#ffffff',
+              }}
+            />
+            <Scatter data={data}>
+              {data.map((entry) => (
+                <Cell key={entry.factor} fill={entry.fill} stroke="#132033" strokeWidth={1.25} />
+              ))}
+              <LabelList
+                dataKey="displayLabel"
+                position="right"
+                offset={8}
+                fontSize={11}
+                fill="#132033"
+              />
+            </Scatter>
+          </ScatterChart>
+        </ResponsiveContainer>
+      </div>
+
+      <p className="text-sm leading-6 text-[#44505C]">
+        Linksonder is minder urgent; rechtsboven vraagt bestuurlijk eerst aandacht. Gebruik dit
+        beeld voor verificatie en prioritering, niet als harde oorzaakverklaring.
+      </p>
     </div>
   )
 }
@@ -226,47 +255,69 @@ export function SdtTriangleMap({ rows }: { rows: BoardroomSdtRow[] }) {
   const point = buildTrianglePoint(rows)
 
   return (
-    <div className="grid gap-5 border border-[rgba(13,27,42,0.15)] bg-white p-5 lg:grid-cols-[minmax(0,0.95fr),minmax(260px,0.85fr)]">
-      <div className="border border-[rgba(13,27,42,0.15)] bg-[#F4F1EA] p-4">
-        <svg viewBox="0 0 100 92" className="h-full w-full" role="img" aria-label="SDT driehoekskaart">
-          <path d="M50 10 L12 82 L88 82 Z" fill="#ffffff" stroke="#132033" strokeWidth="1.5" />
-          <path d="M50 10 L50 82" stroke="rgba(13,27,42,0.15)" strokeWidth="1" strokeDasharray="2 2" />
-          <path d="M12 82 L69 46" stroke="rgba(13,27,42,0.15)" strokeWidth="1" strokeDasharray="2 2" />
-          <path d="M88 82 L31 46" stroke="rgba(13,27,42,0.15)" strokeWidth="1" strokeDasharray="2 2" />
-          <circle cx={point.x} cy={point.y} r="4.5" fill="#feb234" stroke="#132033" strokeWidth="1.5" />
-          <text x="50" y="4" textAnchor="middle" className="fill-[#132033] text-[5px] font-semibold">
-            AUTONOMIE
-          </text>
-          <text x="8" y="89" textAnchor="start" className="fill-[#132033] text-[5px] font-semibold">
-            COMPETENTIE
-          </text>
-          <text x="92" y="89" textAnchor="end" className="fill-[#132033] text-[5px] font-semibold">
-            VERBONDENHEID
-          </text>
-        </svg>
-      </div>
+    <div className="grid gap-5 border border-[rgba(13,27,42,0.15)] bg-white p-5 lg:grid-cols-[minmax(220px,0.72fr),minmax(0,1fr)]">
       <div className="space-y-3">
-        <p className="text-sm leading-6 text-[#44505C]">
-          De positie van de punt laat zien waar de basisbehoeften relatief het meest onder druk
-          staan binnen dit groepsbeeld. Lees de drie dimensies altijd samen, niet als losse diagnose.
-        </p>
-        <div className="grid gap-3">
-          {rows.map((row) => (
-            <div
-              key={row.factor}
-              className="grid gap-2 border border-[rgba(13,27,42,0.15)] bg-[#F4F1EA] px-4 py-3 sm:grid-cols-[minmax(0,1fr)_96px_132px]"
-            >
-              <div>
-                <p className="text-sm font-semibold text-[#132033]">{row.factor}</p>
-                <p className="mt-1 text-xs leading-5 text-[#44505C]">{row.note}</p>
-              </div>
-              <p className="dash-number text-[1.2rem] leading-none text-[#132033]">{row.score}</p>
-              <p className="font-mono text-[0.72rem] font-semibold uppercase tracking-[0.2em] text-[#44505C]">
-                {row.band}
-              </p>
-            </div>
-          ))}
+        <div className="border border-[rgba(13,27,42,0.15)] bg-[#F4F1EA] p-3">
+          <svg
+            viewBox="0 0 100 92"
+            className="h-[190px] w-full"
+            role="img"
+            aria-label="SDT driehoekskaart"
+          >
+            <path d="M50 10 L12 82 L88 82 Z" fill="#ffffff" stroke="#132033" strokeWidth="1.5" />
+            <path
+              d="M50 10 L50 82"
+              stroke="rgba(13,27,42,0.15)"
+              strokeWidth="1"
+              strokeDasharray="2 2"
+            />
+            <path
+              d="M12 82 L69 46"
+              stroke="rgba(13,27,42,0.15)"
+              strokeWidth="1"
+              strokeDasharray="2 2"
+            />
+            <path
+              d="M88 82 L31 46"
+              stroke="rgba(13,27,42,0.15)"
+              strokeWidth="1"
+              strokeDasharray="2 2"
+            />
+            <circle cx={point.x} cy={point.y} r="4.5" fill="#feb234" stroke="#132033" strokeWidth="1.5" />
+            <text x="50" y="4" textAnchor="middle" className="fill-[#132033] text-[5px] font-semibold">
+              AUTONOMIE
+            </text>
+            <text x="8" y="89" textAnchor="start" className="fill-[#132033] text-[5px] font-semibold">
+              COMPETENTIE
+            </text>
+            <text x="92" y="89" textAnchor="end" className="fill-[#132033] text-[5px] font-semibold">
+              VERBONDENHEID
+            </text>
+          </svg>
         </div>
+        <p className="text-sm leading-6 text-[#44505C]">
+          De positie van de punt laat zien welke basisbehoeften relatief meer onder druk staan.
+          Lees dit als verdieping, niet als losse diagnose.
+        </p>
+      </div>
+      <div className="grid gap-3 md:grid-cols-3 lg:grid-cols-1 xl:grid-cols-3">
+        {rows.map((row) => (
+          <div
+            key={row.factor}
+            className="space-y-2 border border-[rgba(13,27,42,0.15)] bg-[#F4F1EA] px-4 py-3"
+          >
+            <p className="font-mono text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-[#44505C]">
+              {row.factor}
+            </p>
+            <p className="dash-number text-[1.4rem] leading-none tracking-[-0.05em] text-[#132033]">
+              {row.score}
+            </p>
+            <p className="font-mono text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-[#A06D11]">
+              {row.band}
+            </p>
+            <p className="text-sm leading-6 text-[#44505C]">{row.note}</p>
+          </div>
+        ))}
       </div>
     </div>
   )


### PR DESCRIPTION
Refines the ExitScan and RetentieScan campaign detail views into dedicated boardroom result shells with a dashboard-first executive strip, safer Dutch product copy, a more readable priority scatterplot, a smaller SDT layer, richer survey-stemmen, and a bounded handoff. Verified with targeted vitest, eslint, and production build.