### PR TITLE
fix: align culture assessment scan type constraints

### DIFF
--- a/migrations/2026_05_23_align_scan_type_constraints.sql
+++ b/migrations/2026_05_23_align_scan_type_constraints.sql
@@ -1,0 +1,47 @@
+-- Migration: align scan_type constraints with the current route contract
+-- Datum: 2026-05-23
+-- Uitvoeren in: Supabase Dashboard -> SQL Editor
+
+ALTER TABLE public.campaigns
+  DROP CONSTRAINT IF EXISTS campaigns_scan_type_check;
+
+ALTER TABLE public.campaigns
+  ADD CONSTRAINT campaigns_scan_type_check
+  CHECK (
+    scan_type IN (
+      'exit',
+      'retention',
+      'pulse',
+      'team',
+      'onboarding',
+      'leadership',
+      'culture_assessment'
+    )
+  );
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name = 'pilot_learning_dossiers'
+  ) THEN
+    ALTER TABLE public.pilot_learning_dossiers
+      DROP CONSTRAINT IF EXISTS pilot_learning_dossiers_scan_type_check;
+
+    ALTER TABLE public.pilot_learning_dossiers
+      ADD CONSTRAINT pilot_learning_dossiers_scan_type_check
+      CHECK (
+        scan_type IS NULL OR scan_type IN (
+          'exit',
+          'retention',
+          'pulse',
+          'team',
+          'onboarding',
+          'leadership',
+          'culture_assessment'
+        )
+      );
+  END IF;
+END $$;

--- a/tests/test_culture_assessment_route_contract.py
+++ b/tests/test_culture_assessment_route_contract.py
@@ -352,3 +352,15 @@ def test_culture_assessment_schema_sql_constraints_include_confirmed_route_contr
 
     assert "qualified_route is null or qualified_route in ('exitscan', 'retentiescan', 'teamscan', 'onboarding', 'leadership', 'combinatie', 'culture_assessment')" in schema_sql
     assert "scan_type in ('exit', 'retention', 'pulse', 'team', 'onboarding', 'leadership', 'culture_assessment')" in schema_sql
+
+
+def test_culture_assessment_runtime_migration_aligns_scan_type_constraints():
+    migration_sql = (
+        Path(__file__).resolve().parents[1] / "migrations/2026_05_23_align_scan_type_constraints.sql"
+    ).read_text(encoding="utf-8").lower()
+
+    assert "campaigns_scan_type_check" in migration_sql
+    assert "pilot_learning_dossiers_scan_type_check" in migration_sql
+    assert "scan_type in (" in migration_sql
+    assert "'culture_assessment'" in migration_sql
+    assert "'leadership'" in migration_sql


### PR DESCRIPTION
## Summary
- add a production-safe SQL migration that aligns `campaigns_scan_type_check` with the current route contract
- update `pilot_learning_dossiers_scan_type_check` in the same migration for parity
- add a focused regression test that guards the runtime migration alongside the existing schema contract

## Why
`Loep Culture Assessment` is now visible in campaign setup again, but production campaign creation still fails because the live database constraint only allows `exit`, `retention`, and `pulse`.

## Verification
- `py -m pytest tests\test_culture_assessment_route_contract.py -q -k "runtime_migration_aligns_scan_type_constraints or schema_sql_constraints_include_confirmed_route_contract"`
- `py -m pytest tests\test_culture_assessment_route_contract.py -q -k "create_culture_assessment or survey_page_renders_for_respondents or report_generation_requires_closed_baseline"`