### PR TITLE
fix: restore culture assessment setup rails

### DIFF
--- a/frontend/lib/campaign-setup.test.ts
+++ b/frontend/lib/campaign-setup.test.ts
@@ -4,6 +4,7 @@ import {
   CAMPAIGN_SCAN_OPTIONS,
   getAllowedDeliveryModes,
   getCampaignNamePlaceholder,
+  getCampaignReportAddOnSetupNote,
   getDefaultModulesForScanType,
   isBaselineOnlyScanType,
   supportsCampaignModuleSelection,
@@ -11,31 +12,24 @@ import {
 } from '@/lib/campaign-setup'
 
 describe('campaign setup rails', () => {
-  it('keeps the supported scan options available in campaign setup', () => {
-    expect(CAMPAIGN_SCAN_OPTIONS.map((option) => option.value)).toEqual([
-      'exit',
-      'retention',
-      'pulse',
-      'team',
-      'onboarding',
-      'leadership',
-    ])
-    expect(getCampaignNamePlaceholder('exit')).toBe('ExitScan Q2 2026')
+  it('registers Loep Culture Assessment as a first-class create option', () => {
+    expect(CAMPAIGN_SCAN_OPTIONS.map((option) => option.value)).toContain('culture_assessment')
+    expect(getCampaignNamePlaceholder('culture_assessment')).toBe('Loep Cultuurbeeld 2026')
   })
 
-  it('keeps pulse, team, onboarding and leadership baseline-only in campaign setup', () => {
-    expect(isBaselineOnlyScanType('pulse')).toBe(true)
-    expect(isBaselineOnlyScanType('team')).toBe(true)
-    expect(isBaselineOnlyScanType('onboarding')).toBe(true)
-    expect(isBaselineOnlyScanType('leadership')).toBe(true)
-    expect(getAllowedDeliveryModes('pulse')).toEqual(['baseline'])
+  it('keeps culture_assessment baseline-only in campaign setup', () => {
+    expect(isBaselineOnlyScanType('culture_assessment')).toBe(true)
+    expect(getAllowedDeliveryModes('culture_assessment')).toEqual(['baseline'])
   })
 
-  it('removes report add-ons from campaign setup now that segment analysis is part of the standard scan layer', () => {
-    expect(getDefaultModulesForScanType('leadership')).toEqual(['leadership', 'role_clarity', 'culture', 'growth'])
-    expect(supportsCampaignModuleSelection('exit')).toBe(true)
+  it('keeps culture_assessment on a fixed instrument and removes report add-on configuration from beheer', () => {
+    expect(getDefaultModulesForScanType('culture_assessment')).toEqual([])
+    expect(supportsCampaignModuleSelection('culture_assessment')).toBe(false)
+    expect(supportsCampaignReportAddOns('culture_assessment')).toBe(false)
+    expect(getCampaignReportAddOnSetupNote('culture_assessment')).toContain('admin/manual-seeded')
+    expect(getCampaignReportAddOnSetupNote('culture_assessment')).toContain('niet klantconfigureerbaar')
     expect(supportsCampaignReportAddOns('exit')).toBe(false)
     expect(supportsCampaignReportAddOns('retention')).toBe(false)
-    expect(supportsCampaignReportAddOns('pulse')).toBe(false)
+    expect(getCampaignReportAddOnSetupNote('retention')).toBeNull()
   })
 })

--- a/frontend/lib/campaign-setup.ts
+++ b/frontend/lib/campaign-setup.ts
@@ -3,6 +3,7 @@ import type { DeliveryMode, ScanType } from '@/lib/types'
 export const CAMPAIGN_SCAN_OPTIONS: Array<{ value: ScanType; title: string; short: string }> = [
   { value: 'exit', title: 'ExitScan', short: 'Vertrek en frictie' },
   { value: 'retention', title: 'RetentieScan', short: 'Behoud onder druk' },
+  { value: 'culture_assessment', title: 'Loep Culture Assessment', short: 'Jaarlijkse cultuur- en engagementbaseline' },
   { value: 'pulse', title: 'Pulse', short: 'Korte momentcheck' },
   { value: 'team', title: 'TeamScan', short: 'Lokaal teambeeld' },
   { value: 'onboarding', title: 'Onboarding 30-60-90', short: 'Vroege instroomcheck' },
@@ -15,12 +16,13 @@ const TEAM_DEFAULT_MODULES = ['leadership', 'culture', 'workload', 'role_clarity
 const LEADERSHIP_DEFAULT_MODULES = ['leadership', 'role_clarity', 'culture', 'growth']
 
 export function isBaselineOnlyScanType(scanType: ScanType) {
-  return scanType === 'pulse' || scanType === 'team' || scanType === 'onboarding' || scanType === 'leadership'
+  return scanType === 'pulse' || scanType === 'team' || scanType === 'onboarding' || scanType === 'leadership' || scanType === 'culture_assessment'
 }
 
 export function getCampaignNamePlaceholder(scanType: ScanType) {
   if (scanType === 'exit') return 'ExitScan Q2 2026'
   if (scanType === 'retention') return 'RetentieScan Voorjaar 2026'
+  if (scanType === 'culture_assessment') return 'Loep Cultuurbeeld 2026'
   if (scanType === 'pulse') return 'Pulse April 2026'
   if (scanType === 'team') return 'TeamScan Operations Q2 2026'
   if (scanType === 'onboarding') return 'Onboarding checkpoint Mei 2026'
@@ -32,17 +34,25 @@ export function getDefaultModulesForScanType(scanType: ScanType): string[] {
   if (scanType === 'team') return TEAM_DEFAULT_MODULES
   if (scanType === 'onboarding') return ONBOARDING_DEFAULT_MODULES
   if (scanType === 'leadership') return LEADERSHIP_DEFAULT_MODULES
+  if (scanType === 'culture_assessment') return []
   return []
 }
 
 export function supportsCampaignModuleSelection(scanType: ScanType) {
-  void scanType
-  return true
+  return scanType !== 'culture_assessment'
 }
 
 export function supportsCampaignReportAddOns(scanType: ScanType) {
   void scanType
   return false
+}
+
+export function getCampaignReportAddOnSetupNote(scanType: ScanType) {
+  if (scanType === 'culture_assessment') {
+    return 'Governed report add-ons zoals segment deep dive blijven in v1 admin/manual-seeded en zijn niet klantconfigureerbaar in campaign setup.'
+  }
+
+  return null
 }
 
 export function getAllowedDeliveryModes(scanType: ScanType): DeliveryMode[] {


### PR DESCRIPTION
## Summary
- restore `Loep Culture Assessment` as a first-class option in campaign setup
- keep `culture_assessment` baseline-only with the correct placeholder and fixed instrument behavior
- restore the v1 governed add-on setup note and lock the behavior with focused regression tests

## Why
`culture_assessment` disappeared again from `Beheer > Campaign aanmaken` on `main`, which made the live dashboard correctly reflect a broken setup state.

## Verification
- `cmd /c npx vitest run --config vitest.config.ts "lib/campaign-setup.test.ts" "app/(dashboard)/beheer/new-campaign-form.guard.test.ts" "app/(dashboard)/beheer/page.test.ts" "app/(dashboard)/campaigns/[id]/page.test.ts"`
- `py -m pytest tests\test_api_flows.py tests\test_culture_assessment_route_contract.py -q -k "create_culture_assessment_campaign_defaults_to_baseline_delivery_mode or create_culture_assessment_campaign_rejects_live_delivery_mode or survey_page_renders_for_respondents or respondent_management_paths_are_available or report_generation_requires_closed_baseline or report_generation_allows_closed_baseline_route or segment_summary_export_requires_governed_add_on or segment_summary_export_public_route_stays_internal_only or segment_summary_export_allows_governed_closed_baseline_internal_route"`