### PR TITLE
[codex] Add Action Center tenant-admin, executive, and rehearsal surfaces

### DIFF
--- a/docs/ops/ACTION_CENTER_FIRST_ROUTE_ONBOARDING_REHEARSAL.md
+++ b/docs/ops/ACTION_CENTER_FIRST_ROUTE_ONBOARDING_REHEARSAL.md
@@ -1,0 +1,32 @@
+# Action Center First Route Onboarding Rehearsal
+
+## Route Family
+- Voer deze rehearsal uit voor precies één goedgekeurde routefamily tegelijk: `exit` of `retention`.
+- Gebruik geen parallelle tweede routefamily in dezelfde drill.
+
+## Participants
+- 1 HR-operator als rhythm owner
+- 1 manager participant binnen de bestaande route/action/review-waarheid
+- 1 support-side observator alleen voor de bounded support interruption drill
+
+## Preflight
+- Bevestig dat de routefamily al goedgekeurd is binnen de huidige Action Center-truth.
+- Bevestig dat de route een eigenaar, reviewmoment en closeout/continuation-pad heeft.
+- Bevestig dat support-access logging actief is voor deze rehearsal.
+
+## First Route Walkthrough
+1. HR opent de route en bevestigt de juiste scope.
+2. Manager ziet alleen de bounded route/action/review-interactie.
+3. Reviewmoment en volgende stap worden teruggelezen.
+4. Closeout of continuation wordt benoemd, maar niet overgeclaimd.
+
+## Support Interruption Drill
+1. Onderbreek de route één keer met een supportvraag.
+2. Leg support-access reden, scope en soort toegang vast.
+3. Bevestig de escalatieroute: product, governance, privacy of incident.
+
+## Exit Conditions
+- HR kan de route zonder founder-only uitleg doorlopen.
+- Manager begrijpt zijn beperkte rol.
+- De support interruption drill laat een gelogd artifact achter.
+- Er wordt geen route expansion, geen workflowverbreding en geen impactclaim geïntroduceerd.

--- a/docs/ops/ACTION_CENTER_RETENTION_AND_DELETION_POLICY.md
+++ b/docs/ops/ACTION_CENTER_RETENTION_AND_DELETION_POLICY.md
@@ -1,0 +1,108 @@
+# Action Center Retention And Deletion Policy
+
+## Status
+Draft operating policy
+
+## Purpose
+This policy defines the bounded retention, archival, and deletion rules for Action Center operating records while Action Center remains embedded, route-bound, and limited to approved route families.
+
+It does not authorize:
+
+- route expansion
+- generic workflow retention policy
+- silent deletion of reviewable operating records
+
+## Scope
+
+This policy applies to:
+
+- Action Center route truth
+- Action Center workspace membership truth
+- Action Center approval and support-access records
+
+This policy does not replace broader platform obligations. It defines the Action Center operating layer that enterprise, governance, privacy, and support review should use when evaluating record lifecycle decisions.
+
+## Record Classes
+
+### Operational runtime truth
+
+Includes:
+
+- route records used to track follow-through state
+- route review, continuation, and closeout state
+- workspace membership records used to determine who may see or act within Action Center
+
+### Support-access records
+
+Includes:
+
+- support access events
+- governance review access events
+- privacy review access events
+- incident access events
+
+### Audit export request records
+
+Includes:
+
+- audit export requests
+- export preparation notes
+- export approval or denial notes
+
+## Retention Rules
+
+### Operational runtime truth
+
+- Operational runtime truth must be retained as the current source of record for active and reviewable Action Center follow-through.
+- Operational runtime truth may be archived only when the record is no longer needed for active follow-through or bounded review.
+- Operational runtime truth may not be silently deleted while it is still needed to explain a route, review decision, continuation, closeout, or access boundary.
+
+### Support-access records
+
+- Support-access records must be retained long enough to explain who accessed Action Center data, why the access occurred, and which route or operating scope was involved when applicable.
+- Support-access records must remain reviewable for governance, privacy, and incident follow-up.
+- Support-access records may not be deleted only because the access later appears routine or low risk.
+
+### Audit export request records
+
+- Audit export request records must be retained long enough to explain what was requested, who approved it, what bounded record set was prepared, and whether delivery occurred.
+- Audit export request records must remain distinguishable from the exported contents themselves.
+- Audit export request records may not be silently removed when they are the only remaining explanation of why a review export was prepared.
+
+## Deletion And Archival Rules
+
+### What can be archived
+
+- completed or superseded operational records that no longer need to drive active Action Center follow-through
+- historical support-access records that no longer require active handling but still need bounded reviewability
+- historical audit export request records once the request outcome is settled and the record only needs historical retention
+
+### What cannot be silently deleted
+
+- operational runtime truth still needed to explain a current or recent review decision
+- support-access records tied to governance, privacy, or incident follow-up
+- audit export request records that provide the only trace of a governance or privacy review package
+- records under active incident, privacy, governance, or customer dispute review
+
+### Who approves deletion
+
+- product/engineering owner confirms whether operational runtime truth is still required as current source of record
+- governance or privacy owner confirms whether the record is still required for governance, privacy, or incident review
+- tenant/customer-side owner is consulted before deleting customer-relevant records that affect explainability of route history or access review
+
+Deletion should be treated as an exception path. If archival preserves explainability while reducing live operating surface, archival is preferred over deletion.
+
+## Archival And Deletion Decision Rules
+
+- archive instead of delete when a record is no longer operationally active but may still be needed for bounded explanation or review
+- deny deletion when the record is part of an unresolved governance, privacy, incident, or customer-trust question
+- escalate ambiguous requests to governance/privacy review rather than relying on founder memory or ad hoc judgment
+
+## Review And Exceptions
+
+- Any exception to this policy must name the decision owner, the affected record class, the reason for the exception, and the next review date.
+- Exceptions do not broaden Action Center scope; they only document why a specific lifecycle decision was made.
+
+## Plain-Language Summary
+
+Action Center records can be archived when they are no longer operationally active, but they cannot be silently deleted if they are still needed to explain route truth, support access, governance review, privacy review, or audit-export decisions.

--- a/docs/ops/ACTION_CENTER_SUPPORT_ACCESS_AND_INCIDENT_MATRIX.md
+++ b/docs/ops/ACTION_CENTER_SUPPORT_ACCESS_AND_INCIDENT_MATRIX.md
@@ -1,0 +1,78 @@
+# Action Center Support Access And Incident Matrix
+
+## Status
+Draft operating matrix
+
+## Purpose
+This matrix defines the bounded response path for support, governance, privacy, and incident questions involving Action Center while keeping the product route-bound and post-scan only.
+
+It exists to answer:
+
+- who owns each case type
+- which response path should be used
+- what logged artifact is required
+- when escalation is mandatory
+
+## Response Matrix
+
+| Case | Owner | Response path | Logged artifact | Escalation |
+|---|---|---|---|---|
+| Product issue | Product/engineering | fix runtime issue | support access event | engineering |
+| Governance issue | HR/governance owner | review route/admin truth | support access event | governance |
+| Privacy question | Founder/privacy owner | review boundaries and retention rules | support access event | privacy |
+| Support configuration question | Customer success or onboarding owner | review tenant/admin setup and bounded operating instructions | support access event | product/engineering if runtime truth is unclear |
+| Incident involving access or record handling | Governance/privacy owner plus engineering | review access event, affected route scope, and retention/deletion constraints | support access event | incident review |
+
+## Case Interpretation Rules
+
+### Product issue
+
+- Use when the question is about incorrect runtime behavior, broken action/review flow, missing access expected by product truth, or route-state defects.
+- The goal is to correct bounded Action Center runtime truth, not broaden scope.
+
+### Governance issue
+
+- Use when the question is about who may act, approve, continue, close out, or review within current approved scope.
+- Governance review should confirm authority boundaries before any runtime change is requested.
+
+### Privacy question
+
+- Use when the question is about access boundaries, retention, deletion, archival, or whether a record should remain reviewable.
+- Privacy review should reference the retention/deletion policy rather than rely on narration alone.
+
+### Support configuration question
+
+- Use when the issue is about onboarding setup, workspace membership interpretation, tenant/admin expectations, or supported operating steps.
+- If the issue exposes a missing runtime control, escalate to product/engineering rather than improvising a permanent workaround.
+
+### Incident involving access or record handling
+
+- Use when the issue may affect customer trust, privacy, governance, or explainability of who accessed what and why.
+- Incident handling must preserve the relevant support-access event and any related retention/deletion decision trail.
+
+## Logging Requirements
+
+Every case in this matrix requires a support access event that captures at least:
+
+- who accessed the relevant Action Center data or operating surface
+- why access occurred
+- which case type was being handled
+- which route or operating scope was affected when applicable
+- when the access occurred
+
+## Escalation Rules
+
+- Escalate to engineering when the bounded runtime truth appears incorrect or incomplete.
+- Escalate to governance when authority, approval, or review boundaries are unclear.
+- Escalate to privacy when the question involves retention, deletion, archival, or data-boundary interpretation.
+- Escalate to incident review when the case affects trust, explainability, or defensibility of access handling.
+
+## Boundaries
+
+- This matrix does not create a generic support desk for all Verisight products.
+- This matrix applies only to Action Center operating cases.
+- This matrix does not authorize broader workflow operations or unrestricted data access.
+
+## Plain-Language Summary
+
+Every Action Center support, governance, privacy, and incident case should follow an explicit owner-and-escalation path and leave behind a support access event so later reviewers can understand who accessed the operating layer, why they did it, and how the case was handled.

--- a/docs/ops/ACTION_CENTER_SUPPORT_REHEARSAL_SCORECARD.md
+++ b/docs/ops/ACTION_CENTER_SUPPORT_REHEARSAL_SCORECARD.md
@@ -1,0 +1,10 @@
+# Action Center Support Rehearsal Scorecard
+
+| Check | Pass rule | Evidence | Status |
+|---|---|---|---|
+| Routefamily bleef bounded | Slechts één goedgekeurde routefamily gebruikt | Rehearsal notes | pending |
+| HR-operator kon zelfstandig lopen | Geen founder-only uitleg nodig | Operator observation | pending |
+| Managerrol bleef light | Geen dashboard-ownership of projectbesturing ontstond | Manager observation | pending |
+| Support interruption drill is gelogd | Support-access event bevat reden, soort en scope | Access log | pending |
+| Escalatiepad was duidelijk | Product, governance, privacy of incident kon direct worden gekozen | Rehearsal notes | pending |
+| Geen overclaiming | Geen causaliteit, monitoring of workflowframing gebruikt | Language check | pending |

--- a/docs/superpowers/plans/2026-05-23-action-center-enterprise-operating-gaps-implementation.md
+++ b/docs/superpowers/plans/2026-05-23-action-center-enterprise-operating-gaps-implementation.md
@@ -1,0 +1,530 @@
+# Action Center Enterprise Operating Gaps Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the highest-risk Action Center enterprise-operating gaps without expanding product scope, route scope, or commercial claims.
+
+**Architecture:** Add one bounded admin-governance layer around the existing Action Center runtime instead of redesigning Action Center itself. The wave should introduce explicit tenant/admin controls, route-activation approval truth, support-access logging, audit-export scaffolding, and retention/deletion policy artifacts while preserving the current `exit` / `retention` route-bound model.
+
+**Tech Stack:** Next.js App Router, TypeScript, Vitest, Supabase schema + SQL migrations, existing Action Center access/governance helpers, admin health surfaces, Markdown operating artifacts.
+
+---
+
+## File Structure
+
+### Existing files to modify
+
+- `C:\Users\larsh\Desktop\Business\Verisight\frontend\lib\suite-access.ts`
+- `C:\Users\larsh\Desktop\Business\Verisight\frontend\lib\suite-access.test.ts`
+- `C:\Users\larsh\Desktop\Business\Verisight\frontend\app\api\action-center\workspace-members\route.ts`
+- `C:\Users\larsh\Desktop\Business\Verisight\frontend\app\(dashboard)\beheer\health\page.tsx`
+- `C:\Users\larsh\Desktop\Business\Verisight\supabase\schema.sql`
+- `C:\Users\larsh\Desktop\Business\Verisight\docs\superpowers\specs\2026-05-23-action-center-first-pass-readiness-assessment.md`
+- `C:\Users\larsh\Desktop\Business\Verisight\docs\superpowers\specs\2026-05-23-action-center-tenant-admin-gap-table.md`
+
+### New files to create
+
+- `C:\Users\larsh\Desktop\Business\Verisight\migrations\2026_05_23_add_action_center_enterprise_admin_controls.sql`
+- `C:\Users\larsh\Desktop\Business\Verisight\frontend\lib\action-center-admin-governance.ts`
+- `C:\Users\larsh\Desktop\Business\Verisight\frontend\lib\action-center-admin-governance.test.ts`
+- `C:\Users\larsh\Desktop\Business\Verisight\frontend\app\api\action-center\admin\route-activation-approvals\route.ts`
+- `C:\Users\larsh\Desktop\Business\Verisight\frontend\app\api\action-center\admin\route-activation-approvals\route.test.ts`
+- `C:\Users\larsh\Desktop\Business\Verisight\frontend\app\api\action-center\admin\support-access-events\route.ts`
+- `C:\Users\larsh\Desktop\Business\Verisight\frontend\app\api\action-center\admin\support-access-events\route.test.ts`
+- `C:\Users\larsh\Desktop\Business\Verisight\frontend\app\api\action-center\admin\audit-exports\route.ts`
+- `C:\Users\larsh\Desktop\Business\Verisight\frontend\app\api\action-center\admin\audit-exports\route.test.ts`
+- `C:\Users\larsh\Desktop\Business\Verisight\docs\superpowers\specs\2026-05-23-action-center-enterprise-operating-verification-sheet.md`
+- `C:\Users\larsh\Desktop\Business\Verisight\docs\ops\ACTION_CENTER_RETENTION_AND_DELETION_POLICY.md`
+- `C:\Users\larsh\Desktop\Business\Verisight\docs\ops\ACTION_CENTER_SUPPORT_ACCESS_AND_INCIDENT_MATRIX.md`
+
+### Responsibility split
+
+- `suite-access*` remains the runtime truth for personas, visibility, and bounded capabilities.
+- `action-center-admin-governance*` becomes the compact helper layer for admin-control decisions that should not be spread across route handlers.
+- `admin/*` API routes expose enterprise-operating controls without broadening the end-user Action Center surface.
+- SQL migration + `schema.sql` become the source of truth for new approval/log/export tables.
+- Docs in `docs/superpowers/specs` and `docs/ops` become the explicit operating proof layer that the readiness assessment currently lacks.
+
+---
+
+### Task 1: Create the enterprise-operating verification sheet and close the doc-level gaps
+
+**Files:**
+- Create: `C:\Users\larsh\Desktop\Business\Verisight\docs\superpowers\specs\2026-05-23-action-center-enterprise-operating-verification-sheet.md`
+- Create: `C:\Users\larsh\Desktop\Business\Verisight\docs\ops\ACTION_CENTER_RETENTION_AND_DELETION_POLICY.md`
+- Create: `C:\Users\larsh\Desktop\Business\Verisight\docs\ops\ACTION_CENTER_SUPPORT_ACCESS_AND_INCIDENT_MATRIX.md`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\docs\superpowers\specs\2026-05-23-action-center-first-pass-readiness-assessment.md`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\docs\superpowers\specs\2026-05-23-action-center-tenant-admin-gap-table.md`
+
+- [ ] **Step 1: Write the failing doc assertions as a checklist**
+
+Add these expected headings to the verification sheet draft:
+
+```md
+# Action Center Enterprise Operating Verification Sheet
+
+## Capability Status Grid
+## Activation Approval Controls
+## Support Access Logging
+## Audit Export Readiness
+## Retention And Deletion Controls
+## Blocking Risks
+```
+
+- [ ] **Step 2: Verify the sheet does not exist yet**
+
+Run:
+
+```powershell
+Test-Path "C:\Users\larsh\Desktop\Business\Verisight\docs\superpowers\specs\2026-05-23-action-center-enterprise-operating-verification-sheet.md"
+```
+
+Expected: `False`
+
+- [ ] **Step 3: Write the verification sheet**
+
+Include one row per high-risk gap with:
+
+```md
+| Capability | Required for near-standalone? | Current runtime evidence | Required owner | Next verification step | Blocking? |
+|---|---|---|---|---|---|
+| Tenant admin role | yes | not explicit | product + engineering | verify role and scope model | yes |
+```
+
+Also include explicit sections for:
+
+- tenant admin
+- executive viewer
+- route activation approvals
+- audit export
+- support access logging
+- retention/deletion policy
+
+- [ ] **Step 4: Write the retention/deletion policy**
+
+The new policy doc must explicitly define:
+
+```md
+## Scope
+- Action Center route truth
+- Action Center workspace membership truth
+- Action Center approval and support-access records
+
+## Retention Rules
+- operational runtime truth
+- support-access records
+- audit export request records
+
+## Deletion And Archival Rules
+- what can be archived
+- what cannot be silently deleted
+- who approves deletion
+```
+
+- [ ] **Step 5: Write the support-access and incident matrix**
+
+The matrix must separate:
+
+```md
+| Case | Owner | Response path | Logged artifact | Escalation |
+|---|---|---|---|---|
+| Product issue | Product/engineering | fix runtime issue | support access event | engineering |
+| Governance issue | HR/governance owner | review route/admin truth | support access event | governance |
+| Privacy question | Founder/privacy owner | review boundaries and retention rules | support access event | privacy |
+```
+
+- [ ] **Step 6: Reconcile the two existing readiness docs**
+
+Update the readiness assessment and gap table so they reference the new verification sheet and policy docs as the next operating layer instead of only calling for them abstractly.
+
+- [ ] **Step 7: Run a placeholder and heading sanity check**
+
+Run:
+
+```powershell
+rg -n "TODO|TBD|placeholder" "C:\Users\larsh\Desktop\Business\Verisight\docs\superpowers\specs\2026-05-23-action-center-enterprise-operating-verification-sheet.md" "C:\Users\larsh\Desktop\Business\Verisight\docs\ops\ACTION_CENTER_RETENTION_AND_DELETION_POLICY.md" "C:\Users\larsh\Desktop\Business\Verisight\docs\ops\ACTION_CENTER_SUPPORT_ACCESS_AND_INCIDENT_MATRIX.md"
+```
+
+Expected: no matches
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-05-23-action-center-enterprise-operating-verification-sheet.md docs/ops/ACTION_CENTER_RETENTION_AND_DELETION_POLICY.md docs/ops/ACTION_CENTER_SUPPORT_ACCESS_AND_INCIDENT_MATRIX.md docs/superpowers/specs/2026-05-23-action-center-first-pass-readiness-assessment.md docs/superpowers/specs/2026-05-23-action-center-tenant-admin-gap-table.md
+git commit -m "docs: add action center enterprise operating verification layer"
+```
+
+---
+
+### Task 2: Add the bounded admin-governance capability layer
+
+**Files:**
+- Create: `C:\Users\larsh\Desktop\Business\Verisight\frontend\lib\action-center-admin-governance.ts`
+- Create: `C:\Users\larsh\Desktop\Business\Verisight\frontend\lib\action-center-admin-governance.test.ts`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\frontend\lib\suite-access.ts`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\frontend\lib\suite-access.test.ts`
+
+- [ ] **Step 1: Write the failing tests for the new capability layer**
+
+Add tests like:
+
+```ts
+it('grants tenant admin only to verisight admin or explicit customer admin capability', () => {
+  expect(resolveActionCenterAdminCapabilities({
+    persona: 'customer_owner',
+    memberRole: 'owner',
+    workspaceRoles: [],
+  }).canManageTenantAdmin).toBe(false)
+})
+
+it('keeps executive viewer aggregated and read-only', () => {
+  expect(resolveActionCenterAdminCapabilities({
+    persona: 'customer_viewer',
+    memberRole: 'viewer',
+    workspaceRoles: [],
+  }).canViewExecutiveReadback).toBe(false)
+})
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run:
+
+```powershell
+npx vitest run "lib/action-center-admin-governance.test.ts" "lib/suite-access.test.ts"
+```
+
+Expected: fail because the helper does not exist and the new capability fields are not wired yet
+
+- [ ] **Step 3: Implement the minimal helper**
+
+Create a helper shaped like:
+
+```ts
+export interface ActionCenterAdminCapabilities {
+  canManageTenantAdmin: boolean
+  canApproveRouteActivation: boolean
+  canRequestAuditExport: boolean
+  canLogSupportAccess: boolean
+  canViewExecutiveReadback: boolean
+}
+
+export function resolveActionCenterAdminCapabilities(...) {
+  return {
+    canManageTenantAdmin: false,
+    canApproveRouteActivation: false,
+    canRequestAuditExport: false,
+    canLogSupportAccess: false,
+    canViewExecutiveReadback: false,
+  }
+}
+```
+
+Then wire it into `suite-access.ts` as additive capability truth without broadening user-facing Action Center access.
+
+- [ ] **Step 4: Re-run the tests and verify they pass**
+
+Run:
+
+```powershell
+npx vitest run "lib/action-center-admin-governance.test.ts" "lib/suite-access.test.ts"
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/lib/action-center-admin-governance.ts frontend/lib/action-center-admin-governance.test.ts frontend/lib/suite-access.ts frontend/lib/suite-access.test.ts
+git commit -m "feat: add action center admin governance capabilities"
+```
+
+---
+
+### Task 3: Add route-activation approval truth and support-access logging truth
+
+**Files:**
+- Create: `C:\Users\larsh\Desktop\Business\Verisight\migrations\2026_05_23_add_action_center_enterprise_admin_controls.sql`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\supabase\schema.sql`
+- Create: `C:\Users\larsh\Desktop\Business\Verisight\frontend\app\api\action-center\admin\route-activation-approvals\route.ts`
+- Create: `C:\Users\larsh\Desktop\Business\Verisight\frontend\app\api\action-center\admin\route-activation-approvals\route.test.ts`
+- Create: `C:\Users\larsh\Desktop\Business\Verisight\frontend\app\api\action-center\admin\support-access-events\route.ts`
+- Create: `C:\Users\larsh\Desktop\Business\Verisight\frontend\app\api\action-center\admin\support-access-events\route.test.ts`
+
+- [ ] **Step 1: Write the failing route tests**
+
+Add tests like:
+
+```ts
+it('rejects route activation approval writes from non-admin actors', async () => {
+  const response = await POST(buildRequest({ actorRole: 'customer_owner' }))
+  expect(response.status).toBe(403)
+})
+
+it('stores support access events with reason and affected route scope', async () => {
+  const response = await POST(buildSupportAccessRequest())
+  expect(response.status).toBe(200)
+})
+```
+
+- [ ] **Step 2: Run the new route tests to verify they fail**
+
+Run:
+
+```powershell
+npx vitest run "app/api/action-center/admin/route-activation-approvals/route.test.ts" "app/api/action-center/admin/support-access-events/route.test.ts"
+```
+
+Expected: fail because the routes and backing tables do not exist yet
+
+- [ ] **Step 3: Add the new SQL tables**
+
+The migration and `schema.sql` must add bounded tables shaped like:
+
+```sql
+create table if not exists public.action_center_route_activation_approvals (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid not null,
+  route_family text not null,
+  scope_value text not null,
+  requested_by uuid not null,
+  approved_by uuid null,
+  approval_status text not null check (approval_status in ('requested','approved','rejected','revoked')),
+  rationale text null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.action_center_support_access_events (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid not null,
+  route_id text null,
+  scope_value text null,
+  accessed_by uuid not null,
+  access_reason text not null,
+  access_kind text not null check (access_kind in ('support','privacy','governance','incident')),
+  created_at timestamptz not null default now()
+);
+```
+
+Keep scope bounded: no generic workflow admin tables.
+
+- [ ] **Step 4: Implement the API routes**
+
+Use the new admin-governance helper to enforce writes.
+The route handlers should accept only the minimal bounded payload:
+
+```ts
+type RouteActivationApprovalBody = {
+  orgId: string
+  routeFamily: 'exit' | 'retention'
+  scopeValue: string
+  rationale?: string | null
+}
+
+type SupportAccessEventBody = {
+  orgId: string
+  routeId?: string | null
+  scopeValue?: string | null
+  accessKind: 'support' | 'privacy' | 'governance' | 'incident'
+  accessReason: string
+}
+```
+
+- [ ] **Step 5: Re-run the route tests and verify they pass**
+
+Run:
+
+```powershell
+npx vitest run "app/api/action-center/admin/route-activation-approvals/route.test.ts" "app/api/action-center/admin/support-access-events/route.test.ts"
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add migrations/2026_05_23_add_action_center_enterprise_admin_controls.sql supabase/schema.sql frontend/app/api/action-center/admin/route-activation-approvals/route.ts frontend/app/api/action-center/admin/route-activation-approvals/route.test.ts frontend/app/api/action-center/admin/support-access-events/route.ts frontend/app/api/action-center/admin/support-access-events/route.test.ts
+git commit -m "feat: add action center activation approvals and support access logs"
+```
+
+---
+
+### Task 4: Add bounded audit-export scaffolding and admin health readback
+
+**Files:**
+- Create: `C:\Users\larsh\Desktop\Business\Verisight\frontend\app\api\action-center\admin\audit-exports\route.ts`
+- Create: `C:\Users\larsh\Desktop\Business\Verisight\frontend\app\api\action-center\admin\audit-exports\route.test.ts`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\frontend\app\(dashboard)\beheer\health\page.tsx`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\frontend\lib\action-center-ops-health.ts`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\frontend\lib\action-center-ops-health.test.ts`
+
+- [ ] **Step 1: Write the failing audit-export and health tests**
+
+Add tests like:
+
+```ts
+it('returns a bounded audit export summary instead of raw unrestricted dumps', async () => {
+  const response = await GET(buildAuditExportRequest())
+  expect(response.status).toBe(200)
+  expect(await response.json()).toMatchObject({
+    routeActivations: expect.any(Array),
+    supportAccessEvents: expect.any(Array),
+  })
+})
+
+it('summarizes support access and route activation coverage in ops health', () => {
+  expect(summarizeActionCenterOpsHealth(rows).supportAccessEventCount).toBe(1)
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+
+```powershell
+npx vitest run "app/api/action-center/admin/audit-exports/route.test.ts" "lib/action-center-ops-health.test.ts"
+```
+
+Expected: fail because export shape and new ops counts do not exist yet
+
+- [ ] **Step 3: Implement the bounded export route**
+
+The route should return:
+
+```ts
+{
+  routeActivations: Array<{ routeFamily: string; approvalStatus: string; scopeValue: string; createdAt: string }>
+  supportAccessEvents: Array<{ accessKind: string; accessReason: string; createdAt: string }>
+}
+```
+
+No unrestricted raw tenant dump, no generic export center.
+
+- [ ] **Step 4: Extend the health summary**
+
+Add support for:
+
+- route activation approval counts
+- support access event counts
+- missing-control messaging when these are absent
+
+Keep the health page admin-only and compact.
+
+- [ ] **Step 5: Re-run the tests and verify they pass**
+
+Run:
+
+```powershell
+npx vitest run "app/api/action-center/admin/audit-exports/route.test.ts" "lib/action-center-ops-health.test.ts"
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/app/api/action-center/admin/audit-exports/route.ts frontend/app/api/action-center/admin/audit-exports/route.test.ts frontend/app/(dashboard)/beheer/health/page.tsx frontend/lib/action-center-ops-health.ts frontend/lib/action-center-ops-health.test.ts
+git commit -m "feat: add action center audit export scaffolding and health readback"
+```
+
+---
+
+### Task 5: Final verification and readiness closeout
+
+**Files:**
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\docs\superpowers\specs\2026-05-23-action-center-first-pass-readiness-assessment.md`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\docs\superpowers\specs\2026-05-23-action-center-tenant-admin-gap-table.md`
+- Modify: `C:\Users\larsh\Desktop\Business\Verisight\docs\superpowers\specs\2026-05-23-action-center-enterprise-operating-verification-sheet.md`
+
+- [ ] **Step 1: Run the full bounded verification set**
+
+Run:
+
+```powershell
+npx vitest run "lib/action-center-admin-governance.test.ts" "lib/suite-access.test.ts" "lib/action-center-ops-health.test.ts" "app/api/action-center/admin/route-activation-approvals/route.test.ts" "app/api/action-center/admin/support-access-events/route.test.ts" "app/api/action-center/admin/audit-exports/route.test.ts" "lib/action-center-governance.test.ts" "lib/action-center-route-contract.test.ts" "app/(dashboard)/action-center/page.route-shell.test.ts"
+```
+
+Expected: PASS
+
+- [ ] **Step 2: Run a diff hygiene check**
+
+Run:
+
+```powershell
+git diff --check
+```
+
+Expected: no whitespace or merge-marker issues
+
+- [ ] **Step 3: Update the verification sheet statuses**
+
+Change each capability from speculative status to one of:
+
+- `ready`
+- `partial`
+- `not_ready`
+
+based on what actually shipped in this wave.
+
+- [ ] **Step 4: Update the first-pass assessment**
+
+Replace the now-resolved blockers around:
+
+- runtime route-family drift
+- route-shell semantic drift
+
+and explicitly call out which enterprise-operating gaps are still unresolved after this wave.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-05-23-action-center-first-pass-readiness-assessment.md docs/superpowers/specs/2026-05-23-action-center-tenant-admin-gap-table.md docs/superpowers/specs/2026-05-23-action-center-enterprise-operating-verification-sheet.md
+git commit -m "docs: close out action center enterprise operating gap wave"
+```
+
+---
+
+## Self-Review
+
+### Spec coverage
+
+This plan covers the high-risk gaps called out in the assessment and gap table:
+
+- tenant/admin role clarity
+- route activation approvals
+- support access logging
+- audit export scaffolding
+- retention/deletion operating policy
+- admin health readback
+
+It intentionally does not cover:
+
+- standalone launch planning
+- route expansion
+- broader GTM
+- generic workflow broadening
+
+### Placeholder scan
+
+This plan contains no `TODO`, `TBD`, or “implement later” placeholders.
+All new artifacts and code paths are named explicitly.
+
+### Type consistency
+
+The new bounded control types stay aligned to the current Action Center truth:
+
+- route families remain `exit | retention`
+- support access kinds remain bounded
+- approval status is explicit and finite
+- no generic task/workflow/admin abstractions are introduced
+
+## Execution Handoff
+
+Plan complete and saved to `C:\Users\larsh\Desktop\Business\Verisight\docs\superpowers\plans\2026-05-23-action-center-enterprise-operating-gaps-implementation.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+**Which approach?**

--- a/docs/superpowers/plans/2026-05-23-action-center-tenant-admin-executive-rehearsal-implementation.md
+++ b/docs/superpowers/plans/2026-05-23-action-center-tenant-admin-executive-rehearsal-implementation.md
@@ -1,0 +1,418 @@
+# Action Center Tenant Admin, Executive Readback, And Rehearsal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the next bounded enterprise-operating layer for Action Center by shipping a tenant-admin surface, an executive readback surface, and a first-route onboarding/support rehearsal pack.
+
+**Architecture:** Build one compact readback/helper layer that both new pages can share. Keep all new runtime surfaces read-only except for links into the already-shipped bounded admin endpoints. Put the rehearsal layer in ops docs plus explicit links from the new tenant-admin surface so operating discipline is visible without inventing a broader workflow system.
+
+**Tech Stack:** Next.js App Router, TypeScript, Vitest, existing Action Center access helpers, existing Action Center admin routes, Markdown operating artifacts.
+
+---
+
+## File Structure
+
+### Existing files to modify
+
+- `C:\Users\larsh\Desktop\wt\ac-admin-wave\frontend\app\(dashboard)\beheer\page.tsx`
+- `C:\Users\larsh\Desktop\wt\ac-admin-wave\frontend\app\(dashboard)\action-center\page.tsx`
+- `C:\Users\larsh\Desktop\wt\ac-admin-wave\frontend\lib\dashboard\shell-navigation.ts`
+- `C:\Users\larsh\Desktop\wt\ac-admin-wave\docs\superpowers\specs\2026-05-23-action-center-first-pass-readiness-assessment.md`
+- `C:\Users\larsh\Desktop\wt\ac-admin-wave\docs\superpowers\specs\2026-05-23-action-center-enterprise-operating-verification-sheet.md`
+
+### New files to create
+
+- `C:\Users\larsh\Desktop\wt\ac-admin-wave\frontend\lib\action-center-enterprise-readback.ts`
+- `C:\Users\larsh\Desktop\wt\ac-admin-wave\frontend\lib\action-center-enterprise-readback.test.ts`
+- `C:\Users\larsh\Desktop\wt\ac-admin-wave\frontend\app\(dashboard)\beheer\action-center-governance\page.tsx`
+- `C:\Users\larsh\Desktop\wt\ac-admin-wave\frontend\app\(dashboard)\beheer\action-center-governance\page.test.ts`
+- `C:\Users\larsh\Desktop\wt\ac-admin-wave\frontend\app\(dashboard)\action-center\executive\page.tsx`
+- `C:\Users\larsh\Desktop\wt\ac-admin-wave\frontend\app\(dashboard)\action-center\executive\page.test.ts`
+- `C:\Users\larsh\Desktop\wt\ac-admin-wave\docs\ops\ACTION_CENTER_FIRST_ROUTE_ONBOARDING_REHEARSAL.md`
+- `C:\Users\larsh\Desktop\wt\ac-admin-wave\docs\ops\ACTION_CENTER_SUPPORT_REHEARSAL_SCORECARD.md`
+
+### Responsibility split
+
+- `action-center-enterprise-readback*` is the shared bounded projection layer for tenant-admin and executive readback summaries.
+- `beheer/action-center-governance/page.tsx` is the tenant-admin surface for governance controls, links, and rehearsal entry.
+- `action-center/executive/page.tsx` is the read-only executive surface.
+- The rehearsal docs define the first-route operating drill without pretending a live result exists.
+
+---
+
+### Task 1: Add the shared enterprise readback helper
+
+**Files:**
+- Create: `C:\Users\larsh\Desktop\wt\ac-admin-wave\frontend\lib\action-center-enterprise-readback.ts`
+- Create: `C:\Users\larsh\Desktop\wt\ac-admin-wave\frontend\lib\action-center-enterprise-readback.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Include tests for:
+
+```ts
+it('builds a tenant admin summary with approval, support, and export counts', () => {
+  expect(
+    buildActionCenterTenantAdminSummary({
+      routeActivationApprovals: [{ routeFamily: 'exit', approvalStatus: 'approved', scopeValue: 'org-1::department::ops', createdAt: '2026-05-23T09:00:00.000Z' }],
+      supportAccessEvents: [{ accessKind: 'support', accessReason: 'Check route', createdAt: '2026-05-23T09:10:00.000Z' }],
+      auditExportRequests: [{ exportScope: 'bounded_summary', requestStatus: 'generated', createdAt: '2026-05-23T09:20:00.000Z' }],
+    }).controlCounts,
+  ).toEqual({
+    routeActivationApprovals: 1,
+    supportAccessEvents: 1,
+    auditExportRequests: 1,
+  })
+})
+
+it('builds a read-only executive summary without manager/task framing', () => {
+  expect(
+    buildActionCenterExecutiveReadback({
+      routeActivationApprovals: [],
+      supportAccessEvents: [],
+      openRouteCount: 4,
+      staleRouteCount: 1,
+      closeoutReadyRouteCount: 2,
+    }).headline,
+  ).toContain('Bestuurlijke follow-through readback')
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```powershell
+npx vitest run "lib/action-center-enterprise-readback.test.ts"
+```
+
+Expected: FAIL because the helper does not exist yet.
+
+- [ ] **Step 3: Implement the minimal helper**
+
+Create a helper shaped like:
+
+```ts
+export function buildActionCenterTenantAdminSummary(args: {
+  routeActivationApprovals: Array<{ routeFamily: string; approvalStatus: string; scopeValue: string; createdAt: string }>
+  supportAccessEvents: Array<{ accessKind: string; accessReason: string; createdAt: string }>
+  auditExportRequests: Array<{ exportScope: string; requestStatus: string; createdAt: string }>
+}) {
+  return {
+    headline: 'Tenant-admin governance overzicht',
+    controlCounts: {
+      routeActivationApprovals: args.routeActivationApprovals.length,
+      supportAccessEvents: args.supportAccessEvents.length,
+      auditExportRequests: args.auditExportRequests.length,
+    },
+  }
+}
+```
+
+Also add a read-only executive builder that returns:
+
+```ts
+{
+  headline: 'Bestuurlijke follow-through readback'
+  summaryRows: [...]
+  operatingBoundaryNote: 'Deze readback toont ritme, review en closeout; geen impactclaim.'
+}
+```
+
+- [ ] **Step 4: Re-run the tests and verify they pass**
+
+Run:
+
+```powershell
+npx vitest run "lib/action-center-enterprise-readback.test.ts"
+```
+
+Expected: PASS.
+
+---
+
+### Task 2: Add the tenant-admin governance surface
+
+**Files:**
+- Create: `C:\Users\larsh\Desktop\wt\ac-admin-wave\frontend\app\(dashboard)\beheer\action-center-governance\page.tsx`
+- Create: `C:\Users\larsh\Desktop\wt\ac-admin-wave\frontend\app\(dashboard)\beheer\action-center-governance\page.test.ts`
+- Modify: `C:\Users\larsh\Desktop\wt\ac-admin-wave\frontend\app\(dashboard)\beheer\page.tsx`
+
+- [ ] **Step 1: Write the failing page test**
+
+Add assertions like:
+
+```ts
+expect(source).toContain('eyebrow="Tenant-admin governance"')
+expect(source).toContain('title="Action Center governance controls"')
+expect(source).toContain('Route activation approvals')
+expect(source).toContain('Support access log')
+expect(source).toContain('Audit export summary')
+expect(source).toContain('Open onboarding rehearsal')
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```powershell
+npx vitest run "app/(dashboard)/beheer/action-center-governance/page.test.ts"
+```
+
+Expected: FAIL because the page does not exist yet.
+
+- [ ] **Step 3: Implement the tenant-admin page**
+
+The page should:
+
+- require authenticated Verisight admin
+- load:
+  - route activation approvals
+  - support access events
+  - audit export requests
+- project them through `buildActionCenterTenantAdminSummary`
+- render compact panels and recent rows
+- link to:
+  - `/beheer/health`
+  - `/action-center/executive`
+  - `docs/ops/ACTION_CENTER_FIRST_ROUTE_ONBOARDING_REHEARSAL.md`
+  - `docs/ops/ACTION_CENTER_SUPPORT_REHEARSAL_SCORECARD.md`
+
+The page must not:
+
+- become a generic admin center
+- expose arbitrary tenant dumps
+- add generic task/workflow controls
+
+- [ ] **Step 4: Add a bounded entry point from beheer**
+
+Add one extra action/link from `beheer/page.tsx`:
+
+```tsx
+<Link href="/beheer/action-center-governance">Open Action Center governance</Link>
+```
+
+Keep it in the existing ops/beheer family.
+
+- [ ] **Step 5: Re-run the page test**
+
+Run:
+
+```powershell
+npx vitest run "app/(dashboard)/beheer/action-center-governance/page.test.ts" "app/(dashboard)/beheer/page.test.ts"
+```
+
+Expected: PASS.
+
+---
+
+### Task 3: Add the executive readback surface
+
+**Files:**
+- Create: `C:\Users\larsh\Desktop\wt\ac-admin-wave\frontend\app\(dashboard)\action-center\executive\page.tsx`
+- Create: `C:\Users\larsh\Desktop\wt\ac-admin-wave\frontend\app\(dashboard)\action-center\executive\page.test.ts`
+- Modify: `C:\Users\larsh\Desktop\wt\ac-admin-wave\frontend\app\(dashboard)\action-center\page.tsx`
+- Modify: `C:\Users\larsh\Desktop\wt\ac-admin-wave\frontend\lib\dashboard\shell-navigation.ts`
+
+- [ ] **Step 1: Write the failing executive page test**
+
+Add assertions like:
+
+```ts
+expect(source).toContain('eyebrow="Executive readback"')
+expect(source).toContain('title="Bestuurlijke follow-through readback"')
+expect(source).toContain('Geen impactclaim')
+expect(source).toContain('Route activation approvals')
+expect(source).not.toContain('Aanmaken')
+expect(source).not.toContain('Projectboard')
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```powershell
+npx vitest run "app/(dashboard)/action-center/executive/page.test.ts"
+```
+
+Expected: FAIL because the page does not exist yet.
+
+- [ ] **Step 3: Implement the read-only executive page**
+
+The page should:
+
+- require authenticated user
+- use `loadSuiteAccessContext`
+- redirect when `!context.canViewExecutiveReadback`
+- load bounded Action Center readback data
+- render:
+  - open routes
+  - stale routes
+  - closeout-ready routes
+  - approval/support/export counts
+  - one operating-boundary note
+
+The hero copy should include:
+
+```tsx
+eyebrow="Executive readback"
+title="Bestuurlijke follow-through readback"
+description="Lees hier alleen ritme, review, closeout en governance-signalen terug. Geen manager-ranking, geen projectboard en geen impactclaim."
+```
+
+- [ ] **Step 4: Add bounded navigation entry points**
+
+Do not broaden primary Action Center nav for everyone.
+Instead:
+
+- add a quick link from `action-center/page.tsx` when `context.canViewExecutiveReadback`
+- add one conditional item in `ACTION_CENTER_NAV` only if you can keep it bounded to readback semantics
+- otherwise keep it as a page-level CTA only
+
+Prefer the CTA-only route if nav conditioning becomes messy.
+
+- [ ] **Step 5: Re-run the executive tests**
+
+Run:
+
+```powershell
+npx vitest run "app/(dashboard)/action-center/executive/page.test.ts" "app/(dashboard)/action-center/page.route-shell.test.ts"
+```
+
+Expected: PASS.
+
+---
+
+### Task 4: Add the onboarding/support rehearsal pack
+
+**Files:**
+- Create: `C:\Users\larsh\Desktop\wt\ac-admin-wave\docs\ops\ACTION_CENTER_FIRST_ROUTE_ONBOARDING_REHEARSAL.md`
+- Create: `C:\Users\larsh\Desktop\wt\ac-admin-wave\docs\ops\ACTION_CENTER_SUPPORT_REHEARSAL_SCORECARD.md`
+- Modify: `C:\Users\larsh\Desktop\wt\ac-admin-wave\docs\superpowers\specs\2026-05-23-action-center-first-pass-readiness-assessment.md`
+- Modify: `C:\Users\larsh\Desktop\wt\ac-admin-wave\docs\superpowers\specs\2026-05-23-action-center-enterprise-operating-verification-sheet.md`
+
+- [ ] **Step 1: Write the rehearsal doc assertions**
+
+The onboarding rehearsal doc must include:
+
+```md
+## Route Family
+## Participants
+## Preflight
+## First Route Walkthrough
+## Support Interruption Drill
+## Exit Conditions
+```
+
+The scorecard must include:
+
+```md
+| Check | Pass rule | Evidence | Status |
+```
+
+- [ ] **Step 2: Verify the docs do not exist yet**
+
+Run:
+
+```powershell
+Test-Path "C:\Users\larsh\Desktop\wt\ac-admin-wave\docs\ops\ACTION_CENTER_FIRST_ROUTE_ONBOARDING_REHEARSAL.md"
+Test-Path "C:\Users\larsh\Desktop\wt\ac-admin-wave\docs\ops\ACTION_CENTER_SUPPORT_REHEARSAL_SCORECARD.md"
+```
+
+Expected: both `False`.
+
+- [ ] **Step 3: Write the rehearsal docs**
+
+Keep them bounded to:
+
+- one approved route family at a time
+- one HR operator
+- one manager participant
+- one support-side interruption drill
+- no route expansion
+- no causal proof claim
+
+- [ ] **Step 4: Reconcile the readiness docs**
+
+Update the assessment and verification sheet so they say:
+
+- tenant/admin packaging is stronger
+- executive readback surface exists
+- onboarding/support rehearsal is defined
+- live evidence is still missing
+
+- [ ] **Step 5: Run a placeholder scan**
+
+Run:
+
+```powershell
+rg -n "TODO|TBD|placeholder" "C:\Users\larsh\Desktop\wt\ac-admin-wave\docs\ops\ACTION_CENTER_FIRST_ROUTE_ONBOARDING_REHEARSAL.md" "C:\Users\larsh\Desktop\wt\ac-admin-wave\docs\ops\ACTION_CENTER_SUPPORT_REHEARSAL_SCORECARD.md"
+```
+
+Expected: no matches.
+
+---
+
+### Task 5: Final verification and closeout
+
+**Files:**
+- All touched files in this wave
+
+- [ ] **Step 1: Run the focused verification set**
+
+Run:
+
+```powershell
+npx vitest run "lib/action-center-enterprise-readback.test.ts" "app/(dashboard)/beheer/action-center-governance/page.test.ts" "app/(dashboard)/beheer/page.test.ts" "app/(dashboard)/action-center/executive/page.test.ts" "app/(dashboard)/action-center/page.route-shell.test.ts" "lib/action-center-admin-governance.test.ts" "lib/suite-access.test.ts" "lib/action-center-ops-health.test.ts" "app/api/action-center/admin/route-activation-approvals/route.test.ts" "app/api/action-center/admin/support-access-events/route.test.ts" "app/api/action-center/admin/audit-exports/route.test.ts"
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run diff hygiene**
+
+Run:
+
+```powershell
+git diff --check
+```
+
+Expected: no whitespace or merge-marker issues for the wave.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/lib/action-center-enterprise-readback.ts frontend/lib/action-center-enterprise-readback.test.ts frontend/app/(dashboard)/beheer/action-center-governance/page.tsx frontend/app/(dashboard)/beheer/action-center-governance/page.test.ts frontend/app/(dashboard)/beheer/page.tsx frontend/app/(dashboard)/action-center/executive/page.tsx frontend/app/(dashboard)/action-center/executive/page.test.ts frontend/app/(dashboard)/action-center/page.tsx frontend/lib/dashboard/shell-navigation.ts docs/ops/ACTION_CENTER_FIRST_ROUTE_ONBOARDING_REHEARSAL.md docs/ops/ACTION_CENTER_SUPPORT_REHEARSAL_SCORECARD.md docs/superpowers/specs/2026-05-23-action-center-first-pass-readiness-assessment.md docs/superpowers/specs/2026-05-23-action-center-enterprise-operating-verification-sheet.md
+git commit -m "feat: add action center tenant admin and executive surfaces"
+```
+
+---
+
+## Self-Review
+
+### Spec coverage
+
+This plan covers:
+
+- tenant-admin packaging
+- executive-viewer packaging
+- onboarding/support rehearsal definition
+
+It intentionally does not cover:
+
+- route expansion
+- standalone launch
+- external GTM
+- live evidence claims
+
+### Placeholder scan
+
+This plan contains no `TODO`, `TBD`, or `implement later` placeholders.
+
+### Type consistency
+
+This plan keeps all new surfaces bounded to the already-approved Action Center truth:
+
+- route families remain `exit | retention`
+- executive readback remains read-only
+- tenant-admin remains governance/readback oriented
+- rehearsal remains a drill, not proof

--- a/docs/superpowers/specs/2026-05-23-action-center-enterprise-operating-verification-sheet.md
+++ b/docs/superpowers/specs/2026-05-23-action-center-enterprise-operating-verification-sheet.md
@@ -24,12 +24,13 @@ It does not authorize:
 
 | Capability | Status | Required for near-standalone? | Current runtime evidence | Required owner | Next verification step | Blocking? |
 |---|---|---|---|---|---|---|
-| Tenant admin role | `partial` | yes | explicit admin-governance capabilities now exist in runtime access truth, but not yet as a full customer-facing admin package | product + engineering | verify whether current capability flags are sufficient for a real tenant-admin operating surface | yes |
-| Executive viewer role | `partial` | yes | read-only executive readback capability now exists in runtime access truth, but no separate executive-viewer surface is packaged | product + commercial | verify aggregated readback boundaries and approved sponsor visibility | yes |
+| Tenant admin role | `partial` | yes | explicit admin-governance capabilities plus a bounded tenant-admin governance surface now exist, but not yet as a fully customer-owned admin package | product + engineering | verify whether the current governance surface is strong enough for real tenant-admin operation | yes |
+| Executive viewer role | `partial` | yes | read-only executive readback capability and a dedicated executive page now exist | product + commercial | verify aggregated readback boundaries and approved sponsor visibility | yes |
 | Route activation approvals | `partial` | yes | bounded approval records, schema truth, API write path, and health readback now exist | product + engineering + governance | verify approval review flow beyond direct admin/API use | yes |
 | Audit export | `partial` | yes | bounded audit-export summary and export-request logging now exist | engineering + governance | verify export request review path and acceptable consumer format | yes |
-| Support access logging | `partial` | yes | bounded support-access event logging, schema truth, and health readback now exist | engineering + support + governance | verify operator workflow and review cadence for logged events | yes |
+| Support access logging | `partial` | yes | bounded support-access event logging, schema truth, health readback, and a rehearsal route now exist | engineering + support + governance | verify operator workflow and review cadence for logged events in a real drill | yes |
 | Retention/deletion policy | `partial` | yes | Action Center-specific retention/deletion policy now exists as an owned operating artifact, but not yet as a runtime control package | governance + privacy + engineering | verify record classes, retention rules, and deletion approvals against real admin/runtime handling | yes |
+| Onboarding/support rehearsal pack | `partial` | yes | bounded rehearsal docs and runtime rehearsal page now exist | product + support + governance | run the first real rehearsal and score it against the support scorecard | yes |
 
 ## Activation Approval Controls
 
@@ -122,7 +123,7 @@ It does not authorize:
 | No explicit tenant-admin package | customer-owned administration is still not yet defensible as a complete Action Center truth package | product + engineering | define bounded tenant-admin surface beyond capability flags alone |
 | No explicit executive-viewer package | sponsor/readback visibility is not yet packaged as a safe role | product + commercial | define aggregated readback boundaries and role language |
 | Approval and export flows are still API-first | route activation and audit readback now exist, but are not yet a complete operator-facing control layer | product + governance + engineering | define review/approval/export workflow beyond direct admin endpoints |
-| Support logging lacks operator rhythm | support involvement is now transparently loggable, but not yet embedded in a lived ops rhythm | support + engineering + governance | define support-access review cadence and escalation handling in practice |
+| Support logging lacks operator rhythm | support involvement is now transparently loggable and rehearsable, but not yet embedded in a lived ops rhythm | support + engineering + governance | run the rehearsal and define support-access review cadence in practice |
 | Retention/deletion remains policy-first | record lifecycle can now be explained, but not yet fully defended through visible runtime controls | governance + privacy + engineering | connect policy to explicit runtime deletion/archive handling |
 
 ## Interpretation Notes

--- a/docs/superpowers/specs/2026-05-23-action-center-enterprise-operating-verification-sheet.md
+++ b/docs/superpowers/specs/2026-05-23-action-center-enterprise-operating-verification-sheet.md
@@ -1,0 +1,132 @@
+# Action Center Enterprise Operating Verification Sheet
+
+## Status
+Updated after bounded enterprise-operating gap wave
+
+## Purpose
+This sheet translates the highest-risk enterprise-operating gaps into a compact verification surface that can be inspected against current runtime truth, owned operating artifacts, and bounded follow-up work.
+
+It exists to answer:
+
+- which enterprise-operating capabilities are required for near-standalone review
+- what current runtime or policy evidence exists today
+- who must own each control
+- which gaps still block disciplined enterprise-operating review
+
+It does not authorize:
+
+- standalone launch
+- route expansion
+- separate GTM
+- workflow broadening
+
+## Capability Status Grid
+
+| Capability | Status | Required for near-standalone? | Current runtime evidence | Required owner | Next verification step | Blocking? |
+|---|---|---|---|---|---|---|
+| Tenant admin role | `partial` | yes | explicit admin-governance capabilities now exist in runtime access truth, but not yet as a full customer-facing admin package | product + engineering | verify whether current capability flags are sufficient for a real tenant-admin operating surface | yes |
+| Executive viewer role | `partial` | yes | read-only executive readback capability now exists in runtime access truth, but no separate executive-viewer surface is packaged | product + commercial | verify aggregated readback boundaries and approved sponsor visibility | yes |
+| Route activation approvals | `partial` | yes | bounded approval records, schema truth, API write path, and health readback now exist | product + engineering + governance | verify approval review flow beyond direct admin/API use | yes |
+| Audit export | `partial` | yes | bounded audit-export summary and export-request logging now exist | engineering + governance | verify export request review path and acceptable consumer format | yes |
+| Support access logging | `partial` | yes | bounded support-access event logging, schema truth, and health readback now exist | engineering + support + governance | verify operator workflow and review cadence for logged events | yes |
+| Retention/deletion policy | `partial` | yes | Action Center-specific retention/deletion policy now exists as an owned operating artifact, but not yet as a runtime control package | governance + privacy + engineering | verify record classes, retention rules, and deletion approvals against real admin/runtime handling | yes |
+
+## Activation Approval Controls
+
+### Current state
+
+- Action Center is bounded to approved route families, and route activation approval truth now exists in schema, API, and admin health readback.
+- The current readiness discussion now has shipped approval truth, but not yet a broader operator-facing review flow.
+
+### Verification points
+
+- activation approval authority is named
+- approval scope is bounded to approved route families only
+- approval records can be reviewed without founder memory
+- revocation or rejection handling is explicit
+
+### Required evidence
+
+- route activation approval artifact or runtime control
+- named approver role
+- example approval record shape
+- rejection/revocation interpretation note
+
+## Support Access Logging
+
+### Current state
+
+- Supportability is directionally present through ops-health thinking, and support access can now be logged as bounded Action Center truth.
+- Enterprise review will still expect support, privacy, governance, and incident access to be separable, inspectable, and used in a real operator rhythm.
+
+### Verification points
+
+- every support-side access path has a required owner
+- access reason is recorded
+- affected route or scope can be identified when applicable
+- escalation path is explicit for product, governance, privacy, and incident cases
+
+### Required evidence
+
+- support-access event model
+- support-access and incident matrix
+- named owner per case type
+- example logged artifact fields
+
+## Audit Export Readiness
+
+### Current state
+
+- Action Center has bounded governance and readback intent, and now has a bounded audit-export summary plus export-request logging.
+- Reviewers now have a disciplined export-ready layer for approvals and support-access evidence, but not yet a broader audited delivery flow.
+
+### Verification points
+
+- export scope is bounded to Action Center operating records
+- export contents do not become a generic tenant dump
+- export request owner is named
+- export review path is explicit
+
+### Required evidence
+
+- export-ready record inventory
+- named export owner
+- bounded export contents definition
+- privacy/governance review note for export scope
+
+## Retention And Deletion Controls
+
+### Current state
+
+- Privacy-safe boundaries are described in existing design and commercial docs, and Action Center-specific retention/deletion rules now exist as owned operating policy.
+- Enterprise-operating review now has a record-by-record interpretation layer, while runtime deletion/archive controls still need proof.
+
+### Verification points
+
+- runtime truth records are distinguished from support/access records
+- silent deletion is prohibited where operational reviewability is required
+- archival rules are explicit
+- deletion approval authority is named
+
+### Required evidence
+
+- retention/deletion policy
+- named deletion approver
+- archive-vs-delete decision rules
+- incident interpretation for disputed deletion requests
+
+## Blocking Risks
+
+| Risk | Why it blocks enterprise-operating review | Immediate owner | Required closure move |
+|---|---|---|---|
+| No explicit tenant-admin package | customer-owned administration is still not yet defensible as a complete Action Center truth package | product + engineering | define bounded tenant-admin surface beyond capability flags alone |
+| No explicit executive-viewer package | sponsor/readback visibility is not yet packaged as a safe role | product + commercial | define aggregated readback boundaries and role language |
+| Approval and export flows are still API-first | route activation and audit readback now exist, but are not yet a complete operator-facing control layer | product + governance + engineering | define review/approval/export workflow beyond direct admin endpoints |
+| Support logging lacks operator rhythm | support involvement is now transparently loggable, but not yet embedded in a lived ops rhythm | support + engineering + governance | define support-access review cadence and escalation handling in practice |
+| Retention/deletion remains policy-first | record lifecycle can now be explained, but not yet fully defended through visible runtime controls | governance + privacy + engineering | connect policy to explicit runtime deletion/archive handling |
+
+## Interpretation Notes
+
+- This sheet is a verification aid, not proof of launch readiness.
+- `yes` under required-for-near-standalone means the capability must be explainable and inspectable before disciplined near-standalone enterprise review.
+- A capability remains blocking until its next verification step is backed by named runtime or policy evidence rather than intent alone.

--- a/docs/superpowers/specs/2026-05-23-action-center-first-pass-readiness-assessment.md
+++ b/docs/superpowers/specs/2026-05-23-action-center-first-pass-readiness-assessment.md
@@ -170,9 +170,8 @@ Evidence:
 
 What is missing or unstable:
 
-- no fully packaged tenant-admin surface
-- no explicit executive-viewer surface
-- approval, export, and support controls are still API/admin-first rather than a mature operator package
+- tenant-admin and executive-viewer surfaces now exist, but remain bounded scaffolding rather than a fully mature customer package
+- approval, export, and support controls are still governance/readback-first rather than a mature operator package
 - retention/deletion remains policy-backed more than runtime-backed
 
 Blocking risk:
@@ -238,7 +237,7 @@ Blocking risk:
 
 Next step:
 
-- define and test a real support/onboarding path against one current route family end-to-end, using [ACTION_CENTER_SUPPORT_ACCESS_AND_INCIDENT_MATRIX.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/ACTION_CENTER_SUPPORT_ACCESS_AND_INCIDENT_MATRIX.md) as the bounded case/owner/escalation baseline
+- run the bounded rehearsal defined in [ACTION_CENTER_FIRST_ROUTE_ONBOARDING_REHEARSAL.md](/C:/Users/larsh/Desktop/wt/ac-admin-wave/docs/ops/ACTION_CENTER_FIRST_ROUTE_ONBOARDING_REHEARSAL.md) and score it with [ACTION_CENTER_SUPPORT_REHEARSAL_SCORECARD.md](/C:/Users/larsh/Desktop/wt/ac-admin-wave/docs/ops/ACTION_CENTER_SUPPORT_REHEARSAL_SCORECARD.md)
 
 ### 6. Onboarding readiness
 
@@ -432,6 +431,9 @@ This wave also adds shipped runtime controls for:
 - support-access event logging
 - bounded audit-export summaries
 - admin health readback
+- tenant-admin governance surface
+- executive readback surface
+- bounded rehearsal surface
 
 That means the enterprise-operating conversation is now more disciplined and partly shipped, while the remaining gap is the maturity of the customer/admin package around those controls.
 
@@ -450,6 +452,7 @@ The repository now has stronger policy and runtime scaffolding, but not yet:
 1. Use [2026-05-23-action-center-enterprise-operating-verification-sheet.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/superpowers/specs/2026-05-23-action-center-enterprise-operating-verification-sheet.md), [ACTION_CENTER_RETENTION_AND_DELETION_POLICY.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/ACTION_CENTER_RETENTION_AND_DELETION_POLICY.md), and [ACTION_CENTER_SUPPORT_ACCESS_AND_INCIDENT_MATRIX.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/ACTION_CENTER_SUPPORT_ACCESS_AND_INCIDENT_MATRIX.md) to score actual tenant/admin capabilities against an explicit enterprise readiness matrix.
 2. Decide which current capabilities are strong enough to be surfaced as a real tenant/admin package and which must remain internal scaffolding.
 3. Keep route scope bounded to `exit` and `retention` while the enterprise-operating package catches up.
+4. Run one real rehearsal through [ACTION_CENTER_FIRST_ROUTE_ONBOARDING_REHEARSAL.md](/C:/Users/larsh/Desktop/wt/ac-admin-wave/docs/ops/ACTION_CENTER_FIRST_ROUTE_ONBOARDING_REHEARSAL.md) before any stronger near-standalone story.
 
 ### After that
 

--- a/docs/superpowers/specs/2026-05-23-action-center-first-pass-readiness-assessment.md
+++ b/docs/superpowers/specs/2026-05-23-action-center-first-pass-readiness-assessment.md
@@ -1,0 +1,465 @@
+# Action Center First-Pass Readiness Assessment
+
+## Status
+First-pass internal assessment updated after enterprise-operating gap wave
+
+## Purpose
+This document records a first-pass readiness assessment of Action Center based on:
+
+- current repository docs
+- current runtime-facing code
+- existing commercial reference artifacts
+- a narrow smoke-pass on Action Center tests
+
+This is not a launch decision.
+It is a bounded assessment of how mature Action Center currently is as:
+
+- an embedded enterprise module
+- a near-standalone explainable product layer
+- a near-standalone sellable product layer
+- a standalone launch candidate
+
+## Assessment Method
+
+### Evidence reviewed
+
+- [2026-05-02-action-center-roadmap-to-commercial-state-design.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/superpowers/specs/2026-05-02-action-center-roadmap-to-commercial-state-design.md)
+- [2026-05-02-action-center-reliable-ops-design.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/superpowers/specs/2026-05-02-action-center-reliable-ops-design.md)
+- [2026-05-02-action-center-reporting-readback-design.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/superpowers/specs/2026-05-02-action-center-reporting-readback-design.md)
+- [EXITSCAN_SALES_ONE_PAGER.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/reference/EXITSCAN_SALES_ONE_PAGER.md)
+- [SALES_COMPARISON_MATRIX.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/reference/SALES_COMPARISON_MATRIX.md)
+- [page.tsx](/C:/Users/larsh/Desktop/Business/Verisight/frontend/app/(dashboard)/action-center/page.tsx)
+- [action-center-admin-governance.ts](/C:/Users/larsh/Desktop/Business/Verisight/frontend/lib/action-center-admin-governance.ts)
+- [action-center-route-contract.ts](/C:/Users/larsh/Desktop/Business/Verisight/frontend/lib/action-center-route-contract.ts)
+- [action-center-governance.test.ts](/C:/Users/larsh/Desktop/Business/Verisight/frontend/lib/action-center-governance.test.ts)
+- [action-center-ops-health.test.ts](/C:/Users/larsh/Desktop/Business/Verisight/frontend/lib/action-center-ops-health.test.ts)
+- [route-activation-approvals/route.test.ts](/C:/Users/larsh/Desktop/Business/Verisight/frontend/app/api/action-center/admin/route-activation-approvals/route.test.ts)
+- [support-access-events/route.test.ts](/C:/Users/larsh/Desktop/Business/Verisight/frontend/app/api/action-center/admin/support-access-events/route.test.ts)
+- [audit-exports/route.test.ts](/C:/Users/larsh/Desktop/Business/Verisight/frontend/app/api/action-center/admin/audit-exports/route.test.ts)
+- [page.route-shell.test.ts](/C:/Users/larsh/Desktop/Business/Verisight/frontend/app/(dashboard)/action-center/page.route-shell.test.ts)
+
+### Smoke-pass run
+
+Command run:
+
+```powershell
+npx vitest run "lib/action-center-admin-governance.test.ts" "lib/suite-access.test.ts" "lib/action-center-ops-health.test.ts" "app/api/action-center/admin/route-activation-approvals/route.test.ts" "app/api/action-center/admin/support-access-events/route.test.ts" "app/api/action-center/admin/audit-exports/route.test.ts" "lib/action-center-governance.test.ts" "lib/action-center-route-contract.test.ts" "app/(dashboard)/action-center/page.route-shell.test.ts"
+```
+
+Observed result:
+
+- `9` files passed
+- `63` tests passed
+- `0` tests failed
+
+The passing tests support the presence of:
+
+- canonical governance role handling
+- compact ops-health evidence
+- canonical route-contract semantics
+
+The updated smoke-pass now confirms that the most visible Action Center shell semantics are aligned again for:
+
+- overview readback wording
+- route action-card wording
+- explicit closeout wording
+- lineage label rendering
+
+## Executive Read
+
+### Bottom line
+
+Action Center is currently:
+
+- `partial` for embedded enterprise readiness
+- `partial` for near-standalone explainability
+- `not_ready` for near-standalone sellability
+- `not_ready` for standalone launch consideration
+
+### Why
+
+The product foundation is real:
+
+- route-bound follow-through exists
+- governance semantics exist
+- route and review semantics exist
+- bounded readback and ops-health direction exist
+- sales artifacts already keep Action Center bounded and secondary
+
+But the current state is not yet strong enough to call Action Center almost independently sellable because:
+
+- current sales framing still positions `Action Center Start` explicitly as an optional add-on rather than a commercially distinct product layer
+- tenant/admin readiness is now materially better, but still not yet a complete customer-safe package
+- support model, onboarding repeatability, and quantified live evidence are not yet demonstrated in runtime
+
+## Readiness By Category
+
+### 1. Product readiness
+
+Status: `partial`
+
+What is present:
+
+- canonical route contract and route lifecycle direction
+- bounded route -> action -> review -> closeout model
+- manager-light interaction model
+- route reopen and continuation semantics
+- explicit route closeout and route review concepts
+
+Evidence:
+
+- [action-center-route-contract.ts](/C:/Users/larsh/Desktop/Business/Verisight/frontend/lib/action-center-route-contract.ts)
+- [2026-05-02-action-center-roadmap-to-commercial-state-design.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/superpowers/specs/2026-05-02-action-center-roadmap-to-commercial-state-design.md)
+
+What is missing or unstable:
+
+- the product boundary is now stronger in runtime, but enterprise-operating controls still sit partly in admin/API scaffolding rather than a full operator package
+- the route-bound runtime is settled more clearly than the customer-admin/runtime packaging around it
+
+Blocking risk:
+
+- the bounded product can now be shown more credibly in runtime, but enterprise-operating maturity still lags behind product semantics
+
+Next step:
+
+- keep the stricter route/runtime truth intact and focus the next wave on tenant/admin packaging, onboarding/support proof, and live evidence
+
+### 2. Governance readiness
+
+Status: `partial`
+
+What is present:
+
+- explicit HR/governance access logic
+- role-based write resolution
+- route-bound governance concepts in product docs
+
+Evidence:
+
+- [action-center-governance.test.ts](/C:/Users/larsh/Desktop/Business/Verisight/frontend/lib/action-center-governance.test.ts)
+- [2026-05-02-action-center-governance-rights-design.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/superpowers/specs/2026-05-02-action-center-governance-rights-design.md)
+
+What is missing or unstable:
+
+- tenant-grade governance is still not demonstrated as a complete, customer-safe operating layer
+- admin roles, approval boundaries, archival controls, and audit export are now explicit, but still not yet a coherent end-user operating package
+
+Blocking risk:
+
+- governance may be strong enough for bounded internal use, but not yet independently defensible in an enterprise review conversation
+
+Next step:
+
+- score actual tenant/admin capabilities against the target readiness matrix and separate documented intent from shipped controls
+- use the new [2026-05-23-action-center-enterprise-operating-verification-sheet.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/superpowers/specs/2026-05-23-action-center-enterprise-operating-verification-sheet.md) as the current source for approval, support-access, audit-export, and retention/deletion control verification
+
+### 3. Tenant/admin readiness
+
+Status: `partial`
+
+What is present:
+
+- route- and workspace-based access control logic
+- explicit admin-governance capability flags in runtime access truth
+- bounded route activation approvals, support-access logging, and audit-export scaffolding
+- a visible admin-first Action Center operating surface
+
+Evidence:
+
+- [page.tsx](/C:/Users/larsh/Desktop/Business/Verisight/frontend/app/(dashboard)/action-center/page.tsx)
+
+What is missing or unstable:
+
+- no fully packaged tenant-admin surface
+- no explicit executive-viewer surface
+- approval, export, and support controls are still API/admin-first rather than a mature operator package
+- retention/deletion remains policy-backed more than runtime-backed
+
+Blocking risk:
+
+- this remains one of the clearest blockers for any near-standalone commercial story, even though it is no longer almost entirely absent
+
+Next step:
+
+- use the explicit capability grid in [2026-05-23-action-center-enterprise-operating-verification-sheet.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/superpowers/specs/2026-05-23-action-center-enterprise-operating-verification-sheet.md) plus the updated [2026-05-23-action-center-tenant-admin-gap-table.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/superpowers/specs/2026-05-23-action-center-tenant-admin-gap-table.md) to verify tenant admin, executive viewer, route activation approval, audit export, support-access logging, and retention/deletion gaps against named policy artifacts
+
+### 4. Security/privacy readiness
+
+Status: `partial`
+
+What is present:
+
+- Action Center is repeatedly framed in docs as post-scan, bounded, and not a dossier or generic workflow system
+- sales/reference materials keep it away from broad monitoring or risk-ledger framing
+
+Evidence:
+
+- [EXITSCAN_SALES_ONE_PAGER.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/reference/EXITSCAN_SALES_ONE_PAGER.md)
+- [SALES_COMPARISON_MATRIX.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/reference/SALES_COMPARISON_MATRIX.md)
+
+What is missing or unstable:
+
+- privacy-safe positioning exists more as commercial and design boundary than as a complete audited operating package
+- no live evidence in this assessment of deletion handling, incident handling, or cross-tenant support controls
+
+Blocking risk:
+
+- enterprise reviewers will ask for operating proof, not only wording discipline
+
+Next step:
+
+- convert privacy/dossier boundaries from narrative rules into an explicit operational checklist with owned controls using [ACTION_CENTER_RETENTION_AND_DELETION_POLICY.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/ACTION_CENTER_RETENTION_AND_DELETION_POLICY.md) and [ACTION_CENTER_SUPPORT_ACCESS_AND_INCIDENT_MATRIX.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/ACTION_CENTER_SUPPORT_ACCESS_AND_INCIDENT_MATRIX.md) as the first owned operating layer
+
+### 5. Support readiness
+
+Status: `partial`
+
+What is present:
+
+- bounded ops-health design
+- telemetry-based critical event summary concept
+- admin-readback counts for route activation approvals and support-access logging
+- support/governance/privacy incident routing policy
+
+Evidence:
+
+- [2026-05-02-action-center-reliable-ops-design.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/superpowers/specs/2026-05-02-action-center-reliable-ops-design.md)
+- [action-center-ops-health.test.ts](/C:/Users/larsh/Desktop/Business/Verisight/frontend/lib/action-center-ops-health.test.ts)
+
+What is missing or unstable:
+
+- no proven support model independent of founder/product memory
+- escalation taxonomy now exists on paper, but has not yet been exercised as lived operating practice
+- no demonstrated rollback or failed-rollout handling model
+
+Blocking risk:
+
+- supportability is still directional rather than proven
+
+Next step:
+
+- define and test a real support/onboarding path against one current route family end-to-end, using [ACTION_CENTER_SUPPORT_ACCESS_AND_INCIDENT_MATRIX.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/ACTION_CENTER_SUPPORT_ACCESS_AND_INCIDENT_MATRIX.md) as the bounded case/owner/escalation baseline
+
+### 6. Onboarding readiness
+
+Status: `partial`
+
+What is present:
+
+- product docs clearly describe Action Center as the layer after the scan
+- manager-light intent is already documented
+
+Evidence:
+
+- [2026-05-02-action-center-roadmap-to-commercial-state-design.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/superpowers/specs/2026-05-02-action-center-roadmap-to-commercial-state-design.md)
+
+What is missing or unstable:
+
+- no demonstrated onboarding pack that proves HR and manager onboarding can happen without bespoke explanation
+- no proven first-route activation checklist visible in current runtime and operating docs
+
+Blocking risk:
+
+- onboarding still appears explainable, but not yet operationally repeatable
+
+Next step:
+
+- produce and dry-run a first-route onboarding flow with explicit pass/fail criteria
+
+### 7. Commercial readiness
+
+Status: `partial`
+
+What is present:
+
+- Action Center already has bounded commercial language
+- sales docs consistently keep it as an optional add-on
+- replacement narrative is implicitly present: it prevents follow-through from disappearing after reporting
+
+Evidence:
+
+- [EXITSCAN_SALES_ONE_PAGER.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/reference/EXITSCAN_SALES_ONE_PAGER.md)
+- [SALES_COMPARISON_MATRIX.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/reference/SALES_COMPARISON_MATRIX.md)
+
+What is missing or unstable:
+
+- Action Center is not yet positioned as a commercially distinct near-standalone layer
+- current sales truth still intentionally suppresses that move
+- there is no validated near-standalone positioning gate in current live commercial use
+
+Blocking risk:
+
+- selling it too early as more than an add-on would create category confusion and likely overclaim the product
+
+Next step:
+
+- validate whether near-standalone positioning should remain internal only for now or be tested in tightly bounded buyer conversations
+
+### 8. Evidence readiness
+
+Status: `not_ready`
+
+What is present:
+
+- telemetry and bounded readback direction
+- route, review, closeout, and continuation semantics that can support later evidence work
+
+Evidence:
+
+- [2026-05-02-action-center-reporting-readback-design.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/superpowers/specs/2026-05-02-action-center-reporting-readback-design.md)
+- [2026-05-02-action-center-reliable-ops-design.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/superpowers/specs/2026-05-02-action-center-reliable-ops-design.md)
+
+What is missing or unstable:
+
+- no evidence here of 3 live customer contexts
+- no evidence here of 30 live route instances
+- no evidence here of validated thresholds for completion, sprawl, stale or repeated-no-progress
+- no evidence here of customer/operator interviews confirming boundedness
+
+Blocking risk:
+
+- this alone blocks any serious standalone consideration
+
+Next step:
+
+- treat live evidence as a separate gate program, not as a documentation exercise
+
+### 9. Category readiness
+
+Status: `partial`
+
+What is present:
+
+- docs strongly describe Action Center as a bounded follow-through layer after scan truth
+- current sales materials consistently prevent generic workflow framing
+
+Evidence:
+
+- [2026-05-02-action-center-roadmap-to-commercial-state-design.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/superpowers/specs/2026-05-02-action-center-roadmap-to-commercial-state-design.md)
+- [EXITSCAN_SALES_ONE_PAGER.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/reference/EXITSCAN_SALES_ONE_PAGER.md)
+
+What is missing or unstable:
+
+- category clarity is still mostly implicit and add-on shaped rather than a fully explicit `Governed Follow-Through` market layer
+- the product boundary is now stronger in code/runtime, but the packaging around it is still not commercially independent enough
+
+Blocking risk:
+
+- category is intellectually clear internally, but not yet fully hardened for independent market explanation
+
+Next step:
+
+- keep category hardening paired with runtime boundary hardening so the language and the product do not drift apart
+
+## Readiness Verdict By Level
+
+### Embedded enterprise ready
+
+Verdict: `partial`
+
+Why:
+
+- the product core is real and the bounded follow-through model exists
+- governance and ops-health direction are real
+- runtime route-family drift and route-shell semantic drift were resolved in this wave
+- but the enterprise-operating package around the core is still only partial
+
+### Near-standalone explainable
+
+Verdict: `partial`
+
+Why:
+
+- the product can be described clearly as a governed follow-through layer
+- current docs and sales materials already defend boundedness well
+- but the explanation is still stronger than the operating proof
+
+### Near-standalone sellable
+
+Verdict: `not_ready`
+
+Why:
+
+- current commercial truth still positions Action Center as an optional add-on
+- tenant/admin, onboarding, and support readiness are not yet hard enough
+- live evidence is not yet present
+
+### Standalone launch ready
+
+Verdict: `not_ready`
+
+Why:
+
+- no quantified gate is satisfied
+- no route-expansion proof is demonstrated
+- no tenant-grade operating package is demonstrated
+- no standalone support and onboarding proof is demonstrated
+
+## Key Blockers
+
+### Blocker 1: Commercial framing is still intentionally add-on-first
+
+Current sales/reference docs position `Action Center Start` as:
+
+- optional
+- bounded
+- secondary
+- not a standalone route
+
+That is commercially disciplined, but it means near-standalone sellability has not yet been earned.
+
+### Blocker 2: Live evidence is still missing
+
+There is no basis in this assessment to claim:
+
+- adoption proof
+- route-family proof at scale
+- causal intervention impact
+- standalone operating readiness
+
+### Blocker 3: Enterprise-operating controls are now explicit, but still only partially packaged
+
+The repository now has an explicit operating layer for:
+
+- enterprise-operating capability verification
+- retention/deletion rules
+- support/governance/privacy incident routing
+
+This wave also adds shipped runtime controls for:
+
+- admin capability flags
+- route activation approval truth
+- support-access event logging
+- bounded audit-export summaries
+- admin health readback
+
+That means the enterprise-operating conversation is now more disciplined and partly shipped, while the remaining gap is the maturity of the customer/admin package around those controls.
+
+### Blocker 4: Support and onboarding are still not proven as repeatable operating routines
+
+The repository now has stronger policy and runtime scaffolding, but not yet:
+
+- a proven onboarding path independent of founder explanation
+- a rehearsed support/access review rhythm
+- a demonstrated failed-rollout or recovery routine
+
+## Recommended Next Steps
+
+### Immediate
+
+1. Use [2026-05-23-action-center-enterprise-operating-verification-sheet.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/superpowers/specs/2026-05-23-action-center-enterprise-operating-verification-sheet.md), [ACTION_CENTER_RETENTION_AND_DELETION_POLICY.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/ACTION_CENTER_RETENTION_AND_DELETION_POLICY.md), and [ACTION_CENTER_SUPPORT_ACCESS_AND_INCIDENT_MATRIX.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/ACTION_CENTER_SUPPORT_ACCESS_AND_INCIDENT_MATRIX.md) to score actual tenant/admin capabilities against an explicit enterprise readiness matrix.
+2. Decide which current capabilities are strong enough to be surfaced as a real tenant/admin package and which must remain internal scaffolding.
+3. Keep route scope bounded to `exit` and `retention` while the enterprise-operating package catches up.
+
+### After that
+
+1. Run one bounded onboarding/support rehearsal for a real route family.
+2. Validate whether `Action Center Start` should remain purely add-on framed or begin tightly bounded near-standalone positioning tests.
+3. Start a separate live-evidence program instead of trying to infer readiness from docs alone.
+
+## Assumptions And Limits
+
+- This assessment is based on the current repository state, not on an externally certified release snapshot.
+- The repository currently contains unrelated local changes outside this document.
+- No buyer interviews, customer interviews, or live-route telemetry thresholds were validated during this assessment.
+- Therefore this document should be treated as a strong internal first pass, not as final launch evidence.

--- a/docs/superpowers/specs/2026-05-23-action-center-tenant-admin-gap-table.md
+++ b/docs/superpowers/specs/2026-05-23-action-center-tenant-admin-gap-table.md
@@ -1,0 +1,89 @@
+# Action Center Tenant/Admin Gap Table
+
+## Status
+First-pass internal gap table updated after enterprise-operating gap wave
+
+## Purpose
+This table translates the current Action Center near-standalone readiness discussion into a concrete tenant/admin capability view.
+
+It does not authorize:
+
+- standalone launch
+- route expansion
+- separate GTM
+
+It answers only:
+
+- what tenant/admin capabilities exist today
+- what is only partially present
+- what is still missing
+- which gaps block near-standalone enterprise readiness
+
+## Reading Guide
+
+Status values:
+
+- `ready`: materially present and defensible enough to build on
+- `partial`: some real capability exists, but not yet as a coherent enterprise control
+- `not_ready`: missing or only implied in docs
+
+## Gap Table
+
+| Capability | Current status | Current evidence | Main gap | Why it matters |
+|---|---|---|---|---|
+| Tenant admin role | `partial` | Explicit admin-governance capabilities now exist in [action-center-admin-governance.ts](/C:/Users/larsh/Desktop/Business/Verisight/frontend/lib/action-center-admin-governance.ts) and are wired through [suite-access.ts](/C:/Users/larsh/Desktop/Business/Verisight/frontend/lib/suite-access.ts) | No clear top-level customer admin control model or dedicated tenant-admin surface | Near-standalone positioning needs customer-owned administration |
+| HR governance admin role | `partial` | HR/governance write resolution exists in [action-center-governance.test.ts](/C:/Users/larsh/Desktop/Business/Verisight/frontend/lib/action-center-governance.test.ts) | Present as access logic, not yet as full admin operating package | Enterprise buyers need explicit governance ownership |
+| Manager participant role | `partial` | Manager-light route participation exists in runtime and route semantics | Role exists, but not yet packaged as a full governed participant model | Manager role must stay bounded and explainable |
+| Executive viewer role | `partial` | Read-only executive readback capability now exists in [action-center-admin-governance.ts](/C:/Users/larsh/Desktop/Business/Verisight/frontend/lib/action-center-admin-governance.ts) | No clear aggregated visibility policy or runtime surface | Needed for safe sponsor/readback access |
+| Verisight/support operator role | `partial` | Verisight admin authority is visible in governance helpers and support-access logging now exists in [support-access-events/route.ts](/C:/Users/larsh/Desktop/Business/Verisight/frontend/app/api/action-center/admin/support-access-events/route.ts) | No explicit customer-safe support role package | Support access must be explainable and auditable |
+| Role-based visibility | `partial` | Current route/workspace access logic is real in [page.tsx](/C:/Users/larsh/Desktop/Business/Verisight/frontend/app/(dashboard)/action-center/page.tsx) | Visibility exists, but no complete enterprise access matrix | Near-standalone trust depends on controlled visibility |
+| Route activation approvals | `partial` | Bounded approval truth now exists in [route-activation-approvals/route.ts](/C:/Users/larsh/Desktop/Business/Verisight/frontend/app/api/action-center/admin/route-activation-approvals/route.ts), [action-center-ops-health.ts](/C:/Users/larsh/Desktop/Business/Verisight/frontend/lib/action-center-ops-health.ts), and `supabase/schema.sql` | Approval flow is still API/admin-first and not yet a complete operator package | Required before multi-route governance can be defended |
+| Route deactivation / archival controls | `not_ready` | No explicit archival control package demonstrated | No visible retirement/archive policy | Enterprise operations need controlled lifecycle beyond open/close |
+| Audit export | `partial` | Bounded export summary and export-request logging now exist in [audit-exports/route.ts](/C:/Users/larsh/Desktop/Business/Verisight/frontend/app/api/action-center/admin/audit-exports/route.ts) | Audit export exists, but only as a bounded summary scaffold | Governance reviews often require portable evidence |
+| Support access logging | `partial` | Policy layer now exists in [ACTION_CENTER_SUPPORT_ACCESS_AND_INCIDENT_MATRIX.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/ACTION_CENTER_SUPPORT_ACCESS_AND_INCIDENT_MATRIX.md), and runtime logging now exists in [support-access-events/route.ts](/C:/Users/larsh/Desktop/Business/Verisight/frontend/app/api/action-center/admin/support-access-events/route.ts) | Support involvement is now transparently recordable, but still not a mature operator workflow | Important for privacy and enterprise review |
+| Data retention controls | `partial` | Policy layer now exists in [ACTION_CENTER_RETENTION_AND_DELETION_POLICY.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/ACTION_CENTER_RETENTION_AND_DELETION_POLICY.md) | Retention is now named as Action Center operating policy, but not yet surfaced as a runtime control package | Needed for privacy and buyer trust |
+| Deletion / archival policy | `partial` | Owned policy artifact now exists in [ACTION_CENTER_RETENTION_AND_DELETION_POLICY.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/ACTION_CENTER_RETENTION_AND_DELETION_POLICY.md) | Lifecycle policy is now explicit, but not yet backed by visible deletion/archive runtime controls | Required for enterprise-operating maturity |
+| Incident process | `partial` | Reliable-ops direction exists in [2026-05-02-action-center-reliable-ops-design.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/superpowers/specs/2026-05-02-action-center-reliable-ops-design.md), and case routing now exists in [ACTION_CENTER_SUPPORT_ACCESS_AND_INCIDENT_MATRIX.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/ACTION_CENTER_SUPPORT_ACCESS_AND_INCIDENT_MATRIX.md) | Ops-health and response routing now exist directionally, but not yet as a full incident runtime model | Near-standalone readiness needs more than telemetry summaries |
+| Environment separation | `not_ready` | No explicit Action Center environment separation model was validated here | Separation may exist elsewhere, but not as Action Center readiness truth | Enterprise buyers will ask how isolated operations are handled |
+
+## Immediate Interpretation
+
+### Strongest current signals
+
+- HR/governance access logic is real
+- manager-light route participation is real
+- route/workspace access is real enough to prove this is not a free-form task board
+
+### Weakest current signals
+
+- tenant admin
+- executive viewer
+- activation approvals as a packaged operator flow
+- audit export as a mature portable evidence flow
+- support logging as a lived operating rhythm
+- retention/deletion controls
+
+These are the clearest blockers between “bounded product concept” and “near-standalone enterprise-operational readiness”.
+
+## Required Next Moves
+
+1. Use [2026-05-23-action-center-enterprise-operating-verification-sheet.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/superpowers/specs/2026-05-23-action-center-enterprise-operating-verification-sheet.md) as the capability-by-capability verification sheet against current runtime and policies.
+2. Separate what already exists elsewhere in the platform from what Action Center can currently claim as its own governed operating package using [ACTION_CENTER_RETENTION_AND_DELETION_POLICY.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/ACTION_CENTER_RETENTION_AND_DELETION_POLICY.md) and [ACTION_CENTER_SUPPORT_ACCESS_AND_INCIDENT_MATRIX.md](/C:/Users/larsh/Desktop/Business/Verisight/docs/ops/ACTION_CENTER_SUPPORT_ACCESS_AND_INCIDENT_MATRIX.md) as the current policy layer.
+3. Resolve the highest-risk blockers first:
+   - tenant admin
+   - executive viewer packaging
+   - route activation approvals as an operator flow
+   - support access logging review rhythm
+   - retention/deletion policy
+   - audit export maturity
+
+## Boundaries
+
+This table does not change Action Center product truth.
+
+It does not authorize:
+
+- standalone launch
+- route expansion
+- workflow broadening
+- broader commercial claims

--- a/frontend/app/(dashboard)/action-center/executive/page.test.ts
+++ b/frontend/app/(dashboard)/action-center/executive/page.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('action center executive readback page', () => {
+  it('keeps the page bounded to read-only governance readback', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+
+    expect(source).toContain('eyebrow="Executive readback"')
+    expect(source).toContain('title="Bestuurlijke follow-through readback"')
+    expect(source).toContain('Geen impactclaim')
+    expect(source).toContain('Route activation approvals')
+    expect(source).not.toContain('Projectboard')
+    expect(source).not.toContain('Actie aanmaken')
+  })
+})

--- a/frontend/app/(dashboard)/action-center/executive/page.tsx
+++ b/frontend/app/(dashboard)/action-center/executive/page.tsx
@@ -1,0 +1,133 @@
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import {
+  DashboardChip,
+  DashboardHero,
+  DashboardPanel,
+  DashboardSection,
+} from '@/components/dashboard/dashboard-primitives'
+import { buildActionCenterExecutiveReadback } from '@/lib/action-center-enterprise-readback'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { createClient } from '@/lib/supabase/server'
+import { loadSuiteAccessContext } from '@/lib/suite-access-server'
+
+export default async function ActionCenterExecutivePage() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/login')
+  }
+
+  const { context } = await loadSuiteAccessContext(supabase, user.id)
+
+  if (!context.canViewExecutiveReadback) {
+    redirect('/action-center')
+  }
+
+  const orgIds = [...new Set([...context.organizationIds, ...context.workspaceOrgIds])]
+  const adminClient = createAdminClient()
+  const [
+    { data: campaignsRaw },
+    { data: routeCloseoutsRaw },
+    { data: routeActivationApprovalsRaw },
+    { data: supportAccessEventsRaw },
+  ] = await Promise.all([
+    orgIds.length > 0
+      ? adminClient
+          .from('campaigns')
+          .select('id, created_at, scan_type')
+          .in('organization_id', orgIds)
+      : Promise.resolve({ data: [] }),
+    orgIds.length > 0
+      ? adminClient
+          .from('action_center_route_closeouts')
+          .select('route_id, closeout_status')
+          .in('org_id', orgIds)
+      : Promise.resolve({ data: [] }),
+    orgIds.length > 0
+      ? adminClient
+          .from('action_center_route_activation_approvals')
+          .select('route_family, approval_status, scope_value, created_at')
+          .in('org_id', orgIds)
+      : Promise.resolve({ data: [] }),
+    orgIds.length > 0
+      ? adminClient
+          .from('action_center_support_access_events')
+          .select('access_kind, access_reason, created_at')
+          .in('org_id', orgIds)
+      : Promise.resolve({ data: [] }),
+  ])
+
+  const campaigns = (campaignsRaw ?? []).filter((campaign) =>
+    campaign.scan_type === 'exit' || campaign.scan_type === 'retention',
+  )
+  const routeCloseouts = routeCloseoutsRaw ?? []
+  const now = Date.now()
+  const staleRouteCount = campaigns.filter((campaign) => {
+    const ageInDays = (now - new Date(campaign.created_at).getTime()) / (1000 * 60 * 60 * 24)
+    return ageInDays >= 45
+  }).length
+
+  const executiveReadback = buildActionCenterExecutiveReadback({
+    routeActivationApprovals: (routeActivationApprovalsRaw ?? []).map((row) => ({
+      routeFamily: row.route_family,
+      approvalStatus: row.approval_status,
+      scopeValue: row.scope_value,
+      createdAt: row.created_at,
+    })),
+    supportAccessEvents: (supportAccessEventsRaw ?? []).map((row) => ({
+      accessKind: row.access_kind,
+      accessReason: row.access_reason,
+      createdAt: row.created_at,
+    })),
+    openRouteCount: campaigns.length,
+    staleRouteCount,
+    closeoutReadyRouteCount: routeCloseouts.filter((row) => row.closeout_status === 'afgerond').length,
+  })
+
+  return (
+    <div className="space-y-6">
+      <DashboardHero
+        surface="ops"
+        tone="slate"
+        eyebrow="Executive readback"
+        title="Bestuurlijke follow-through readback"
+        description="Lees hier alleen ritme, review, closeout en governance-signalen terug. Geen impactclaim, geen manager-ranking en geen personeelsdossier."
+        meta={
+          <>
+            <DashboardChip surface="ops" label={`${executiveReadback.summaryRows[0]?.value ?? 0} open routes`} tone="slate" />
+            <DashboardChip surface="ops" label={`${executiveReadback.summaryRows[2]?.value ?? 0} closeout-ready`} tone="emerald" />
+          </>
+        }
+        actions={
+          <Link
+            href="/action-center"
+            className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+          >
+            Terug naar Action Center
+          </Link>
+        }
+      />
+
+      <DashboardSection
+        title="Bestuurlijke signalen"
+        description={executiveReadback.operatingBoundaryNote}
+      >
+        <div className="grid gap-4 lg:grid-cols-3">
+          {executiveReadback.summaryRows.map((row) => (
+            <DashboardPanel
+              key={row.label}
+              title={row.label}
+              value={`${row.value}`}
+              body={row.label === 'Route activation approvals' ? 'Route activation approvals binnen goedgekeurde routefamilies.' : 'Read-only bestuurlijke telling voor follow-through.'}
+              tone={row.label === 'Closeout-ready routes' ? 'emerald' : 'slate'}
+            />
+          ))}
+        </div>
+      </DashboardSection>
+    </div>
+  )
+}

--- a/frontend/app/(dashboard)/action-center/page.tsx
+++ b/frontend/app/(dashboard)/action-center/page.tsx
@@ -1,7 +1,13 @@
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { ActionCenterPreview } from '@/components/dashboard/action-center-preview'
-import { buildLiveActionCenterItems, getLiveActionCenterSummary } from '@/lib/action-center-live'
+import { resolveActionCenterEntryParams } from '@/lib/action-center-entry'
+import {
+  buildLiveActionCenterItems,
+  getLiveActionCenterSummary,
+  isLiveActionCenterScanType,
+} from '@/lib/action-center-live'
+import { getActionCenterReviewRhythmData } from '@/lib/action-center-review-rhythm-data'
 import { buildActionCenterRouteId } from '@/lib/action-center-route-contract'
 import { projectActionCenterRouteCloseout } from '@/lib/action-center-route-closeout'
 import {
@@ -65,9 +71,15 @@ type ActionCenterScopeRow = {
   peopleCount: number
 }
 
+type ActionCenterPageSearchParams = {
+  focus?: string | string[]
+  source?: string | string[]
+  view?: string | string[]
+}
+
 function getDisplayName(email: string | null | undefined) {
-  if (!email) return 'Verisight gebruiker'
-  const localPart = email.split('@')[0] ?? 'verisight-gebruiker'
+  if (!email) return 'Loep gebruiker'
+  const localPart = email.split('@')[0] ?? 'loep-gebruiker'
   return localPart
     .split(/[._-]/)
     .filter(Boolean)
@@ -79,8 +91,13 @@ function normalizeDepartmentLabel(value: string | null | undefined) {
   return value?.trim() || null
 }
 
-function buildDepartmentScopeValue(orgId: string, departmentLabel: string) {
-  return `${orgId}::department::${departmentLabel.toLowerCase()}`
+function normalizeDepartmentKey(value: string | null | undefined) {
+  const label = normalizeDepartmentLabel(value)
+  return label ? label.toLowerCase() : null
+}
+
+function buildDepartmentScopeValue(orgId: string, departmentKey: string) {
+  return `${orgId}::department::${departmentKey}`
 }
 
 function buildCampaignFallbackScopeValue(orgId: string, campaignId: string) {
@@ -92,18 +109,32 @@ function buildActionCenterScopes(args: {
   departmentLabels: string[]
   fallbackPeopleCount: number
 }) {
-  const departmentCounts = args.departmentLabels.reduce<Record<string, number>>((acc, label) => {
-    acc[label] = (acc[label] ?? 0) + 1
+  const departmentCounts = args.departmentLabels.reduce<Record<string, { label: string; peopleCount: number }>>((acc, label) => {
+    const departmentKey = normalizeDepartmentKey(label)
+    if (!departmentKey) {
+      return acc
+    }
+
+    const existing = acc[departmentKey]
+    if (existing) {
+      existing.peopleCount += 1
+      return acc
+    }
+
+    acc[departmentKey] = {
+      label,
+      peopleCount: 1,
+    }
     return acc
   }, {})
   const departmentEntries = Object.entries(departmentCounts)
 
   if (departmentEntries.length > 0) {
-    return departmentEntries.map<ActionCenterScopeRow>(([departmentLabel, peopleCount]) => ({
+    return departmentEntries.map<ActionCenterScopeRow>(([departmentKey, department]) => ({
       scopeType: 'department',
-      scopeValue: buildDepartmentScopeValue(args.campaign.organization_id, departmentLabel),
-      scopeLabel: departmentLabel,
-      peopleCount,
+      scopeValue: buildDepartmentScopeValue(args.campaign.organization_id, departmentKey),
+      scopeLabel: department.label,
+      peopleCount: department.peopleCount,
     }))
   }
 
@@ -136,11 +167,16 @@ function getManagerAssignment(
 export default async function ActionCenterPage({
   searchParams,
 }: {
-  searchParams?: Promise<{ focus?: string; source?: string }>
+  searchParams?: Promise<ActionCenterPageSearchParams>
 }) {
   const params = (await searchParams) ?? {}
-  const focusItemId = typeof params.focus === 'string' ? params.focus : null
-  const source = typeof params.source === 'string' ? params.source : null
+  const entry = resolveActionCenterEntryParams({
+    focus: typeof params.focus === 'string' ? params.focus : null,
+    view: typeof params.view === 'string' ? params.view : null,
+    source: typeof params.source === 'string' ? params.source : null,
+  })
+  const focusItemId = entry.focus
+  const source = entry.source
   const supabase = await createClient()
   const {
     data: { user },
@@ -416,7 +452,7 @@ export default async function ActionCenterPage({
         return {
           campaign,
           stats: statsByCampaignId.get(campaign.id) ?? null,
-          organizationName: organizationById.get(campaign.organization_id)?.name ?? 'Verisight organisatie',
+          organizationName: organizationById.get(campaign.organization_id)?.name ?? 'Loep organisatie',
           memberRole: roleByOrgId[campaign.organization_id] ?? null,
           scopeType: scope.scopeType,
           scopeValue: scope.scopeValue,
@@ -460,18 +496,35 @@ export default async function ActionCenterPage({
   const itemHrefs = context.canViewInsights
     ? Object.fromEntries(items.map((item) => [item.id, `/campaigns/${item.coreSemantics.route.campaignId}`]))
     : {}
+  const focusedItemId = focusItemId ? (items.find((item) => item.id === focusItemId)?.id ?? null) : null
+  const matchingCampaignItems = focusItemId
+    ? items.filter((item) => item.coreSemantics.route.campaignId === focusItemId)
+    : []
+  const hasAmbiguousCampaignFocus = focusedItemId === null && matchingCampaignItems.length > 1
   const initialSelectedItemId =
-    focusItemId
-      ? (items.find((item) => item.id === focusItemId)?.id ??
-        items.find((item) => item.coreSemantics.route.campaignId === focusItemId)?.id ??
-        null)
-      : items[0]?.id ?? null
+    focusedItemId ??
+    (matchingCampaignItems.length === 1 ? (matchingCampaignItems[0]?.id ?? null) : null) ??
+    (hasAmbiguousCampaignFocus ? null : (items[0]?.id ?? null))
   const workspaceSubtitle =
     source === 'campaign-detail'
       ? 'Geopend vanuit campaign detail: hier worden eigenaarschap, eerste managerstap en reviewritme expliciet.'
+      : source === 'review-moments'
+      ? 'Geopend vanuit reviewmomenten: hier blijft de gekoppelde opvolging en reviewcontext bij elkaar.'
       : summary.productCount > 0
         ? `Live opvolging over ${summary.productCount} product${summary.productCount === 1 ? '' : 'en'}`
         : 'Live opvolging'
+  const governanceReadback = await getActionCenterReviewRhythmData({
+    items,
+    now: new Date(),
+    routeScanTypeByRouteId: Object.fromEntries(
+      liveContexts
+        .filter((context) => isLiveActionCenterScanType(context.campaign.scan_type))
+        .map((context) => [
+          buildActionCenterRouteId(context.campaign.id, context.scopeValue),
+          context.campaign.scan_type,
+        ]),
+    ) as Record<string, 'exit' | 'retention' | 'leadership' | 'pulse' | 'team' | 'onboarding'>,
+  })
 
   if (items.length === 0) {
     return (
@@ -535,7 +588,7 @@ export default async function ActionCenterPage({
       <ActionCenterPreview
         initialItems={items}
         initialSelectedItemId={initialSelectedItemId}
-        initialView="overview"
+        initialView={entry.view}
         fallbackOwnerName={getDisplayName(user.email)}
         ownerOptions={ownerOptions}
         managerOptions={managerOptions}
@@ -543,6 +596,8 @@ export default async function ActionCenterPage({
         managerAssignmentEndpoint="/api/action-center/workspace-members"
         canRespondToRequests={context.canUpdateActionCenter}
         managerResponseEndpoint="/api/action-center-manager-responses"
+        routeActionEndpoint="/api/action-center-route-actions"
+        actionReviewEndpoint="/api/action-center-action-reviews"
         canCloseRoutes={context.canManageActionCenterAssignments}
         routeCloseoutEndpoint="/api/action-center-route-closeouts"
         routeFollowUpEndpoint="/api/action-center-route-follow-ups"
@@ -554,7 +609,10 @@ export default async function ActionCenterPage({
         readOnly
         itemHrefs={itemHrefs}
         hideSidebar
-        boundedOverviewOnly
+        boundedOverviewOnly={entry.view === 'overview'}
+        allowEmptyInitialSelection={hasAmbiguousCampaignFocus}
+        governanceQueue={governanceReadback.governanceQueue}
+        measurementReadback={governanceReadback.measurementReadback}
       />
     </div>
   )

--- a/frontend/app/(dashboard)/action-center/page.tsx
+++ b/frontend/app/(dashboard)/action-center/page.tsx
@@ -1,12 +1,7 @@
+import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { ActionCenterPreview } from '@/components/dashboard/action-center-preview'
-import { resolveActionCenterEntryParams } from '@/lib/action-center-entry'
-import {
-  buildLiveActionCenterItems,
-  getLiveActionCenterSummary,
-  isLiveActionCenterScanType,
-} from '@/lib/action-center-live'
-import { getActionCenterReviewRhythmData } from '@/lib/action-center-review-rhythm-data'
+import { buildLiveActionCenterItems, getLiveActionCenterSummary } from '@/lib/action-center-live'
 import { buildActionCenterRouteId } from '@/lib/action-center-route-contract'
 import { projectActionCenterRouteCloseout } from '@/lib/action-center-route-closeout'
 import {
@@ -70,15 +65,9 @@ type ActionCenterScopeRow = {
   peopleCount: number
 }
 
-type ActionCenterPageSearchParams = {
-  focus?: string | string[]
-  source?: string | string[]
-  view?: string | string[]
-}
-
 function getDisplayName(email: string | null | undefined) {
-  if (!email) return 'Loep gebruiker'
-  const localPart = email.split('@')[0] ?? 'loep-gebruiker'
+  if (!email) return 'Verisight gebruiker'
+  const localPart = email.split('@')[0] ?? 'verisight-gebruiker'
   return localPart
     .split(/[._-]/)
     .filter(Boolean)
@@ -90,13 +79,8 @@ function normalizeDepartmentLabel(value: string | null | undefined) {
   return value?.trim() || null
 }
 
-function normalizeDepartmentKey(value: string | null | undefined) {
-  const label = normalizeDepartmentLabel(value)
-  return label ? label.toLowerCase() : null
-}
-
-function buildDepartmentScopeValue(orgId: string, departmentKey: string) {
-  return `${orgId}::department::${departmentKey}`
+function buildDepartmentScopeValue(orgId: string, departmentLabel: string) {
+  return `${orgId}::department::${departmentLabel.toLowerCase()}`
 }
 
 function buildCampaignFallbackScopeValue(orgId: string, campaignId: string) {
@@ -108,32 +92,18 @@ function buildActionCenterScopes(args: {
   departmentLabels: string[]
   fallbackPeopleCount: number
 }) {
-  const departmentCounts = args.departmentLabels.reduce<Record<string, { label: string; peopleCount: number }>>((acc, label) => {
-    const departmentKey = normalizeDepartmentKey(label)
-    if (!departmentKey) {
-      return acc
-    }
-
-    const existing = acc[departmentKey]
-    if (existing) {
-      existing.peopleCount += 1
-      return acc
-    }
-
-    acc[departmentKey] = {
-      label,
-      peopleCount: 1,
-    }
+  const departmentCounts = args.departmentLabels.reduce<Record<string, number>>((acc, label) => {
+    acc[label] = (acc[label] ?? 0) + 1
     return acc
   }, {})
   const departmentEntries = Object.entries(departmentCounts)
 
   if (departmentEntries.length > 0) {
-    return departmentEntries.map<ActionCenterScopeRow>(([departmentKey, department]) => ({
+    return departmentEntries.map<ActionCenterScopeRow>(([departmentLabel, peopleCount]) => ({
       scopeType: 'department',
-      scopeValue: buildDepartmentScopeValue(args.campaign.organization_id, departmentKey),
-      scopeLabel: department.label,
-      peopleCount: department.peopleCount,
+      scopeValue: buildDepartmentScopeValue(args.campaign.organization_id, departmentLabel),
+      scopeLabel: departmentLabel,
+      peopleCount,
     }))
   }
 
@@ -166,16 +136,11 @@ function getManagerAssignment(
 export default async function ActionCenterPage({
   searchParams,
 }: {
-  searchParams?: Promise<ActionCenterPageSearchParams>
+  searchParams?: Promise<{ focus?: string; source?: string }>
 }) {
   const params = (await searchParams) ?? {}
-  const entry = resolveActionCenterEntryParams({
-    focus: typeof params.focus === 'string' ? params.focus : null,
-    view: typeof params.view === 'string' ? params.view : null,
-    source: typeof params.source === 'string' ? params.source : null,
-  })
-  const focusItemId = entry.focus
-  const source = entry.source
+  const focusItemId = typeof params.focus === 'string' ? params.focus : null
+  const source = typeof params.source === 'string' ? params.source : null
   const supabase = await createClient()
   const {
     data: { user },
@@ -248,7 +213,7 @@ export default async function ActionCenterPage({
 
   const organizations = (organizationsRaw ?? []) as Organization[]
   const campaigns = ((campaignsRaw ?? []) as Campaign[]).filter((campaign) =>
-    ['exit', 'retention', 'onboarding', 'pulse', 'leadership'].includes(campaign.scan_type),
+    ['exit', 'retention'].includes(campaign.scan_type),
   )
   const campaignIds = campaigns.map((campaign) => campaign.id)
   const stats = (statsRaw ?? []) as CampaignStats[]
@@ -451,7 +416,7 @@ export default async function ActionCenterPage({
         return {
           campaign,
           stats: statsByCampaignId.get(campaign.id) ?? null,
-          organizationName: organizationById.get(campaign.organization_id)?.name ?? 'Loep organisatie',
+          organizationName: organizationById.get(campaign.organization_id)?.name ?? 'Verisight organisatie',
           memberRole: roleByOrgId[campaign.organization_id] ?? null,
           scopeType: scope.scopeType,
           scopeValue: scope.scopeValue,
@@ -495,35 +460,18 @@ export default async function ActionCenterPage({
   const itemHrefs = context.canViewInsights
     ? Object.fromEntries(items.map((item) => [item.id, `/campaigns/${item.coreSemantics.route.campaignId}`]))
     : {}
-  const focusedItemId = focusItemId ? (items.find((item) => item.id === focusItemId)?.id ?? null) : null
-  const matchingCampaignItems = focusItemId
-    ? items.filter((item) => item.coreSemantics.route.campaignId === focusItemId)
-    : []
-  const hasAmbiguousCampaignFocus = focusedItemId === null && matchingCampaignItems.length > 1
   const initialSelectedItemId =
-    focusedItemId ??
-    (matchingCampaignItems.length === 1 ? (matchingCampaignItems[0]?.id ?? null) : null) ??
-    (hasAmbiguousCampaignFocus ? null : (items[0]?.id ?? null))
+    focusItemId
+      ? (items.find((item) => item.id === focusItemId)?.id ??
+        items.find((item) => item.coreSemantics.route.campaignId === focusItemId)?.id ??
+        null)
+      : items[0]?.id ?? null
   const workspaceSubtitle =
     source === 'campaign-detail'
       ? 'Geopend vanuit campaign detail: hier worden eigenaarschap, eerste managerstap en reviewritme expliciet.'
-      : source === 'review-moments'
-      ? 'Geopend vanuit reviewmomenten: hier blijft de gekoppelde opvolging en reviewcontext bij elkaar.'
       : summary.productCount > 0
         ? `Live opvolging over ${summary.productCount} product${summary.productCount === 1 ? '' : 'en'}`
         : 'Live opvolging'
-  const governanceReadback = await getActionCenterReviewRhythmData({
-    items,
-    now: new Date(),
-    routeScanTypeByRouteId: Object.fromEntries(
-      liveContexts
-        .filter((context) => isLiveActionCenterScanType(context.campaign.scan_type))
-        .map((context) => [
-          buildActionCenterRouteId(context.campaign.id, context.scopeValue),
-          context.campaign.scan_type,
-        ]),
-    ) as Record<string, 'exit' | 'retention' | 'leadership' | 'pulse' | 'team' | 'onboarding'>,
-  })
 
   if (items.length === 0) {
     return (
@@ -563,34 +511,51 @@ export default async function ActionCenterPage({
   }
 
   return (
-    <ActionCenterPreview
-      initialItems={items}
-      initialSelectedItemId={initialSelectedItemId}
-      initialView={entry.view}
-      fallbackOwnerName={getDisplayName(user.email)}
-      ownerOptions={ownerOptions}
-      managerOptions={managerOptions}
-      canAssignManagers={context.canManageActionCenterAssignments}
-      managerAssignmentEndpoint="/api/action-center/workspace-members"
-      canRespondToRequests={context.canUpdateActionCenter}
-      managerResponseEndpoint="/api/action-center-manager-responses"
-      routeActionEndpoint="/api/action-center-route-actions"
-      actionReviewEndpoint="/api/action-center-action-reviews"
-      canCloseRoutes={context.canManageActionCenterAssignments}
-      routeCloseoutEndpoint="/api/action-center-route-closeouts"
-      routeFollowUpEndpoint="/api/action-center-route-follow-ups"
-      currentUserId={user.id}
-      workbenchHref={context.canViewInsights ? '/dashboard' : '/action-center'}
-      workbenchLabel={context.canViewInsights ? 'Open broncampagne' : 'Blijf in Action Center'}
-      workspaceName={getDisplayName(user.email)}
-      workspaceSubtitle={workspaceSubtitle}
-      readOnly
-      itemHrefs={itemHrefs}
-      hideSidebar
-      boundedOverviewOnly={entry.view === 'overview'}
-      allowEmptyInitialSelection={hasAmbiguousCampaignFocus}
-      governanceQueue={governanceReadback.governanceQueue}
-      measurementReadback={governanceReadback.measurementReadback}
-    />
+    <div className="space-y-4">
+      {context.canViewExecutiveReadback ? (
+        <div className="rounded-[1.75rem] border border-slate-200 bg-white px-5 py-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                Executive readback
+              </p>
+              <p className="mt-1 text-sm text-slate-700">
+                Open de bestuurlijke readback voor ritme, closeout en governance-signalen. Geen impactclaim en geen manager-ranking.
+              </p>
+            </div>
+            <Link
+              href="/action-center/executive"
+              className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+            >
+              Open executive readback
+            </Link>
+          </div>
+        </div>
+      ) : null}
+      <ActionCenterPreview
+        initialItems={items}
+        initialSelectedItemId={initialSelectedItemId}
+        initialView="overview"
+        fallbackOwnerName={getDisplayName(user.email)}
+        ownerOptions={ownerOptions}
+        managerOptions={managerOptions}
+        canAssignManagers={context.canManageActionCenterAssignments}
+        managerAssignmentEndpoint="/api/action-center/workspace-members"
+        canRespondToRequests={context.canUpdateActionCenter}
+        managerResponseEndpoint="/api/action-center-manager-responses"
+        canCloseRoutes={context.canManageActionCenterAssignments}
+        routeCloseoutEndpoint="/api/action-center-route-closeouts"
+        routeFollowUpEndpoint="/api/action-center-route-follow-ups"
+        currentUserId={user.id}
+        workbenchHref={context.canViewInsights ? '/dashboard' : '/action-center'}
+        workbenchLabel={context.canViewInsights ? 'Open broncampagne' : 'Blijf in Action Center'}
+        workspaceName={getDisplayName(user.email)}
+        workspaceSubtitle={workspaceSubtitle}
+        readOnly
+        itemHrefs={itemHrefs}
+        hideSidebar
+        boundedOverviewOnly
+      />
+    </div>
   )
 }

--- a/frontend/app/(dashboard)/beheer/action-center-governance/page.test.ts
+++ b/frontend/app/(dashboard)/beheer/action-center-governance/page.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('action center governance admin page', () => {
+  it('renders a bounded tenant-admin governance surface', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+
+    expect(source).toContain('eyebrow="Tenant-admin governance"')
+    expect(source).toContain('title="Action Center governance controls"')
+    expect(source).toContain('Route activation approvals')
+    expect(source).toContain('Support access log')
+    expect(source).toContain('Audit export summary')
+    expect(source).toContain('Open onboarding rehearsal')
+  })
+})

--- a/frontend/app/(dashboard)/beheer/action-center-governance/page.tsx
+++ b/frontend/app/(dashboard)/beheer/action-center-governance/page.tsx
@@ -1,0 +1,169 @@
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import {
+  DashboardChip,
+  DashboardHero,
+  DashboardPanel,
+  DashboardSection,
+} from '@/components/dashboard/dashboard-primitives'
+import { buildActionCenterTenantAdminSummary } from '@/lib/action-center-enterprise-readback'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { createClient } from '@/lib/supabase/server'
+
+export default async function ActionCenterGovernancePage() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/login')
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('is_verisight_admin')
+    .eq('id', user.id)
+    .single()
+
+  if (profile?.is_verisight_admin !== true) {
+    redirect('/dashboard')
+  }
+
+  const adminClient = createAdminClient()
+  const [
+    { data: routeActivationApprovalsRaw },
+    { data: supportAccessEventsRaw },
+    { data: auditExportRequestsRaw },
+  ] = await Promise.all([
+    adminClient
+      .from('action_center_route_activation_approvals')
+      .select('route_family, approval_status, scope_value, created_at')
+      .order('created_at', { ascending: false })
+      .limit(8),
+    adminClient
+      .from('action_center_support_access_events')
+      .select('access_kind, access_reason, created_at')
+      .order('created_at', { ascending: false })
+      .limit(8),
+    adminClient
+      .from('action_center_audit_export_requests')
+      .select('export_scope, request_status, created_at')
+      .order('created_at', { ascending: false })
+      .limit(8),
+  ])
+
+  const summary = buildActionCenterTenantAdminSummary({
+    routeActivationApprovals: (routeActivationApprovalsRaw ?? []).map((row) => ({
+      routeFamily: row.route_family,
+      approvalStatus: row.approval_status,
+      scopeValue: row.scope_value,
+      createdAt: row.created_at,
+    })),
+    supportAccessEvents: (supportAccessEventsRaw ?? []).map((row) => ({
+      accessKind: row.access_kind,
+      accessReason: row.access_reason,
+      createdAt: row.created_at,
+    })),
+    auditExportRequests: (auditExportRequestsRaw ?? []).map((row) => ({
+      exportScope: row.export_scope,
+      requestStatus: row.request_status,
+      createdAt: row.created_at,
+    })),
+  })
+
+  return (
+    <div className="space-y-6">
+      <DashboardHero
+        surface="ops"
+        tone="slate"
+        eyebrow="Tenant-admin governance"
+        title="Action Center governance controls"
+        description="Gebruik deze bounded surface om approvals, support-access, export-signalen en de eerste operating rehearsal bij elkaar te houden. Geen generiek admin-center en geen workflowboard."
+        meta={
+          <>
+            <DashboardChip surface="ops" label={`${summary.controlCounts.routeActivationApprovals} approvals`} tone="slate" />
+            <DashboardChip surface="ops" label={`${summary.controlCounts.supportAccessEvents} support logs`} tone="amber" />
+            <DashboardChip surface="ops" label={`${summary.controlCounts.auditExportRequests} exports`} tone="emerald" />
+          </>
+        }
+        actions={
+          <>
+            <Link
+              href="/beheer/health"
+              className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+            >
+              Open health review
+            </Link>
+            <Link
+              href="/action-center/executive"
+              className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+            >
+              Open executive readback
+            </Link>
+          </>
+        }
+      />
+
+      <DashboardSection
+        title="Control counts"
+        description={summary.boundaryNote}
+      >
+        <div className="grid gap-4 lg:grid-cols-3">
+          <DashboardPanel
+            title="Route activation approvals"
+            value={`${summary.controlCounts.routeActivationApprovals}`}
+            body="Bevestigde activaties voor goedgekeurde routefamilies."
+            tone="slate"
+          />
+          <DashboardPanel
+            title="Support access log"
+            value={`${summary.controlCounts.supportAccessEvents}`}
+            body="Gelogde support-, governance-, privacy- en incidenttoegang."
+            tone="amber"
+          />
+          <DashboardPanel
+            title="Audit export summary"
+            value={`${summary.controlCounts.auditExportRequests}`}
+            body="Aantal bounded exportverzoeken voor governance-readback."
+            tone="emerald"
+          />
+        </div>
+      </DashboardSection>
+
+      <DashboardSection
+        title="Rehearsal links"
+        description="Gebruik deze docs voor de eerste HR/operator-run zonder founder-only uitleg."
+      >
+        <div className="grid gap-4 lg:grid-cols-2">
+          <DashboardPanel
+            title="Open onboarding rehearsal"
+            value="First route"
+            body="Stapsgewijze eerste route-run voor HR, manager en bounded supportcheck."
+            tone="slate"
+          />
+          <DashboardPanel
+            title="Open support scorecard"
+            value="Pass / fail"
+            body="Compacte scorecard voor support- en governance-signalen tijdens de rehearsal."
+            tone="slate"
+          />
+        </div>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <a
+            href="/beheer/action-center-governance/rehearsal"
+            className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+          >
+            Open onboarding rehearsal
+          </a>
+          <a
+            href="/beheer/action-center-governance/rehearsal"
+            className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+          >
+            Open support scorecard
+          </a>
+        </div>
+      </DashboardSection>
+    </div>
+  )
+}

--- a/frontend/app/(dashboard)/beheer/action-center-governance/rehearsal/page.test.ts
+++ b/frontend/app/(dashboard)/beheer/action-center-governance/rehearsal/page.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('action center rehearsal page', () => {
+  it('keeps the rehearsal bounded to one route family and one support drill', () => {
+    const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+
+    expect(source).toContain('eyebrow="Rehearsal pack"')
+    expect(source).toContain('title="First-route onboarding and support rehearsal"')
+    expect(source).toContain('één routefamily tegelijk')
+    expect(source).toContain('support interruption drill')
+    expect(source).not.toContain('route expansion')
+  })
+})

--- a/frontend/app/(dashboard)/beheer/action-center-governance/rehearsal/page.tsx
+++ b/frontend/app/(dashboard)/beheer/action-center-governance/rehearsal/page.tsx
@@ -1,0 +1,60 @@
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import {
+  DashboardHero,
+  DashboardPanel,
+  DashboardSection,
+} from '@/components/dashboard/dashboard-primitives'
+import { createClient } from '@/lib/supabase/server'
+
+export default async function ActionCenterRehearsalPage() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/login')
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('is_verisight_admin')
+    .eq('id', user.id)
+    .single()
+
+  if (profile?.is_verisight_admin !== true) {
+    redirect('/dashboard')
+  }
+
+  return (
+    <div className="space-y-6">
+      <DashboardHero
+        surface="ops"
+        tone="slate"
+        eyebrow="Rehearsal pack"
+        title="First-route onboarding and support rehearsal"
+        description="Gebruik deze bounded drill voor één routefamily tegelijk, met een HR-operator, een managerparticipant en precies een support interruption drill. Geen routeverbreding en geen proof-claim."
+        actions={
+          <Link
+            href="/beheer/action-center-governance"
+            className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+          >
+            Terug naar governance controls
+          </Link>
+        }
+      />
+
+      <DashboardSection
+        title="Run"
+        description="Voer eerst de HR- en managerflow uit, en pas daarna de support interruption drill."
+      >
+        <div className="grid gap-4 lg:grid-cols-3">
+          <DashboardPanel title="Stap 1" value="Preflight" body="Controleer routefamily, eigenaar, reviewmoment en closeout-grens." tone="slate" />
+          <DashboardPanel title="Stap 2" value="First route" body="Loop de eerste route door met HR en manager zonder extra uitleg buiten de pack." tone="emerald" />
+          <DashboardPanel title="Stap 3" value="Support interruption drill" body="Forceer een bounded supportvraag en leg de access-log en escalatieroute vast." tone="amber" />
+        </div>
+      </DashboardSection>
+    </div>
+  )
+}

--- a/frontend/app/(dashboard)/beheer/health/page.tsx
+++ b/frontend/app/(dashboard)/beheer/health/page.tsx
@@ -3,11 +3,13 @@ import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { DashboardChip, DashboardDisclosure, DashboardHero, DashboardPanel, DashboardSection } from '@/components/dashboard/dashboard-primitives'
 import {
+  getActionCenterAdminControlLabel,
   getActionCenterOpsEventLabel,
   summarizeActionCenterOpsHealth,
 } from '@/lib/action-center-ops-health'
 import { countSuiteTelemetryEventRows, getSuiteTelemetryEventLabel } from '@/lib/telemetry/events'
 import { listSuiteTelemetryEventRows } from '@/lib/telemetry/store'
+import { createAdminClient } from '@/lib/supabase/admin'
 import { createClient } from '@/lib/supabase/server'
 
 export default async function HealthPage() {
@@ -32,16 +34,42 @@ export default async function HealthPage() {
 
   const rows = await listSuiteTelemetryEventRows()
   const counts = countSuiteTelemetryEventRows(rows)
-  const actionCenterOps = summarizeActionCenterOpsHealth(rows)
+  const adminClient = createAdminClient()
+  const [
+    { data: routeActivationApprovalsRaw },
+    { data: supportAccessEventsRaw },
+  ] = await Promise.all([
+    adminClient
+      .from('action_center_route_activation_approvals')
+      .select('route_family, approval_status, scope_value, created_at')
+      .order('created_at', { ascending: false }),
+    adminClient
+      .from('action_center_support_access_events')
+      .select('access_kind, access_reason, created_at')
+      .order('created_at', { ascending: false }),
+  ])
+  const actionCenterOps = summarizeActionCenterOpsHealth(rows, {
+    routeActivationApprovals: (routeActivationApprovalsRaw ?? []).map((row) => ({
+      routeFamily: row.route_family,
+      approvalStatus: row.approval_status,
+      scopeValue: row.scope_value,
+      createdAt: row.created_at,
+    })),
+    supportAccessEvents: (supportAccessEventsRaw ?? []).map((row) => ({
+      accessKind: row.access_kind,
+      accessReason: row.access_reason,
+      createdAt: row.created_at,
+    })),
+  })
 
   return (
     <div className="space-y-6">
       <DashboardHero
         surface="ops"
         tone="slate"
-        eyebrow="Transition deep link"
-        title="Health transition registry"
-        description="Gebruik deze route als expert registry voor activatie, denied access en Action Center follow-through zodra een setup- of supportvraag daarom vraagt. Dit is een verdiepingslaag, geen primaire beheerbestemming."
+        eyebrow="Health review"
+        title="Suite health evidence"
+        description="Gebruik deze route als bounded health-check voor activatie, denied access en Action Center follow-through. Geen analytics-stack, wel compacte operations-evidence."
         meta={
           <>
             <DashboardChip surface="ops" label={`${counts.owner_access_confirmed} owner access`} tone="emerald" />
@@ -59,8 +87,8 @@ export default async function HealthPage() {
       />
 
       <DashboardSection
-        title="Expert registry"
-        description="Open deze deep link alleen wanneer activation evidence of follow-through coverage opnieuw gelezen moet worden."
+        title="Kernsignalen"
+        description="Gebruik de minimale signal set om wekelijks snel te zien waar activatie of follow-through begint te schuiven."
       >
         <div className="grid gap-4 lg:grid-cols-3">
           <DashboardPanel title="Owner access confirmed" value={`${counts.owner_access_confirmed}`} body="Owner-toegang bevestigd binnen de insights-shell." tone="emerald" />
@@ -88,6 +116,8 @@ export default async function HealthPage() {
               <DashboardPanel title="Managers toegewezen" value={`${actionCenterOps.ownerAssignedCount}`} body="Eigenaarschap bevestigd via Action Center telemetry." tone="slate" />
               <DashboardPanel title="Reviews gepland" value={`${actionCenterOps.reviewScheduledCount}`} body="Reviewmomenten die operations direct kan terugvinden." tone="emerald" />
               <DashboardPanel title="Closeouts vastgelegd" value={`${actionCenterOps.closeoutRecordedCount}`} body="Routes met expliciet slot in de huidige evidence." tone="slate" />
+              <DashboardPanel title="Route activatie approvals" value={`${actionCenterOps.routeActivationApprovalCount}`} body="Bounded approval truth voor route-activatie per organisatie." tone="slate" />
+              <DashboardPanel title="Support access events" value={`${actionCenterOps.supportAccessEventCount}`} body="Gelogde support-, privacy- en governance-access voor Action Center." tone="amber" />
             </div>
             <div className="rounded-[2rem] border border-slate-200 bg-white p-6">
               <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-slate-500">Kritieke flow coverage</h3>
@@ -106,6 +136,11 @@ export default async function HealthPage() {
                 {actionCenterOps.latestEventAt
                   ? new Date(actionCenterOps.latestEventAt).toLocaleString('nl-NL')
                   : 'nog niet aanwezig'}
+              </p>
+              <p className="mt-2 text-sm text-slate-600">
+                {actionCenterOps.missingControlTypes.length > 0
+                  ? `Nog niet zichtbaar in admin-readback: ${actionCenterOps.missingControlTypes.map(getActionCenterAdminControlLabel).join(', ')}.`
+                  : 'De bounded admin-controls zijn minimaal eenmaal zichtbaar in de huidige readbacklaag.'}
               </p>
             </div>
           </div>

--- a/frontend/app/(dashboard)/beheer/page.tsx
+++ b/frontend/app/(dashboard)/beheer/page.tsx
@@ -4,14 +4,22 @@ import type { ReactNode } from 'react'
 import { AddRespondentsForm } from '@/components/dashboard/add-respondents-form'
 import { ArchiveOrgButton } from '@/components/dashboard/archive-org-button'
 import { ClientAccessList } from '@/components/dashboard/client-access-list'
-import { DashboardChip, DashboardSection } from '@/components/dashboard/dashboard-primitives'
+import {
+  DashboardChip,
+  DashboardHero,
+  DashboardPanel,
+  DashboardSection,
+  DashboardSummaryBar,
+} from '@/components/dashboard/dashboard-primitives'
 import { DeleteOrgButton } from '@/components/dashboard/delete-org-button'
 import { InviteClientUserForm } from '@/components/dashboard/invite-client-user-form'
 import { NewCampaignForm } from '@/components/dashboard/new-campaign-form'
 import { NewOrgForm } from '@/components/dashboard/new-org-form'
+import { OperatorOnboardingBlueprint } from '@/components/dashboard/onboarding-panels'
 import { getDeliveryModeLabel } from '@/lib/implementation-readiness'
+import { getDeliveryCheckpointTitle, getDeliveryExceptionLabel, getDeliveryLifecycleLabel } from '@/lib/ops-delivery'
 import { createClient } from '@/lib/supabase/server'
-import { type Campaign, type CampaignStats, type Organization, type OrgInvite } from '@/lib/types'
+import { hasCampaignAddOn, REPORT_ADD_ON_LABELS, type Campaign, type CampaignStats, type Organization, type OrgInvite } from '@/lib/types'
 
 export default async function BeheerPage() {
   const supabase = await createClient()
@@ -52,7 +60,6 @@ export default async function BeheerPage() {
     : { data: [] }
 
   const campaigns = (campaignsRaw ?? []) as Campaign[]
-  const activeCampaignCount = campaigns.filter((campaign) => campaign.is_active).length
   const campaignCountByOrg = campaigns.reduce<Record<string, number>>((acc, campaign) => {
     acc[campaign.organization_id] = (acc[campaign.organization_id] ?? 0) + 1
     return acc
@@ -99,133 +106,523 @@ export default async function BeheerPage() {
   })) as OrgInvite[]
 
   const pendingInviteCount = invites.filter((invite) => !invite.accepted_at).length
+  const { data: deliveryRecordsRaw } = campaignIds.length
+    ? await supabase
+        .from('campaign_delivery_records')
+        .select('id, campaign_id, lifecycle_stage, exception_status, next_step, operator_owner, campaigns(id, name, scan_type)')
+        .in('campaign_id', campaignIds)
+        .order('updated_at', { ascending: false })
+    : { data: [] }
+
+  const deliveryRecords = (deliveryRecordsRaw ?? []) as Array<{
+    id: string
+    campaign_id: string
+    lifecycle_stage: string
+    exception_status: string
+    next_step: string | null
+    operator_owner: string | null
+    campaigns:
+      | { id: string; name: string; scan_type: 'exit' | 'retention' }
+      | { id: string; name: string; scan_type: 'exit' | 'retention' }[]
+      | null
+  }>
+  const blockedDeliveries = deliveryRecords.filter((record) => record.exception_status !== 'none')
+  const deliveryRecordIds = deliveryRecords.map((record) => record.id)
+  const { data: deliveryCheckpointsRaw } = deliveryRecordIds.length
+    ? await supabase
+        .from('campaign_delivery_checkpoints')
+        .select('id, delivery_record_id, checkpoint_key, manual_state, exception_status, last_auto_summary')
+        .in('delivery_record_id', deliveryRecordIds)
+    : { data: [] }
+  const deliveryCheckpoints = (deliveryCheckpointsRaw ?? []) as Array<{
+    id: string
+    delivery_record_id: string
+    checkpoint_key: string
+    manual_state: string
+    exception_status: string
+    last_auto_summary: string | null
+  }>
+
+  const firstValueReachedCount = deliveryRecords.filter((record) =>
+    ['first_value_reached', 'first_management_use', 'follow_up_decided', 'learning_closed'].includes(record.lifecycle_stage),
+  ).length
+  const openFollowUpCount = deliveryRecords.filter(
+    (record) => !['follow_up_decided', 'learning_closed'].includes(record.lifecycle_stage),
+  ).length
+  const deliveriesNeedingAttention = deliveryRecords
+    .filter(
+      (record) =>
+        record.exception_status !== 'none' ||
+        ['setup_in_progress', 'import_cleared', 'client_activation_pending'].includes(record.lifecycle_stage),
+    )
+    .slice(0, 4)
+  const pendingCheckpointConfirmations = deliveryCheckpoints.filter((checkpoint) => checkpoint.manual_state === 'pending')
+  const checkpointExceptions = deliveryCheckpoints.filter((checkpoint) => checkpoint.exception_status !== 'none')
+  const deliveryRecordById = Object.fromEntries(deliveryRecords.map((record) => [record.id, record]))
+  const reportDeliveryGaps = pendingCheckpointConfirmations.filter((checkpoint) => {
+    if (checkpoint.checkpoint_key !== 'report_delivery') return false
+    const record = deliveryRecordById[checkpoint.delivery_record_id]
+    return Boolean(
+      record &&
+        ['first_value_reached', 'first_management_use', 'follow_up_decided', 'learning_closed'].includes(record.lifecycle_stage),
+    )
+  })
+  const clientActivationGaps = pendingCheckpointConfirmations.filter((checkpoint) => {
+    if (checkpoint.checkpoint_key !== 'client_activation') return false
+    const record = deliveryRecordById[checkpoint.delivery_record_id]
+    return Boolean(
+      record &&
+        ['client_activation_pending', 'client_activation_confirmed', 'first_value_reached', 'first_management_use'].includes(
+          record.lifecycle_stage,
+        ),
+    )
+  })
+  const opsAttentionRows = pendingCheckpointConfirmations
+    .map((checkpoint) => {
+      const record = deliveryRecordById[checkpoint.delivery_record_id]
+      const campaign = record ? (Array.isArray(record.campaigns) ? record.campaigns[0] : record.campaigns) : null
+      if (!record || !campaign) return null
+      return {
+        checkpoint,
+        record,
+        campaign,
+      }
+    })
+    .filter(Boolean)
+    .slice(0, 6) as Array<{
+    checkpoint: {
+      id: string
+      checkpoint_key: string
+      manual_state: string
+      exception_status: string
+      last_auto_summary: string | null
+    }
+    record: (typeof deliveryRecords)[number]
+    campaign: { id: string; name: string; scan_type: 'exit' | 'retention' }
+  }>
 
   const step1Done = activeOrgs.length > 0
   const step2Done = campaigns.some((campaign) => campaign.is_active)
   const step3Done = (respondentCount ?? 0) > 0
   const step4Done = step2Done && (clientAccessCount ?? 0) > 0
+  const activeCampaignCount = campaigns.filter((campaign) => campaign.is_active).length
   const liveRespondentCount = respondentCount ?? 0
   const confirmedClientAccessCount = clientAccessCount ?? 0
   const setupProgressCount = [step1Done, step2Done, step3Done, step4Done].filter(Boolean).length
-  const selectedCampaign = campaigns.find((campaign) => campaign.is_active) ?? campaigns[0] ?? null
-  const selectedOrganization =
-    (selectedCampaign ? orgs.find((org) => org.id === selectedCampaign.organization_id) : null) ??
-    activeOrgs[0] ??
-    orgs[0] ??
-    null
 
   return (
     <div className="space-y-6">
-      <section className="rounded-[28px] border border-slate-200 bg-white px-6 py-6 shadow-[0_10px_30px_rgba(19,32,51,0.05)]">
-        <div className="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
-          <div className="space-y-3">
-            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">Admin setup</p>
-            <div className="space-y-2">
-              <h1 className="text-3xl font-semibold tracking-[-0.04em] text-slate-950">Beheer</h1>
-              <p className="max-w-2xl text-sm leading-6 text-slate-600">
-                Zet hier de klantcontext op: organisatie, campaign, respondenten en klanttoegang.
-              </p>
-            </div>
-          </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <DashboardChip surface="ops" label={`${setupProgressCount}/4 setupstappen`} tone={setupProgressCount === 4 ? 'emerald' : 'amber'} />
+      <DashboardHero
+        surface="ops"
+        tone="slate"
+        eyebrow="Adminroute voor setup"
+        title="Operationele setup"
+        description="Gebruik dit overzicht voor organisatie-setup, campaign-setup, respondentimport en klantactivatie. Buyer-facing dashboards blijven apart; dit scherm houdt Verisight-werk, handoff en open operationele acties compact scanbaar."
+        meta={
+          <>
             <DashboardChip surface="ops" label={`${activeOrgs.length} actieve organisatie${activeOrgs.length === 1 ? '' : 's'}`} />
             <DashboardChip surface="ops" label={`${activeCampaignCount} actieve campaign${activeCampaignCount === 1 ? '' : 's'}`} tone="slate" />
+            <DashboardChip
+              surface="ops"
+              label={
+                pendingInviteCount === 0
+                  ? 'Geen open activaties'
+                  : `${pendingInviteCount} activatie${pendingInviteCount === 1 ? '' : 's'} wacht`
+              }
+              tone={pendingInviteCount > 0 ? 'amber' : 'emerald'}
+            />
+          </>
+        }
+        actions={
+          <>
+            <Link
+              href="/beheer/contact-aanvragen"
+              className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+            >
+              Open contactaanvragen
+            </Link>
+            <Link
+              href="/beheer/klantlearnings"
+              className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+            >
+              Open klantlearnings
+            </Link>
+            <Link
+              href="/beheer/billing"
+              className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+            >
+              Open billing registry
+            </Link>
+            <Link
+              href="/beheer/health"
+              className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+            >
+              Open health review
+            </Link>
+            <Link
+              href="/beheer/action-center-governance"
+              className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+            >
+              Open Action Center governance
+            </Link>
+            <Link
+              href="/beheer/proof"
+              className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+            >
+              Open case proof registry
+            </Link>
+          </>
+        }
+        aside={
+          <div className="space-y-3 text-sm text-slate-700">
+            <p className="font-semibold text-slate-950">Werkvolgorde voor Verisight</p>
+            <p>1. Organisatie, 2. campaign, 3. import en uitnodiging, 4. klanttoegang bevestigen.</p>
+            <p className="text-xs leading-5 text-slate-500">
+              Geen buyer-facing premiumlaag hier: dit scherm blijft utilitair en taakgericht, ook wanneer het dezelfde dashboardprimitives gebruikt.
+            </p>
           </div>
-        </div>
-      </section>
+        }
+      />
 
-      <section className="rounded-[28px] border border-slate-900 bg-slate-950 px-6 py-5 text-white shadow-[0_14px_34px_rgba(15,23,42,0.24)]">
-        <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
-          <div className="space-y-3">
-            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-300">Setupcontext</p>
-            <div className="grid gap-3 md:grid-cols-2">
-              <div className="rounded-[20px] border border-white/10 bg-white/5 px-4 py-4">
-                <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Geselecteerde organisatie</p>
-                <p className="mt-2 text-base font-semibold text-white">{selectedOrganization?.name ?? 'Nog geen organisatie gekozen'}</p>
-                <p className="mt-1 text-sm text-slate-300">
-                  {selectedOrganization
-                    ? `${campaignCountByOrg[selectedOrganization.id] ?? 0} campaign${(campaignCountByOrg[selectedOrganization.id] ?? 0) === 1 ? '' : 's'}`
-                    : 'Maak eerst een organisatie aan'}
-                </p>
-              </div>
-              <div className="rounded-[20px] border border-white/10 bg-white/5 px-4 py-4">
-                <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Geselecteerde campaign</p>
-                <p className="mt-2 text-base font-semibold text-white">{selectedCampaign?.name ?? 'Nog geen campaign gekozen'}</p>
-                <p className="mt-1 text-sm text-slate-300">
-                  {selectedCampaign
-                    ? `${selectedCampaign.scan_type === 'exit' ? 'ExitScan' : 'RetentieScan'} · ${selectedCampaign.is_active ? 'Actief' : 'Gearchiveerd'}`
-                    : 'Respondenten en klanttoegang worden actief na campaign-keuze'}
-                </p>
-              </div>
+      <DashboardSummaryBar
+        surface="ops"
+        items={[
+          {
+            label: 'Setupvoortgang',
+            value: `${setupProgressCount}/4 stappen actief`,
+            tone: setupProgressCount === 4 ? 'emerald' : 'amber',
+          },
+          {
+            label: 'Respondenten',
+            value: `${liveRespondentCount} gekoppeld`,
+            tone: liveRespondentCount > 0 ? 'emerald' : 'slate',
+          },
+          {
+            label: 'Klanttoegang',
+            value: `${confirmedClientAccessCount} bevestigd`,
+            tone: confirmedClientAccessCount > 0 ? 'emerald' : 'slate',
+          },
+          {
+            label: 'Open aandacht',
+            value: `${blockedDeliveries.length + pendingCheckpointConfirmations.length} items`,
+            tone: blockedDeliveries.length + pendingCheckpointConfirmations.length > 0 ? 'amber' : 'slate',
+          },
+        ]}
+        anchors={[
+          { id: 'cadence', label: 'Cadence' },
+          { id: 'werkvolgorde', label: 'Werkvolgorde' },
+          { id: 'setup', label: 'Setup' },
+          { id: 'campagnes', label: 'Campagnes' },
+        ]}
+      />
+
+      <DashboardSection
+        id="cadence"
+        surface="ops"
+        eyebrow="Cadence"
+        title="Open delivery- en activatiewerk"
+        description="Gebruik deze laag om open exceptions, pending checkpoints en klantactivatie compact te scannen. Dit is operationele besturing, niet de buyer-facing managementlaag."
+        aside={
+          <DashboardChip
+            surface="ops"
+            label={
+              deliveryRecords.length === 0
+                ? 'Nog geen deliveryrecords'
+                : `${deliveryRecords.length} deliveryrecord${deliveryRecords.length === 1 ? '' : 's'}`
+            }
+            tone="slate"
+          />
+        }
+      >
+        {deliveryRecords.length === 0 ? (
+          <DashboardPanel
+            surface="ops"
+            title="Nog geen deliveryrecords zichtbaar"
+            body="Zodra een campaign deliverytracking gebruikt, verschijnen hier open lifecycle- en checkpointsignalen. Tot die tijd blijft de beheerroute vooral gericht op setup."
+            tone="slate"
+          />
+        ) : (
+          <div className="space-y-4">
+            <div className="grid gap-4 xl:grid-cols-4">
+              <DashboardPanel
+                surface="ops"
+                eyebrow="Delivery"
+                title="Actieve deliveryrecords"
+                value={`${deliveryRecords.length}`}
+                body="Elke campaign bewaart lifecycle en exception-status in dezelfde adminlaag."
+                tone="slate"
+              />
+              <DashboardPanel
+                surface="ops"
+                eyebrow="Exceptions"
+                title="Open exceptions"
+                value={`${blockedDeliveries.length}`}
+                body="Blocked, recovery en wacht-op-klant blijven zichtbaar zonder losse notities."
+                tone={blockedDeliveries.length > 0 ? 'amber' : 'slate'}
+              />
+              <DashboardPanel
+                surface="ops"
+                eyebrow="Value"
+                title="First value bereikt"
+                value={`${firstValueReachedCount}`}
+                body="Campaigns die al voorbij setup zijn en managementwaarde hebben bereikt."
+                tone={firstValueReachedCount > 0 ? 'emerald' : 'slate'}
+              />
+              <DashboardPanel
+                surface="ops"
+                eyebrow="Follow-up"
+                title="Open follow-up"
+                value={`${openFollowUpCount}`}
+                body="Campaigns zonder expliciet gesloten learning- of follow-upbesluit."
+                tone={openFollowUpCount > 0 ? 'amber' : 'slate'}
+              />
             </div>
+
+            <div className="grid gap-4 xl:grid-cols-4">
+              <DashboardPanel
+                surface="ops"
+                eyebrow="Checkpoints"
+                title="Pending confirmations"
+                value={`${pendingCheckpointConfirmations.length}`}
+                body="Handmatige bevestigingen op intake, import, activatie, report of management use."
+                tone={pendingCheckpointConfirmations.length > 0 ? 'amber' : 'slate'}
+              />
+              <DashboardPanel
+                surface="ops"
+                eyebrow="Checkpoints"
+                title="Checkpoint exceptions"
+                value={`${checkpointExceptions.length}`}
+                body="Exceptions op checkpointniveau die expliciete recovery vragen."
+                tone={checkpointExceptions.length > 0 ? 'amber' : 'slate'}
+              />
+              <DashboardPanel
+                surface="ops"
+                eyebrow="Activation"
+                title="Activation gaps"
+                value={`${clientActivationGaps.length}`}
+                body="Campaigns waar klantactivatie nog geen bevestigde afronding kent."
+                tone={clientActivationGaps.length > 0 ? 'amber' : 'slate'}
+              />
+              <DashboardPanel
+                surface="ops"
+                eyebrow="Reports"
+                title="Report gaps"
+                value={`${reportDeliveryGaps.length}`}
+                body="Campagnes die managementwaarde naderen zonder bevestigde report delivery."
+                tone={reportDeliveryGaps.length > 0 ? 'amber' : 'slate'}
+              />
+            </div>
+
+            {deliveriesNeedingAttention.length > 0 ? (
+              <div className="grid gap-3 lg:grid-cols-2">
+                {deliveriesNeedingAttention.map((record) => {
+                  const campaign = Array.isArray(record.campaigns) ? record.campaigns[0] : record.campaigns
+                  return (
+                    <div key={record.id} className="rounded-[20px] border border-slate-200 bg-white px-4 py-4 text-sm text-slate-700 shadow-[0_6px_18px_rgba(19,32,51,0.035)]">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <DashboardChip
+                          surface="ops"
+                          label={campaign?.scan_type === 'retention' ? 'RetentieScan' : 'ExitScan'}
+                          tone="slate"
+                        />
+                        <DashboardChip
+                          surface="ops"
+                          label={getDeliveryLifecycleLabel(record.lifecycle_stage as never)}
+                          tone="slate"
+                        />
+                        {record.exception_status !== 'none' ? (
+                          <DashboardChip
+                            surface="ops"
+                            label={getDeliveryExceptionLabel(record.exception_status as never)}
+                            tone="amber"
+                          />
+                        ) : null}
+                      </div>
+                      <p className="mt-3 text-sm font-semibold text-slate-950">{campaign?.name ?? 'Onbekende campaign'}</p>
+                      <p className="mt-2 leading-6 text-slate-600">
+                        {record.next_step ? `Volgende stap: ${record.next_step}` : 'Nog geen expliciete volgende stap opgeslagen.'}
+                      </p>
+                      {record.operator_owner ? (
+                        <p className="mt-2 text-xs text-slate-500">Eigenaar: {record.operator_owner}</p>
+                      ) : null}
+                      <a
+                        href={`/campaigns/${record.campaign_id}`}
+                        className="mt-3 inline-flex items-center rounded-full border border-slate-300 bg-slate-50 px-3 py-2 text-xs font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-100"
+                      >
+                        Open deliverylaag
+                      </a>
+                    </div>
+                  )
+                })}
+              </div>
+            ) : null}
+
+            {opsAttentionRows.length > 0 ? (
+              <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4">
+                <div className="flex flex-col gap-1 border-b border-slate-200 pb-3">
+                  <h3 className="text-sm font-semibold text-slate-900">Open ops loops</h3>
+                  <p className="text-sm leading-6 text-slate-500">
+                    Werk direct acceptance, escalatie en follow-through bij vanuit deze compacte lijst.
+                  </p>
+                </div>
+                <div className="mt-3 space-y-3">
+                  {opsAttentionRows.map(({ checkpoint, record, campaign }) => (
+                    <div key={checkpoint.id} className="rounded-[18px] border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <DashboardChip surface="ops" label={campaign.scan_type === 'retention' ? 'RetentieScan' : 'ExitScan'} />
+                        <DashboardChip surface="ops" label={getDeliveryLifecycleLabel(record.lifecycle_stage as never)} />
+                        <DashboardChip
+                          surface="ops"
+                          label={getDeliveryCheckpointTitle(checkpoint.checkpoint_key as never)}
+                          tone="amber"
+                        />
+                      </div>
+                      <p className="mt-3 font-semibold text-slate-950">{campaign.name}</p>
+                      <p className="mt-1 leading-6 text-slate-600">
+                        {checkpoint.last_auto_summary ??
+                          'Nog geen autosamenvatting opgeslagen; open de deliverylaag om acceptance en recovery expliciet te bevestigen.'}
+                      </p>
+                      <div className="mt-3 flex flex-wrap items-center gap-3 text-xs text-slate-500">
+                        <span>Handmatige status: nog bevestigen</span>
+                        {record.operator_owner ? <span>Eigenaar: {record.operator_owner}</span> : null}
+                      </div>
+                      <a
+                        href={`/campaigns/${record.campaign_id}`}
+                        className="mt-3 inline-flex items-center rounded-full border border-slate-300 bg-slate-50 px-3 py-2 text-xs font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-100"
+                      >
+                        Open checkpoint
+                      </a>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : null}
           </div>
+        )}
+      </DashboardSection>
+
+      <DashboardSection
+        id="werkvolgorde"
+        surface="ops"
+        eyebrow="Werkvolgorde"
+        title="Werkvolgorde voor Verisight"
+        description="Houd dezelfde assisted setupvolgorde aan over alle adminroutes heen. Dit maakt handoff, import-QA, activatie en learningregistratie sneller scanbaar zonder de buyer-facing shell te imiteren."
+        aside={<DashboardChip surface="ops" label={`${setupProgressCount}/4 setupstappen actief`} tone={step4Done ? 'emerald' : 'amber'} />}
+      >
+        <div className="space-y-5">
           <div className="flex flex-wrap items-center gap-2">
-            <DashboardChip surface="ops" label={`${liveRespondentCount} respondenten`} tone={liveRespondentCount > 0 ? 'emerald' : 'slate'} />
-            <DashboardChip surface="ops" label={`${confirmedClientAccessCount} klanttoegang`} tone={step4Done ? 'emerald' : 'amber'} />
-            <DashboardChip surface="ops" label={selectedCampaign ? 'Campaign gekozen' : 'Campaign ontbreekt'} tone={selectedCampaign ? 'emerald' : 'amber'} />
+            <StepBadge n={1} label="Organisatie" done={step1Done} />
+            <div className="h-px w-6 bg-slate-200" />
+            <StepBadge n={2} label="Campaign" done={step2Done} />
+            <div className="h-px w-6 bg-slate-200" />
+            <StepBadge n={3} label="Import & uitnodigen" done={step3Done} />
+            <div className="h-px w-6 bg-slate-200" />
+            <StepBadge n={4} label="Klanttoegang" done={step4Done} />
+          </div>
+
+          <OperatorOnboardingBlueprint />
+
+          <div className="grid gap-3 lg:grid-cols-5">
+            <DashboardPanel
+              surface="ops"
+              eyebrow="Assets"
+              title="Interne handover-assets"
+              body="Gebruik voor assisted setup de repo-checklists docs/IMPLEMENTATION_OPERATOR_CHECKLIST.md en docs/CLIENT_ONBOARDING_CHECKLIST.md."
+              tone="slate"
+            />
+            <DashboardPanel
+              surface="ops"
+              eyebrow="Learning"
+              title="Learning default"
+              body="Leg pilots en vroege klantlessen vast in /beheer/klantlearnings, zodat buyer-signalen en implementationfrictie niet in losse notities verdwijnen."
+              tone="slate"
+            />
+            <DashboardPanel
+              surface="ops"
+              eyebrow="Billing"
+              title="Billing default"
+              body="Maak contract, betaalwijze en assisted launch readiness expliciet in /beheer/billing zonder seat-, plan- of checkoutfictie."
+              tone="slate"
+            />
+            <DashboardPanel
+              surface="ops"
+              eyebrow="Health"
+              title="Health review default"
+              body="Gebruik /beheer/health voor bounded activation-, denied-access- en follow-through signalen zonder brede analytics-stack."
+              tone="slate"
+            />
+            <DashboardPanel
+              surface="ops"
+              eyebrow="Proof"
+              title="Proof ladder default"
+              body="Beweeg cases via /beheer/proof bewust van lesson_only naar public_usable in plaats van sample-output direct als klantbewijs te gebruiken."
+              tone="slate"
+            />
+            <DashboardPanel
+              surface="ops"
+              eyebrow="Acceptatie"
+              title="Bevestig echte activatie"
+              body="Behandel klanttoegang pas als afgerond wanneer activatie echt bevestigd is. Een invite versturen is start, nog geen oplevering."
+              tone="amber"
+            />
           </div>
         </div>
-      </section>
+      </DashboardSection>
 
       <DashboardSection
         id="setup"
         surface="ops"
         eyebrow="Setup"
         title="Organisatie, campaign, import en klanttoegang"
-        description="Werk de setup direct af in vaste volgorde."
+        description="Werk direct de setup af in dezelfde adminlaag. Het ritme is compacter dan het buyer-dashboard: minder framing, meer taakuitvoering."
         aside={<DashboardChip surface="ops" label={`${campaigns.length} campaign${campaigns.length === 1 ? '' : 's'} totaal`} />}
       >
-        <div className="grid gap-5">
+        <div className="grid gap-5 lg:grid-cols-2">
           <StepCard done={step1Done} number={1} title="Organisatie aanmaken">
             {orgs.length > 0 ? (
-              <div className="space-y-4">
-                <div>
+              <div className="space-y-2">
+                {orgs.map((org) => (
+                  <div key={org.id} className="flex items-start justify-between gap-3 rounded-[18px] border border-slate-200 bg-slate-50 px-3 py-3 text-sm text-slate-700">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        <span className={org.is_active ? 'text-emerald-600' : 'text-slate-400'}>{org.is_active ? '✓' : '○'}</span>
+                        <span className="font-medium text-slate-900">{org.name}</span>
+                        <span className="truncate text-xs text-slate-400">({org.slug})</span>
+                        {!org.is_active ? (
+                          <span className="rounded-full bg-slate-200 px-2 py-0.5 text-[11px] font-medium text-slate-600">
+                            Gearchiveerd
+                          </span>
+                        ) : null}
+                      </div>
+                      <p className="mt-1 text-xs text-slate-500">{campaignCountByOrg[org.id] ?? 0} campaign(s) gekoppeld</p>
+                    </div>
+                    <div className="flex items-start gap-2">
+                      <ArchiveOrgButton orgId={org.id} orgName={org.name} isActive={org.is_active} />
+                      <DeleteOrgButton orgId={org.id} orgName={org.name} campaignCount={campaignCountByOrg[org.id] ?? 0} />
+                    </div>
+                  </div>
+                ))}
+
+                {archivedOrgs.length > 0 ? (
+                  <p className="text-xs text-slate-500">
+                    Gearchiveerde organisaties blijven beschikbaar voor historie, maar horen niet meer in nieuwe setupstappen.
+                  </p>
+                ) : null}
+
+                <div className="border-t border-slate-200 pt-3">
                   <p className="mb-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Nieuwe organisatie</p>
                   <NewOrgForm />
                 </div>
-
-                <details className="rounded-[18px] border border-slate-200 bg-slate-50 px-4 py-3">
-                  <summary className="cursor-pointer list-none">
-                    <div className="flex items-center justify-between gap-3">
-                      <div>
-                        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Bestaande organisaties</p>
-                        <p className="mt-1 text-sm text-slate-600">{orgs.length} organisatie{orgs.length === 1 ? '' : 's'}</p>
-                      </div>
-                      <span className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
-                        {archivedOrgs.length > 0 ? `${archivedOrgs.length} archief` : 'Actueel'}
-                      </span>
-                    </div>
-                  </summary>
-                  <div className="mt-4 space-y-2 border-t border-slate-200 pt-4">
-                    {orgs.map((org) => (
-                      <div
-                        key={org.id}
-                        className="flex flex-col gap-3 rounded-[16px] border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 lg:flex-row lg:items-center lg:justify-between"
-                      >
-                        <div className="min-w-0">
-                          <div className="flex flex-wrap items-center gap-2">
-                            <span className={org.is_active ? 'text-emerald-600' : 'text-slate-400'}>{org.is_active ? '✓' : '○'}</span>
-                            <span className="font-medium text-slate-900">{org.name}</span>
-                            <span className="truncate text-xs text-slate-400">({org.slug})</span>
-                            {!org.is_active ? (
-                              <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[11px] font-medium text-slate-500">Archief</span>
-                            ) : null}
-                          </div>
-                          <p className="mt-1 text-xs text-slate-500">{campaignCountByOrg[org.id] ?? 0} campaign(s)</p>
-                        </div>
-                        <div className="flex flex-wrap items-center gap-2">
-                          <ArchiveOrgButton orgId={org.id} orgName={org.name} isActive={org.is_active} />
-                          <DeleteOrgButton orgId={org.id} orgName={org.name} campaignCount={campaignCountByOrg[org.id] ?? 0} />
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </details>
               </div>
             ) : (
               <div className="space-y-3">
-                <p className="text-sm leading-6 text-slate-600">Maak eerst de organisatie aan. Daarna worden campaign en vervolgstappen beschikbaar.</p>
+                <DashboardPanel
+                  surface="ops"
+                  eyebrow="Start"
+                  title="Nog geen organisaties zichtbaar"
+                  body="Maak eerst de klantorganisatie aan. Daarna worden campaign- en activatiestappen automatisch bruikbaar."
+                  tone="slate"
+                />
                 <NewOrgForm />
               </div>
             )}
@@ -239,15 +636,18 @@ export default async function BeheerPage() {
             )}
           </StepCard>
 
-          <StepCard done={step3Done} number={3} title="Respondenten importeren" span="full">
-            {!selectedCampaign ? (
-              <LockedStep message="Import wordt actief nadat je een campaign hebt gekozen." />
+          <StepCard done={step3Done} number={3} title="Respondenten importeren en uitnodigen" span="full">
+            {campaigns.length === 0 ? (
+              <LockedStep message="Maak eerst een campaign aan." />
             ) : (
-              <div className="space-y-4">
-                <div className="flex flex-wrap items-center gap-2">
-                  <DashboardChip surface="ops" label={selectedCampaign.name} tone="slate" />
-                  <DashboardChip surface="ops" label={selectedCampaign.scan_type === 'exit' ? 'ExitScan' : 'RetentieScan'} tone="slate" />
-                </div>
+              <div className="space-y-5">
+                <DashboardPanel
+                  surface="ops"
+                  eyebrow="Input"
+                  title="Import blijft assisted"
+                  body="Gebruik een klantbestand met e-mailadressen en optionele segmentvelden. Verisight doet QA en verzending; de klant blijft verantwoordelijk voor correcte input en respons."
+                  tone="slate"
+                />
 
                 {campaigns.filter((campaign) => campaign.is_active).length === 0 ? (
                   <div className="rounded-[18px] border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
@@ -257,150 +657,79 @@ export default async function BeheerPage() {
 
                 <AddRespondentsForm campaigns={campaigns} organizations={orgs} />
 
-                <details className="rounded-[18px] border border-slate-200 bg-slate-50 px-4 py-3">
-                  <summary className="cursor-pointer list-none">
-                    <div className="flex items-center justify-between gap-3">
-                      <div>
-                        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Bestaande campaigns</p>
-                        <p className="mt-1 text-sm text-slate-600">{campaigns.length} campaign{campaigns.length === 1 ? '' : 's'}</p>
-                      </div>
-                      <span className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Overzicht</span>
-                    </div>
-                  </summary>
-                  <div className="mt-4 space-y-2 border-t border-slate-200 pt-4">
-                    {campaigns.map((campaign) => (
-                      <div
-                        key={campaign.id}
-                        className="flex flex-col gap-3 rounded-[16px] border border-slate-200 bg-white px-4 py-3 lg:flex-row lg:items-center lg:justify-between"
-                      >
-                        <div className="min-w-0 flex-1">
-                          <div className="mb-1 flex flex-wrap items-center gap-2">
-                            <DashboardChip surface="ops" label={campaign.scan_type === 'exit' ? 'ExitScan' : 'RetentieScan'} />
-                            <DashboardChip surface="ops" label={getDeliveryModeLabel(campaign.delivery_mode, campaign.scan_type)} />
-                            <span className={`text-xs font-medium ${campaign.is_active ? 'text-emerald-700' : 'text-slate-400'}`}>
-                              {campaign.is_active ? '● Actief' : '○ Archief'}
-                            </span>
-                          </div>
-                          <p className="truncate text-sm font-medium text-slate-900">{campaign.name}</p>
-                          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-slate-500">
-                            <span>
-                              {new Date(campaign.created_at).toLocaleDateString('nl-NL', {
-                                day: 'numeric',
-                                month: 'short',
-                                year: 'numeric',
-                              })}
-                            </span>
-                          </div>
+                <div className="space-y-2 border-t border-slate-200 pt-3">
+                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Bestaande campaigns</p>
+                  {campaigns.map((campaign) => (
+                    <div key={campaign.id} className="flex items-center justify-between rounded-[18px] border border-slate-200 bg-slate-50 px-4 py-3">
+                      <div className="min-w-0 flex-1">
+                        <div className="mb-0.5 flex flex-wrap items-center gap-2">
+                          <DashboardChip surface="ops" label={campaign.scan_type === 'exit' ? 'ExitScan' : 'RetentieScan'} />
+                          <DashboardChip surface="ops" label={getDeliveryModeLabel(campaign.delivery_mode, campaign.scan_type)} />
+                          <span className={`text-xs font-medium ${campaign.is_active ? 'text-emerald-700' : 'text-slate-400'}`}>
+                            {campaign.is_active ? '● Actief' : '○ Gearchiveerd'}
+                          </span>
                         </div>
-                        <a
-                          href={`/campaigns/${campaign.id}`}
-                          className="flex-shrink-0 rounded-full border border-slate-300 bg-white px-3 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
-                        >
-                          {campaign.is_active ? 'Open' : 'Archief'}
-                        </a>
+                        <p className="truncate text-sm font-medium text-slate-900">{campaign.name}</p>
+                        {hasCampaignAddOn(campaign, 'segment_deep_dive') ? (
+                          <p className="mt-1 text-xs font-medium text-slate-700">
+                            Add-on actief: {REPORT_ADD_ON_LABELS.segment_deep_dive}
+                          </p>
+                        ) : null}
+                        <p className="text-xs text-slate-500">
+                          Aangemaakt{' '}
+                          {new Date(campaign.created_at).toLocaleDateString('nl-NL', {
+                            day: 'numeric',
+                            month: 'long',
+                            year: 'numeric',
+                          })}
+                        </p>
                       </div>
-                    ))}
-                  </div>
-                </details>
+                      <a
+                        href={`/campaigns/${campaign.id}`}
+                        className="ml-4 flex-shrink-0 rounded-full border border-slate-300 bg-white px-3 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+                      >
+                        {campaign.is_active ? 'Open campaign' : 'Bekijk archief'}
+                      </a>
+                    </div>
+                  ))}
+                </div>
               </div>
             )}
           </StepCard>
 
-          <StepCard done={step4Done} number={4} title="Klanttoegang activeren" span="full">
+          <StepCard done={step4Done} number={4} title="Klantdashboard activeren" span="full">
             {activeOrgs.length === 0 ? (
               <LockedStep message="Maak eerst een actieve organisatie aan of heractiveer een gearchiveerde organisatie." />
-            ) : !selectedCampaign ? (
-              <LockedStep message="Klanttoegang opent na campaign-keuze, maar blijft organisatiegebonden." />
+            ) : campaigns.filter((campaign) => campaign.is_active).length === 0 ? (
+              <LockedStep message="Maak eerst een actieve campaign aan voordat je klanttoegang activeert." />
             ) : (
-              <div className="space-y-4">
+              <div className="space-y-5">
+                <DashboardPanel
+                  surface="ops"
+                  eyebrow="Activatie"
+                  title="Bevestig dashboardtoegang pas na echte activatie"
+                  body="Nieuwe gebruikers ontvangen een activatiemail; bestaande accounts worden direct gekoppeld. Deze stap telt operationeel pas mee zodra toegang echt bevestigd is."
+                  tone="slate"
+                />
                 {pendingInviteCount > 0 && confirmedClientAccessCount === 0 ? (
                   <div className="rounded-[18px] border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
-                    Er lopen al klantactivaties, maar er is nog geen bevestigde dashboardtoegang.
+                    Er lopen al klantactivaties, maar er is nog geen bevestigde dashboardtoegang. Laat deze stap open staan tot echte activatie.
                   </div>
                 ) : null}
                 <InviteClientUserForm orgs={activeOrgs} />
-                <details className="rounded-[18px] border border-slate-200 bg-slate-50 px-4 py-3">
-                  <summary className="cursor-pointer list-none">
-                    <div className="flex flex-wrap items-center justify-between gap-3">
-                      <div>
-                        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Bestaande toegang</p>
-                        <p className="mt-1 text-sm text-slate-600">{confirmedClientAccessCount} bevestigd</p>
-                      </div>
-                      {pendingInviteCount > 0 ? (
-                        <DashboardChip surface="ops" label={`${pendingInviteCount} wacht op activatie`} tone="amber" />
-                      ) : (
-                        <span className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Overzicht</span>
-                      )}
-                    </div>
-                  </summary>
-                  <div className="mt-4 border-t border-slate-200 pt-4">
-                    <ClientAccessList invites={invites} />
+                <div className="space-y-3 border-t border-slate-200 pt-4">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Klanttoegang en uitnodigingen</p>
+                    {pendingInviteCount > 0 ? (
+                      <DashboardChip surface="ops" label={`${pendingInviteCount} wacht op activatie`} tone="amber" />
+                    ) : null}
                   </div>
-                </details>
+                  <ClientAccessList invites={invites} />
+                </div>
               </div>
             )}
           </StepCard>
         </div>
-      </DashboardSection>
-
-      <DashboardSection
-        id="werkbanken"
-        surface="ops"
-        eyebrow="Werkbanken"
-        title="Secundaire werkbanken"
-        description="Alleen na setup."
-      >
-        <div className="grid gap-3 lg:grid-cols-2">
-          <WorkbenchLinkCard
-            href="/beheer/contact-aanvragen"
-            eyebrow="Instroom"
-            title="Contact-aanvragen"
-            body="Nieuwe aanvragen."
-          />
-          <WorkbenchLinkCard
-            href="/beheer/klantlearnings"
-            eyebrow="Learning"
-            title="Klantlearnings"
-            body="Lessen en proof-context."
-          />
-        </div>
-      </DashboardSection>
-
-      <DashboardSection
-        id="operations"
-        surface="ops"
-        eyebrow="Operations"
-        title="Operations & registries"
-        description="Alleen wanneer nodig."
-      >
-        <details className="rounded-[22px] border border-slate-200 bg-white px-5 py-4 shadow-[0_8px_24px_rgba(19,32,51,0.04)]">
-          <summary className="cursor-pointer list-none">
-            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-              <p className="text-sm font-semibold text-slate-950">Open operations & registries</p>
-              <span className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Secundair</span>
-            </div>
-          </summary>
-          <div className="mt-5 grid gap-3 border-t border-slate-200 pt-5 lg:grid-cols-3">
-            <WorkbenchLinkCard
-              href="/beheer/billing"
-              eyebrow="Billing"
-              title="Billing readiness"
-              body="Contract en betaalstatus."
-            />
-            <WorkbenchLinkCard
-              href="/beheer/health"
-              eyebrow="Health"
-              title="Health-signalen"
-              body="Activatie en follow-through."
-            />
-            <WorkbenchLinkCard
-              href="/beheer/proof"
-              eyebrow="Proof"
-              title="Proof-status"
-              body="Proof-ladder en status."
-            />
-          </div>
-        </details>
       </DashboardSection>
 
       {campaignStats.length > 0 ? (
@@ -409,126 +738,110 @@ export default async function BeheerPage() {
           surface="ops"
           eyebrow="Campagnes"
           title="Campagne-statusoverzicht"
-          description="Alleen voor controle."
+          description="Respons, risicosignaal en voortgang per campaign blijven hier compact uitleesbaar voor operators en beheerders."
           aside={<DashboardChip surface="ops" label={`${campaignStats.length} campaignstats`} tone="slate" />}
         >
-          <details className="rounded-[22px] border border-slate-200 bg-white px-5 py-4 shadow-[0_8px_24px_rgba(19,32,51,0.04)]">
-            <summary className="cursor-pointer list-none">
-              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                <p className="text-sm font-semibold text-slate-950">Toon campagne-statusoverzicht</p>
-                <span className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">{campaignStats.length} campaigns</span>
-              </div>
-            </summary>
-            <div className="mt-5 overflow-x-auto border-t border-slate-200 pt-5">
-              <div className="overflow-x-auto rounded-[20px] border border-slate-200 bg-white">
-                <table className="w-full text-sm">
-                  <thead>
-                    <tr className="border-b border-slate-200 bg-slate-50 text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
-                      <th className="px-5 py-3 text-left">Campaign</th>
-                      <th className="px-5 py-3 text-left">Organisatie</th>
-                      <th className="px-5 py-3 text-center">Status</th>
-                      <th className="px-5 py-3 text-right">Uitgenodigd</th>
-                      <th className="px-5 py-3 text-right">Ingevuld</th>
-                      <th className="px-5 py-3 text-right">Respons</th>
-                      <th className="px-5 py-3 text-right">Gem. risico</th>
-                      <th className="px-4 py-3" />
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-slate-100">
-                    {campaignStats.map((stats) => {
-                      const pct = stats.completion_rate_pct ?? 0
-                      const org = orgs.find((item) => item.id === stats.organization_id)
-                      return (
-                        <tr key={stats.campaign_id} className="hover:bg-slate-50/70">
-                          <td className="px-5 py-3">
-                            <div className="font-medium text-slate-900">{stats.campaign_name}</div>
-                            <div className="mt-0.5 text-xs text-slate-500">{stats.scan_type === 'exit' ? 'ExitScan' : 'RetentieScan'}</div>
-                          </td>
-                          <td className="px-5 py-3 text-slate-600">{org?.name ?? '—'}</td>
-                          <td className="px-5 py-3 text-center">
-                            <span
-                              className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${
-                                stats.is_active ? 'bg-emerald-50 text-emerald-700' : 'bg-slate-100 text-slate-500'
+          <div className="overflow-x-auto rounded-[20px] border border-slate-200 bg-white">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-slate-200 bg-slate-50 text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                  <th className="px-5 py-3 text-left">Campaign</th>
+                  <th className="px-5 py-3 text-left">Organisatie</th>
+                  <th className="px-5 py-3 text-center">Status</th>
+                  <th className="px-5 py-3 text-right">Uitgenodigd</th>
+                  <th className="px-5 py-3 text-right">Ingevuld</th>
+                  <th className="px-5 py-3 text-right">Respons</th>
+                  <th className="px-5 py-3 text-right">Gem. risico</th>
+                  <th className="px-4 py-3" />
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100">
+                {campaignStats.map((stats) => {
+                  const pct = stats.completion_rate_pct ?? 0
+                  const org = orgs.find((item) => item.id === stats.organization_id)
+                  return (
+                    <tr key={stats.campaign_id} className="hover:bg-slate-50/70">
+                      <td className="px-5 py-3">
+                        <div className="font-medium text-slate-900">{stats.campaign_name}</div>
+                        <div className="mt-0.5 text-xs text-slate-500">
+                          {stats.scan_type === 'exit' ? 'ExitScan' : 'RetentieScan'}
+                        </div>
+                      </td>
+                      <td className="px-5 py-3 text-slate-600">{org?.name ?? '—'}</td>
+                      <td className="px-5 py-3 text-center">
+                        <span
+                          className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${
+                            stats.is_active ? 'bg-emerald-50 text-emerald-700' : 'bg-slate-100 text-slate-500'
+                          }`}
+                        >
+                          <span className={`h-1.5 w-1.5 rounded-full ${stats.is_active ? 'bg-emerald-600' : 'bg-slate-400'}`} />
+                          {stats.is_active ? 'Actief' : 'Gesloten'}
+                        </span>
+                      </td>
+                      <td className="px-5 py-3 text-right tabular-nums text-slate-700">{stats.total_invited ?? 0}</td>
+                      <td className="px-5 py-3 text-right tabular-nums text-slate-700">{stats.total_completed ?? 0}</td>
+                      <td className="px-5 py-3 text-right">
+                        <div className="flex items-center justify-end gap-2">
+                          <div className="h-1.5 w-16 overflow-hidden rounded-full bg-slate-100">
+                            <div
+                              className={`h-full rounded-full ${
+                                pct >= 60 ? 'bg-emerald-500' : pct >= 30 ? 'bg-amber-400' : 'bg-red-400'
                               }`}
-                            >
-                              <span className={`h-1.5 w-1.5 rounded-full ${stats.is_active ? 'bg-emerald-600' : 'bg-slate-400'}`} />
-                              {stats.is_active ? 'Actief' : 'Gesloten'}
-                            </span>
-                          </td>
-                          <td className="px-5 py-3 text-right tabular-nums text-slate-700">{stats.total_invited ?? 0}</td>
-                          <td className="px-5 py-3 text-right tabular-nums text-slate-700">{stats.total_completed ?? 0}</td>
-                          <td className="px-5 py-3 text-right">
-                            <div className="flex items-center justify-end gap-2">
-                              <div className="h-1.5 w-16 overflow-hidden rounded-full bg-slate-100">
-                                <div
-                                  className={`h-full rounded-full ${
-                                    pct >= 60 ? 'bg-emerald-500' : pct >= 30 ? 'bg-amber-400' : 'bg-red-400'
-                                  }`}
-                                  style={{ width: `${Math.min(pct, 100)}%` }}
-                                />
-                              </div>
-                              <span className="w-9 text-xs font-semibold tabular-nums text-slate-700">{pct}%</span>
-                            </div>
-                          </td>
-                          <td className="px-5 py-3 text-right tabular-nums text-slate-700">
-                            {stats.avg_risk_score ? (
-                              <span
-                                className={`font-semibold ${
-                                  stats.avg_risk_score >= 7
-                                    ? 'text-red-600'
-                                    : stats.avg_risk_score >= 4.5
-                                      ? 'text-amber-600'
-                                      : 'text-emerald-700'
-                                }`}
-                              >
-                                {stats.avg_risk_score.toFixed(1)}
-                              </span>
-                            ) : (
-                              <span className="text-xs text-slate-300">—</span>
-                            )}
-                          </td>
-                          <td className="px-4 py-3">
-                            <a
-                              href={`/campaigns/${stats.campaign_id}`}
-                              className="rounded-full border border-slate-300 bg-white px-3 py-2 text-xs font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
-                            >
-                              Open campaign
-                            </a>
-                          </td>
-                        </tr>
-                      )
-                    })}
-                  </tbody>
-                </table>
-              </div>
-            </div>
-          </details>
+                              style={{ width: `${Math.min(pct, 100)}%` }}
+                            />
+                          </div>
+                          <span className="w-9 text-xs font-semibold tabular-nums text-slate-700">{pct}%</span>
+                        </div>
+                      </td>
+                      <td className="px-5 py-3 text-right tabular-nums text-slate-700">
+                        {stats.avg_risk_score ? (
+                          <span
+                            className={`font-semibold ${
+                              stats.avg_risk_score >= 7
+                                ? 'text-red-600'
+                                : stats.avg_risk_score >= 4.5
+                                  ? 'text-amber-600'
+                                  : 'text-emerald-700'
+                            }`}
+                          >
+                            {stats.avg_risk_score.toFixed(1)}
+                          </span>
+                        ) : (
+                          <span className="text-xs text-slate-300">—</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3">
+                        <a
+                          href={`/campaigns/${stats.campaign_id}`}
+                          className="rounded-full border border-slate-300 bg-white px-3 py-2 text-xs font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+                        >
+                          Open campaign
+                        </a>
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
         </DashboardSection>
       ) : null}
     </div>
   )
 }
 
-function WorkbenchLinkCard({
-  href,
-  eyebrow,
-  title,
-  body,
-}: {
-  href: string
-  eyebrow: string
-  title: string
-  body: string
-}) {
+function StepBadge({ n, label, done }: { n: number; label: string; done: boolean }) {
   return (
-    <Link
-      href={href}
-      className="rounded-[20px] border border-slate-200 bg-white px-5 py-5 shadow-[0_8px_24px_rgba(19,32,51,0.04)] transition hover:border-slate-300 hover:bg-slate-50"
-    >
-      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">{eyebrow}</p>
-      <p className="mt-3 text-lg font-semibold tracking-[-0.02em] text-slate-950">{title}</p>
-      <p className="mt-3 text-sm leading-6 text-slate-600">{body}</p>
-    </Link>
+    <div className="flex items-center gap-1.5">
+      <div
+        className={`flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full text-xs font-bold ${
+          done ? 'bg-emerald-600 text-white' : 'bg-slate-200 text-slate-600'
+        }`}
+      >
+        {done ? '✓' : n}
+      </div>
+      <span className={`hidden text-xs font-medium sm:block ${done ? 'text-emerald-700' : 'text-slate-600'}`}>{label}</span>
+    </div>
   )
 }
 
@@ -567,5 +880,9 @@ function StepCard({
 }
 
 function LockedStep({ message }: { message: string }) {
-  return <div className="rounded-[18px] border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-500">{message}</div>
+  return (
+    <div className="rounded-[18px] border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-500">
+      {message}
+    </div>
+  )
 }

--- a/frontend/app/(dashboard)/beheer/page.tsx
+++ b/frontend/app/(dashboard)/beheer/page.tsx
@@ -4,22 +4,14 @@ import type { ReactNode } from 'react'
 import { AddRespondentsForm } from '@/components/dashboard/add-respondents-form'
 import { ArchiveOrgButton } from '@/components/dashboard/archive-org-button'
 import { ClientAccessList } from '@/components/dashboard/client-access-list'
-import {
-  DashboardChip,
-  DashboardHero,
-  DashboardPanel,
-  DashboardSection,
-  DashboardSummaryBar,
-} from '@/components/dashboard/dashboard-primitives'
+import { DashboardChip, DashboardSection } from '@/components/dashboard/dashboard-primitives'
 import { DeleteOrgButton } from '@/components/dashboard/delete-org-button'
 import { InviteClientUserForm } from '@/components/dashboard/invite-client-user-form'
 import { NewCampaignForm } from '@/components/dashboard/new-campaign-form'
 import { NewOrgForm } from '@/components/dashboard/new-org-form'
-import { OperatorOnboardingBlueprint } from '@/components/dashboard/onboarding-panels'
 import { getDeliveryModeLabel } from '@/lib/implementation-readiness'
-import { getDeliveryCheckpointTitle, getDeliveryExceptionLabel, getDeliveryLifecycleLabel } from '@/lib/ops-delivery'
 import { createClient } from '@/lib/supabase/server'
-import { hasCampaignAddOn, REPORT_ADD_ON_LABELS, type Campaign, type CampaignStats, type Organization, type OrgInvite } from '@/lib/types'
+import { type Campaign, type CampaignStats, type Organization, type OrgInvite } from '@/lib/types'
 
 export default async function BeheerPage() {
   const supabase = await createClient()
@@ -60,6 +52,7 @@ export default async function BeheerPage() {
     : { data: [] }
 
   const campaigns = (campaignsRaw ?? []) as Campaign[]
+  const activeCampaignCount = campaigns.filter((campaign) => campaign.is_active).length
   const campaignCountByOrg = campaigns.reduce<Record<string, number>>((acc, campaign) => {
     acc[campaign.organization_id] = (acc[campaign.organization_id] ?? 0) + 1
     return acc
@@ -106,523 +99,133 @@ export default async function BeheerPage() {
   })) as OrgInvite[]
 
   const pendingInviteCount = invites.filter((invite) => !invite.accepted_at).length
-  const { data: deliveryRecordsRaw } = campaignIds.length
-    ? await supabase
-        .from('campaign_delivery_records')
-        .select('id, campaign_id, lifecycle_stage, exception_status, next_step, operator_owner, campaigns(id, name, scan_type)')
-        .in('campaign_id', campaignIds)
-        .order('updated_at', { ascending: false })
-    : { data: [] }
-
-  const deliveryRecords = (deliveryRecordsRaw ?? []) as Array<{
-    id: string
-    campaign_id: string
-    lifecycle_stage: string
-    exception_status: string
-    next_step: string | null
-    operator_owner: string | null
-    campaigns:
-      | { id: string; name: string; scan_type: 'exit' | 'retention' }
-      | { id: string; name: string; scan_type: 'exit' | 'retention' }[]
-      | null
-  }>
-  const blockedDeliveries = deliveryRecords.filter((record) => record.exception_status !== 'none')
-  const deliveryRecordIds = deliveryRecords.map((record) => record.id)
-  const { data: deliveryCheckpointsRaw } = deliveryRecordIds.length
-    ? await supabase
-        .from('campaign_delivery_checkpoints')
-        .select('id, delivery_record_id, checkpoint_key, manual_state, exception_status, last_auto_summary')
-        .in('delivery_record_id', deliveryRecordIds)
-    : { data: [] }
-  const deliveryCheckpoints = (deliveryCheckpointsRaw ?? []) as Array<{
-    id: string
-    delivery_record_id: string
-    checkpoint_key: string
-    manual_state: string
-    exception_status: string
-    last_auto_summary: string | null
-  }>
-
-  const firstValueReachedCount = deliveryRecords.filter((record) =>
-    ['first_value_reached', 'first_management_use', 'follow_up_decided', 'learning_closed'].includes(record.lifecycle_stage),
-  ).length
-  const openFollowUpCount = deliveryRecords.filter(
-    (record) => !['follow_up_decided', 'learning_closed'].includes(record.lifecycle_stage),
-  ).length
-  const deliveriesNeedingAttention = deliveryRecords
-    .filter(
-      (record) =>
-        record.exception_status !== 'none' ||
-        ['setup_in_progress', 'import_cleared', 'client_activation_pending'].includes(record.lifecycle_stage),
-    )
-    .slice(0, 4)
-  const pendingCheckpointConfirmations = deliveryCheckpoints.filter((checkpoint) => checkpoint.manual_state === 'pending')
-  const checkpointExceptions = deliveryCheckpoints.filter((checkpoint) => checkpoint.exception_status !== 'none')
-  const deliveryRecordById = Object.fromEntries(deliveryRecords.map((record) => [record.id, record]))
-  const reportDeliveryGaps = pendingCheckpointConfirmations.filter((checkpoint) => {
-    if (checkpoint.checkpoint_key !== 'report_delivery') return false
-    const record = deliveryRecordById[checkpoint.delivery_record_id]
-    return Boolean(
-      record &&
-        ['first_value_reached', 'first_management_use', 'follow_up_decided', 'learning_closed'].includes(record.lifecycle_stage),
-    )
-  })
-  const clientActivationGaps = pendingCheckpointConfirmations.filter((checkpoint) => {
-    if (checkpoint.checkpoint_key !== 'client_activation') return false
-    const record = deliveryRecordById[checkpoint.delivery_record_id]
-    return Boolean(
-      record &&
-        ['client_activation_pending', 'client_activation_confirmed', 'first_value_reached', 'first_management_use'].includes(
-          record.lifecycle_stage,
-        ),
-    )
-  })
-  const opsAttentionRows = pendingCheckpointConfirmations
-    .map((checkpoint) => {
-      const record = deliveryRecordById[checkpoint.delivery_record_id]
-      const campaign = record ? (Array.isArray(record.campaigns) ? record.campaigns[0] : record.campaigns) : null
-      if (!record || !campaign) return null
-      return {
-        checkpoint,
-        record,
-        campaign,
-      }
-    })
-    .filter(Boolean)
-    .slice(0, 6) as Array<{
-    checkpoint: {
-      id: string
-      checkpoint_key: string
-      manual_state: string
-      exception_status: string
-      last_auto_summary: string | null
-    }
-    record: (typeof deliveryRecords)[number]
-    campaign: { id: string; name: string; scan_type: 'exit' | 'retention' }
-  }>
 
   const step1Done = activeOrgs.length > 0
   const step2Done = campaigns.some((campaign) => campaign.is_active)
   const step3Done = (respondentCount ?? 0) > 0
   const step4Done = step2Done && (clientAccessCount ?? 0) > 0
-  const activeCampaignCount = campaigns.filter((campaign) => campaign.is_active).length
   const liveRespondentCount = respondentCount ?? 0
   const confirmedClientAccessCount = clientAccessCount ?? 0
   const setupProgressCount = [step1Done, step2Done, step3Done, step4Done].filter(Boolean).length
+  const selectedCampaign = campaigns.find((campaign) => campaign.is_active) ?? campaigns[0] ?? null
+  const selectedOrganization =
+    (selectedCampaign ? orgs.find((org) => org.id === selectedCampaign.organization_id) : null) ??
+    activeOrgs[0] ??
+    orgs[0] ??
+    null
 
   return (
     <div className="space-y-6">
-      <DashboardHero
-        surface="ops"
-        tone="slate"
-        eyebrow="Adminroute voor setup"
-        title="Operationele setup"
-        description="Gebruik dit overzicht voor organisatie-setup, campaign-setup, respondentimport en klantactivatie. Buyer-facing dashboards blijven apart; dit scherm houdt Verisight-werk, handoff en open operationele acties compact scanbaar."
-        meta={
-          <>
+      <section className="rounded-[28px] border border-slate-200 bg-white px-6 py-6 shadow-[0_10px_30px_rgba(19,32,51,0.05)]">
+        <div className="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
+          <div className="space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">Admin setup</p>
+            <div className="space-y-2">
+              <h1 className="text-3xl font-semibold tracking-[-0.04em] text-slate-950">Beheer</h1>
+              <p className="max-w-2xl text-sm leading-6 text-slate-600">
+                Zet hier de klantcontext op: organisatie, campaign, respondenten en klanttoegang.
+              </p>
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <DashboardChip surface="ops" label={`${setupProgressCount}/4 setupstappen`} tone={setupProgressCount === 4 ? 'emerald' : 'amber'} />
             <DashboardChip surface="ops" label={`${activeOrgs.length} actieve organisatie${activeOrgs.length === 1 ? '' : 's'}`} />
             <DashboardChip surface="ops" label={`${activeCampaignCount} actieve campaign${activeCampaignCount === 1 ? '' : 's'}`} tone="slate" />
-            <DashboardChip
-              surface="ops"
-              label={
-                pendingInviteCount === 0
-                  ? 'Geen open activaties'
-                  : `${pendingInviteCount} activatie${pendingInviteCount === 1 ? '' : 's'} wacht`
-              }
-              tone={pendingInviteCount > 0 ? 'amber' : 'emerald'}
-            />
-          </>
-        }
-        actions={
-          <>
-            <Link
-              href="/beheer/contact-aanvragen"
-              className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
-            >
-              Open contactaanvragen
-            </Link>
-            <Link
-              href="/beheer/klantlearnings"
-              className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
-            >
-              Open klantlearnings
-            </Link>
-            <Link
-              href="/beheer/billing"
-              className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
-            >
-              Open billing registry
-            </Link>
-            <Link
-              href="/beheer/health"
-              className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
-            >
-              Open health review
-            </Link>
-            <Link
-              href="/beheer/action-center-governance"
-              className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
-            >
-              Open Action Center governance
-            </Link>
-            <Link
-              href="/beheer/proof"
-              className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
-            >
-              Open case proof registry
-            </Link>
-          </>
-        }
-        aside={
-          <div className="space-y-3 text-sm text-slate-700">
-            <p className="font-semibold text-slate-950">Werkvolgorde voor Verisight</p>
-            <p>1. Organisatie, 2. campaign, 3. import en uitnodiging, 4. klanttoegang bevestigen.</p>
-            <p className="text-xs leading-5 text-slate-500">
-              Geen buyer-facing premiumlaag hier: dit scherm blijft utilitair en taakgericht, ook wanneer het dezelfde dashboardprimitives gebruikt.
-            </p>
-          </div>
-        }
-      />
-
-      <DashboardSummaryBar
-        surface="ops"
-        items={[
-          {
-            label: 'Setupvoortgang',
-            value: `${setupProgressCount}/4 stappen actief`,
-            tone: setupProgressCount === 4 ? 'emerald' : 'amber',
-          },
-          {
-            label: 'Respondenten',
-            value: `${liveRespondentCount} gekoppeld`,
-            tone: liveRespondentCount > 0 ? 'emerald' : 'slate',
-          },
-          {
-            label: 'Klanttoegang',
-            value: `${confirmedClientAccessCount} bevestigd`,
-            tone: confirmedClientAccessCount > 0 ? 'emerald' : 'slate',
-          },
-          {
-            label: 'Open aandacht',
-            value: `${blockedDeliveries.length + pendingCheckpointConfirmations.length} items`,
-            tone: blockedDeliveries.length + pendingCheckpointConfirmations.length > 0 ? 'amber' : 'slate',
-          },
-        ]}
-        anchors={[
-          { id: 'cadence', label: 'Cadence' },
-          { id: 'werkvolgorde', label: 'Werkvolgorde' },
-          { id: 'setup', label: 'Setup' },
-          { id: 'campagnes', label: 'Campagnes' },
-        ]}
-      />
-
-      <DashboardSection
-        id="cadence"
-        surface="ops"
-        eyebrow="Cadence"
-        title="Open delivery- en activatiewerk"
-        description="Gebruik deze laag om open exceptions, pending checkpoints en klantactivatie compact te scannen. Dit is operationele besturing, niet de buyer-facing managementlaag."
-        aside={
-          <DashboardChip
-            surface="ops"
-            label={
-              deliveryRecords.length === 0
-                ? 'Nog geen deliveryrecords'
-                : `${deliveryRecords.length} deliveryrecord${deliveryRecords.length === 1 ? '' : 's'}`
-            }
-            tone="slate"
-          />
-        }
-      >
-        {deliveryRecords.length === 0 ? (
-          <DashboardPanel
-            surface="ops"
-            title="Nog geen deliveryrecords zichtbaar"
-            body="Zodra een campaign deliverytracking gebruikt, verschijnen hier open lifecycle- en checkpointsignalen. Tot die tijd blijft de beheerroute vooral gericht op setup."
-            tone="slate"
-          />
-        ) : (
-          <div className="space-y-4">
-            <div className="grid gap-4 xl:grid-cols-4">
-              <DashboardPanel
-                surface="ops"
-                eyebrow="Delivery"
-                title="Actieve deliveryrecords"
-                value={`${deliveryRecords.length}`}
-                body="Elke campaign bewaart lifecycle en exception-status in dezelfde adminlaag."
-                tone="slate"
-              />
-              <DashboardPanel
-                surface="ops"
-                eyebrow="Exceptions"
-                title="Open exceptions"
-                value={`${blockedDeliveries.length}`}
-                body="Blocked, recovery en wacht-op-klant blijven zichtbaar zonder losse notities."
-                tone={blockedDeliveries.length > 0 ? 'amber' : 'slate'}
-              />
-              <DashboardPanel
-                surface="ops"
-                eyebrow="Value"
-                title="First value bereikt"
-                value={`${firstValueReachedCount}`}
-                body="Campaigns die al voorbij setup zijn en managementwaarde hebben bereikt."
-                tone={firstValueReachedCount > 0 ? 'emerald' : 'slate'}
-              />
-              <DashboardPanel
-                surface="ops"
-                eyebrow="Follow-up"
-                title="Open follow-up"
-                value={`${openFollowUpCount}`}
-                body="Campaigns zonder expliciet gesloten learning- of follow-upbesluit."
-                tone={openFollowUpCount > 0 ? 'amber' : 'slate'}
-              />
-            </div>
-
-            <div className="grid gap-4 xl:grid-cols-4">
-              <DashboardPanel
-                surface="ops"
-                eyebrow="Checkpoints"
-                title="Pending confirmations"
-                value={`${pendingCheckpointConfirmations.length}`}
-                body="Handmatige bevestigingen op intake, import, activatie, report of management use."
-                tone={pendingCheckpointConfirmations.length > 0 ? 'amber' : 'slate'}
-              />
-              <DashboardPanel
-                surface="ops"
-                eyebrow="Checkpoints"
-                title="Checkpoint exceptions"
-                value={`${checkpointExceptions.length}`}
-                body="Exceptions op checkpointniveau die expliciete recovery vragen."
-                tone={checkpointExceptions.length > 0 ? 'amber' : 'slate'}
-              />
-              <DashboardPanel
-                surface="ops"
-                eyebrow="Activation"
-                title="Activation gaps"
-                value={`${clientActivationGaps.length}`}
-                body="Campaigns waar klantactivatie nog geen bevestigde afronding kent."
-                tone={clientActivationGaps.length > 0 ? 'amber' : 'slate'}
-              />
-              <DashboardPanel
-                surface="ops"
-                eyebrow="Reports"
-                title="Report gaps"
-                value={`${reportDeliveryGaps.length}`}
-                body="Campagnes die managementwaarde naderen zonder bevestigde report delivery."
-                tone={reportDeliveryGaps.length > 0 ? 'amber' : 'slate'}
-              />
-            </div>
-
-            {deliveriesNeedingAttention.length > 0 ? (
-              <div className="grid gap-3 lg:grid-cols-2">
-                {deliveriesNeedingAttention.map((record) => {
-                  const campaign = Array.isArray(record.campaigns) ? record.campaigns[0] : record.campaigns
-                  return (
-                    <div key={record.id} className="rounded-[20px] border border-slate-200 bg-white px-4 py-4 text-sm text-slate-700 shadow-[0_6px_18px_rgba(19,32,51,0.035)]">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <DashboardChip
-                          surface="ops"
-                          label={campaign?.scan_type === 'retention' ? 'RetentieScan' : 'ExitScan'}
-                          tone="slate"
-                        />
-                        <DashboardChip
-                          surface="ops"
-                          label={getDeliveryLifecycleLabel(record.lifecycle_stage as never)}
-                          tone="slate"
-                        />
-                        {record.exception_status !== 'none' ? (
-                          <DashboardChip
-                            surface="ops"
-                            label={getDeliveryExceptionLabel(record.exception_status as never)}
-                            tone="amber"
-                          />
-                        ) : null}
-                      </div>
-                      <p className="mt-3 text-sm font-semibold text-slate-950">{campaign?.name ?? 'Onbekende campaign'}</p>
-                      <p className="mt-2 leading-6 text-slate-600">
-                        {record.next_step ? `Volgende stap: ${record.next_step}` : 'Nog geen expliciete volgende stap opgeslagen.'}
-                      </p>
-                      {record.operator_owner ? (
-                        <p className="mt-2 text-xs text-slate-500">Eigenaar: {record.operator_owner}</p>
-                      ) : null}
-                      <a
-                        href={`/campaigns/${record.campaign_id}`}
-                        className="mt-3 inline-flex items-center rounded-full border border-slate-300 bg-slate-50 px-3 py-2 text-xs font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-100"
-                      >
-                        Open deliverylaag
-                      </a>
-                    </div>
-                  )
-                })}
-              </div>
-            ) : null}
-
-            {opsAttentionRows.length > 0 ? (
-              <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4">
-                <div className="flex flex-col gap-1 border-b border-slate-200 pb-3">
-                  <h3 className="text-sm font-semibold text-slate-900">Open ops loops</h3>
-                  <p className="text-sm leading-6 text-slate-500">
-                    Werk direct acceptance, escalatie en follow-through bij vanuit deze compacte lijst.
-                  </p>
-                </div>
-                <div className="mt-3 space-y-3">
-                  {opsAttentionRows.map(({ checkpoint, record, campaign }) => (
-                    <div key={checkpoint.id} className="rounded-[18px] border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <DashboardChip surface="ops" label={campaign.scan_type === 'retention' ? 'RetentieScan' : 'ExitScan'} />
-                        <DashboardChip surface="ops" label={getDeliveryLifecycleLabel(record.lifecycle_stage as never)} />
-                        <DashboardChip
-                          surface="ops"
-                          label={getDeliveryCheckpointTitle(checkpoint.checkpoint_key as never)}
-                          tone="amber"
-                        />
-                      </div>
-                      <p className="mt-3 font-semibold text-slate-950">{campaign.name}</p>
-                      <p className="mt-1 leading-6 text-slate-600">
-                        {checkpoint.last_auto_summary ??
-                          'Nog geen autosamenvatting opgeslagen; open de deliverylaag om acceptance en recovery expliciet te bevestigen.'}
-                      </p>
-                      <div className="mt-3 flex flex-wrap items-center gap-3 text-xs text-slate-500">
-                        <span>Handmatige status: nog bevestigen</span>
-                        {record.operator_owner ? <span>Eigenaar: {record.operator_owner}</span> : null}
-                      </div>
-                      <a
-                        href={`/campaigns/${record.campaign_id}`}
-                        className="mt-3 inline-flex items-center rounded-full border border-slate-300 bg-slate-50 px-3 py-2 text-xs font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-100"
-                      >
-                        Open checkpoint
-                      </a>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            ) : null}
-          </div>
-        )}
-      </DashboardSection>
-
-      <DashboardSection
-        id="werkvolgorde"
-        surface="ops"
-        eyebrow="Werkvolgorde"
-        title="Werkvolgorde voor Verisight"
-        description="Houd dezelfde assisted setupvolgorde aan over alle adminroutes heen. Dit maakt handoff, import-QA, activatie en learningregistratie sneller scanbaar zonder de buyer-facing shell te imiteren."
-        aside={<DashboardChip surface="ops" label={`${setupProgressCount}/4 setupstappen actief`} tone={step4Done ? 'emerald' : 'amber'} />}
-      >
-        <div className="space-y-5">
-          <div className="flex flex-wrap items-center gap-2">
-            <StepBadge n={1} label="Organisatie" done={step1Done} />
-            <div className="h-px w-6 bg-slate-200" />
-            <StepBadge n={2} label="Campaign" done={step2Done} />
-            <div className="h-px w-6 bg-slate-200" />
-            <StepBadge n={3} label="Import & uitnodigen" done={step3Done} />
-            <div className="h-px w-6 bg-slate-200" />
-            <StepBadge n={4} label="Klanttoegang" done={step4Done} />
-          </div>
-
-          <OperatorOnboardingBlueprint />
-
-          <div className="grid gap-3 lg:grid-cols-5">
-            <DashboardPanel
-              surface="ops"
-              eyebrow="Assets"
-              title="Interne handover-assets"
-              body="Gebruik voor assisted setup de repo-checklists docs/IMPLEMENTATION_OPERATOR_CHECKLIST.md en docs/CLIENT_ONBOARDING_CHECKLIST.md."
-              tone="slate"
-            />
-            <DashboardPanel
-              surface="ops"
-              eyebrow="Learning"
-              title="Learning default"
-              body="Leg pilots en vroege klantlessen vast in /beheer/klantlearnings, zodat buyer-signalen en implementationfrictie niet in losse notities verdwijnen."
-              tone="slate"
-            />
-            <DashboardPanel
-              surface="ops"
-              eyebrow="Billing"
-              title="Billing default"
-              body="Maak contract, betaalwijze en assisted launch readiness expliciet in /beheer/billing zonder seat-, plan- of checkoutfictie."
-              tone="slate"
-            />
-            <DashboardPanel
-              surface="ops"
-              eyebrow="Health"
-              title="Health review default"
-              body="Gebruik /beheer/health voor bounded activation-, denied-access- en follow-through signalen zonder brede analytics-stack."
-              tone="slate"
-            />
-            <DashboardPanel
-              surface="ops"
-              eyebrow="Proof"
-              title="Proof ladder default"
-              body="Beweeg cases via /beheer/proof bewust van lesson_only naar public_usable in plaats van sample-output direct als klantbewijs te gebruiken."
-              tone="slate"
-            />
-            <DashboardPanel
-              surface="ops"
-              eyebrow="Acceptatie"
-              title="Bevestig echte activatie"
-              body="Behandel klanttoegang pas als afgerond wanneer activatie echt bevestigd is. Een invite versturen is start, nog geen oplevering."
-              tone="amber"
-            />
           </div>
         </div>
-      </DashboardSection>
+      </section>
+
+      <section className="rounded-[28px] border border-slate-900 bg-slate-950 px-6 py-5 text-white shadow-[0_14px_34px_rgba(15,23,42,0.24)]">
+        <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
+          <div className="space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-300">Setupcontext</p>
+            <div className="grid gap-3 md:grid-cols-2">
+              <div className="rounded-[20px] border border-white/10 bg-white/5 px-4 py-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Geselecteerde organisatie</p>
+                <p className="mt-2 text-base font-semibold text-white">{selectedOrganization?.name ?? 'Nog geen organisatie gekozen'}</p>
+                <p className="mt-1 text-sm text-slate-300">
+                  {selectedOrganization
+                    ? `${campaignCountByOrg[selectedOrganization.id] ?? 0} campaign${(campaignCountByOrg[selectedOrganization.id] ?? 0) === 1 ? '' : 's'}`
+                    : 'Maak eerst een organisatie aan'}
+                </p>
+              </div>
+              <div className="rounded-[20px] border border-white/10 bg-white/5 px-4 py-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Geselecteerde campaign</p>
+                <p className="mt-2 text-base font-semibold text-white">{selectedCampaign?.name ?? 'Nog geen campaign gekozen'}</p>
+                <p className="mt-1 text-sm text-slate-300">
+                  {selectedCampaign
+                    ? `${selectedCampaign.scan_type === 'exit' ? 'ExitScan' : 'RetentieScan'} · ${selectedCampaign.is_active ? 'Actief' : 'Gearchiveerd'}`
+                    : 'Respondenten en klanttoegang worden actief na campaign-keuze'}
+                </p>
+              </div>
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <DashboardChip surface="ops" label={`${liveRespondentCount} respondenten`} tone={liveRespondentCount > 0 ? 'emerald' : 'slate'} />
+            <DashboardChip surface="ops" label={`${confirmedClientAccessCount} klanttoegang`} tone={step4Done ? 'emerald' : 'amber'} />
+            <DashboardChip surface="ops" label={selectedCampaign ? 'Campaign gekozen' : 'Campaign ontbreekt'} tone={selectedCampaign ? 'emerald' : 'amber'} />
+          </div>
+        </div>
+      </section>
 
       <DashboardSection
         id="setup"
         surface="ops"
         eyebrow="Setup"
         title="Organisatie, campaign, import en klanttoegang"
-        description="Werk direct de setup af in dezelfde adminlaag. Het ritme is compacter dan het buyer-dashboard: minder framing, meer taakuitvoering."
+        description="Werk de setup direct af in vaste volgorde."
         aside={<DashboardChip surface="ops" label={`${campaigns.length} campaign${campaigns.length === 1 ? '' : 's'} totaal`} />}
       >
-        <div className="grid gap-5 lg:grid-cols-2">
+        <div className="grid gap-5">
           <StepCard done={step1Done} number={1} title="Organisatie aanmaken">
             {orgs.length > 0 ? (
-              <div className="space-y-2">
-                {orgs.map((org) => (
-                  <div key={org.id} className="flex items-start justify-between gap-3 rounded-[18px] border border-slate-200 bg-slate-50 px-3 py-3 text-sm text-slate-700">
-                    <div className="min-w-0">
-                      <div className="flex items-center gap-2">
-                        <span className={org.is_active ? 'text-emerald-600' : 'text-slate-400'}>{org.is_active ? '✓' : '○'}</span>
-                        <span className="font-medium text-slate-900">{org.name}</span>
-                        <span className="truncate text-xs text-slate-400">({org.slug})</span>
-                        {!org.is_active ? (
-                          <span className="rounded-full bg-slate-200 px-2 py-0.5 text-[11px] font-medium text-slate-600">
-                            Gearchiveerd
-                          </span>
-                        ) : null}
-                      </div>
-                      <p className="mt-1 text-xs text-slate-500">{campaignCountByOrg[org.id] ?? 0} campaign(s) gekoppeld</p>
-                    </div>
-                    <div className="flex items-start gap-2">
-                      <ArchiveOrgButton orgId={org.id} orgName={org.name} isActive={org.is_active} />
-                      <DeleteOrgButton orgId={org.id} orgName={org.name} campaignCount={campaignCountByOrg[org.id] ?? 0} />
-                    </div>
-                  </div>
-                ))}
-
-                {archivedOrgs.length > 0 ? (
-                  <p className="text-xs text-slate-500">
-                    Gearchiveerde organisaties blijven beschikbaar voor historie, maar horen niet meer in nieuwe setupstappen.
-                  </p>
-                ) : null}
-
-                <div className="border-t border-slate-200 pt-3">
+              <div className="space-y-4">
+                <div>
                   <p className="mb-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Nieuwe organisatie</p>
                   <NewOrgForm />
                 </div>
+
+                <details className="rounded-[18px] border border-slate-200 bg-slate-50 px-4 py-3">
+                  <summary className="cursor-pointer list-none">
+                    <div className="flex items-center justify-between gap-3">
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Bestaande organisaties</p>
+                        <p className="mt-1 text-sm text-slate-600">{orgs.length} organisatie{orgs.length === 1 ? '' : 's'}</p>
+                      </div>
+                      <span className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+                        {archivedOrgs.length > 0 ? `${archivedOrgs.length} archief` : 'Actueel'}
+                      </span>
+                    </div>
+                  </summary>
+                  <div className="mt-4 space-y-2 border-t border-slate-200 pt-4">
+                    {orgs.map((org) => (
+                      <div
+                        key={org.id}
+                        className="flex flex-col gap-3 rounded-[16px] border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 lg:flex-row lg:items-center lg:justify-between"
+                      >
+                        <div className="min-w-0">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <span className={org.is_active ? 'text-emerald-600' : 'text-slate-400'}>{org.is_active ? '✓' : '○'}</span>
+                            <span className="font-medium text-slate-900">{org.name}</span>
+                            <span className="truncate text-xs text-slate-400">({org.slug})</span>
+                            {!org.is_active ? (
+                              <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[11px] font-medium text-slate-500">Archief</span>
+                            ) : null}
+                          </div>
+                          <p className="mt-1 text-xs text-slate-500">{campaignCountByOrg[org.id] ?? 0} campaign(s)</p>
+                        </div>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <ArchiveOrgButton orgId={org.id} orgName={org.name} isActive={org.is_active} />
+                          <DeleteOrgButton orgId={org.id} orgName={org.name} campaignCount={campaignCountByOrg[org.id] ?? 0} />
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </details>
               </div>
             ) : (
               <div className="space-y-3">
-                <DashboardPanel
-                  surface="ops"
-                  eyebrow="Start"
-                  title="Nog geen organisaties zichtbaar"
-                  body="Maak eerst de klantorganisatie aan. Daarna worden campaign- en activatiestappen automatisch bruikbaar."
-                  tone="slate"
-                />
+                <p className="text-sm leading-6 text-slate-600">Maak eerst de organisatie aan. Daarna worden campaign en vervolgstappen beschikbaar.</p>
                 <NewOrgForm />
               </div>
             )}
@@ -636,18 +239,15 @@ export default async function BeheerPage() {
             )}
           </StepCard>
 
-          <StepCard done={step3Done} number={3} title="Respondenten importeren en uitnodigen" span="full">
-            {campaigns.length === 0 ? (
-              <LockedStep message="Maak eerst een campaign aan." />
+          <StepCard done={step3Done} number={3} title="Respondenten importeren" span="full">
+            {!selectedCampaign ? (
+              <LockedStep message="Import wordt actief nadat je een campaign hebt gekozen." />
             ) : (
-              <div className="space-y-5">
-                <DashboardPanel
-                  surface="ops"
-                  eyebrow="Input"
-                  title="Import blijft assisted"
-                  body="Gebruik een klantbestand met e-mailadressen en optionele segmentvelden. Verisight doet QA en verzending; de klant blijft verantwoordelijk voor correcte input en respons."
-                  tone="slate"
-                />
+              <div className="space-y-4">
+                <div className="flex flex-wrap items-center gap-2">
+                  <DashboardChip surface="ops" label={selectedCampaign.name} tone="slate" />
+                  <DashboardChip surface="ops" label={selectedCampaign.scan_type === 'exit' ? 'ExitScan' : 'RetentieScan'} tone="slate" />
+                </div>
 
                 {campaigns.filter((campaign) => campaign.is_active).length === 0 ? (
                   <div className="rounded-[18px] border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
@@ -657,79 +257,156 @@ export default async function BeheerPage() {
 
                 <AddRespondentsForm campaigns={campaigns} organizations={orgs} />
 
-                <div className="space-y-2 border-t border-slate-200 pt-3">
-                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Bestaande campaigns</p>
-                  {campaigns.map((campaign) => (
-                    <div key={campaign.id} className="flex items-center justify-between rounded-[18px] border border-slate-200 bg-slate-50 px-4 py-3">
-                      <div className="min-w-0 flex-1">
-                        <div className="mb-0.5 flex flex-wrap items-center gap-2">
-                          <DashboardChip surface="ops" label={campaign.scan_type === 'exit' ? 'ExitScan' : 'RetentieScan'} />
-                          <DashboardChip surface="ops" label={getDeliveryModeLabel(campaign.delivery_mode, campaign.scan_type)} />
-                          <span className={`text-xs font-medium ${campaign.is_active ? 'text-emerald-700' : 'text-slate-400'}`}>
-                            {campaign.is_active ? '● Actief' : '○ Gearchiveerd'}
-                          </span>
-                        </div>
-                        <p className="truncate text-sm font-medium text-slate-900">{campaign.name}</p>
-                        {hasCampaignAddOn(campaign, 'segment_deep_dive') ? (
-                          <p className="mt-1 text-xs font-medium text-slate-700">
-                            Add-on actief: {REPORT_ADD_ON_LABELS.segment_deep_dive}
-                          </p>
-                        ) : null}
-                        <p className="text-xs text-slate-500">
-                          Aangemaakt{' '}
-                          {new Date(campaign.created_at).toLocaleDateString('nl-NL', {
-                            day: 'numeric',
-                            month: 'long',
-                            year: 'numeric',
-                          })}
-                        </p>
+                <details className="rounded-[18px] border border-slate-200 bg-slate-50 px-4 py-3">
+                  <summary className="cursor-pointer list-none">
+                    <div className="flex items-center justify-between gap-3">
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Bestaande campaigns</p>
+                        <p className="mt-1 text-sm text-slate-600">{campaigns.length} campaign{campaigns.length === 1 ? '' : 's'}</p>
                       </div>
-                      <a
-                        href={`/campaigns/${campaign.id}`}
-                        className="ml-4 flex-shrink-0 rounded-full border border-slate-300 bg-white px-3 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
-                      >
-                        {campaign.is_active ? 'Open campaign' : 'Bekijk archief'}
-                      </a>
+                      <span className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Overzicht</span>
                     </div>
-                  ))}
-                </div>
+                  </summary>
+                  <div className="mt-4 space-y-2 border-t border-slate-200 pt-4">
+                    {campaigns.map((campaign) => (
+                      <div
+                        key={campaign.id}
+                        className="flex flex-col gap-3 rounded-[16px] border border-slate-200 bg-white px-4 py-3 lg:flex-row lg:items-center lg:justify-between"
+                      >
+                        <div className="min-w-0 flex-1">
+                          <div className="mb-1 flex flex-wrap items-center gap-2">
+                            <DashboardChip surface="ops" label={campaign.scan_type === 'exit' ? 'ExitScan' : 'RetentieScan'} />
+                            <DashboardChip surface="ops" label={getDeliveryModeLabel(campaign.delivery_mode, campaign.scan_type)} />
+                            <span className={`text-xs font-medium ${campaign.is_active ? 'text-emerald-700' : 'text-slate-400'}`}>
+                              {campaign.is_active ? '● Actief' : '○ Archief'}
+                            </span>
+                          </div>
+                          <p className="truncate text-sm font-medium text-slate-900">{campaign.name}</p>
+                          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-slate-500">
+                            <span>
+                              {new Date(campaign.created_at).toLocaleDateString('nl-NL', {
+                                day: 'numeric',
+                                month: 'short',
+                                year: 'numeric',
+                              })}
+                            </span>
+                          </div>
+                        </div>
+                        <a
+                          href={`/campaigns/${campaign.id}`}
+                          className="flex-shrink-0 rounded-full border border-slate-300 bg-white px-3 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+                        >
+                          {campaign.is_active ? 'Open' : 'Archief'}
+                        </a>
+                      </div>
+                    ))}
+                  </div>
+                </details>
               </div>
             )}
           </StepCard>
 
-          <StepCard done={step4Done} number={4} title="Klantdashboard activeren" span="full">
+          <StepCard done={step4Done} number={4} title="Klanttoegang activeren" span="full">
             {activeOrgs.length === 0 ? (
               <LockedStep message="Maak eerst een actieve organisatie aan of heractiveer een gearchiveerde organisatie." />
-            ) : campaigns.filter((campaign) => campaign.is_active).length === 0 ? (
-              <LockedStep message="Maak eerst een actieve campaign aan voordat je klanttoegang activeert." />
+            ) : !selectedCampaign ? (
+              <LockedStep message="Klanttoegang opent na campaign-keuze, maar blijft organisatiegebonden." />
             ) : (
-              <div className="space-y-5">
-                <DashboardPanel
-                  surface="ops"
-                  eyebrow="Activatie"
-                  title="Bevestig dashboardtoegang pas na echte activatie"
-                  body="Nieuwe gebruikers ontvangen een activatiemail; bestaande accounts worden direct gekoppeld. Deze stap telt operationeel pas mee zodra toegang echt bevestigd is."
-                  tone="slate"
-                />
+              <div className="space-y-4">
                 {pendingInviteCount > 0 && confirmedClientAccessCount === 0 ? (
                   <div className="rounded-[18px] border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
-                    Er lopen al klantactivaties, maar er is nog geen bevestigde dashboardtoegang. Laat deze stap open staan tot echte activatie.
+                    Er lopen al klantactivaties, maar er is nog geen bevestigde dashboardtoegang.
                   </div>
                 ) : null}
                 <InviteClientUserForm orgs={activeOrgs} />
-                <div className="space-y-3 border-t border-slate-200 pt-4">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Klanttoegang en uitnodigingen</p>
-                    {pendingInviteCount > 0 ? (
-                      <DashboardChip surface="ops" label={`${pendingInviteCount} wacht op activatie`} tone="amber" />
-                    ) : null}
+                <details className="rounded-[18px] border border-slate-200 bg-slate-50 px-4 py-3">
+                  <summary className="cursor-pointer list-none">
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Bestaande toegang</p>
+                        <p className="mt-1 text-sm text-slate-600">{confirmedClientAccessCount} bevestigd</p>
+                      </div>
+                      {pendingInviteCount > 0 ? (
+                        <DashboardChip surface="ops" label={`${pendingInviteCount} wacht op activatie`} tone="amber" />
+                      ) : (
+                        <span className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Overzicht</span>
+                      )}
+                    </div>
+                  </summary>
+                  <div className="mt-4 border-t border-slate-200 pt-4">
+                    <ClientAccessList invites={invites} />
                   </div>
-                  <ClientAccessList invites={invites} />
-                </div>
+                </details>
               </div>
             )}
           </StepCard>
         </div>
+      </DashboardSection>
+
+      <DashboardSection
+        id="werkbanken"
+        surface="ops"
+        eyebrow="Werkbanken"
+        title="Secundaire werkbanken"
+        description="Alleen na setup."
+      >
+      <div className="grid gap-3 lg:grid-cols-2">
+        <WorkbenchLinkCard
+          href="/beheer/contact-aanvragen"
+          eyebrow="Instroom"
+          title="Contact-aanvragen"
+            body="Nieuwe aanvragen."
+          />
+        <WorkbenchLinkCard
+          href="/beheer/klantlearnings"
+          eyebrow="Learning"
+          title="Klantlearnings"
+          body="Lessen en proof-context."
+        />
+        <WorkbenchLinkCard
+          href="/beheer/action-center-governance"
+          eyebrow="Governance"
+          title="Action Center governance"
+          body="Tenant-admin controls, executive readback en bounded rehearsal."
+        />
+      </div>
+      </DashboardSection>
+
+      <DashboardSection
+        id="operations"
+        surface="ops"
+        eyebrow="Operations"
+        title="Operations & registries"
+        description="Alleen wanneer nodig."
+      >
+        <details className="rounded-[22px] border border-slate-200 bg-white px-5 py-4 shadow-[0_8px_24px_rgba(19,32,51,0.04)]">
+          <summary className="cursor-pointer list-none">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-sm font-semibold text-slate-950">Open operations & registries</p>
+              <span className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Secundair</span>
+            </div>
+          </summary>
+          <div className="mt-5 grid gap-3 border-t border-slate-200 pt-5 lg:grid-cols-3">
+            <WorkbenchLinkCard
+              href="/beheer/billing"
+              eyebrow="Billing"
+              title="Billing readiness"
+              body="Contract en betaalstatus."
+            />
+            <WorkbenchLinkCard
+              href="/beheer/health"
+              eyebrow="Health"
+              title="Health-signalen"
+              body="Activatie en follow-through."
+            />
+            <WorkbenchLinkCard
+              href="/beheer/proof"
+              eyebrow="Proof"
+              title="Proof-status"
+              body="Proof-ladder en status."
+            />
+          </div>
+        </details>
       </DashboardSection>
 
       {campaignStats.length > 0 ? (
@@ -738,110 +415,126 @@ export default async function BeheerPage() {
           surface="ops"
           eyebrow="Campagnes"
           title="Campagne-statusoverzicht"
-          description="Respons, risicosignaal en voortgang per campaign blijven hier compact uitleesbaar voor operators en beheerders."
+          description="Alleen voor controle."
           aside={<DashboardChip surface="ops" label={`${campaignStats.length} campaignstats`} tone="slate" />}
         >
-          <div className="overflow-x-auto rounded-[20px] border border-slate-200 bg-white">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b border-slate-200 bg-slate-50 text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
-                  <th className="px-5 py-3 text-left">Campaign</th>
-                  <th className="px-5 py-3 text-left">Organisatie</th>
-                  <th className="px-5 py-3 text-center">Status</th>
-                  <th className="px-5 py-3 text-right">Uitgenodigd</th>
-                  <th className="px-5 py-3 text-right">Ingevuld</th>
-                  <th className="px-5 py-3 text-right">Respons</th>
-                  <th className="px-5 py-3 text-right">Gem. risico</th>
-                  <th className="px-4 py-3" />
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-slate-100">
-                {campaignStats.map((stats) => {
-                  const pct = stats.completion_rate_pct ?? 0
-                  const org = orgs.find((item) => item.id === stats.organization_id)
-                  return (
-                    <tr key={stats.campaign_id} className="hover:bg-slate-50/70">
-                      <td className="px-5 py-3">
-                        <div className="font-medium text-slate-900">{stats.campaign_name}</div>
-                        <div className="mt-0.5 text-xs text-slate-500">
-                          {stats.scan_type === 'exit' ? 'ExitScan' : 'RetentieScan'}
-                        </div>
-                      </td>
-                      <td className="px-5 py-3 text-slate-600">{org?.name ?? '—'}</td>
-                      <td className="px-5 py-3 text-center">
-                        <span
-                          className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${
-                            stats.is_active ? 'bg-emerald-50 text-emerald-700' : 'bg-slate-100 text-slate-500'
-                          }`}
-                        >
-                          <span className={`h-1.5 w-1.5 rounded-full ${stats.is_active ? 'bg-emerald-600' : 'bg-slate-400'}`} />
-                          {stats.is_active ? 'Actief' : 'Gesloten'}
-                        </span>
-                      </td>
-                      <td className="px-5 py-3 text-right tabular-nums text-slate-700">{stats.total_invited ?? 0}</td>
-                      <td className="px-5 py-3 text-right tabular-nums text-slate-700">{stats.total_completed ?? 0}</td>
-                      <td className="px-5 py-3 text-right">
-                        <div className="flex items-center justify-end gap-2">
-                          <div className="h-1.5 w-16 overflow-hidden rounded-full bg-slate-100">
-                            <div
-                              className={`h-full rounded-full ${
-                                pct >= 60 ? 'bg-emerald-500' : pct >= 30 ? 'bg-amber-400' : 'bg-red-400'
-                              }`}
-                              style={{ width: `${Math.min(pct, 100)}%` }}
-                            />
-                          </div>
-                          <span className="w-9 text-xs font-semibold tabular-nums text-slate-700">{pct}%</span>
-                        </div>
-                      </td>
-                      <td className="px-5 py-3 text-right tabular-nums text-slate-700">
-                        {stats.avg_risk_score ? (
-                          <span
-                            className={`font-semibold ${
-                              stats.avg_risk_score >= 7
-                                ? 'text-red-600'
-                                : stats.avg_risk_score >= 4.5
-                                  ? 'text-amber-600'
-                                  : 'text-emerald-700'
-                            }`}
-                          >
-                            {stats.avg_risk_score.toFixed(1)}
-                          </span>
-                        ) : (
-                          <span className="text-xs text-slate-300">—</span>
-                        )}
-                      </td>
-                      <td className="px-4 py-3">
-                        <a
-                          href={`/campaigns/${stats.campaign_id}`}
-                          className="rounded-full border border-slate-300 bg-white px-3 py-2 text-xs font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
-                        >
-                          Open campaign
-                        </a>
-                      </td>
+          <details className="rounded-[22px] border border-slate-200 bg-white px-5 py-4 shadow-[0_8px_24px_rgba(19,32,51,0.04)]">
+            <summary className="cursor-pointer list-none">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <p className="text-sm font-semibold text-slate-950">Toon campagne-statusoverzicht</p>
+                <span className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">{campaignStats.length} campaigns</span>
+              </div>
+            </summary>
+            <div className="mt-5 overflow-x-auto border-t border-slate-200 pt-5">
+              <div className="overflow-x-auto rounded-[20px] border border-slate-200 bg-white">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-slate-200 bg-slate-50 text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                      <th className="px-5 py-3 text-left">Campaign</th>
+                      <th className="px-5 py-3 text-left">Organisatie</th>
+                      <th className="px-5 py-3 text-center">Status</th>
+                      <th className="px-5 py-3 text-right">Uitgenodigd</th>
+                      <th className="px-5 py-3 text-right">Ingevuld</th>
+                      <th className="px-5 py-3 text-right">Respons</th>
+                      <th className="px-5 py-3 text-right">Gem. risico</th>
+                      <th className="px-4 py-3" />
                     </tr>
-                  )
-                })}
-              </tbody>
-            </table>
-          </div>
+                  </thead>
+                  <tbody className="divide-y divide-slate-100">
+                    {campaignStats.map((stats) => {
+                      const pct = stats.completion_rate_pct ?? 0
+                      const org = orgs.find((item) => item.id === stats.organization_id)
+                      return (
+                        <tr key={stats.campaign_id} className="hover:bg-slate-50/70">
+                          <td className="px-5 py-3">
+                            <div className="font-medium text-slate-900">{stats.campaign_name}</div>
+                            <div className="mt-0.5 text-xs text-slate-500">{stats.scan_type === 'exit' ? 'ExitScan' : 'RetentieScan'}</div>
+                          </td>
+                          <td className="px-5 py-3 text-slate-600">{org?.name ?? '—'}</td>
+                          <td className="px-5 py-3 text-center">
+                            <span
+                              className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${
+                                stats.is_active ? 'bg-emerald-50 text-emerald-700' : 'bg-slate-100 text-slate-500'
+                              }`}
+                            >
+                              <span className={`h-1.5 w-1.5 rounded-full ${stats.is_active ? 'bg-emerald-600' : 'bg-slate-400'}`} />
+                              {stats.is_active ? 'Actief' : 'Gesloten'}
+                            </span>
+                          </td>
+                          <td className="px-5 py-3 text-right tabular-nums text-slate-700">{stats.total_invited ?? 0}</td>
+                          <td className="px-5 py-3 text-right tabular-nums text-slate-700">{stats.total_completed ?? 0}</td>
+                          <td className="px-5 py-3 text-right">
+                            <div className="flex items-center justify-end gap-2">
+                              <div className="h-1.5 w-16 overflow-hidden rounded-full bg-slate-100">
+                                <div
+                                  className={`h-full rounded-full ${
+                                    pct >= 60 ? 'bg-emerald-500' : pct >= 30 ? 'bg-amber-400' : 'bg-red-400'
+                                  }`}
+                                  style={{ width: `${Math.min(pct, 100)}%` }}
+                                />
+                              </div>
+                              <span className="w-9 text-xs font-semibold tabular-nums text-slate-700">{pct}%</span>
+                            </div>
+                          </td>
+                          <td className="px-5 py-3 text-right tabular-nums text-slate-700">
+                            {stats.avg_risk_score ? (
+                              <span
+                                className={`font-semibold ${
+                                  stats.avg_risk_score >= 7
+                                    ? 'text-red-600'
+                                    : stats.avg_risk_score >= 4.5
+                                      ? 'text-amber-600'
+                                      : 'text-emerald-700'
+                                }`}
+                              >
+                                {stats.avg_risk_score.toFixed(1)}
+                              </span>
+                            ) : (
+                              <span className="text-xs text-slate-300">—</span>
+                            )}
+                          </td>
+                          <td className="px-4 py-3">
+                            <a
+                              href={`/campaigns/${stats.campaign_id}`}
+                              className="rounded-full border border-slate-300 bg-white px-3 py-2 text-xs font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+                            >
+                              Open campaign
+                            </a>
+                          </td>
+                        </tr>
+                      )
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </details>
         </DashboardSection>
       ) : null}
     </div>
   )
 }
 
-function StepBadge({ n, label, done }: { n: number; label: string; done: boolean }) {
+function WorkbenchLinkCard({
+  href,
+  eyebrow,
+  title,
+  body,
+}: {
+  href: string
+  eyebrow: string
+  title: string
+  body: string
+}) {
   return (
-    <div className="flex items-center gap-1.5">
-      <div
-        className={`flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full text-xs font-bold ${
-          done ? 'bg-emerald-600 text-white' : 'bg-slate-200 text-slate-600'
-        }`}
-      >
-        {done ? '✓' : n}
-      </div>
-      <span className={`hidden text-xs font-medium sm:block ${done ? 'text-emerald-700' : 'text-slate-600'}`}>{label}</span>
-    </div>
+    <Link
+      href={href}
+      className="rounded-[20px] border border-slate-200 bg-white px-5 py-5 shadow-[0_8px_24px_rgba(19,32,51,0.04)] transition hover:border-slate-300 hover:bg-slate-50"
+    >
+      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">{eyebrow}</p>
+      <p className="mt-3 text-lg font-semibold tracking-[-0.02em] text-slate-950">{title}</p>
+      <p className="mt-3 text-sm leading-6 text-slate-600">{body}</p>
+    </Link>
   )
 }
 
@@ -880,9 +573,5 @@ function StepCard({
 }
 
 function LockedStep({ message }: { message: string }) {
-  return (
-    <div className="rounded-[18px] border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-500">
-      {message}
-    </div>
-  )
+  return <div className="rounded-[18px] border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-500">{message}</div>
 }

--- a/frontend/app/api/action-center/admin/audit-exports/route.test.ts
+++ b/frontend/app/api/action-center/admin/audit-exports/route.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockGetUser, mockLoadSuiteAccessContext, mockAdminFrom } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockLoadSuiteAccessContext: vi.fn(),
+  mockAdminFrom: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: async () => ({
+    auth: {
+      getUser: mockGetUser,
+    },
+  }),
+}))
+
+vi.mock('@/lib/suite-access-server', () => ({
+  loadSuiteAccessContext: mockLoadSuiteAccessContext,
+}))
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: () => ({
+    from: mockAdminFrom,
+  }),
+}))
+
+import { GET } from './route'
+
+function makeRequest(url = 'http://localhost/api/action-center/admin/audit-exports?orgId=org-1') {
+  return new Request(url, { method: 'GET' })
+}
+
+function createSelectManyQuery(result: { data: unknown; error: unknown }) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    order: vi.fn().mockResolvedValue(result),
+  }
+}
+
+function createInsertQuery(result: { data: unknown; error: unknown }) {
+  return {
+    insert: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue(result),
+  }
+}
+
+describe('action center audit exports route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns a bounded audit export summary instead of raw unrestricted dumps', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'admin-1' } },
+    })
+    mockLoadSuiteAccessContext.mockResolvedValue({
+      context: {
+        isVerisightAdmin: true,
+        canRequestAuditExport: true,
+        organizationIds: [],
+        workspaceOrgIds: [],
+      },
+      orgMemberships: [],
+      workspaceMemberships: [],
+    })
+
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === 'action_center_route_activation_approvals') {
+        return createSelectManyQuery({
+          data: [
+            {
+              route_family: 'exit',
+              approval_status: 'approved',
+              scope_value: 'org-1::department::operations',
+              created_at: '2026-05-23T09:00:00.000Z',
+            },
+          ],
+          error: null,
+        })
+      }
+
+      if (table === 'action_center_support_access_events') {
+        return createSelectManyQuery({
+          data: [
+            {
+              access_kind: 'support',
+              access_reason: 'Investigate route state',
+              created_at: '2026-05-23T09:10:00.000Z',
+            },
+          ],
+          error: null,
+        })
+      }
+
+      if (table === 'action_center_audit_export_requests') {
+        return createInsertQuery({
+          data: { id: 'export-1' },
+          error: null,
+        })
+      }
+
+      throw new Error(`Unexpected table ${table}`)
+    })
+
+    const response = await GET(makeRequest())
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      routeActivations: expect.any(Array),
+      supportAccessEvents: expect.any(Array),
+    })
+  })
+})

--- a/frontend/app/api/action-center/admin/audit-exports/route.ts
+++ b/frontend/app/api/action-center/admin/audit-exports/route.ts
@@ -1,0 +1,100 @@
+import { NextResponse } from 'next/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { createClient } from '@/lib/supabase/server'
+import { loadSuiteAccessContext } from '@/lib/suite-access-server'
+import { canAccessActionCenterAdminOrg } from '../../../../../lib/action-center-admin-governance'
+
+export async function GET(request: Request) {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ detail: 'Niet ingelogd.' }, { status: 401 })
+  }
+
+  const { context } = await loadSuiteAccessContext(supabase, user.id)
+  const { searchParams } = new URL(request.url)
+  const orgId = searchParams.get('orgId')?.trim() ?? null
+
+  if (!orgId) {
+    return NextResponse.json({ detail: 'orgId is verplicht.' }, { status: 400 })
+  }
+
+  if (!context.canRequestAuditExport) {
+    return NextResponse.json({ detail: 'Alleen bounded tenant-admin actors mogen audit exports opvragen.' }, { status: 403 })
+  }
+
+  if (
+    !canAccessActionCenterAdminOrg({
+      isVerisightAdmin: context.isVerisightAdmin,
+      organizationIds: context.organizationIds,
+      workspaceOrgIds: context.workspaceOrgIds,
+      orgId,
+    })
+  ) {
+    return NextResponse.json({ detail: 'Geen toegang tot deze organisatie voor audit export readback.' }, { status: 403 })
+  }
+
+  const adminClient = createAdminClient()
+  const { error: requestError } = await adminClient
+    .from('action_center_audit_export_requests')
+    .insert({
+      org_id: orgId,
+      requested_by: user.id,
+      export_scope: 'bounded_summary',
+      request_status: 'generated',
+    })
+    .select('*')
+    .single()
+
+  if (requestError) {
+    return NextResponse.json({ detail: requestError.message }, { status: 500 })
+  }
+
+  const [
+    { data: routeActivationsRaw, error: routeActivationsError },
+    { data: supportAccessEventsRaw, error: supportAccessEventsError },
+  ] = await Promise.all([
+    adminClient
+      .from('action_center_route_activation_approvals')
+      .select('route_family, approval_status, scope_value, created_at')
+      .eq('org_id', orgId)
+      .order('created_at', { ascending: false }),
+    adminClient
+      .from('action_center_support_access_events')
+      .select('access_kind, access_reason, created_at')
+      .eq('org_id', orgId)
+      .order('created_at', { ascending: false }),
+  ])
+
+  if (routeActivationsError || supportAccessEventsError) {
+    return NextResponse.json(
+      {
+        detail:
+          routeActivationsError?.message ??
+          supportAccessEventsError?.message ??
+          'Audit export readback laden mislukt.',
+      },
+      { status: 500 },
+    )
+  }
+
+  return NextResponse.json(
+    {
+      routeActivations: (routeActivationsRaw ?? []).map((row) => ({
+        routeFamily: row.route_family,
+        approvalStatus: row.approval_status,
+        scopeValue: row.scope_value,
+        createdAt: row.created_at,
+      })),
+      supportAccessEvents: (supportAccessEventsRaw ?? []).map((row) => ({
+        accessKind: row.access_kind,
+        accessReason: row.access_reason,
+        createdAt: row.created_at,
+      })),
+    },
+    { status: 200 },
+  )
+}

--- a/frontend/app/api/action-center/admin/route-activation-approvals/route.test.ts
+++ b/frontend/app/api/action-center/admin/route-activation-approvals/route.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockGetUser, mockLoadSuiteAccessContext, mockAdminFrom } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockLoadSuiteAccessContext: vi.fn(),
+  mockAdminFrom: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: async () => ({
+    auth: {
+      getUser: mockGetUser,
+    },
+  }),
+}))
+
+vi.mock('@/lib/suite-access-server', () => ({
+  loadSuiteAccessContext: mockLoadSuiteAccessContext,
+}))
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: () => ({
+    from: mockAdminFrom,
+  }),
+}))
+
+import { POST } from './route'
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/action-center/admin/route-activation-approvals', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+}
+
+function createUpsertQuery(result: { data: unknown; error: unknown }) {
+  return {
+    upsert: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue(result),
+  }
+}
+
+describe('action center route activation approvals route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('rejects route activation approval writes from non-admin actors', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'customer-owner-1' } },
+    })
+    mockLoadSuiteAccessContext.mockResolvedValue({
+      context: {
+        isVerisightAdmin: false,
+        canApproveRouteActivation: false,
+        organizationIds: ['org-1'],
+        workspaceOrgIds: [],
+      },
+      orgMemberships: [{ org_id: 'org-1', role: 'owner' }],
+      workspaceMemberships: [],
+    })
+
+    const response = await POST(
+      makeRequest({
+        orgId: 'org-1',
+        routeFamily: 'exit',
+        scopeValue: 'org-1::department::operations',
+      }),
+    )
+
+    expect(response.status).toBe(403)
+  })
+
+  it('stores a bounded approval record for approved route families', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'admin-1' } },
+    })
+    mockLoadSuiteAccessContext.mockResolvedValue({
+      context: {
+        isVerisightAdmin: true,
+        canApproveRouteActivation: true,
+        organizationIds: [],
+        workspaceOrgIds: [],
+      },
+      orgMemberships: [],
+      workspaceMemberships: [],
+    })
+
+    const upsertQuery = createUpsertQuery({
+      data: {
+        id: 'approval-1',
+        org_id: 'org-1',
+        route_family: 'exit',
+        scope_value: 'org-1::department::operations',
+        requested_by: 'admin-1',
+        approved_by: 'admin-1',
+        approval_status: 'approved',
+        rationale: 'Enterprise operating approval',
+        created_at: '2026-05-23T09:00:00.000Z',
+      },
+      error: null,
+    })
+
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === 'action_center_route_activation_approvals') {
+        return upsertQuery
+      }
+
+      throw new Error(`Unexpected table ${table}`)
+    })
+
+    const response = await POST(
+      makeRequest({
+        orgId: 'org-1',
+        routeFamily: 'exit',
+        scopeValue: 'org-1::department::operations',
+        rationale: 'Enterprise operating approval',
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(upsertQuery.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        org_id: 'org-1',
+        route_family: 'exit',
+        scope_value: 'org-1::department::operations',
+        requested_by: 'admin-1',
+        approved_by: 'admin-1',
+        approval_status: 'approved',
+        rationale: 'Enterprise operating approval',
+      }),
+      { onConflict: 'org_id,route_family,scope_value' },
+    )
+
+    await expect(response.json()).resolves.toMatchObject({
+      approval: {
+        routeFamily: 'exit',
+        approvalStatus: 'approved',
+      },
+    })
+  })
+})

--- a/frontend/app/api/action-center/admin/route-activation-approvals/route.ts
+++ b/frontend/app/api/action-center/admin/route-activation-approvals/route.ts
@@ -1,0 +1,118 @@
+import { NextResponse } from 'next/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { createClient } from '@/lib/supabase/server'
+import { loadSuiteAccessContext } from '@/lib/suite-access-server'
+import {
+  ACTION_CENTER_APPROVED_ROUTE_FAMILIES,
+  canAccessActionCenterAdminOrg,
+  type ActionCenterApprovedRouteFamily,
+} from '../../../../../lib/action-center-admin-governance'
+
+type RouteActivationApprovalBody = {
+  orgId?: string
+  routeFamily?: string
+  scopeValue?: string
+  rationale?: string | null
+}
+
+function normalizeText(value: string | null | undefined) {
+  const trimmed = value?.trim() ?? ''
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function parseBody(body: RouteActivationApprovalBody | null) {
+  const orgId = normalizeText(body?.orgId)
+  const routeFamily = normalizeText(body?.routeFamily) as ActionCenterApprovedRouteFamily | null
+  const scopeValue = normalizeText(body?.scopeValue)
+  const rationale = normalizeText(body?.rationale)
+
+  if (
+    !orgId ||
+    !scopeValue ||
+    !routeFamily ||
+    !ACTION_CENTER_APPROVED_ROUTE_FAMILIES.includes(routeFamily)
+  ) {
+    throw new Error('Ongeldige route activation approval input.')
+  }
+
+  return {
+    orgId,
+    routeFamily,
+    scopeValue,
+    rationale,
+  }
+}
+
+export async function POST(request: Request) {
+  const body = (await request.json().catch(() => null)) as RouteActivationApprovalBody | null
+
+  let parsed
+  try {
+    parsed = parseBody(body)
+  } catch {
+    return NextResponse.json({ detail: 'Ongeldige route activation approval input.' }, { status: 400 })
+  }
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ detail: 'Niet ingelogd.' }, { status: 401 })
+  }
+
+  const { context } = await loadSuiteAccessContext(supabase, user.id)
+
+  if (!context.canApproveRouteActivation) {
+    return NextResponse.json({ detail: 'Alleen bounded tenant-admin actors mogen route activatie goedkeuren.' }, { status: 403 })
+  }
+
+  if (
+    !canAccessActionCenterAdminOrg({
+      isVerisightAdmin: context.isVerisightAdmin,
+      organizationIds: context.organizationIds,
+      workspaceOrgIds: context.workspaceOrgIds,
+      orgId: parsed.orgId,
+    })
+  ) {
+    return NextResponse.json({ detail: 'Geen toegang tot deze organisatie voor route activatie.' }, { status: 403 })
+  }
+
+  const adminClient = createAdminClient()
+  const { data, error } = await adminClient
+    .from('action_center_route_activation_approvals')
+    .upsert(
+      {
+        org_id: parsed.orgId,
+        route_family: parsed.routeFamily,
+        scope_value: parsed.scopeValue,
+        requested_by: user.id,
+        approved_by: user.id,
+        approval_status: 'approved',
+        rationale: parsed.rationale,
+        updated_by: user.id,
+      },
+      { onConflict: 'org_id,route_family,scope_value' },
+    )
+    .select('*')
+    .single()
+
+  if (error || !data) {
+    return NextResponse.json({ detail: error?.message ?? 'Route activation approval opslaan mislukt.' }, { status: 500 })
+  }
+
+  return NextResponse.json(
+    {
+      approval: {
+        id: data.id,
+        routeFamily: data.route_family,
+        approvalStatus: data.approval_status,
+        scopeValue: data.scope_value,
+        rationale: data.rationale,
+        createdAt: data.created_at,
+      },
+    },
+    { status: 200 },
+  )
+}

--- a/frontend/app/api/action-center/admin/support-access-events/route.test.ts
+++ b/frontend/app/api/action-center/admin/support-access-events/route.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockGetUser, mockLoadSuiteAccessContext, mockAdminFrom } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockLoadSuiteAccessContext: vi.fn(),
+  mockAdminFrom: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: async () => ({
+    auth: {
+      getUser: mockGetUser,
+    },
+  }),
+}))
+
+vi.mock('@/lib/suite-access-server', () => ({
+  loadSuiteAccessContext: mockLoadSuiteAccessContext,
+}))
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: () => ({
+    from: mockAdminFrom,
+  }),
+}))
+
+import { POST } from './route'
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/action-center/admin/support-access-events', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+}
+
+function createInsertQuery(result: { data: unknown; error: unknown }) {
+  return {
+    insert: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue(result),
+  }
+}
+
+describe('action center support access events route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('rejects support access writes from non-admin actors', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'customer-owner-1' } },
+    })
+    mockLoadSuiteAccessContext.mockResolvedValue({
+      context: {
+        isVerisightAdmin: false,
+        canLogSupportAccess: false,
+        organizationIds: ['org-1'],
+        workspaceOrgIds: [],
+      },
+      orgMemberships: [{ org_id: 'org-1', role: 'owner' }],
+      workspaceMemberships: [],
+    })
+
+    const response = await POST(
+      makeRequest({
+        orgId: 'org-1',
+        routeId: 'route-1',
+        scopeValue: 'org-1::department::operations',
+        accessKind: 'support',
+        accessReason: 'Investigate route state',
+      }),
+    )
+
+    expect(response.status).toBe(403)
+  })
+
+  it('stores support access events with reason and affected route scope', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'admin-1' } },
+    })
+    mockLoadSuiteAccessContext.mockResolvedValue({
+      context: {
+        isVerisightAdmin: true,
+        canLogSupportAccess: true,
+        organizationIds: [],
+        workspaceOrgIds: [],
+      },
+      orgMemberships: [],
+      workspaceMemberships: [],
+    })
+
+    const insertQuery = createInsertQuery({
+      data: {
+        id: 'support-1',
+        org_id: 'org-1',
+        route_id: 'route-1',
+        scope_value: 'org-1::department::operations',
+        accessed_by: 'admin-1',
+        access_kind: 'support',
+        access_reason: 'Investigate route state',
+        created_at: '2026-05-23T09:00:00.000Z',
+      },
+      error: null,
+    })
+
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === 'action_center_support_access_events') {
+        return insertQuery
+      }
+
+      throw new Error(`Unexpected table ${table}`)
+    })
+
+    const response = await POST(
+      makeRequest({
+        orgId: 'org-1',
+        routeId: 'route-1',
+        scopeValue: 'org-1::department::operations',
+        accessKind: 'support',
+        accessReason: 'Investigate route state',
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(insertQuery.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        org_id: 'org-1',
+        route_id: 'route-1',
+        scope_value: 'org-1::department::operations',
+        accessed_by: 'admin-1',
+        access_kind: 'support',
+        access_reason: 'Investigate route state',
+      }),
+    )
+
+    await expect(response.json()).resolves.toMatchObject({
+      supportAccessEvent: {
+        accessKind: 'support',
+        routeId: 'route-1',
+      },
+    })
+  })
+})

--- a/frontend/app/api/action-center/admin/support-access-events/route.ts
+++ b/frontend/app/api/action-center/admin/support-access-events/route.ts
@@ -1,0 +1,116 @@
+import { NextResponse } from 'next/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { createClient } from '@/lib/supabase/server'
+import { loadSuiteAccessContext } from '@/lib/suite-access-server'
+import {
+  ACTION_CENTER_SUPPORT_ACCESS_KINDS,
+  canAccessActionCenterAdminOrg,
+  type ActionCenterSupportAccessKind,
+} from '../../../../../lib/action-center-admin-governance'
+
+type SupportAccessEventBody = {
+  orgId?: string
+  routeId?: string | null
+  scopeValue?: string | null
+  accessKind?: string
+  accessReason?: string
+}
+
+function normalizeText(value: string | null | undefined) {
+  const trimmed = value?.trim() ?? ''
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function parseBody(body: SupportAccessEventBody | null) {
+  const orgId = normalizeText(body?.orgId)
+  const routeId = normalizeText(body?.routeId)
+  const scopeValue = normalizeText(body?.scopeValue)
+  const accessKind = normalizeText(body?.accessKind) as ActionCenterSupportAccessKind | null
+  const accessReason = normalizeText(body?.accessReason)
+
+  if (
+    !orgId ||
+    !accessReason ||
+    !accessKind ||
+    !ACTION_CENTER_SUPPORT_ACCESS_KINDS.includes(accessKind)
+  ) {
+    throw new Error('Ongeldige support access input.')
+  }
+
+  return {
+    orgId,
+    routeId,
+    scopeValue,
+    accessKind,
+    accessReason,
+  }
+}
+
+export async function POST(request: Request) {
+  const body = (await request.json().catch(() => null)) as SupportAccessEventBody | null
+
+  let parsed
+  try {
+    parsed = parseBody(body)
+  } catch {
+    return NextResponse.json({ detail: 'Ongeldige support access input.' }, { status: 400 })
+  }
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ detail: 'Niet ingelogd.' }, { status: 401 })
+  }
+
+  const { context } = await loadSuiteAccessContext(supabase, user.id)
+
+  if (!context.canLogSupportAccess) {
+    return NextResponse.json({ detail: 'Alleen bounded tenant-admin actors mogen support access loggen.' }, { status: 403 })
+  }
+
+  if (
+    !canAccessActionCenterAdminOrg({
+      isVerisightAdmin: context.isVerisightAdmin,
+      organizationIds: context.organizationIds,
+      workspaceOrgIds: context.workspaceOrgIds,
+      orgId: parsed.orgId,
+    })
+  ) {
+    return NextResponse.json({ detail: 'Geen toegang tot deze organisatie voor support access logging.' }, { status: 403 })
+  }
+
+  const adminClient = createAdminClient()
+  const { data, error } = await adminClient
+    .from('action_center_support_access_events')
+    .insert({
+      org_id: parsed.orgId,
+      route_id: parsed.routeId,
+      scope_value: parsed.scopeValue,
+      accessed_by: user.id,
+      access_kind: parsed.accessKind,
+      access_reason: parsed.accessReason,
+    })
+    .select('*')
+    .single()
+
+  if (error || !data) {
+    return NextResponse.json({ detail: error?.message ?? 'Support access event opslaan mislukt.' }, { status: 500 })
+  }
+
+  return NextResponse.json(
+    {
+      supportAccessEvent: {
+        id: data.id,
+        routeId: data.route_id,
+        scopeValue: data.scope_value,
+        accessKind: data.access_kind,
+        accessReason: data.access_reason,
+        createdAt: data.created_at,
+      },
+    },
+    { status: 200 },
+  )
+}

--- a/frontend/components/dashboard/action-center-preview.tsx
+++ b/frontend/components/dashboard/action-center-preview.tsx
@@ -8,21 +8,11 @@ import type {
   ActionCenterRouteContract,
   ActionCenterRouteStatus,
 } from '@/lib/action-center-route-contract'
-import { summarizeActionCenterRouteActions } from '@/lib/action-center-route-contract'
 import {
   ACTION_CENTER_MANAGER_RESPONSE_THEME_OPTIONS,
   getActionCenterManagerResponseLabel,
   hasPrimaryManagerAction,
 } from '@/lib/action-center-manager-responses'
-import {
-  projectActionCenterRouteActionCard,
-  type ActionCenterRouteActionRecord,
-} from '@/lib/action-center-route-actions'
-import {
-  projectActionCenterActionReview,
-  type ActionCenterActionConfidenceLevel,
-  type ActionCenterActionEvidenceSource,
-} from '@/lib/action-center-action-reviews'
 import type {
   ActionCenterRouteCloseoutReason,
   ActionCenterRouteCloseoutStatus,
@@ -36,11 +26,6 @@ import {
   getLiveActionCenterSummary,
   type ActionCenterWorkspaceReadbackSummary,
 } from '@/lib/action-center-live'
-import {
-  buildActionCenterEntryHref,
-  isActionCenterEntrySource,
-  type ActionCenterEntrySource,
-} from '@/lib/action-center-entry'
 import type {
   ActionCenterPreviewItem,
   ActionCenterPreviewManagerOption,
@@ -50,25 +35,10 @@ import type {
 } from '@/lib/action-center-preview-model'
 import type {
   ActionCenterManagerActionThemeKey,
-  ActionCenterManagerActionStatus,
   ActionCenterManagerResponse,
   ActionCenterManagerResponseType,
 } from '@/lib/pilot-learning'
-import {
-  ActionCenterActionReviewEditor,
-  type ActionCenterActionReviewEditorValue,
-} from './action-center-action-review-editor'
-import {
-  ActionCenterRouteActionEditor,
-  type ActionCenterRouteActionEditorSubmissionState,
-  serializeActionCenterRouteActionEditorValue,
-  type ActionCenterRouteActionEditorValue,
-} from './action-center-route-action-editor'
-import { ActionCenterGovernanceQueue as ActionCenterGovernanceQueueSection } from './action-center-governance-queue'
-import { ActionCenterMeasurementReadback as ActionCenterMeasurementReadbackSection } from './action-center-measurement-readback'
 import React, { useDeferredValue, useEffect, useMemo, useState } from 'react'
-import type { ActionCenterGovernanceQueue } from '@/lib/action-center-governance-queues'
-import type { ActionCenterMeasurementReadback } from '@/lib/action-center-measurement-readback'
 
 export type {
   ActionCenterPreviewItem,
@@ -90,8 +60,6 @@ interface Props {
   managerAssignmentEndpoint?: string
   canRespondToRequests?: boolean
   managerResponseEndpoint?: string
-  routeActionEndpoint?: string
-  actionReviewEndpoint?: string
   canCloseRoutes?: boolean
   routeCloseoutEndpoint?: string
   routeFollowUpEndpoint?: string
@@ -104,9 +72,6 @@ interface Props {
   itemHrefs?: Record<string, string>
   hideSidebar?: boolean
   boundedOverviewOnly?: boolean
-  allowEmptyInitialSelection?: boolean
-  governanceQueue?: ActionCenterGovernanceQueue | null
-  measurementReadback?: ActionCenterMeasurementReadback | null
 }
 
 interface CreateActionFormState {
@@ -140,15 +105,6 @@ interface RouteCloseoutFormState {
   closeoutReason: ActionCenterRouteCloseoutReason
   closeoutNote: string
 }
-
-type RouteActionValidationDisposition = 'valid' | 'invalid' | 'needs_hr_review'
-
-function isPersistedDraftSubmissionDisposition(
-  disposition: RouteActionValidationDisposition | null | undefined,
-): disposition is Extract<RouteActionValidationDisposition, 'invalid' | 'needs_hr_review'> {
-  return disposition === 'invalid' || disposition === 'needs_hr_review'
-}
-type RouteActionFeedbackTone = 'error' | 'warning'
 
 type ManagerActionPhase =
   | 'awaiting-first-move'
@@ -464,8 +420,7 @@ function getCreateDefaults(items: ActionCenterPreviewItem[]) {
 
 function buildManagerResponseDefaults(item: ActionCenterPreviewItem | null): ManagerResponseFormState {
   const response = item?.managerResponse ?? null
-  const routeActionGoverned = isRouteActionGoverned(item)
-  const hasPrimaryAction = !routeActionGoverned && Boolean(
+  const hasPrimaryAction = Boolean(
     response?.primary_action_theme_key &&
       response.primary_action_text &&
       response.primary_action_expected_effect,
@@ -480,49 +435,9 @@ function buildManagerResponseDefaults(item: ActionCenterPreviewItem | null): Man
         : ''),
     reviewScheduledFor: response?.review_scheduled_for ?? item?.reviewDate ?? '',
     includePrimaryAction: hasPrimaryAction,
-    primaryActionThemeKey: routeActionGoverned ? '' : response?.primary_action_theme_key ?? '',
-    primaryActionText: routeActionGoverned ? '' : response?.primary_action_text ?? '',
-    primaryActionExpectedEffect: routeActionGoverned ? '' : response?.primary_action_expected_effect ?? '',
-  }
-}
-
-export function isRouteActionGoverned(item: ActionCenterPreviewItem | null) {
-  return (item?.coreSemantics.routeActionCards.length ?? 0) > 0
-}
-
-export function resolveManagerResponsePrimaryActionPayload(args: {
-  routeActionCardCount: number
-  includePrimaryAction: boolean
-  primaryActionThemeKey: ActionCenterManagerActionThemeKey | ''
-  primaryActionText: string
-  primaryActionExpectedEffect: string
-}): {
-  primary_action_theme_key: ActionCenterManagerActionThemeKey | null
-  primary_action_text: string | null
-  primary_action_expected_effect: string | null
-  primary_action_status: ActionCenterManagerActionStatus | null
-} {
-  if (args.routeActionCardCount > 0 || !args.includePrimaryAction) {
-    return {
-      primary_action_theme_key: null,
-      primary_action_text: null,
-      primary_action_expected_effect: null,
-      primary_action_status: null,
-    }
-  }
-
-  const primaryActionThemeKey = args.primaryActionThemeKey || null
-  const primaryActionText = args.primaryActionText.trim() || null
-  const primaryActionExpectedEffect = args.primaryActionExpectedEffect.trim() || null
-  const hasCompletePrimaryAction = Boolean(
-    primaryActionThemeKey && primaryActionText && primaryActionExpectedEffect,
-  )
-
-  return {
-    primary_action_theme_key: primaryActionThemeKey,
-    primary_action_text: primaryActionText,
-    primary_action_expected_effect: primaryActionExpectedEffect,
-    primary_action_status: hasCompletePrimaryAction ? 'active' : null,
+    primaryActionThemeKey: response?.primary_action_theme_key ?? '',
+    primaryActionText: response?.primary_action_text ?? '',
+    primaryActionExpectedEffect: response?.primary_action_expected_effect ?? '',
   }
 }
 
@@ -547,27 +462,6 @@ function getManagerResponseProjectedStatus(
   }
 
   return hasPrimaryManagerAction(response) ? 'in-uitvoering' : 'te-bespreken'
-}
-
-function resolveRouteContractStatusFromPreviewStatus(
-  status: ActionCenterPreviewStatus,
-): Exclude<ActionCenterRouteStatus, 'open-verzoek'> {
-  switch (status) {
-    case 'te-bespreken':
-      return 'te-bespreken'
-    case 'in-uitvoering':
-    case 'reviewbaar':
-      return 'in-uitvoering'
-    case 'geblokkeerd':
-      return 'geblokkeerd'
-    case 'afgerond':
-      return 'afgerond'
-    case 'gestopt':
-      return 'gestopt'
-    case 'open-verzoek':
-    default:
-      return 'te-bespreken'
-  }
 }
 
 function getManagerActionPhase(item: ActionCenterPreviewItem | null): ManagerActionPhase {
@@ -644,250 +538,6 @@ function getManagerActionSurfaceCopy(item: ActionCenterPreviewItem | null) {
   }
 }
 
-function getRouteActionThemeLabel(themeKey: ActionCenterRouteActionRecord['themeKey']) {
-  return (
-    ACTION_CENTER_MANAGER_RESPONSE_THEME_OPTIONS.find((option) => option.value === themeKey)?.label ??
-    themeKey ??
-    'Nog geen thema'
-  )
-}
-
-function getRouteActionStatusLabel(status: ActionCenterRouteActionRecord['status']) {
-  switch (status) {
-    case 'open':
-      return 'Actief'
-    case 'in_review':
-      return 'Reviewbaar'
-    case 'afgerond':
-      return 'Afgerond'
-    case 'gestopt':
-      return 'Gestopt'
-    default:
-      return 'Nog niet reviewbaar'
-  }
-}
-
-function getRouteActionStatusTone(status: ActionCenterRouteActionRecord['status']) {
-  switch (status) {
-    case 'open':
-      return 'border-[#d7ece8] bg-[#eef9f6] text-[#28776f]'
-    case 'in_review':
-      return 'border-[#ffe1c7] bg-[#fff3e8] text-[#bb6b1f]'
-    case 'afgerond':
-      return 'border-[#d5ebdb] bg-[#edf8f0] text-[#2f8454]'
-    case 'gestopt':
-      return 'border-[#f0d9d4] bg-[#fff1ef] text-[#c4584d]'
-    default:
-      return 'border-[#e3d8ca] bg-[#fbf7f1] text-[#6b6257]'
-  }
-}
-
-function getActionReviewOutcomeLabel(outcome: ActionCenterActionReviewEditorValue['actionOutcome']) {
-  switch (outcome) {
-    case 'effect-zichtbaar':
-      return 'Effect zichtbaar'
-    case 'bijsturen-nodig':
-      return 'Bijsturen nodig'
-    case 'nog-te-vroeg':
-      return 'Nog te vroeg'
-    case 'stoppen':
-    default:
-      return 'Stoppen'
-  }
-}
-
-function getRouteActionDraftDispositionMessage(disposition: RouteActionValidationDisposition) {
-  switch (disposition) {
-    case 'needs_hr_review':
-      return 'Deze actie vraagt eerst HR-beoordeling.'
-    case 'invalid':
-      return 'Pas deze actie aan zodat hij bounded en route-specifiek is.'
-    case 'valid':
-    default:
-      return null
-  }
-}
-
-function getRouteActionPersistedDraftStatusMessage() {
-  return 'Draft opgeslagen, nog niet live in deze route.'
-}
-
-export function buildPersistedRouteActionFeedback(args: {
-  value: ActionCenterRouteActionEditorValue
-  validationDisposition: Extract<RouteActionValidationDisposition, 'invalid' | 'needs_hr_review'>
-  validationMessage: string
-}) {
-  const statusMessage = getRouteActionPersistedDraftStatusMessage()
-
-  return {
-    message: `${statusMessage} ${args.validationMessage}`,
-    tone: 'warning' as const,
-    validationDisposition: args.validationDisposition,
-    validationMessage: args.validationMessage,
-    statusMessage,
-    persistedDraftFingerprint: serializeActionCenterRouteActionEditorValue(args.value),
-  }
-}
-
-function getNextRouteActionStatusFromReviewOutcome(
-  outcome: ActionCenterActionReviewEditorValue['actionOutcome'],
-): Extract<ActionCenterRouteActionRecord['status'], 'open' | 'afgerond' | 'gestopt'> {
-  switch (outcome) {
-    case 'effect-zichtbaar':
-      return 'afgerond'
-    case 'stoppen':
-      return 'gestopt'
-    case 'bijsturen-nodig':
-    case 'nog-te-vroeg':
-    default:
-      return 'open'
-  }
-}
-
-function getRouteActionMutationStateLabel(status: 'reviewbaar' | 'in-uitvoering') {
-  return status === 'reviewbaar' ? 'Reviewbaar' : 'In uitvoering'
-}
-
-function buildRouteActionMutationProgressSummary(args: {
-  status: 'reviewbaar' | 'in-uitvoering'
-  actionCount: number
-  reviewPressureCount: number
-}) {
-  if (args.status === 'reviewbaar') {
-    return args.reviewPressureCount > 0
-      ? `${args.reviewPressureCount} actie${args.reviewPressureCount === 1 ? '' : 's'} of reviewmoment${args.reviewPressureCount === 1 ? '' : 'en'} vragen nu expliciete teruglezing.`
-      : `${args.actionCount} actie${args.actionCount === 1 ? '' : 's'} dragen deze route, maar reviewdruk wint nu van uitvoering.`
-  }
-
-  return `${args.actionCount} actie${args.actionCount === 1 ? '' : 's'} dragen nu de lokale follow-through in deze route.`
-}
-
-function buildRouteActionMutationOverviewSummary(args: {
-  status: 'reviewbaar' | 'in-uitvoering'
-  actionCount: number
-  reviewPressureCount: number
-}) {
-  if (args.status === 'reviewbaar') {
-    return args.reviewPressureCount > 0
-      ? `Actieve route waarbij ${args.reviewPressureCount} reviewmoment${args.reviewPressureCount === 1 ? '' : 'en'} nu aandacht vraagt.`
-      : 'Actieve route die nu expliciete teruglezing en review vraagt.'
-  }
-
-  return `Actieve route met ${args.actionCount} expliciete actie${args.actionCount === 1 ? '' : 's'} in dezelfde follow-through.`
-}
-
-function buildRouteActionMutationSummaryText(args: {
-  actionCount: number
-  reviewPressureCount: number
-  completedCount: number
-}) {
-  const parts = [`${args.actionCount} ${args.actionCount === 1 ? 'actie' : 'acties'}`]
-
-  if (args.reviewPressureCount > 0) {
-    parts.push(`${args.reviewPressureCount} reviewbaar`)
-  } else if (args.completedCount > 0) {
-    parts.push(`${args.completedCount} afgerond`)
-  } else {
-    parts.push('actief in deze route')
-  }
-
-  return parts.join(' - ')
-}
-
-export function synchronizeActionCenterRouteActionSurface(
-  item: ActionCenterPreviewItem,
-  cards: ActionCenterPreviewItem['coreSemantics']['routeActionCards'],
-) {
-  const persistedCards = cards.filter(
-    (card): card is typeof card & { status: NonNullable<typeof card.status>; reviewScheduledFor: string } =>
-      card.status !== null && Boolean(card.reviewScheduledFor),
-  )
-
-  if (persistedCards.length === 0) {
-    return finalizeActionCenterPreviewItem(
-      {
-        ...item,
-        coreSemantics: {
-          ...item.coreSemantics,
-          routeActionCards: cards,
-        },
-      },
-      { recomputeCoreSemantics: false },
-    )
-  }
-
-  const aggregate = summarizeActionCenterRouteActions(
-    persistedCards.map((card) => ({
-      actionId: card.actionId,
-      status: card.status,
-      reviewScheduledFor: card.reviewScheduledFor,
-    })),
-  )
-  const surfaceStatus = aggregate.routeStatus === 'reviewbaar' ? 'reviewbaar' : 'in-uitvoering'
-  const reviewPressureCount = persistedCards.filter(
-    (card) =>
-      card.status === 'in_review' ||
-      (card.status === 'open' && card.reviewScheduledFor <= new Date().toISOString().slice(0, 10)),
-  ).length
-  const completedCount = persistedCards.filter((card) => card.status === 'afgerond').length
-  const nextReviewDate = aggregate.nextReviewScheduledFor ?? item.reviewDate
-
-  return finalizeActionCenterPreviewItem(
-    {
-      ...item,
-      status: surfaceStatus,
-      reviewDate: nextReviewDate,
-      reviewDateLabel: formatShortDate(nextReviewDate),
-      summary: buildRouteActionMutationSummaryText({
-        actionCount: persistedCards.length,
-        reviewPressureCount,
-        completedCount,
-      }),
-      coreSemantics: {
-        ...item.coreSemantics,
-        routeActionCards: cards,
-        routeSummary: {
-          stateLabel: getRouteActionMutationStateLabel(surfaceStatus),
-          overviewSummary: buildRouteActionMutationOverviewSummary({
-            status: surfaceStatus,
-            actionCount: persistedCards.length,
-            reviewPressureCount,
-          }),
-          routeAsk:
-            surfaceStatus === 'reviewbaar'
-              ? 'Kijk nu expliciet terug op de lopende follow-through en bepaal wat de route daarna vraagt.'
-              : 'Houd de actielaag klein en zorg dat review per actie leidend blijft voor verdere uitvoering.',
-          progressSummary: buildRouteActionMutationProgressSummary({
-            status: surfaceStatus,
-            actionCount: persistedCards.length,
-            reviewPressureCount,
-          }),
-        },
-        routeCloseout: {
-          ...item.coreSemantics.routeCloseout,
-          readyForCloseout: aggregate.readyForCloseout,
-        },
-      },
-    },
-    { recomputeCoreSemantics: false },
-  )
-}
-
-function hasExplicitRouteCloseoutMetadata(item: ActionCenterPreviewItem | null) {
-  if (!item) {
-    return false
-  }
-
-  const closeout = item.coreSemantics.routeCloseout
-  return Boolean(
-    closeout.closeoutStatus ||
-      closeout.closeoutReason ||
-      closeout.closeoutNote ||
-      closeout.closedAt ||
-      closeout.closedByRole,
-  )
-}
-
 function getRouteSummaryDisplay(item: ActionCenterPreviewItem) {
   return (
     item.coreSemantics.routeSummary ?? {
@@ -911,29 +561,17 @@ function applyManagerResponseToItem(
   item: ActionCenterPreviewItem,
   response: ActionCenterManagerResponse,
 ): ActionCenterPreviewItem {
-  const routeActionGoverned = isRouteActionGoverned(item)
-  const nextStatus: ActionCenterRouteStatus = routeActionGoverned
-    ? item.coreSemantics.route.routeStatus ?? resolveRouteContractStatusFromPreviewStatus(item.status)
-    : getManagerResponseProjectedStatus(item.status, response)
-  const followThroughMode =
-    routeActionGoverned
-      ? item.coreSemantics.route.followThroughMode
-      : hasPrimaryManagerAction(response)
-        ? 'primary_action'
-        : 'bounded_response'
+  const nextStatus = getManagerResponseProjectedStatus(item.status, response)
+  const followThroughMode = hasPrimaryManagerAction(response) ? 'primary_action' : 'bounded_response'
   const nextRoute: ActionCenterRouteContract = {
     ...item.coreSemantics.route,
     routeStatus: nextStatus,
-    intervention: routeActionGoverned
-      ? item.coreSemantics.route.intervention
-      : response.primary_action_text ?? null,
-    expectedEffect: routeActionGoverned
-      ? item.coreSemantics.route.expectedEffect
-      : response.primary_action_expected_effect ?? null,
+    intervention: response.primary_action_text ?? null,
+    expectedEffect: response.primary_action_expected_effect ?? null,
     reviewScheduledFor: response.review_scheduled_for,
     managerResponseType: response.response_type,
     managerResponseNote: response.response_note,
-    primaryActionThemeKey: routeActionGoverned ? null : response.primary_action_theme_key ?? null,
+    primaryActionThemeKey: response.primary_action_theme_key ?? null,
     followThroughMode,
   }
 
@@ -1207,8 +845,6 @@ export function ActionCenterPreview({
   managerAssignmentEndpoint,
   canRespondToRequests = false,
   managerResponseEndpoint,
-  routeActionEndpoint,
-  actionReviewEndpoint,
   canCloseRoutes = false,
   routeCloseoutEndpoint,
   routeFollowUpEndpoint,
@@ -1221,13 +857,9 @@ export function ActionCenterPreview({
   itemHrefs = {},
   hideSidebar = false,
   boundedOverviewOnly = false,
-  allowEmptyInitialSelection = false,
-  governanceQueue = null,
-  measurementReadback = null,
 }: Props) {
   const explicitlySelectedInitialItem = initialItems.find((item) => item.id === initialSelectedItemId) ?? null
-  const initialSelectedItem =
-    explicitlySelectedInitialItem ?? (boundedOverviewOnly || allowEmptyInitialSelection ? null : initialItems[0] ?? null)
+  const initialSelectedItem = explicitlySelectedInitialItem ?? (boundedOverviewOnly ? null : initialItems[0] ?? null)
   const [items, setItems] = useState(() => initialItems.map((item) => finalizeActionCenterPreviewItem(item)))
   const [activeView, setActiveView] = useState<ActionCenterPreviewView>(initialView)
   const [selectedItemId, setSelectedItemId] = useState(initialSelectedItem?.id ?? null)
@@ -1241,19 +873,6 @@ export function ActionCenterPreview({
   )
   const [managerResponsePending, setManagerResponsePending] = useState(false)
   const [managerResponseError, setManagerResponseError] = useState<string | null>(null)
-  const [routeActionEditorOpen, setRouteActionEditorOpen] = useState(false)
-  const [routeActionPending, setRouteActionPending] = useState(false)
-  const [routeActionFeedback, setRouteActionFeedback] = useState<{
-    message: string
-    tone: RouteActionFeedbackTone
-    validationDisposition?: RouteActionValidationDisposition | null
-    validationMessage?: string | null
-    statusMessage?: string | null
-    persistedDraftFingerprint?: string | null
-  } | null>(null)
-  const [openReviewActionId, setOpenReviewActionId] = useState<string | null>(null)
-  const [actionReviewPendingActionId, setActionReviewPendingActionId] = useState<string | null>(null)
-  const [actionReviewError, setActionReviewError] = useState<string | null>(null)
   const [routeCloseoutForm, setRouteCloseoutForm] = useState<RouteCloseoutFormState>(() => buildRouteCloseoutDefaults())
   const [routeCloseoutPanelOpen, setRouteCloseoutPanelOpen] = useState(false)
   const [routeCloseoutPending, setRouteCloseoutPending] = useState(false)
@@ -1263,13 +882,13 @@ export function ActionCenterPreview({
   const deferredSearchQuery = useDeferredValue(searchQuery)
 
   useEffect(() => {
-    if (!boundedOverviewOnly && !allowEmptyInitialSelection && !selectedItemId && items[0]) {
+    if (!boundedOverviewOnly && !selectedItemId && items[0]) {
       setSelectedItemId(items[0].id)
     }
     if (!selectedTeamId && items[0]) {
       setSelectedTeamId(items[0].teamId)
     }
-  }, [allowEmptyInitialSelection, boundedOverviewOnly, items, selectedItemId, selectedTeamId])
+  }, [boundedOverviewOnly, items, selectedItemId, selectedTeamId])
 
   useEffect(() => {
     if (boundedOverviewOnly && activeView !== 'overview') {
@@ -1311,7 +930,7 @@ export function ActionCenterPreview({
 
   const selectedItem = selectedItemId
     ? filteredItems.find((item) => item.id === selectedItemId) ?? items.find((item) => item.id === selectedItemId) ?? null
-    : boundedOverviewOnly || allowEmptyInitialSelection
+    : boundedOverviewOnly
       ? null
       : filteredItems[0] ?? items[0] ?? null
   const managerActionSurfaceCopy = getManagerActionSurfaceCopy(selectedItem)
@@ -1319,10 +938,6 @@ export function ActionCenterPreview({
   useEffect(() => {
     setManagerResponseForm(buildManagerResponseDefaults(selectedItem))
     setManagerResponseError(null)
-    setRouteActionEditorOpen(false)
-    setRouteActionFeedback(null)
-    setOpenReviewActionId(null)
-    setActionReviewError(null)
   }, [selectedItem])
   useEffect(() => {
     setRouteCloseoutForm(buildRouteCloseoutDefaults())
@@ -1406,27 +1021,6 @@ export function ActionCenterPreview({
         currentUserId &&
         selectedItem.ownerId === currentUserId,
     )
-  const canUseRouteActionFlow =
-    Boolean(
-      routeActionEndpoint &&
-        selectedItem?.orgId &&
-        supportsManagerResponseFlow(selectedItem) &&
-        selectedItem?.managerResponse?.id &&
-        selectedItem?.ownerId &&
-        currentUserId &&
-        selectedItem.ownerId === currentUserId,
-    )
-  const allowInlinePrimaryAction = !isRouteActionGoverned(selectedItem)
-  const canUseActionReviewFlow =
-    Boolean(
-      actionReviewEndpoint &&
-        selectedItem?.orgId &&
-        supportsManagerResponseFlow(selectedItem) &&
-        selectedItem?.managerResponse?.id &&
-        selectedItem?.ownerId &&
-        currentUserId &&
-        selectedItem.ownerId === currentUserId,
-    )
   const canRenderFollowUpRoute = Boolean(
     routeFollowUpEndpoint &&
       canAssignManagers &&
@@ -1473,50 +1067,11 @@ export function ActionCenterPreview({
     : null
   const canShowFollowUpRouteAffordance = Boolean(canRenderFollowUpRoute && !followUpRouteBlockReason)
 
-  function replaceEntryUrl(args: {
-    focus?: string | null
-    view: ActionCenterPreviewView
-  }) {
-    if (typeof window === 'undefined') return
-
-    const nextHref = buildContextualEntryHref(window.location.href, {
-      focus: args.focus ?? selectedItemId,
-      view: args.view,
-    })
-
-    window.history.replaceState(window.history.state, '', nextHref)
-  }
-
-  function setContextualView(
-    nextView: ActionCenterPreviewView,
-    options?: {
-      focus?: string | null
-    },
-  ) {
-    setActiveView(nextView)
-    replaceEntryUrl({ focus: options?.focus ?? selectedItemId, view: nextView })
-  }
-
   function updateItem(itemId: string, updater: (item: ActionCenterPreviewItem) => ActionCenterPreviewItem) {
     setItems((currentItems) =>
       currentItems.map((item) =>
         item.id === itemId ? finalizeActionCenterPreviewItem(updater(item), { recomputeCoreSemantics: true }) : item,
       ),
-    )
-  }
-
-  function updateRouteActionCards(
-    itemId: string,
-    updater: (cards: ActionCenterPreviewItem['coreSemantics']['routeActionCards']) => ActionCenterPreviewItem['coreSemantics']['routeActionCards'],
-  ) {
-    setItems((currentItems) =>
-      currentItems.map((item) => {
-        if (item.id !== itemId) {
-          return item
-        }
-
-        return synchronizeActionCenterRouteActionSurface(item, updater(item.coreSemantics.routeActionCards))
-      }),
     )
   }
 
@@ -1567,8 +1122,9 @@ export function ActionCenterPreview({
     })
 
     setItems((current) => [newItem, ...current])
+    setSelectedItemId(newItem.id)
     setSelectedTeamId(newItem.teamId)
-    focusActionRoute(newItem.id)
+    setActiveView('actions')
     setShowCreateModal(false)
     setCreateForm(getCreateDefaults([newItem, ...items]))
   }
@@ -1629,14 +1185,6 @@ export function ActionCenterPreview({
       return
     }
 
-    const primaryActionPayload = resolveManagerResponsePrimaryActionPayload({
-      routeActionCardCount: selectedItem.coreSemantics.routeActionCards.length,
-      includePrimaryAction: managerResponseForm.includePrimaryAction,
-      primaryActionThemeKey: managerResponseForm.primaryActionThemeKey,
-      primaryActionText: managerResponseForm.primaryActionText,
-      primaryActionExpectedEffect: managerResponseForm.primaryActionExpectedEffect,
-    })
-
     setManagerResponsePending(true)
     setManagerResponseError(null)
 
@@ -1649,7 +1197,19 @@ export function ActionCenterPreview({
       response_type: managerResponseForm.responseType,
       response_note: managerResponseForm.responseNote,
       review_scheduled_for: managerResponseForm.reviewScheduledFor,
-      ...primaryActionPayload,
+      primary_action_theme_key:
+        managerResponseForm.includePrimaryAction && managerResponseForm.primaryActionThemeKey
+          ? managerResponseForm.primaryActionThemeKey
+          : null,
+      primary_action_text:
+        managerResponseForm.includePrimaryAction && managerResponseForm.primaryActionText.trim()
+          ? managerResponseForm.primaryActionText
+          : null,
+      primary_action_expected_effect:
+        managerResponseForm.includePrimaryAction && managerResponseForm.primaryActionExpectedEffect.trim()
+          ? managerResponseForm.primaryActionExpectedEffect
+          : null,
+      primary_action_status: managerResponseForm.includePrimaryAction ? 'active' : null,
     }
 
     try {
@@ -1689,158 +1249,6 @@ export function ActionCenterPreview({
       )
     } finally {
       setManagerResponsePending(false)
-    }
-  }
-
-  async function handleRouteActionSave(value: ActionCenterRouteActionEditorValue) {
-    if (!selectedItem || !routeActionEndpoint || !selectedItem.orgId || !supportsManagerResponseFlow(selectedItem)) {
-      return false
-    }
-
-    setRouteActionPending(true)
-    setRouteActionFeedback(null)
-
-    try {
-      const response = await fetch(routeActionEndpoint, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          campaign_id: selectedItem.coreSemantics.route.campaignId,
-          route_scope_type: selectedItem.scopeType,
-          route_scope_value: selectedItem.teamId,
-          manager_user_id: selectedItem.ownerId ?? '',
-          primary_action_theme_key: value.themeKey || null,
-          primary_action_text: value.actionText,
-          primary_action_expected_effect: value.expectedEffect,
-          review_scheduled_for: value.reviewScheduledFor,
-        }),
-      })
-      const result = (await response.json().catch(() => null)) as
-        | {
-            action?: Record<string, unknown>
-            actionDraft?: { validationDisposition?: RouteActionValidationDisposition | null }
-            validationDisposition?: RouteActionValidationDisposition | null
-            validationMessage?: string | null
-            detail?: string
-          }
-        | null
-
-      if (!response.ok || !result?.action || !result?.actionDraft) {
-        throw new Error(result?.detail ?? 'Route action opslaan mislukt.')
-      }
-
-      const validationDisposition =
-        result.validationDisposition ?? result.actionDraft.validationDisposition ?? 'invalid'
-      const validationMessage =
-        result.validationMessage ?? getRouteActionDraftDispositionMessage(validationDisposition)
-
-      if (validationDisposition !== 'valid') {
-        setRouteActionFeedback(
-          buildPersistedRouteActionFeedback({
-            value,
-            validationDisposition,
-            validationMessage: validationMessage ?? 'Route action opslaan mislukt.',
-          }),
-        )
-        return false
-      }
-
-      const actionCard = projectActionCenterRouteActionCard(result.action)
-      updateRouteActionCards(selectedItem.id, (cards) => [
-        ...cards,
-        {
-          actionId: actionCard.actionId,
-          themeKey: actionCard.themeKey,
-          actionText: actionCard.actionText ?? '',
-          reviewScheduledFor: actionCard.reviewScheduledFor ?? '',
-          expectedEffect: actionCard.expectedEffect ?? '',
-          status: actionCard.status,
-          latestReview: null,
-        },
-      ])
-      setRouteActionEditorOpen(false)
-      setRouteActionFeedback(null)
-      return true
-    } catch (error) {
-      setRouteActionFeedback({
-        message: error instanceof Error ? error.message : 'Route action opslaan mislukt.',
-        tone: 'error',
-        validationDisposition: null,
-        validationMessage: null,
-        statusMessage: null,
-        persistedDraftFingerprint: null,
-      })
-      return false
-    } finally {
-      setRouteActionPending(false)
-    }
-  }
-
-  async function handleActionReviewSave(
-    actionId: string,
-    value: ActionCenterActionReviewEditorValue,
-  ) {
-    if (!actionReviewEndpoint || !selectedItem) {
-      return
-    }
-
-    setActionReviewPendingActionId(actionId)
-    setActionReviewError(null)
-
-    try {
-      const response = await fetch(actionReviewEndpoint, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          action_id: actionId,
-          reviewed_at: new Date().toISOString(),
-          observation: value.observation,
-          action_outcome: value.actionOutcome,
-          evidence_source: value.evidenceSource,
-          confidence_level: value.confidenceLevel,
-          follow_up_note: value.followUpNote.trim() || null,
-        }),
-      })
-      const result = (await response.json().catch(() => null)) as
-        | {
-            review?: Record<string, unknown>
-            submittedStructuredMetadata?: {
-              evidence_source?: ActionCenterActionEvidenceSource | null
-              confidence_level?: ActionCenterActionConfidenceLevel | null
-            }
-            detail?: string
-          }
-        | null
-
-      if (!response.ok || !result?.review) {
-        throw new Error(result?.detail ?? 'Route action review opslaan mislukt.')
-      }
-
-      const projectedReview = projectActionCenterActionReview({
-        ...result.review,
-        evidence_source: result.submittedStructuredMetadata?.evidence_source ?? null,
-        confidence_level: result.submittedStructuredMetadata?.confidence_level ?? null,
-      })
-      updateRouteActionCards(selectedItem.id, (cards) =>
-        cards.map((card) =>
-          card.actionId === actionId
-            ? {
-                ...card,
-                status: getNextRouteActionStatusFromReviewOutcome(projectedReview.actionOutcome),
-                latestReview: projectedReview,
-              }
-            : card,
-        ),
-      )
-      setOpenReviewActionId(null)
-    } catch (error) {
-      setActionReviewError(error instanceof Error ? error.message : 'Route action review opslaan mislukt.')
-    } finally {
-      setActionReviewPendingActionId(null)
     }
   }
 
@@ -1948,7 +1356,11 @@ export function ActionCenterPreview({
   function focusActionRoute(routeId: string) {
     setSelectedItemId(routeId)
     setActiveView('actions')
-    replaceEntryUrl({ focus: routeId, view: 'actions' })
+    if (typeof window !== 'undefined') {
+      const url = new URL(window.location.href)
+      url.searchParams.set('focus', routeId)
+      window.history.replaceState(window.history.state, '', `${url.pathname}${url.search}${url.hash}`)
+    }
   }
 
   function handleStatusChange(nextStatus: ActionCenterPreviewStatus) {
@@ -2033,7 +1445,7 @@ export function ActionCenterPreview({
                 : item.key === 'managers'
                   ? navigationCounts.managers
                   : navigationCounts.teams,
-        onClick: () => setContextualView(item.key),
+        onClick: () => setActiveView(item.key),
       }))
     : []
 
@@ -2069,7 +1481,7 @@ export function ActionCenterPreview({
                   label: 'Overzicht',
                   active: activeView === 'overview',
                   count: 0,
-                  onClick: () => setContextualView('overview'),
+                  onClick: () => setActiveView('overview'),
                 },
               ]}
             />
@@ -2087,7 +1499,7 @@ export function ActionCenterPreview({
                       : item.key === 'managers'
                         ? navigationCounts.managers
                         : navigationCounts.teams,
-                onClick: () => setContextualView(item.key),
+                onClick: () => setActiveView(item.key),
               }))}
             />
 
@@ -2211,12 +1623,7 @@ export function ActionCenterPreview({
                   upcomingReviews={upcomingReviews}
                   overviewStatusCounts={overviewStatusCounts}
                   selectedItem={selectedItem}
-                  governanceQueue={governanceQueue}
-                  measurementReadback={measurementReadback}
-                  onSelectItem={(itemId) => {
-                    setSelectedItemId(itemId)
-                    replaceEntryUrl({ focus: itemId, view: 'overview' })
-                  }}
+                  onSelectItem={setSelectedItemId}
                   selectedItemHref={selectedItemHref}
                   workbenchLabel={workbenchLabel}
                 />
@@ -2256,7 +1663,7 @@ export function ActionCenterPreview({
                       <button
                         type="button"
                         className="text-sm font-semibold text-[#4a5f74] transition hover:text-[#132033]"
-                        onClick={() => setContextualView('actions')}
+                        onClick={() => setActiveView('actions')}
                       >
                         Open actielijst
                       </button>
@@ -2267,7 +1674,10 @@ export function ActionCenterPreview({
                           key={item.id}
                           type="button"
                           className="flex w-full flex-col gap-4 py-5 text-left transition hover:bg-[#f8f2eb]"
-                          onClick={() => focusActionRoute(item.id)}
+                          onClick={() => {
+                            setSelectedItemId(item.id)
+                            setActiveView('actions')
+                          }}
                         >
                           <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
                             <div className="min-w-0">
@@ -2326,9 +1736,10 @@ export function ActionCenterPreview({
                         className="inline-flex min-h-11 items-center rounded-full bg-[#ff9b4a] px-4.5 py-2.5 text-sm font-semibold text-[#132033] transition hover:brightness-[0.98]"
                         onClick={() => {
                           if (focusItem) {
-                            focusActionRoute(focusItem.id)
+                            setSelectedItemId(focusItem.id)
+                            setActiveView('actions')
                           } else {
-                            setContextualView('actions')
+                            setActiveView('actions')
                           }
                         }}
                       >
@@ -2357,7 +1768,7 @@ export function ActionCenterPreview({
                               className="flex w-full items-start justify-between gap-4 rounded-[16px] border border-white/10 bg-white/[0.03] px-4 py-3.5 text-left transition hover:bg-white/[0.06]"
                               onClick={() => {
                                 setSelectedItemId(item.id)
-                                setContextualView('reviews', { focus: item.id })
+                                setActiveView('reviews')
                               }}
                             >
                               <div className="min-w-0">
@@ -2396,7 +1807,7 @@ export function ActionCenterPreview({
                       <button
                         type="button"
                         className="min-h-11 rounded-full border border-[#ded3c6] px-4.5 py-2.5 text-sm font-semibold text-[#1a2533] transition hover:border-[#1a2533]"
-                        onClick={() => setContextualView('managers')}
+                        onClick={() => setActiveView('managers')}
                       >
                         Open managers
                       </button>
@@ -2474,7 +1885,7 @@ export function ActionCenterPreview({
                     <button
                       type="button"
                       className="inline-flex min-h-11 items-center rounded-full border border-[#ded3c6] bg-[#fcfaf7] px-4.5 py-2.5 text-sm font-semibold text-[#1a2533] transition hover:border-[#1a2533]"
-                      onClick={() => setContextualView('overview')}
+                      onClick={() => setActiveView('overview')}
                     >
                       Terug naar overzicht
                     </button>
@@ -2633,6 +2044,54 @@ export function ActionCenterPreview({
                           </div>
                         ) : null}
                       </div>
+                      {selectedItem.coreSemantics.routeActionCards.length > 0 ? (
+                        <div className="rounded-[28px] border border-[#e4d9cb] bg-white px-7 py-7 shadow-[0_12px_36px_rgba(19,32,51,0.06)]">
+                          <div className="border-b border-[#ece4d8] pb-5">
+                            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Actieroute</p>
+                            <h3 className="mt-2 text-[1.35rem] font-semibold tracking-[-0.03em] text-[#132033]">Acties in deze route</h3>
+                          </div>
+                          <div className="mt-6 space-y-4">
+                            {selectedItem.coreSemantics.routeActionCards.map((actionCard) => (
+                              <div
+                                key={actionCard.actionId}
+                                className="rounded-[22px] border border-[#efe7dc] bg-[#fcfaf7] px-5 py-5"
+                              >
+                                <div className="flex flex-wrap items-center gap-3 text-sm text-[#6d6458]">
+                                  <MiniTag>{getActionCardThemeLabel(actionCard.themeKey)}</MiniTag>
+                                  <StatusPill
+                                    status={
+                                      actionCard.status === 'in_review'
+                                        ? 'reviewbaar'
+                                        : actionCard.status === 'open'
+                                          ? 'in-uitvoering'
+                                          : actionCard.status === 'afgerond'
+                                            ? 'afgerond'
+                                            : 'gestopt'
+                                    }
+                                  />
+                                  <span className="ml-auto font-semibold text-[#5a7088]">
+                                    Review {formatShortDate(actionCard.reviewScheduledFor)}
+                                  </span>
+                                </div>
+                                <p className="mt-4 text-[1.02rem] font-semibold leading-7 text-[#132033]">
+                                  {actionCard.actionText}
+                                </p>
+                                <p className="mt-2 text-sm leading-7 text-[#4f6175]">{actionCard.expectedEffect}</p>
+                                {actionCard.latestReview ? (
+                                  <div className="mt-4 rounded-[18px] border border-[#eadfce] bg-white px-4 py-4">
+                                    <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">
+                                      Laatste review ({getActionReviewOutcomeLabel(actionCard.latestReview.actionOutcome)})
+                                    </p>
+                                    <p className="mt-3 text-sm leading-7 text-[#32465d]">
+                                      {actionCard.latestReview.observation}
+                                    </p>
+                                  </div>
+                                ) : null}
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      ) : null}
                     </section>
 
                     <section className="space-y-6">
@@ -2927,7 +2386,9 @@ export function ActionCenterPreview({
                         </div>
                       ) : null}
 
-                      {selectedItem && (isClosedRouteStatus(selectedItem.status) || hasExplicitRouteCloseoutMetadata(selectedItem)) ? (
+                      {selectedItem &&
+                      (isClosedRouteStatus(selectedItem.status) ||
+                        Boolean(selectedItem.coreSemantics.routeCloseout.closeoutStatus)) ? (
                         <div className="rounded-[24px] border border-[#e4d9cb] bg-white px-6 py-6 shadow-[0_12px_36px_rgba(19,32,51,0.06)]">
                           <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">
                             Route afgesloten
@@ -3103,100 +2564,78 @@ export function ActionCenterPreview({
                                 />
                               </FormField>
 
-                              {allowInlinePrimaryAction ? (
-                                <>
-                                  <label className="flex items-start gap-3 rounded-[18px] border border-[#ece4d8] bg-[#fcfaf7] px-4 py-4 text-sm text-[#42556b]">
-                                    <input
-                                      type="checkbox"
-                                      checked={managerResponseForm.includePrimaryAction}
+                              <label className="flex items-start gap-3 rounded-[18px] border border-[#ece4d8] bg-[#fcfaf7] px-4 py-4 text-sm text-[#42556b]">
+                                <input
+                                  type="checkbox"
+                                  checked={managerResponseForm.includePrimaryAction}
+                                  onChange={(event) =>
+                                    setManagerResponseForm((current) => ({
+                                      ...current,
+                                      includePrimaryAction: event.target.checked,
+                                    }))
+                                  }
+                                  className="mt-1 h-4 w-4 rounded border-[#d6cbbb] text-[#132033]"
+                                />
+                                <span className="leading-7">
+                                  {managerActionSurfaceCopy.primaryActionToggle}
+                                </span>
+                              </label>
+
+                              {managerResponseForm.includePrimaryAction ? (
+                                <div className="space-y-4 rounded-[20px] border border-[#ece4d8] bg-[#fcfaf7] px-4 py-4">
+                                  <p className="text-sm leading-7 text-[#4f6175]">
+                                    Deze extra stap maakt de route concreter, maar houdt de uitvoering nog steeds klein totdat aparte actiekaarten echt helpen.
+                                  </p>
+
+                                  <FormField label="Thema van deze eerste concrete stap">
+                                    <select
+                                      value={managerResponseForm.primaryActionThemeKey}
                                       onChange={(event) =>
                                         setManagerResponseForm((current) => ({
                                           ...current,
-                                          includePrimaryAction: event.target.checked,
+                                          primaryActionThemeKey: event.target.value as ActionCenterManagerActionThemeKey | '',
                                         }))
                                       }
-                                      className="mt-1 h-4 w-4 rounded border-[#d6cbbb] text-[#132033]"
+                                      className="w-full rounded-2xl border border-[#ddd3c7] bg-white px-4 py-3 text-sm text-[#132033] outline-none transition focus:border-[#ff9b4a]"
+                                    >
+                                      <option value="">Kies productthema</option>
+                                      {ACTION_CENTER_MANAGER_RESPONSE_THEME_OPTIONS.map((option) => (
+                                        <option key={option.value} value={option.value}>
+                                          {option.label}
+                                        </option>
+                                      ))}
+                                    </select>
+                                  </FormField>
+
+                                  <FormField label="Wat is die eerste concrete stap?">
+                                    <textarea
+                                      value={managerResponseForm.primaryActionText}
+                                      onChange={(event) =>
+                                        setManagerResponseForm((current) => ({
+                                          ...current,
+                                          primaryActionText: event.target.value,
+                                        }))
+                                      }
+                                      placeholder="Bijv. plan deze week een kort teamgesprek over feedbackritme en spreek daar één vaste terugkoppeling af."
+                                      className="min-h-[105px] w-full rounded-2xl border border-[#ddd3c7] bg-white px-4 py-3 text-sm leading-7 text-[#132033] outline-none transition focus:border-[#ff9b4a]"
                                     />
-                                    <span className="leading-7">
-                                      {managerActionSurfaceCopy.primaryActionToggle}
-                                    </span>
-                                  </label>
+                                  </FormField>
 
-                                  {managerResponseForm.includePrimaryAction ? (
-                                    <div className="space-y-4 rounded-[20px] border border-[#ece4d8] bg-[#fcfaf7] px-4 py-4">
-                                      <p className="text-sm leading-7 text-[#4f6175]">
-                                        Deze extra stap maakt de route concreter, maar houdt de uitvoering nog steeds klein totdat aparte actiekaarten echt helpen.
-                                      </p>
-
-                                      <FormField label="Thema van deze eerste concrete stap">
-                                        <select
-                                          value={managerResponseForm.primaryActionThemeKey}
-                                          onChange={(event) =>
-                                            setManagerResponseForm((current) => ({
-                                              ...current,
-                                              primaryActionThemeKey: event.target.value as ActionCenterManagerActionThemeKey | '',
-                                            }))
-                                          }
-                                          className="w-full rounded-2xl border border-[#ddd3c7] bg-white px-4 py-3 text-sm text-[#132033] outline-none transition focus:border-[#ff9b4a]"
-                                        >
-                                          <option value="">Kies productthema</option>
-                                          {ACTION_CENTER_MANAGER_RESPONSE_THEME_OPTIONS.map((option) => (
-                                            <option key={option.value} value={option.value}>
-                                              {option.label}
-                                            </option>
-                                          ))}
-                                        </select>
-                                      </FormField>
-
-                                      <FormField label="Wat is die eerste concrete stap?">
-                                        <textarea
-                                          value={managerResponseForm.primaryActionText}
-                                          onChange={(event) =>
-                                            setManagerResponseForm((current) => ({
-                                              ...current,
-                                              primaryActionText: event.target.value,
-                                            }))
-                                          }
-                                          placeholder="Bijv. plan deze week een kort teamgesprek over feedbackritme en spreek daar één vaste terugkoppeling af."
-                                          className="min-h-[105px] w-full rounded-2xl border border-[#ddd3c7] bg-white px-4 py-3 text-sm leading-7 text-[#132033] outline-none transition focus:border-[#ff9b4a]"
-                                        />
-                                      </FormField>
-
-                                      <FormField label="Wat moet deze stap zichtbaar maken?">
-                                        <textarea
-                                          value={managerResponseForm.primaryActionExpectedEffect}
-                                          onChange={(event) =>
-                                            setManagerResponseForm((current) => ({
-                                              ...current,
-                                              primaryActionExpectedEffect: event.target.value,
-                                            }))
-                                          }
-                                          placeholder="Bijv. binnen twee weken moet duidelijk worden of feedbackafspraken consistenter terugkomen in het team."
-                                          className="min-h-[105px] w-full rounded-2xl border border-[#ddd3c7] bg-white px-4 py-3 text-sm leading-7 text-[#132033] outline-none transition focus:border-[#ff9b4a]"
-                                        />
-                                      </FormField>
-                                    </div>
-                                  ) : null}
-                                </>
-                              ) : (
-                                <div className="space-y-3 rounded-[20px] border border-[#ece4d8] bg-[#fcfaf7] px-4 py-4">
-                                  <p className="text-sm leading-7 text-[#4f6175]">
-                                    Concrete acties voeg je hieronder toe in deze route. Zo blijft dit eerste managerantwoord compact en blijft er maar één primaire actie-ingang over.
-                                  </p>
-                                  {selectedItem.managerResponse?.primary_action_text ? (
-                                    <SignalRow
-                                      label="Eerste managerstap"
-                                      value={selectedItem.managerResponse.primary_action_text}
+                                  <FormField label="Wat moet deze stap zichtbaar maken?">
+                                    <textarea
+                                      value={managerResponseForm.primaryActionExpectedEffect}
+                                      onChange={(event) =>
+                                        setManagerResponseForm((current) => ({
+                                          ...current,
+                                          primaryActionExpectedEffect: event.target.value,
+                                        }))
+                                      }
+                                      placeholder="Bijv. binnen twee weken moet duidelijk worden of feedbackafspraken consistenter terugkomen in het team."
+                                      className="min-h-[105px] w-full rounded-2xl border border-[#ddd3c7] bg-white px-4 py-3 text-sm leading-7 text-[#132033] outline-none transition focus:border-[#ff9b4a]"
                                     />
-                                  ) : null}
-                                  {selectedItem.managerResponse?.primary_action_expected_effect ? (
-                                    <SignalRow
-                                      label="Zichtbaar effect"
-                                      value={selectedItem.managerResponse.primary_action_expected_effect}
-                                    />
-                                  ) : null}
+                                  </FormField>
                                 </div>
-                              )}
+                              ) : null}
 
                               {managerResponseError ? (
                                 <div className="rounded-[18px] border border-[#f3c0bc] bg-[#fff1ef] px-4 py-4 text-sm leading-7 text-[#9c3f36]">
@@ -3260,153 +2699,6 @@ export function ActionCenterPreview({
                         </div>
                       ) : null}
 
-                      {selectedItem.coreSemantics.routeActionCards.length > 0 || canUseRouteActionFlow ? (
-                        <div className="rounded-[24px] border border-[#e4d9cb] bg-white px-6 py-6 shadow-[0_12px_36px_rgba(19,32,51,0.06)]">
-                          <div className="flex flex-wrap items-start justify-between gap-4">
-                            <div>
-                              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">
-                                Actieroute
-                              </p>
-                              <h3 className="mt-3 text-[1.35rem] font-semibold tracking-[-0.03em] text-[#132033]">
-                                Acties in deze route
-                              </h3>
-                              <p className="mt-3 text-sm leading-7 text-[#4f6175]">
-                                Houd elke actie klein: 1 concrete stap, 1 reviewdatum, 1 zichtbare observatie.
-                              </p>
-                            </div>
-                            {canUseRouteActionFlow ? (
-                              <button
-                                type="button"
-                                className="inline-flex min-h-11 items-center rounded-full border border-[#ded3c6] bg-[#fcfaf7] px-4.5 py-2.5 text-sm font-semibold text-[#1a2533] transition hover:border-[#1a2533]"
-                                onClick={() => {
-                                  setRouteActionEditorOpen((current) => !current)
-                                }}
-                              >
-                                Actie toevoegen
-                              </button>
-                            ) : null}
-                          </div>
-
-                          {routeActionEditorOpen ? (
-                            <div className="mt-5">
-                              <ActionCenterRouteActionEditor
-                                onSave={handleRouteActionSave}
-                                pending={routeActionPending}
-                                title="Nieuwe routeactie"
-                                description="Houd dit compact: 1 concrete stap, 1 reviewdatum en 1 zichtbaar effect."
-                                error={
-                                  routeActionFeedback?.validationDisposition
-                                    ? null
-                                    : routeActionFeedback?.message ?? null
-                                }
-                                feedbackTone={routeActionFeedback?.tone ?? 'error'}
-                                submissionState={
-                                  isPersistedDraftSubmissionDisposition(
-                                    routeActionFeedback?.validationDisposition,
-                                  ) &&
-                                  routeActionFeedback.validationMessage &&
-                                  routeActionFeedback.statusMessage &&
-                                  routeActionFeedback.persistedDraftFingerprint
-                                    ? ({
-                                        validationDisposition:
-                                          routeActionFeedback.validationDisposition,
-                                        statusMessage: routeActionFeedback.statusMessage,
-                                        validationMessage: routeActionFeedback.validationMessage,
-                                        persistedDraftFingerprint:
-                                          routeActionFeedback.persistedDraftFingerprint,
-                                      } satisfies ActionCenterRouteActionEditorSubmissionState)
-                                    : null
-                                }
-                                submitLabel="Actie opslaan"
-                              />
-                            </div>
-                          ) : routeActionFeedback ? (
-                            <div
-                              className={`mt-5 rounded-[18px] border px-4 py-4 text-sm leading-7 ${
-                                routeActionFeedback.tone === 'warning'
-                                  ? 'border-[#ffe1c7] bg-[#fff8ef] text-[#9a5a17]'
-                                  : 'border-[#f3c0bc] bg-[#fff1ef] text-[#9c3f36]'
-                              }`}
-                            >
-                              {routeActionFeedback.message}
-                            </div>
-                          ) : null}
-
-                          {selectedItem.coreSemantics.routeActionCards.length > 0 ? (
-                            <div className="mt-5 space-y-4">
-                              {selectedItem.coreSemantics.routeActionCards.map((action) => (
-                                <div
-                                  key={action.actionId}
-                                  className="rounded-[18px] border border-[#eadfce] bg-[#fcfaf7] px-4 py-4"
-                                >
-                                  <div className="flex flex-wrap items-center justify-between gap-3">
-                                    <div className="flex flex-wrap items-center gap-2 text-sm text-[#6d6458]">
-                                      <MiniTag>{getRouteActionThemeLabel(action.themeKey)}</MiniTag>
-                                      <span className={`inline-flex items-center rounded-xl border px-3 py-1.5 text-sm font-semibold ${getRouteActionStatusTone(action.status)}`}>
-                                        {getRouteActionStatusLabel(action.status)}
-                                      </span>
-                                    </div>
-                                    <span className="text-sm font-semibold text-[#5a7088]">
-                                      Review {formatLongDate(action.reviewScheduledFor)}
-                                    </span>
-                                  </div>
-
-                                  <p className="mt-4 text-[1rem] font-semibold leading-7 text-[#132033]">
-                                    {action.actionText}
-                                  </p>
-                                  <p className="mt-2 text-sm leading-7 text-[#4f6175]">
-                                    {action.expectedEffect}
-                                  </p>
-
-                                  {action.latestReview ? (
-                                    <div className="mt-4 rounded-[16px] border border-[#e5ddd1] bg-white px-4 py-4">
-                                      <p className="text-sm font-semibold text-[#132033]">
-                                        Laatste review ({getActionReviewOutcomeLabel(action.latestReview.actionOutcome)})
-                                      </p>
-                                      <p className="mt-2 text-sm leading-7 text-[#4f6175]">
-                                        {action.latestReview.observation}
-                                      </p>
-                                      {action.latestReview.followUpNote ? (
-                                        <p className="mt-2 text-sm leading-7 text-[#6d6458]">
-                                          {action.latestReview.followUpNote}
-                                        </p>
-                                      ) : null}
-                                    </div>
-                                  ) : null}
-
-                                  {canUseActionReviewFlow && action.status === 'in_review' && !action.latestReview ? (
-                                    <div className="mt-4">
-                                      {openReviewActionId === action.actionId ? (
-                                        <ActionCenterActionReviewEditor
-                                          onSave={(value) => void handleActionReviewSave(action.actionId, value)}
-                                          pending={actionReviewPendingActionId === action.actionId}
-                                          error={actionReviewError}
-                                        />
-                                      ) : (
-                                        <button
-                                          type="button"
-                                          className="inline-flex min-h-11 items-center rounded-full bg-[#ffb16e] px-4.5 py-2.5 text-sm font-semibold text-[#132033] transition hover:brightness-[0.98]"
-                                          onClick={() => {
-                                            setOpenReviewActionId(action.actionId)
-                                            setActionReviewError(null)
-                                          }}
-                                        >
-                                          Review toevoegen
-                                        </button>
-                                      )}
-                                    </div>
-                                  ) : null}
-                                </div>
-                              ))}
-                            </div>
-                          ) : (
-                            <div className="mt-5">
-                              <EmptyBlock text="Nog geen expliciete actiekaart vastgelegd. Houd de route klein tot een concrete actie echt helpt." />
-                            </div>
-                          )}
-                        </div>
-                      ) : null}
-
                       <div className="rounded-[24px] border border-[#e4d9cb] bg-[#fcfaf7] px-6 py-6 shadow-[0_12px_36px_rgba(19,32,51,0.06)]">
                         <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Bespreekvoorbereiding</p>
                         <p className="mt-3 text-sm leading-8 text-[#4f6175]">
@@ -3455,12 +2747,8 @@ export function ActionCenterPreview({
                 </div>
               ) : (
                 <EmptySection
-                  title={allowEmptyInitialSelection ? 'Kies eerst een route' : 'Nog geen acties beschikbaar'}
-                  body={
-                    allowEmptyInitialSelection
-                      ? 'Voor deze campagne zijn meerdere zichtbare routes gevonden. Kies eerst de juiste afdeling of route om de actiecontext te openen.'
-                      : 'Zodra er routes live staan, verschijnt hier automatisch de eerstvolgende managerstap, begrensde reactie of actiekaart.'
-                  }
+                  title="Nog geen acties beschikbaar"
+                  body="Zodra er routes live staan, verschijnt hier automatisch de eerstvolgende managerstap, begrensde reactie of actiekaart."
                 />
               )
             ) : null}
@@ -3492,7 +2780,8 @@ export function ActionCenterPreview({
                       items={overdueReviews}
                       emptyText="In deze selectie staan nu geen achterstallige reviews meer open."
                       onOpen={(item) => {
-                        focusActionRoute(item.id)
+                        setSelectedItemId(item.id)
+                        setActiveView('actions')
                       }}
                     />
                     <ReviewLane
@@ -3500,7 +2789,8 @@ export function ActionCenterPreview({
                       items={thisWeekReviews}
                       emptyText="Voor deze week staat nu geen nieuw reviewgesprek meer open."
                       onOpen={(item) => {
-                        focusActionRoute(item.id)
+                        setSelectedItemId(item.id)
+                        setActiveView('actions')
                       }}
                     />
                     <ReviewLane
@@ -3508,7 +2798,8 @@ export function ActionCenterPreview({
                       items={nextWeekReviews}
                       emptyText="Voor volgende week is nog geen nieuw reviewgesprek ingepland."
                       onOpen={(item) => {
-                        focusActionRoute(item.id)
+                        setSelectedItemId(item.id)
+                        setActiveView('actions')
                       }}
                     />
                   </section>
@@ -3540,7 +2831,8 @@ export function ActionCenterPreview({
                         className="mt-6 inline-flex min-h-11 rounded-full bg-[#ff9b4a] px-4.5 py-2.5 text-sm font-semibold text-[#132033] transition hover:brightness-[0.98]"
                         onClick={() => {
                           if (upcomingReviews[0]) {
-                            focusActionRoute(upcomingReviews[0].id)
+                            setSelectedItemId(upcomingReviews[0].id)
+                            setActiveView('actions')
                           }
                         }}
                       >
@@ -3629,7 +2921,7 @@ export function ActionCenterPreview({
                               className="text-left"
                               onClick={() => {
                                 setSelectedTeamId(team.id)
-                                setContextualView('teams')
+                                setActiveView('teams')
                               }}
                             >
                               <p className="font-semibold">{team.label}</p>
@@ -3755,7 +3047,10 @@ export function ActionCenterPreview({
                               key={item.id}
                               type="button"
                               className="flex w-full items-start justify-between gap-4 rounded-[22px] border border-[#ebe1d5] bg-[#fcfaf7] px-5 py-5 text-left transition hover:border-[#d7cab9]"
-                              onClick={() => focusActionRoute(item.id)}
+                              onClick={() => {
+                                setSelectedItemId(item.id)
+                                setActiveView('actions')
+                              }}
                             >
                               <div className="min-w-0">
                                 <div className="flex flex-wrap items-center gap-2 text-sm text-[#6d6458]">
@@ -3815,7 +3110,10 @@ export function ActionCenterPreview({
                                 key={item.id}
                                 type="button"
                                 className="w-full rounded-[18px] border border-[#efe7dc] bg-[#fcfaf7] px-4 py-4 text-left transition hover:border-[#d7cab9]"
-                                onClick={() => focusActionRoute(item.id)}
+                                onClick={() => {
+                                  setSelectedItemId(item.id)
+                                  setActiveView('actions')
+                                }}
                               >
                                 <p className="font-semibold text-[#132033]">{item.title}</p>
                                 <p className="mt-1 text-sm text-[#5d6f84]">Volgende bespreking {item.reviewDateLabel}</p>
@@ -4020,14 +3318,32 @@ function SidebarGroup({
   )
 }
 
+function getActionCardThemeLabel(themeKey: ActionCenterManagerActionThemeKey) {
+  return (
+    ACTION_CENTER_MANAGER_RESPONSE_THEME_OPTIONS.find((option) => option.value === themeKey)?.label ?? themeKey
+  )
+}
+
+function getActionReviewOutcomeLabel(outcome: 'effect-zichtbaar' | 'bijsturen-nodig' | 'nog-te-vroeg' | 'stoppen') {
+  switch (outcome) {
+    case 'effect-zichtbaar':
+      return 'Effect zichtbaar'
+    case 'bijsturen-nodig':
+      return 'Bijsturen nodig'
+    case 'nog-te-vroeg':
+      return 'Nog te vroeg'
+    case 'stoppen':
+    default:
+      return 'Stoppen'
+  }
+}
+
 function ActionCenterBoundedOverview({
   visibleItems,
   blockedItems,
   upcomingReviews,
   overviewStatusCounts,
   selectedItem,
-  governanceQueue,
-  measurementReadback,
   onSelectItem,
   selectedItemHref,
   workbenchLabel,
@@ -4043,8 +3359,6 @@ function ActionCenterBoundedOverview({
     closed: number
   }
   selectedItem: ActionCenterPreviewItem | null
-  governanceQueue: ActionCenterGovernanceQueue | null
-  measurementReadback: ActionCenterMeasurementReadback | null
   onSelectItem: (itemId: string) => void
   selectedItemHref: string
   workbenchLabel: string
@@ -4061,7 +3375,7 @@ function ActionCenterBoundedOverview({
         <ActionCenterBoundedCounter
           label="Te bespreken / reviewbaar"
           value={`${overviewStatusCounts.reviewReady + overviewStatusCounts.blocked}`}
-          detail={`${overviewStatusCounts.blocked} Geblokkeerd / ${overviewStatusCounts.reviewReady} reviewbaar`}
+          detail={`${overviewStatusCounts.reviewReady} reviewbaar / ${overviewStatusCounts.blocked} Geblokkeerd`}
           tone="red"
         />
         <ActionCenterBoundedCounter
@@ -4073,18 +3387,10 @@ function ActionCenterBoundedOverview({
       </div>
 
       <div className="flex flex-wrap items-center gap-x-6 gap-y-2 border-b border-[#ebe1d5] pb-4 text-sm text-[#6d6458]">
-        <span>Afgerond {overviewStatusCounts.closed}</span>
-        <span>
-          Niet beschikbaar{' '}
-          {typeof overviewStatusCounts.unavailable === 'number' ? overviewStatusCounts.unavailable : 'n.v.t.'}
-        </span>
+        <span>Afgerond: {overviewStatusCounts.closed}</span>
+        <span>Niet beschikbaar: {overviewStatusCounts.unavailable ?? 0}</span>
         <span>{visibleItems.length} zichtbare route{visibleItems.length === 1 ? '' : 's'}</span>
       </div>
-
-      {governanceQueue ? <ActionCenterGovernanceQueueSection queue={governanceQueue} /> : null}
-      {measurementReadback ? (
-        <ActionCenterMeasurementReadbackSection readback={measurementReadback} />
-      ) : null}
 
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1.65fr),minmax(320px,0.95fr)]">
         <section className="rounded-[24px] border border-[#e4d9cb] bg-white">
@@ -4115,10 +3421,10 @@ function ActionCenterBoundedOverview({
         <div className="space-y-6">
           <aside className="rounded-[24px] border border-[#e4d9cb] bg-[#fcfaf7] px-6 py-6">
             <div>
-              <div className="flex items-center justify-between gap-3">
-                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Wat vraagt nu aandacht?</p>
-                <span className="text-xs text-[#7d7368]">{blockedItems.length} Geblokkeerd</span>
-              </div>
+                      <div className="flex items-center justify-between gap-3">
+                        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Nu signalen</p>
+                        <span className="text-xs text-[#7d7368]">{blockedItems.length} geblokkeerd</span>
+                      </div>
               <div className="mt-4 space-y-3">
                 {blockedItems.length === 0 ? (
                   <EmptyBlock text="Er staan nu geen geblokkeerde routes in deze selectie." />
@@ -4169,6 +3475,7 @@ function ActionCenterBoundedOverview({
           <section className="rounded-[24px] border border-[#e4d9cb] bg-white px-6 py-6">
             {selectedItem ? (
               <>
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Wat vraagt nu aandacht?</p>
                 <div className="flex flex-wrap items-center gap-3">
                   <StatusPill status={selectedItem.status} />
                   <span className="text-sm font-semibold text-[#5a7088]">{selectedItem.code}</span>
@@ -4201,7 +3508,7 @@ function ActionCenterBoundedOverview({
               </>
             ) : (
               <>
-                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Gekozen route</p>
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Wat vraagt nu aandacht?</p>
                 <h2 className="mt-3 text-[1.45rem] font-semibold tracking-[-0.04em] text-[#132033]">Kies eerst een route</h2>
                 <p className="mt-3 text-sm leading-7 text-[#42556b]">
                   Selecteer een item uit de lijst om status, scope, eigenaar en reviewdiscipline in detail te zien.
@@ -4537,21 +3844,40 @@ function buildDetailLineageEntries(
   item: ActionCenterPreviewItem,
   routeTitlesById: ReadonlyMap<string, string>,
 ): ActionCenterDetailLineageEntry[] {
-  const routeLineage = item.coreSemantics.route
-  const { backwardLabel, backwardRouteId, forwardLabel, forwardRouteId } = item.coreSemantics.lineageSummary
-  const fallbackBackwardLabel =
-    backwardLabel ??
-    (routeLineage.lineageLabel === 'Heropend traject' || routeLineage.followUpFromRouteId
-      ? routeLineage.lineageLabel
+  const legacyLineage = (item.coreSemantics as ActionCenterPreviewItem['coreSemantics'] & {
+    lineageSemantics?: {
+      label?: string | null
+      followUpFromRouteId?: string | null
+      followUpTargetRouteId?: string | null
+    }
+  }).lineageSemantics
+  const backwardLabel =
+    item.coreSemantics.lineageSummary.backwardLabel ??
+    (legacyLineage?.label === 'Heropend traject' || legacyLineage?.label === 'Vervolg op eerdere route'
+      ? legacyLineage.label
+      : null) ??
+    (item.coreSemantics.route.lineageLabel === 'Heropend traject' ||
+    item.coreSemantics.route.lineageLabel === 'Vervolg op eerdere route'
+      ? item.coreSemantics.route.lineageLabel
       : null)
-  const fallbackBackwardRouteId = backwardRouteId ?? routeLineage.followUpFromRouteId ?? null
+  const backwardRouteId =
+    item.coreSemantics.lineageSummary.backwardRouteId ??
+    legacyLineage?.followUpFromRouteId ??
+    item.coreSemantics.route.followUpFromRouteId
+  const forwardLabel =
+    item.coreSemantics.lineageSummary.forwardLabel ??
+    (legacyLineage?.label === 'Later opgevolgd' ? legacyLineage.label : null)
+  const forwardRouteId =
+    item.coreSemantics.lineageSummary.forwardRouteId ??
+    legacyLineage?.followUpTargetRouteId ??
+    item.coreSemantics.route.followUpTargetRouteId
   const entries: Array<ActionCenterDetailLineageEntry | null> = [
-    fallbackBackwardLabel
+    backwardLabel
       ? {
           key: 'backward',
-          label: fallbackBackwardLabel,
-          routeId: fallbackBackwardRouteId,
-          routeTitle: fallbackBackwardRouteId ? (routeTitlesById.get(fallbackBackwardRouteId) ?? null) : null,
+          label: backwardLabel,
+          routeId: backwardRouteId,
+          routeTitle: backwardRouteId ? (routeTitlesById.get(backwardRouteId) ?? null) : null,
         }
       : null,
     forwardLabel
@@ -4565,37 +3891,6 @@ function buildDetailLineageEntries(
   ]
 
   return entries.filter((entry): entry is ActionCenterDetailLineageEntry => entry !== null)
-}
-
-export function buildContextualEntryHref(
-  currentHref: string,
-  args: {
-    focus?: string | null
-    view: ActionCenterPreviewView
-  },
-) {
-  const url = new URL(currentHref)
-  const source = url.searchParams.get('source')
-  const nextSource: ActionCenterEntrySource | null = isActionCenterEntrySource(source) ? source : null
-  const canonicalEntryHref = buildActionCenterEntryHref({
-    focus: args.focus ?? null,
-    view: args.view,
-    source: nextSource,
-  })
-  const canonicalEntryUrl = new URL(canonicalEntryHref, url.origin)
-
-  for (const key of ['focus', 'view', 'source'] as const) {
-    const value = canonicalEntryUrl.searchParams.get(key)
-
-    if (value === null) {
-      url.searchParams.delete(key)
-      continue
-    }
-
-    url.searchParams.set(key, value)
-  }
-
-  return `${url.pathname}${url.search}${url.hash}`
 }
 
 function RouteFieldCard({ label, value }: { label: string; value: string }) {

--- a/frontend/components/dashboard/action-center-preview.tsx
+++ b/frontend/components/dashboard/action-center-preview.tsx
@@ -8,11 +8,21 @@ import type {
   ActionCenterRouteContract,
   ActionCenterRouteStatus,
 } from '@/lib/action-center-route-contract'
+import { summarizeActionCenterRouteActions } from '@/lib/action-center-route-contract'
 import {
   ACTION_CENTER_MANAGER_RESPONSE_THEME_OPTIONS,
   getActionCenterManagerResponseLabel,
   hasPrimaryManagerAction,
 } from '@/lib/action-center-manager-responses'
+import {
+  projectActionCenterRouteActionCard,
+  type ActionCenterRouteActionRecord,
+} from '@/lib/action-center-route-actions'
+import {
+  projectActionCenterActionReview,
+  type ActionCenterActionConfidenceLevel,
+  type ActionCenterActionEvidenceSource,
+} from '@/lib/action-center-action-reviews'
 import type {
   ActionCenterRouteCloseoutReason,
   ActionCenterRouteCloseoutStatus,
@@ -26,6 +36,11 @@ import {
   getLiveActionCenterSummary,
   type ActionCenterWorkspaceReadbackSummary,
 } from '@/lib/action-center-live'
+import {
+  buildActionCenterEntryHref,
+  isActionCenterEntrySource,
+  type ActionCenterEntrySource,
+} from '@/lib/action-center-entry'
 import type {
   ActionCenterPreviewItem,
   ActionCenterPreviewManagerOption,
@@ -35,10 +50,25 @@ import type {
 } from '@/lib/action-center-preview-model'
 import type {
   ActionCenterManagerActionThemeKey,
+  ActionCenterManagerActionStatus,
   ActionCenterManagerResponse,
   ActionCenterManagerResponseType,
 } from '@/lib/pilot-learning'
+import {
+  ActionCenterActionReviewEditor,
+  type ActionCenterActionReviewEditorValue,
+} from './action-center-action-review-editor'
+import {
+  ActionCenterRouteActionEditor,
+  type ActionCenterRouteActionEditorSubmissionState,
+  serializeActionCenterRouteActionEditorValue,
+  type ActionCenterRouteActionEditorValue,
+} from './action-center-route-action-editor'
+import { ActionCenterGovernanceQueue as ActionCenterGovernanceQueueSection } from './action-center-governance-queue'
+import { ActionCenterMeasurementReadback as ActionCenterMeasurementReadbackSection } from './action-center-measurement-readback'
 import React, { useDeferredValue, useEffect, useMemo, useState } from 'react'
+import type { ActionCenterGovernanceQueue } from '@/lib/action-center-governance-queues'
+import type { ActionCenterMeasurementReadback } from '@/lib/action-center-measurement-readback'
 
 export type {
   ActionCenterPreviewItem,
@@ -60,6 +90,8 @@ interface Props {
   managerAssignmentEndpoint?: string
   canRespondToRequests?: boolean
   managerResponseEndpoint?: string
+  routeActionEndpoint?: string
+  actionReviewEndpoint?: string
   canCloseRoutes?: boolean
   routeCloseoutEndpoint?: string
   routeFollowUpEndpoint?: string
@@ -72,6 +104,9 @@ interface Props {
   itemHrefs?: Record<string, string>
   hideSidebar?: boolean
   boundedOverviewOnly?: boolean
+  allowEmptyInitialSelection?: boolean
+  governanceQueue?: ActionCenterGovernanceQueue | null
+  measurementReadback?: ActionCenterMeasurementReadback | null
 }
 
 interface CreateActionFormState {
@@ -105,6 +140,15 @@ interface RouteCloseoutFormState {
   closeoutReason: ActionCenterRouteCloseoutReason
   closeoutNote: string
 }
+
+type RouteActionValidationDisposition = 'valid' | 'invalid' | 'needs_hr_review'
+
+function isPersistedDraftSubmissionDisposition(
+  disposition: RouteActionValidationDisposition | null | undefined,
+): disposition is Extract<RouteActionValidationDisposition, 'invalid' | 'needs_hr_review'> {
+  return disposition === 'invalid' || disposition === 'needs_hr_review'
+}
+type RouteActionFeedbackTone = 'error' | 'warning'
 
 type ManagerActionPhase =
   | 'awaiting-first-move'
@@ -420,7 +464,8 @@ function getCreateDefaults(items: ActionCenterPreviewItem[]) {
 
 function buildManagerResponseDefaults(item: ActionCenterPreviewItem | null): ManagerResponseFormState {
   const response = item?.managerResponse ?? null
-  const hasPrimaryAction = Boolean(
+  const routeActionGoverned = isRouteActionGoverned(item)
+  const hasPrimaryAction = !routeActionGoverned && Boolean(
     response?.primary_action_theme_key &&
       response.primary_action_text &&
       response.primary_action_expected_effect,
@@ -435,9 +480,49 @@ function buildManagerResponseDefaults(item: ActionCenterPreviewItem | null): Man
         : ''),
     reviewScheduledFor: response?.review_scheduled_for ?? item?.reviewDate ?? '',
     includePrimaryAction: hasPrimaryAction,
-    primaryActionThemeKey: response?.primary_action_theme_key ?? '',
-    primaryActionText: response?.primary_action_text ?? '',
-    primaryActionExpectedEffect: response?.primary_action_expected_effect ?? '',
+    primaryActionThemeKey: routeActionGoverned ? '' : response?.primary_action_theme_key ?? '',
+    primaryActionText: routeActionGoverned ? '' : response?.primary_action_text ?? '',
+    primaryActionExpectedEffect: routeActionGoverned ? '' : response?.primary_action_expected_effect ?? '',
+  }
+}
+
+export function isRouteActionGoverned(item: ActionCenterPreviewItem | null) {
+  return (item?.coreSemantics.routeActionCards.length ?? 0) > 0
+}
+
+export function resolveManagerResponsePrimaryActionPayload(args: {
+  routeActionCardCount: number
+  includePrimaryAction: boolean
+  primaryActionThemeKey: ActionCenterManagerActionThemeKey | ''
+  primaryActionText: string
+  primaryActionExpectedEffect: string
+}): {
+  primary_action_theme_key: ActionCenterManagerActionThemeKey | null
+  primary_action_text: string | null
+  primary_action_expected_effect: string | null
+  primary_action_status: ActionCenterManagerActionStatus | null
+} {
+  if (args.routeActionCardCount > 0 || !args.includePrimaryAction) {
+    return {
+      primary_action_theme_key: null,
+      primary_action_text: null,
+      primary_action_expected_effect: null,
+      primary_action_status: null,
+    }
+  }
+
+  const primaryActionThemeKey = args.primaryActionThemeKey || null
+  const primaryActionText = args.primaryActionText.trim() || null
+  const primaryActionExpectedEffect = args.primaryActionExpectedEffect.trim() || null
+  const hasCompletePrimaryAction = Boolean(
+    primaryActionThemeKey && primaryActionText && primaryActionExpectedEffect,
+  )
+
+  return {
+    primary_action_theme_key: primaryActionThemeKey,
+    primary_action_text: primaryActionText,
+    primary_action_expected_effect: primaryActionExpectedEffect,
+    primary_action_status: hasCompletePrimaryAction ? 'active' : null,
   }
 }
 
@@ -462,6 +547,27 @@ function getManagerResponseProjectedStatus(
   }
 
   return hasPrimaryManagerAction(response) ? 'in-uitvoering' : 'te-bespreken'
+}
+
+function resolveRouteContractStatusFromPreviewStatus(
+  status: ActionCenterPreviewStatus,
+): Exclude<ActionCenterRouteStatus, 'open-verzoek'> {
+  switch (status) {
+    case 'te-bespreken':
+      return 'te-bespreken'
+    case 'in-uitvoering':
+    case 'reviewbaar':
+      return 'in-uitvoering'
+    case 'geblokkeerd':
+      return 'geblokkeerd'
+    case 'afgerond':
+      return 'afgerond'
+    case 'gestopt':
+      return 'gestopt'
+    case 'open-verzoek':
+    default:
+      return 'te-bespreken'
+  }
 }
 
 function getManagerActionPhase(item: ActionCenterPreviewItem | null): ManagerActionPhase {
@@ -538,6 +644,250 @@ function getManagerActionSurfaceCopy(item: ActionCenterPreviewItem | null) {
   }
 }
 
+function getRouteActionThemeLabel(themeKey: ActionCenterRouteActionRecord['themeKey']) {
+  return (
+    ACTION_CENTER_MANAGER_RESPONSE_THEME_OPTIONS.find((option) => option.value === themeKey)?.label ??
+    themeKey ??
+    'Nog geen thema'
+  )
+}
+
+function getRouteActionStatusLabel(status: ActionCenterRouteActionRecord['status']) {
+  switch (status) {
+    case 'open':
+      return 'Actief'
+    case 'in_review':
+      return 'Reviewbaar'
+    case 'afgerond':
+      return 'Afgerond'
+    case 'gestopt':
+      return 'Gestopt'
+    default:
+      return 'Nog niet reviewbaar'
+  }
+}
+
+function getRouteActionStatusTone(status: ActionCenterRouteActionRecord['status']) {
+  switch (status) {
+    case 'open':
+      return 'border-[#d7ece8] bg-[#eef9f6] text-[#28776f]'
+    case 'in_review':
+      return 'border-[#ffe1c7] bg-[#fff3e8] text-[#bb6b1f]'
+    case 'afgerond':
+      return 'border-[#d5ebdb] bg-[#edf8f0] text-[#2f8454]'
+    case 'gestopt':
+      return 'border-[#f0d9d4] bg-[#fff1ef] text-[#c4584d]'
+    default:
+      return 'border-[#e3d8ca] bg-[#fbf7f1] text-[#6b6257]'
+  }
+}
+
+function getActionReviewOutcomeLabel(outcome: ActionCenterActionReviewEditorValue['actionOutcome']) {
+  switch (outcome) {
+    case 'effect-zichtbaar':
+      return 'Effect zichtbaar'
+    case 'bijsturen-nodig':
+      return 'Bijsturen nodig'
+    case 'nog-te-vroeg':
+      return 'Nog te vroeg'
+    case 'stoppen':
+    default:
+      return 'Stoppen'
+  }
+}
+
+function getRouteActionDraftDispositionMessage(disposition: RouteActionValidationDisposition) {
+  switch (disposition) {
+    case 'needs_hr_review':
+      return 'Deze actie vraagt eerst HR-beoordeling.'
+    case 'invalid':
+      return 'Pas deze actie aan zodat hij bounded en route-specifiek is.'
+    case 'valid':
+    default:
+      return null
+  }
+}
+
+function getRouteActionPersistedDraftStatusMessage() {
+  return 'Draft opgeslagen, nog niet live in deze route.'
+}
+
+export function buildPersistedRouteActionFeedback(args: {
+  value: ActionCenterRouteActionEditorValue
+  validationDisposition: Extract<RouteActionValidationDisposition, 'invalid' | 'needs_hr_review'>
+  validationMessage: string
+}) {
+  const statusMessage = getRouteActionPersistedDraftStatusMessage()
+
+  return {
+    message: `${statusMessage} ${args.validationMessage}`,
+    tone: 'warning' as const,
+    validationDisposition: args.validationDisposition,
+    validationMessage: args.validationMessage,
+    statusMessage,
+    persistedDraftFingerprint: serializeActionCenterRouteActionEditorValue(args.value),
+  }
+}
+
+function getNextRouteActionStatusFromReviewOutcome(
+  outcome: ActionCenterActionReviewEditorValue['actionOutcome'],
+): Extract<ActionCenterRouteActionRecord['status'], 'open' | 'afgerond' | 'gestopt'> {
+  switch (outcome) {
+    case 'effect-zichtbaar':
+      return 'afgerond'
+    case 'stoppen':
+      return 'gestopt'
+    case 'bijsturen-nodig':
+    case 'nog-te-vroeg':
+    default:
+      return 'open'
+  }
+}
+
+function getRouteActionMutationStateLabel(status: 'reviewbaar' | 'in-uitvoering') {
+  return status === 'reviewbaar' ? 'Reviewbaar' : 'In uitvoering'
+}
+
+function buildRouteActionMutationProgressSummary(args: {
+  status: 'reviewbaar' | 'in-uitvoering'
+  actionCount: number
+  reviewPressureCount: number
+}) {
+  if (args.status === 'reviewbaar') {
+    return args.reviewPressureCount > 0
+      ? `${args.reviewPressureCount} actie${args.reviewPressureCount === 1 ? '' : 's'} of reviewmoment${args.reviewPressureCount === 1 ? '' : 'en'} vragen nu expliciete teruglezing.`
+      : `${args.actionCount} actie${args.actionCount === 1 ? '' : 's'} dragen deze route, maar reviewdruk wint nu van uitvoering.`
+  }
+
+  return `${args.actionCount} actie${args.actionCount === 1 ? '' : 's'} dragen nu de lokale follow-through in deze route.`
+}
+
+function buildRouteActionMutationOverviewSummary(args: {
+  status: 'reviewbaar' | 'in-uitvoering'
+  actionCount: number
+  reviewPressureCount: number
+}) {
+  if (args.status === 'reviewbaar') {
+    return args.reviewPressureCount > 0
+      ? `Actieve route waarbij ${args.reviewPressureCount} reviewmoment${args.reviewPressureCount === 1 ? '' : 'en'} nu aandacht vraagt.`
+      : 'Actieve route die nu expliciete teruglezing en review vraagt.'
+  }
+
+  return `Actieve route met ${args.actionCount} expliciete actie${args.actionCount === 1 ? '' : 's'} in dezelfde follow-through.`
+}
+
+function buildRouteActionMutationSummaryText(args: {
+  actionCount: number
+  reviewPressureCount: number
+  completedCount: number
+}) {
+  const parts = [`${args.actionCount} ${args.actionCount === 1 ? 'actie' : 'acties'}`]
+
+  if (args.reviewPressureCount > 0) {
+    parts.push(`${args.reviewPressureCount} reviewbaar`)
+  } else if (args.completedCount > 0) {
+    parts.push(`${args.completedCount} afgerond`)
+  } else {
+    parts.push('actief in deze route')
+  }
+
+  return parts.join(' - ')
+}
+
+export function synchronizeActionCenterRouteActionSurface(
+  item: ActionCenterPreviewItem,
+  cards: ActionCenterPreviewItem['coreSemantics']['routeActionCards'],
+) {
+  const persistedCards = cards.filter(
+    (card): card is typeof card & { status: NonNullable<typeof card.status>; reviewScheduledFor: string } =>
+      card.status !== null && Boolean(card.reviewScheduledFor),
+  )
+
+  if (persistedCards.length === 0) {
+    return finalizeActionCenterPreviewItem(
+      {
+        ...item,
+        coreSemantics: {
+          ...item.coreSemantics,
+          routeActionCards: cards,
+        },
+      },
+      { recomputeCoreSemantics: false },
+    )
+  }
+
+  const aggregate = summarizeActionCenterRouteActions(
+    persistedCards.map((card) => ({
+      actionId: card.actionId,
+      status: card.status,
+      reviewScheduledFor: card.reviewScheduledFor,
+    })),
+  )
+  const surfaceStatus = aggregate.routeStatus === 'reviewbaar' ? 'reviewbaar' : 'in-uitvoering'
+  const reviewPressureCount = persistedCards.filter(
+    (card) =>
+      card.status === 'in_review' ||
+      (card.status === 'open' && card.reviewScheduledFor <= new Date().toISOString().slice(0, 10)),
+  ).length
+  const completedCount = persistedCards.filter((card) => card.status === 'afgerond').length
+  const nextReviewDate = aggregate.nextReviewScheduledFor ?? item.reviewDate
+
+  return finalizeActionCenterPreviewItem(
+    {
+      ...item,
+      status: surfaceStatus,
+      reviewDate: nextReviewDate,
+      reviewDateLabel: formatShortDate(nextReviewDate),
+      summary: buildRouteActionMutationSummaryText({
+        actionCount: persistedCards.length,
+        reviewPressureCount,
+        completedCount,
+      }),
+      coreSemantics: {
+        ...item.coreSemantics,
+        routeActionCards: cards,
+        routeSummary: {
+          stateLabel: getRouteActionMutationStateLabel(surfaceStatus),
+          overviewSummary: buildRouteActionMutationOverviewSummary({
+            status: surfaceStatus,
+            actionCount: persistedCards.length,
+            reviewPressureCount,
+          }),
+          routeAsk:
+            surfaceStatus === 'reviewbaar'
+              ? 'Kijk nu expliciet terug op de lopende follow-through en bepaal wat de route daarna vraagt.'
+              : 'Houd de actielaag klein en zorg dat review per actie leidend blijft voor verdere uitvoering.',
+          progressSummary: buildRouteActionMutationProgressSummary({
+            status: surfaceStatus,
+            actionCount: persistedCards.length,
+            reviewPressureCount,
+          }),
+        },
+        routeCloseout: {
+          ...item.coreSemantics.routeCloseout,
+          readyForCloseout: aggregate.readyForCloseout,
+        },
+      },
+    },
+    { recomputeCoreSemantics: false },
+  )
+}
+
+function hasExplicitRouteCloseoutMetadata(item: ActionCenterPreviewItem | null) {
+  if (!item) {
+    return false
+  }
+
+  const closeout = item.coreSemantics.routeCloseout
+  return Boolean(
+    closeout.closeoutStatus ||
+      closeout.closeoutReason ||
+      closeout.closeoutNote ||
+      closeout.closedAt ||
+      closeout.closedByRole,
+  )
+}
+
 function getRouteSummaryDisplay(item: ActionCenterPreviewItem) {
   return (
     item.coreSemantics.routeSummary ?? {
@@ -561,17 +911,29 @@ function applyManagerResponseToItem(
   item: ActionCenterPreviewItem,
   response: ActionCenterManagerResponse,
 ): ActionCenterPreviewItem {
-  const nextStatus = getManagerResponseProjectedStatus(item.status, response)
-  const followThroughMode = hasPrimaryManagerAction(response) ? 'primary_action' : 'bounded_response'
+  const routeActionGoverned = isRouteActionGoverned(item)
+  const nextStatus: ActionCenterRouteStatus = routeActionGoverned
+    ? item.coreSemantics.route.routeStatus ?? resolveRouteContractStatusFromPreviewStatus(item.status)
+    : getManagerResponseProjectedStatus(item.status, response)
+  const followThroughMode =
+    routeActionGoverned
+      ? item.coreSemantics.route.followThroughMode
+      : hasPrimaryManagerAction(response)
+        ? 'primary_action'
+        : 'bounded_response'
   const nextRoute: ActionCenterRouteContract = {
     ...item.coreSemantics.route,
     routeStatus: nextStatus,
-    intervention: response.primary_action_text ?? null,
-    expectedEffect: response.primary_action_expected_effect ?? null,
+    intervention: routeActionGoverned
+      ? item.coreSemantics.route.intervention
+      : response.primary_action_text ?? null,
+    expectedEffect: routeActionGoverned
+      ? item.coreSemantics.route.expectedEffect
+      : response.primary_action_expected_effect ?? null,
     reviewScheduledFor: response.review_scheduled_for,
     managerResponseType: response.response_type,
     managerResponseNote: response.response_note,
-    primaryActionThemeKey: response.primary_action_theme_key ?? null,
+    primaryActionThemeKey: routeActionGoverned ? null : response.primary_action_theme_key ?? null,
     followThroughMode,
   }
 
@@ -845,6 +1207,8 @@ export function ActionCenterPreview({
   managerAssignmentEndpoint,
   canRespondToRequests = false,
   managerResponseEndpoint,
+  routeActionEndpoint,
+  actionReviewEndpoint,
   canCloseRoutes = false,
   routeCloseoutEndpoint,
   routeFollowUpEndpoint,
@@ -857,9 +1221,13 @@ export function ActionCenterPreview({
   itemHrefs = {},
   hideSidebar = false,
   boundedOverviewOnly = false,
+  allowEmptyInitialSelection = false,
+  governanceQueue = null,
+  measurementReadback = null,
 }: Props) {
   const explicitlySelectedInitialItem = initialItems.find((item) => item.id === initialSelectedItemId) ?? null
-  const initialSelectedItem = explicitlySelectedInitialItem ?? (boundedOverviewOnly ? null : initialItems[0] ?? null)
+  const initialSelectedItem =
+    explicitlySelectedInitialItem ?? (boundedOverviewOnly || allowEmptyInitialSelection ? null : initialItems[0] ?? null)
   const [items, setItems] = useState(() => initialItems.map((item) => finalizeActionCenterPreviewItem(item)))
   const [activeView, setActiveView] = useState<ActionCenterPreviewView>(initialView)
   const [selectedItemId, setSelectedItemId] = useState(initialSelectedItem?.id ?? null)
@@ -873,6 +1241,19 @@ export function ActionCenterPreview({
   )
   const [managerResponsePending, setManagerResponsePending] = useState(false)
   const [managerResponseError, setManagerResponseError] = useState<string | null>(null)
+  const [routeActionEditorOpen, setRouteActionEditorOpen] = useState(false)
+  const [routeActionPending, setRouteActionPending] = useState(false)
+  const [routeActionFeedback, setRouteActionFeedback] = useState<{
+    message: string
+    tone: RouteActionFeedbackTone
+    validationDisposition?: RouteActionValidationDisposition | null
+    validationMessage?: string | null
+    statusMessage?: string | null
+    persistedDraftFingerprint?: string | null
+  } | null>(null)
+  const [openReviewActionId, setOpenReviewActionId] = useState<string | null>(null)
+  const [actionReviewPendingActionId, setActionReviewPendingActionId] = useState<string | null>(null)
+  const [actionReviewError, setActionReviewError] = useState<string | null>(null)
   const [routeCloseoutForm, setRouteCloseoutForm] = useState<RouteCloseoutFormState>(() => buildRouteCloseoutDefaults())
   const [routeCloseoutPanelOpen, setRouteCloseoutPanelOpen] = useState(false)
   const [routeCloseoutPending, setRouteCloseoutPending] = useState(false)
@@ -882,13 +1263,13 @@ export function ActionCenterPreview({
   const deferredSearchQuery = useDeferredValue(searchQuery)
 
   useEffect(() => {
-    if (!boundedOverviewOnly && !selectedItemId && items[0]) {
+    if (!boundedOverviewOnly && !allowEmptyInitialSelection && !selectedItemId && items[0]) {
       setSelectedItemId(items[0].id)
     }
     if (!selectedTeamId && items[0]) {
       setSelectedTeamId(items[0].teamId)
     }
-  }, [boundedOverviewOnly, items, selectedItemId, selectedTeamId])
+  }, [allowEmptyInitialSelection, boundedOverviewOnly, items, selectedItemId, selectedTeamId])
 
   useEffect(() => {
     if (boundedOverviewOnly && activeView !== 'overview') {
@@ -930,7 +1311,7 @@ export function ActionCenterPreview({
 
   const selectedItem = selectedItemId
     ? filteredItems.find((item) => item.id === selectedItemId) ?? items.find((item) => item.id === selectedItemId) ?? null
-    : boundedOverviewOnly
+    : boundedOverviewOnly || allowEmptyInitialSelection
       ? null
       : filteredItems[0] ?? items[0] ?? null
   const managerActionSurfaceCopy = getManagerActionSurfaceCopy(selectedItem)
@@ -938,6 +1319,10 @@ export function ActionCenterPreview({
   useEffect(() => {
     setManagerResponseForm(buildManagerResponseDefaults(selectedItem))
     setManagerResponseError(null)
+    setRouteActionEditorOpen(false)
+    setRouteActionFeedback(null)
+    setOpenReviewActionId(null)
+    setActionReviewError(null)
   }, [selectedItem])
   useEffect(() => {
     setRouteCloseoutForm(buildRouteCloseoutDefaults())
@@ -1021,6 +1406,27 @@ export function ActionCenterPreview({
         currentUserId &&
         selectedItem.ownerId === currentUserId,
     )
+  const canUseRouteActionFlow =
+    Boolean(
+      routeActionEndpoint &&
+        selectedItem?.orgId &&
+        supportsManagerResponseFlow(selectedItem) &&
+        selectedItem?.managerResponse?.id &&
+        selectedItem?.ownerId &&
+        currentUserId &&
+        selectedItem.ownerId === currentUserId,
+    )
+  const allowInlinePrimaryAction = !isRouteActionGoverned(selectedItem)
+  const canUseActionReviewFlow =
+    Boolean(
+      actionReviewEndpoint &&
+        selectedItem?.orgId &&
+        supportsManagerResponseFlow(selectedItem) &&
+        selectedItem?.managerResponse?.id &&
+        selectedItem?.ownerId &&
+        currentUserId &&
+        selectedItem.ownerId === currentUserId,
+    )
   const canRenderFollowUpRoute = Boolean(
     routeFollowUpEndpoint &&
       canAssignManagers &&
@@ -1067,11 +1473,50 @@ export function ActionCenterPreview({
     : null
   const canShowFollowUpRouteAffordance = Boolean(canRenderFollowUpRoute && !followUpRouteBlockReason)
 
+  function replaceEntryUrl(args: {
+    focus?: string | null
+    view: ActionCenterPreviewView
+  }) {
+    if (typeof window === 'undefined') return
+
+    const nextHref = buildContextualEntryHref(window.location.href, {
+      focus: args.focus ?? selectedItemId,
+      view: args.view,
+    })
+
+    window.history.replaceState(window.history.state, '', nextHref)
+  }
+
+  function setContextualView(
+    nextView: ActionCenterPreviewView,
+    options?: {
+      focus?: string | null
+    },
+  ) {
+    setActiveView(nextView)
+    replaceEntryUrl({ focus: options?.focus ?? selectedItemId, view: nextView })
+  }
+
   function updateItem(itemId: string, updater: (item: ActionCenterPreviewItem) => ActionCenterPreviewItem) {
     setItems((currentItems) =>
       currentItems.map((item) =>
         item.id === itemId ? finalizeActionCenterPreviewItem(updater(item), { recomputeCoreSemantics: true }) : item,
       ),
+    )
+  }
+
+  function updateRouteActionCards(
+    itemId: string,
+    updater: (cards: ActionCenterPreviewItem['coreSemantics']['routeActionCards']) => ActionCenterPreviewItem['coreSemantics']['routeActionCards'],
+  ) {
+    setItems((currentItems) =>
+      currentItems.map((item) => {
+        if (item.id !== itemId) {
+          return item
+        }
+
+        return synchronizeActionCenterRouteActionSurface(item, updater(item.coreSemantics.routeActionCards))
+      }),
     )
   }
 
@@ -1122,9 +1567,8 @@ export function ActionCenterPreview({
     })
 
     setItems((current) => [newItem, ...current])
-    setSelectedItemId(newItem.id)
     setSelectedTeamId(newItem.teamId)
-    setActiveView('actions')
+    focusActionRoute(newItem.id)
     setShowCreateModal(false)
     setCreateForm(getCreateDefaults([newItem, ...items]))
   }
@@ -1185,6 +1629,14 @@ export function ActionCenterPreview({
       return
     }
 
+    const primaryActionPayload = resolveManagerResponsePrimaryActionPayload({
+      routeActionCardCount: selectedItem.coreSemantics.routeActionCards.length,
+      includePrimaryAction: managerResponseForm.includePrimaryAction,
+      primaryActionThemeKey: managerResponseForm.primaryActionThemeKey,
+      primaryActionText: managerResponseForm.primaryActionText,
+      primaryActionExpectedEffect: managerResponseForm.primaryActionExpectedEffect,
+    })
+
     setManagerResponsePending(true)
     setManagerResponseError(null)
 
@@ -1197,19 +1649,7 @@ export function ActionCenterPreview({
       response_type: managerResponseForm.responseType,
       response_note: managerResponseForm.responseNote,
       review_scheduled_for: managerResponseForm.reviewScheduledFor,
-      primary_action_theme_key:
-        managerResponseForm.includePrimaryAction && managerResponseForm.primaryActionThemeKey
-          ? managerResponseForm.primaryActionThemeKey
-          : null,
-      primary_action_text:
-        managerResponseForm.includePrimaryAction && managerResponseForm.primaryActionText.trim()
-          ? managerResponseForm.primaryActionText
-          : null,
-      primary_action_expected_effect:
-        managerResponseForm.includePrimaryAction && managerResponseForm.primaryActionExpectedEffect.trim()
-          ? managerResponseForm.primaryActionExpectedEffect
-          : null,
-      primary_action_status: managerResponseForm.includePrimaryAction ? 'active' : null,
+      ...primaryActionPayload,
     }
 
     try {
@@ -1249,6 +1689,158 @@ export function ActionCenterPreview({
       )
     } finally {
       setManagerResponsePending(false)
+    }
+  }
+
+  async function handleRouteActionSave(value: ActionCenterRouteActionEditorValue) {
+    if (!selectedItem || !routeActionEndpoint || !selectedItem.orgId || !supportsManagerResponseFlow(selectedItem)) {
+      return false
+    }
+
+    setRouteActionPending(true)
+    setRouteActionFeedback(null)
+
+    try {
+      const response = await fetch(routeActionEndpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          campaign_id: selectedItem.coreSemantics.route.campaignId,
+          route_scope_type: selectedItem.scopeType,
+          route_scope_value: selectedItem.teamId,
+          manager_user_id: selectedItem.ownerId ?? '',
+          primary_action_theme_key: value.themeKey || null,
+          primary_action_text: value.actionText,
+          primary_action_expected_effect: value.expectedEffect,
+          review_scheduled_for: value.reviewScheduledFor,
+        }),
+      })
+      const result = (await response.json().catch(() => null)) as
+        | {
+            action?: Record<string, unknown>
+            actionDraft?: { validationDisposition?: RouteActionValidationDisposition | null }
+            validationDisposition?: RouteActionValidationDisposition | null
+            validationMessage?: string | null
+            detail?: string
+          }
+        | null
+
+      if (!response.ok || !result?.action || !result?.actionDraft) {
+        throw new Error(result?.detail ?? 'Route action opslaan mislukt.')
+      }
+
+      const validationDisposition =
+        result.validationDisposition ?? result.actionDraft.validationDisposition ?? 'invalid'
+      const validationMessage =
+        result.validationMessage ?? getRouteActionDraftDispositionMessage(validationDisposition)
+
+      if (validationDisposition !== 'valid') {
+        setRouteActionFeedback(
+          buildPersistedRouteActionFeedback({
+            value,
+            validationDisposition,
+            validationMessage: validationMessage ?? 'Route action opslaan mislukt.',
+          }),
+        )
+        return false
+      }
+
+      const actionCard = projectActionCenterRouteActionCard(result.action)
+      updateRouteActionCards(selectedItem.id, (cards) => [
+        ...cards,
+        {
+          actionId: actionCard.actionId,
+          themeKey: actionCard.themeKey,
+          actionText: actionCard.actionText ?? '',
+          reviewScheduledFor: actionCard.reviewScheduledFor ?? '',
+          expectedEffect: actionCard.expectedEffect ?? '',
+          status: actionCard.status,
+          latestReview: null,
+        },
+      ])
+      setRouteActionEditorOpen(false)
+      setRouteActionFeedback(null)
+      return true
+    } catch (error) {
+      setRouteActionFeedback({
+        message: error instanceof Error ? error.message : 'Route action opslaan mislukt.',
+        tone: 'error',
+        validationDisposition: null,
+        validationMessage: null,
+        statusMessage: null,
+        persistedDraftFingerprint: null,
+      })
+      return false
+    } finally {
+      setRouteActionPending(false)
+    }
+  }
+
+  async function handleActionReviewSave(
+    actionId: string,
+    value: ActionCenterActionReviewEditorValue,
+  ) {
+    if (!actionReviewEndpoint || !selectedItem) {
+      return
+    }
+
+    setActionReviewPendingActionId(actionId)
+    setActionReviewError(null)
+
+    try {
+      const response = await fetch(actionReviewEndpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          action_id: actionId,
+          reviewed_at: new Date().toISOString(),
+          observation: value.observation,
+          action_outcome: value.actionOutcome,
+          evidence_source: value.evidenceSource,
+          confidence_level: value.confidenceLevel,
+          follow_up_note: value.followUpNote.trim() || null,
+        }),
+      })
+      const result = (await response.json().catch(() => null)) as
+        | {
+            review?: Record<string, unknown>
+            submittedStructuredMetadata?: {
+              evidence_source?: ActionCenterActionEvidenceSource | null
+              confidence_level?: ActionCenterActionConfidenceLevel | null
+            }
+            detail?: string
+          }
+        | null
+
+      if (!response.ok || !result?.review) {
+        throw new Error(result?.detail ?? 'Route action review opslaan mislukt.')
+      }
+
+      const projectedReview = projectActionCenterActionReview({
+        ...result.review,
+        evidence_source: result.submittedStructuredMetadata?.evidence_source ?? null,
+        confidence_level: result.submittedStructuredMetadata?.confidence_level ?? null,
+      })
+      updateRouteActionCards(selectedItem.id, (cards) =>
+        cards.map((card) =>
+          card.actionId === actionId
+            ? {
+                ...card,
+                status: getNextRouteActionStatusFromReviewOutcome(projectedReview.actionOutcome),
+                latestReview: projectedReview,
+              }
+            : card,
+        ),
+      )
+      setOpenReviewActionId(null)
+    } catch (error) {
+      setActionReviewError(error instanceof Error ? error.message : 'Route action review opslaan mislukt.')
+    } finally {
+      setActionReviewPendingActionId(null)
     }
   }
 
@@ -1356,11 +1948,7 @@ export function ActionCenterPreview({
   function focusActionRoute(routeId: string) {
     setSelectedItemId(routeId)
     setActiveView('actions')
-    if (typeof window !== 'undefined') {
-      const url = new URL(window.location.href)
-      url.searchParams.set('focus', routeId)
-      window.history.replaceState(window.history.state, '', `${url.pathname}${url.search}${url.hash}`)
-    }
+    replaceEntryUrl({ focus: routeId, view: 'actions' })
   }
 
   function handleStatusChange(nextStatus: ActionCenterPreviewStatus) {
@@ -1445,7 +2033,7 @@ export function ActionCenterPreview({
                 : item.key === 'managers'
                   ? navigationCounts.managers
                   : navigationCounts.teams,
-        onClick: () => setActiveView(item.key),
+        onClick: () => setContextualView(item.key),
       }))
     : []
 
@@ -1481,7 +2069,7 @@ export function ActionCenterPreview({
                   label: 'Overzicht',
                   active: activeView === 'overview',
                   count: 0,
-                  onClick: () => setActiveView('overview'),
+                  onClick: () => setContextualView('overview'),
                 },
               ]}
             />
@@ -1499,7 +2087,7 @@ export function ActionCenterPreview({
                       : item.key === 'managers'
                         ? navigationCounts.managers
                         : navigationCounts.teams,
-                onClick: () => setActiveView(item.key),
+                onClick: () => setContextualView(item.key),
               }))}
             />
 
@@ -1623,7 +2211,12 @@ export function ActionCenterPreview({
                   upcomingReviews={upcomingReviews}
                   overviewStatusCounts={overviewStatusCounts}
                   selectedItem={selectedItem}
-                  onSelectItem={setSelectedItemId}
+                  governanceQueue={governanceQueue}
+                  measurementReadback={measurementReadback}
+                  onSelectItem={(itemId) => {
+                    setSelectedItemId(itemId)
+                    replaceEntryUrl({ focus: itemId, view: 'overview' })
+                  }}
                   selectedItemHref={selectedItemHref}
                   workbenchLabel={workbenchLabel}
                 />
@@ -1663,7 +2256,7 @@ export function ActionCenterPreview({
                       <button
                         type="button"
                         className="text-sm font-semibold text-[#4a5f74] transition hover:text-[#132033]"
-                        onClick={() => setActiveView('actions')}
+                        onClick={() => setContextualView('actions')}
                       >
                         Open actielijst
                       </button>
@@ -1674,10 +2267,7 @@ export function ActionCenterPreview({
                           key={item.id}
                           type="button"
                           className="flex w-full flex-col gap-4 py-5 text-left transition hover:bg-[#f8f2eb]"
-                          onClick={() => {
-                            setSelectedItemId(item.id)
-                            setActiveView('actions')
-                          }}
+                          onClick={() => focusActionRoute(item.id)}
                         >
                           <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
                             <div className="min-w-0">
@@ -1736,10 +2326,9 @@ export function ActionCenterPreview({
                         className="inline-flex min-h-11 items-center rounded-full bg-[#ff9b4a] px-4.5 py-2.5 text-sm font-semibold text-[#132033] transition hover:brightness-[0.98]"
                         onClick={() => {
                           if (focusItem) {
-                            setSelectedItemId(focusItem.id)
-                            setActiveView('actions')
+                            focusActionRoute(focusItem.id)
                           } else {
-                            setActiveView('actions')
+                            setContextualView('actions')
                           }
                         }}
                       >
@@ -1768,7 +2357,7 @@ export function ActionCenterPreview({
                               className="flex w-full items-start justify-between gap-4 rounded-[16px] border border-white/10 bg-white/[0.03] px-4 py-3.5 text-left transition hover:bg-white/[0.06]"
                               onClick={() => {
                                 setSelectedItemId(item.id)
-                                setActiveView('reviews')
+                                setContextualView('reviews', { focus: item.id })
                               }}
                             >
                               <div className="min-w-0">
@@ -1807,7 +2396,7 @@ export function ActionCenterPreview({
                       <button
                         type="button"
                         className="min-h-11 rounded-full border border-[#ded3c6] px-4.5 py-2.5 text-sm font-semibold text-[#1a2533] transition hover:border-[#1a2533]"
-                        onClick={() => setActiveView('managers')}
+                        onClick={() => setContextualView('managers')}
                       >
                         Open managers
                       </button>
@@ -1885,7 +2474,7 @@ export function ActionCenterPreview({
                     <button
                       type="button"
                       className="inline-flex min-h-11 items-center rounded-full border border-[#ded3c6] bg-[#fcfaf7] px-4.5 py-2.5 text-sm font-semibold text-[#1a2533] transition hover:border-[#1a2533]"
-                      onClick={() => setActiveView('overview')}
+                      onClick={() => setContextualView('overview')}
                     >
                       Terug naar overzicht
                     </button>
@@ -2044,54 +2633,6 @@ export function ActionCenterPreview({
                           </div>
                         ) : null}
                       </div>
-                      {selectedItem.coreSemantics.routeActionCards.length > 0 ? (
-                        <div className="rounded-[28px] border border-[#e4d9cb] bg-white px-7 py-7 shadow-[0_12px_36px_rgba(19,32,51,0.06)]">
-                          <div className="border-b border-[#ece4d8] pb-5">
-                            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Actieroute</p>
-                            <h3 className="mt-2 text-[1.35rem] font-semibold tracking-[-0.03em] text-[#132033]">Acties in deze route</h3>
-                          </div>
-                          <div className="mt-6 space-y-4">
-                            {selectedItem.coreSemantics.routeActionCards.map((actionCard) => (
-                              <div
-                                key={actionCard.actionId}
-                                className="rounded-[22px] border border-[#efe7dc] bg-[#fcfaf7] px-5 py-5"
-                              >
-                                <div className="flex flex-wrap items-center gap-3 text-sm text-[#6d6458]">
-                                  <MiniTag>{getActionCardThemeLabel(actionCard.themeKey)}</MiniTag>
-                                  <StatusPill
-                                    status={
-                                      actionCard.status === 'in_review'
-                                        ? 'reviewbaar'
-                                        : actionCard.status === 'open'
-                                          ? 'in-uitvoering'
-                                          : actionCard.status === 'afgerond'
-                                            ? 'afgerond'
-                                            : 'gestopt'
-                                    }
-                                  />
-                                  <span className="ml-auto font-semibold text-[#5a7088]">
-                                    Review {formatShortDate(actionCard.reviewScheduledFor)}
-                                  </span>
-                                </div>
-                                <p className="mt-4 text-[1.02rem] font-semibold leading-7 text-[#132033]">
-                                  {actionCard.actionText}
-                                </p>
-                                <p className="mt-2 text-sm leading-7 text-[#4f6175]">{actionCard.expectedEffect}</p>
-                                {actionCard.latestReview ? (
-                                  <div className="mt-4 rounded-[18px] border border-[#eadfce] bg-white px-4 py-4">
-                                    <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">
-                                      Laatste review ({getActionReviewOutcomeLabel(actionCard.latestReview.actionOutcome)})
-                                    </p>
-                                    <p className="mt-3 text-sm leading-7 text-[#32465d]">
-                                      {actionCard.latestReview.observation}
-                                    </p>
-                                  </div>
-                                ) : null}
-                              </div>
-                            ))}
-                          </div>
-                        </div>
-                      ) : null}
                     </section>
 
                     <section className="space-y-6">
@@ -2386,9 +2927,7 @@ export function ActionCenterPreview({
                         </div>
                       ) : null}
 
-                      {selectedItem &&
-                      (isClosedRouteStatus(selectedItem.status) ||
-                        Boolean(selectedItem.coreSemantics.routeCloseout.closeoutStatus)) ? (
+                      {selectedItem && (isClosedRouteStatus(selectedItem.status) || hasExplicitRouteCloseoutMetadata(selectedItem)) ? (
                         <div className="rounded-[24px] border border-[#e4d9cb] bg-white px-6 py-6 shadow-[0_12px_36px_rgba(19,32,51,0.06)]">
                           <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">
                             Route afgesloten
@@ -2564,78 +3103,100 @@ export function ActionCenterPreview({
                                 />
                               </FormField>
 
-                              <label className="flex items-start gap-3 rounded-[18px] border border-[#ece4d8] bg-[#fcfaf7] px-4 py-4 text-sm text-[#42556b]">
-                                <input
-                                  type="checkbox"
-                                  checked={managerResponseForm.includePrimaryAction}
-                                  onChange={(event) =>
-                                    setManagerResponseForm((current) => ({
-                                      ...current,
-                                      includePrimaryAction: event.target.checked,
-                                    }))
-                                  }
-                                  className="mt-1 h-4 w-4 rounded border-[#d6cbbb] text-[#132033]"
-                                />
-                                <span className="leading-7">
-                                  {managerActionSurfaceCopy.primaryActionToggle}
-                                </span>
-                              </label>
+                              {allowInlinePrimaryAction ? (
+                                <>
+                                  <label className="flex items-start gap-3 rounded-[18px] border border-[#ece4d8] bg-[#fcfaf7] px-4 py-4 text-sm text-[#42556b]">
+                                    <input
+                                      type="checkbox"
+                                      checked={managerResponseForm.includePrimaryAction}
+                                      onChange={(event) =>
+                                        setManagerResponseForm((current) => ({
+                                          ...current,
+                                          includePrimaryAction: event.target.checked,
+                                        }))
+                                      }
+                                      className="mt-1 h-4 w-4 rounded border-[#d6cbbb] text-[#132033]"
+                                    />
+                                    <span className="leading-7">
+                                      {managerActionSurfaceCopy.primaryActionToggle}
+                                    </span>
+                                  </label>
 
-                              {managerResponseForm.includePrimaryAction ? (
-                                <div className="space-y-4 rounded-[20px] border border-[#ece4d8] bg-[#fcfaf7] px-4 py-4">
+                                  {managerResponseForm.includePrimaryAction ? (
+                                    <div className="space-y-4 rounded-[20px] border border-[#ece4d8] bg-[#fcfaf7] px-4 py-4">
+                                      <p className="text-sm leading-7 text-[#4f6175]">
+                                        Deze extra stap maakt de route concreter, maar houdt de uitvoering nog steeds klein totdat aparte actiekaarten echt helpen.
+                                      </p>
+
+                                      <FormField label="Thema van deze eerste concrete stap">
+                                        <select
+                                          value={managerResponseForm.primaryActionThemeKey}
+                                          onChange={(event) =>
+                                            setManagerResponseForm((current) => ({
+                                              ...current,
+                                              primaryActionThemeKey: event.target.value as ActionCenterManagerActionThemeKey | '',
+                                            }))
+                                          }
+                                          className="w-full rounded-2xl border border-[#ddd3c7] bg-white px-4 py-3 text-sm text-[#132033] outline-none transition focus:border-[#ff9b4a]"
+                                        >
+                                          <option value="">Kies productthema</option>
+                                          {ACTION_CENTER_MANAGER_RESPONSE_THEME_OPTIONS.map((option) => (
+                                            <option key={option.value} value={option.value}>
+                                              {option.label}
+                                            </option>
+                                          ))}
+                                        </select>
+                                      </FormField>
+
+                                      <FormField label="Wat is die eerste concrete stap?">
+                                        <textarea
+                                          value={managerResponseForm.primaryActionText}
+                                          onChange={(event) =>
+                                            setManagerResponseForm((current) => ({
+                                              ...current,
+                                              primaryActionText: event.target.value,
+                                            }))
+                                          }
+                                          placeholder="Bijv. plan deze week een kort teamgesprek over feedbackritme en spreek daar één vaste terugkoppeling af."
+                                          className="min-h-[105px] w-full rounded-2xl border border-[#ddd3c7] bg-white px-4 py-3 text-sm leading-7 text-[#132033] outline-none transition focus:border-[#ff9b4a]"
+                                        />
+                                      </FormField>
+
+                                      <FormField label="Wat moet deze stap zichtbaar maken?">
+                                        <textarea
+                                          value={managerResponseForm.primaryActionExpectedEffect}
+                                          onChange={(event) =>
+                                            setManagerResponseForm((current) => ({
+                                              ...current,
+                                              primaryActionExpectedEffect: event.target.value,
+                                            }))
+                                          }
+                                          placeholder="Bijv. binnen twee weken moet duidelijk worden of feedbackafspraken consistenter terugkomen in het team."
+                                          className="min-h-[105px] w-full rounded-2xl border border-[#ddd3c7] bg-white px-4 py-3 text-sm leading-7 text-[#132033] outline-none transition focus:border-[#ff9b4a]"
+                                        />
+                                      </FormField>
+                                    </div>
+                                  ) : null}
+                                </>
+                              ) : (
+                                <div className="space-y-3 rounded-[20px] border border-[#ece4d8] bg-[#fcfaf7] px-4 py-4">
                                   <p className="text-sm leading-7 text-[#4f6175]">
-                                    Deze extra stap maakt de route concreter, maar houdt de uitvoering nog steeds klein totdat aparte actiekaarten echt helpen.
+                                    Concrete acties voeg je hieronder toe in deze route. Zo blijft dit eerste managerantwoord compact en blijft er maar één primaire actie-ingang over.
                                   </p>
-
-                                  <FormField label="Thema van deze eerste concrete stap">
-                                    <select
-                                      value={managerResponseForm.primaryActionThemeKey}
-                                      onChange={(event) =>
-                                        setManagerResponseForm((current) => ({
-                                          ...current,
-                                          primaryActionThemeKey: event.target.value as ActionCenterManagerActionThemeKey | '',
-                                        }))
-                                      }
-                                      className="w-full rounded-2xl border border-[#ddd3c7] bg-white px-4 py-3 text-sm text-[#132033] outline-none transition focus:border-[#ff9b4a]"
-                                    >
-                                      <option value="">Kies productthema</option>
-                                      {ACTION_CENTER_MANAGER_RESPONSE_THEME_OPTIONS.map((option) => (
-                                        <option key={option.value} value={option.value}>
-                                          {option.label}
-                                        </option>
-                                      ))}
-                                    </select>
-                                  </FormField>
-
-                                  <FormField label="Wat is die eerste concrete stap?">
-                                    <textarea
-                                      value={managerResponseForm.primaryActionText}
-                                      onChange={(event) =>
-                                        setManagerResponseForm((current) => ({
-                                          ...current,
-                                          primaryActionText: event.target.value,
-                                        }))
-                                      }
-                                      placeholder="Bijv. plan deze week een kort teamgesprek over feedbackritme en spreek daar één vaste terugkoppeling af."
-                                      className="min-h-[105px] w-full rounded-2xl border border-[#ddd3c7] bg-white px-4 py-3 text-sm leading-7 text-[#132033] outline-none transition focus:border-[#ff9b4a]"
+                                  {selectedItem.managerResponse?.primary_action_text ? (
+                                    <SignalRow
+                                      label="Eerste managerstap"
+                                      value={selectedItem.managerResponse.primary_action_text}
                                     />
-                                  </FormField>
-
-                                  <FormField label="Wat moet deze stap zichtbaar maken?">
-                                    <textarea
-                                      value={managerResponseForm.primaryActionExpectedEffect}
-                                      onChange={(event) =>
-                                        setManagerResponseForm((current) => ({
-                                          ...current,
-                                          primaryActionExpectedEffect: event.target.value,
-                                        }))
-                                      }
-                                      placeholder="Bijv. binnen twee weken moet duidelijk worden of feedbackafspraken consistenter terugkomen in het team."
-                                      className="min-h-[105px] w-full rounded-2xl border border-[#ddd3c7] bg-white px-4 py-3 text-sm leading-7 text-[#132033] outline-none transition focus:border-[#ff9b4a]"
+                                  ) : null}
+                                  {selectedItem.managerResponse?.primary_action_expected_effect ? (
+                                    <SignalRow
+                                      label="Zichtbaar effect"
+                                      value={selectedItem.managerResponse.primary_action_expected_effect}
                                     />
-                                  </FormField>
+                                  ) : null}
                                 </div>
-                              ) : null}
+                              )}
 
                               {managerResponseError ? (
                                 <div className="rounded-[18px] border border-[#f3c0bc] bg-[#fff1ef] px-4 py-4 text-sm leading-7 text-[#9c3f36]">
@@ -2699,6 +3260,153 @@ export function ActionCenterPreview({
                         </div>
                       ) : null}
 
+                      {selectedItem.coreSemantics.routeActionCards.length > 0 || canUseRouteActionFlow ? (
+                        <div className="rounded-[24px] border border-[#e4d9cb] bg-white px-6 py-6 shadow-[0_12px_36px_rgba(19,32,51,0.06)]">
+                          <div className="flex flex-wrap items-start justify-between gap-4">
+                            <div>
+                              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">
+                                Actieroute
+                              </p>
+                              <h3 className="mt-3 text-[1.35rem] font-semibold tracking-[-0.03em] text-[#132033]">
+                                Acties in deze route
+                              </h3>
+                              <p className="mt-3 text-sm leading-7 text-[#4f6175]">
+                                Houd elke actie klein: 1 concrete stap, 1 reviewdatum, 1 zichtbare observatie.
+                              </p>
+                            </div>
+                            {canUseRouteActionFlow ? (
+                              <button
+                                type="button"
+                                className="inline-flex min-h-11 items-center rounded-full border border-[#ded3c6] bg-[#fcfaf7] px-4.5 py-2.5 text-sm font-semibold text-[#1a2533] transition hover:border-[#1a2533]"
+                                onClick={() => {
+                                  setRouteActionEditorOpen((current) => !current)
+                                }}
+                              >
+                                Actie toevoegen
+                              </button>
+                            ) : null}
+                          </div>
+
+                          {routeActionEditorOpen ? (
+                            <div className="mt-5">
+                              <ActionCenterRouteActionEditor
+                                onSave={handleRouteActionSave}
+                                pending={routeActionPending}
+                                title="Nieuwe routeactie"
+                                description="Houd dit compact: 1 concrete stap, 1 reviewdatum en 1 zichtbaar effect."
+                                error={
+                                  routeActionFeedback?.validationDisposition
+                                    ? null
+                                    : routeActionFeedback?.message ?? null
+                                }
+                                feedbackTone={routeActionFeedback?.tone ?? 'error'}
+                                submissionState={
+                                  isPersistedDraftSubmissionDisposition(
+                                    routeActionFeedback?.validationDisposition,
+                                  ) &&
+                                  routeActionFeedback.validationMessage &&
+                                  routeActionFeedback.statusMessage &&
+                                  routeActionFeedback.persistedDraftFingerprint
+                                    ? ({
+                                        validationDisposition:
+                                          routeActionFeedback.validationDisposition,
+                                        statusMessage: routeActionFeedback.statusMessage,
+                                        validationMessage: routeActionFeedback.validationMessage,
+                                        persistedDraftFingerprint:
+                                          routeActionFeedback.persistedDraftFingerprint,
+                                      } satisfies ActionCenterRouteActionEditorSubmissionState)
+                                    : null
+                                }
+                                submitLabel="Actie opslaan"
+                              />
+                            </div>
+                          ) : routeActionFeedback ? (
+                            <div
+                              className={`mt-5 rounded-[18px] border px-4 py-4 text-sm leading-7 ${
+                                routeActionFeedback.tone === 'warning'
+                                  ? 'border-[#ffe1c7] bg-[#fff8ef] text-[#9a5a17]'
+                                  : 'border-[#f3c0bc] bg-[#fff1ef] text-[#9c3f36]'
+                              }`}
+                            >
+                              {routeActionFeedback.message}
+                            </div>
+                          ) : null}
+
+                          {selectedItem.coreSemantics.routeActionCards.length > 0 ? (
+                            <div className="mt-5 space-y-4">
+                              {selectedItem.coreSemantics.routeActionCards.map((action) => (
+                                <div
+                                  key={action.actionId}
+                                  className="rounded-[18px] border border-[#eadfce] bg-[#fcfaf7] px-4 py-4"
+                                >
+                                  <div className="flex flex-wrap items-center justify-between gap-3">
+                                    <div className="flex flex-wrap items-center gap-2 text-sm text-[#6d6458]">
+                                      <MiniTag>{getRouteActionThemeLabel(action.themeKey)}</MiniTag>
+                                      <span className={`inline-flex items-center rounded-xl border px-3 py-1.5 text-sm font-semibold ${getRouteActionStatusTone(action.status)}`}>
+                                        {getRouteActionStatusLabel(action.status)}
+                                      </span>
+                                    </div>
+                                    <span className="text-sm font-semibold text-[#5a7088]">
+                                      Review {formatLongDate(action.reviewScheduledFor)}
+                                    </span>
+                                  </div>
+
+                                  <p className="mt-4 text-[1rem] font-semibold leading-7 text-[#132033]">
+                                    {action.actionText}
+                                  </p>
+                                  <p className="mt-2 text-sm leading-7 text-[#4f6175]">
+                                    {action.expectedEffect}
+                                  </p>
+
+                                  {action.latestReview ? (
+                                    <div className="mt-4 rounded-[16px] border border-[#e5ddd1] bg-white px-4 py-4">
+                                      <p className="text-sm font-semibold text-[#132033]">
+                                        Laatste review ({getActionReviewOutcomeLabel(action.latestReview.actionOutcome)})
+                                      </p>
+                                      <p className="mt-2 text-sm leading-7 text-[#4f6175]">
+                                        {action.latestReview.observation}
+                                      </p>
+                                      {action.latestReview.followUpNote ? (
+                                        <p className="mt-2 text-sm leading-7 text-[#6d6458]">
+                                          {action.latestReview.followUpNote}
+                                        </p>
+                                      ) : null}
+                                    </div>
+                                  ) : null}
+
+                                  {canUseActionReviewFlow && action.status === 'in_review' && !action.latestReview ? (
+                                    <div className="mt-4">
+                                      {openReviewActionId === action.actionId ? (
+                                        <ActionCenterActionReviewEditor
+                                          onSave={(value) => void handleActionReviewSave(action.actionId, value)}
+                                          pending={actionReviewPendingActionId === action.actionId}
+                                          error={actionReviewError}
+                                        />
+                                      ) : (
+                                        <button
+                                          type="button"
+                                          className="inline-flex min-h-11 items-center rounded-full bg-[#ffb16e] px-4.5 py-2.5 text-sm font-semibold text-[#132033] transition hover:brightness-[0.98]"
+                                          onClick={() => {
+                                            setOpenReviewActionId(action.actionId)
+                                            setActionReviewError(null)
+                                          }}
+                                        >
+                                          Review toevoegen
+                                        </button>
+                                      )}
+                                    </div>
+                                  ) : null}
+                                </div>
+                              ))}
+                            </div>
+                          ) : (
+                            <div className="mt-5">
+                              <EmptyBlock text="Nog geen expliciete actiekaart vastgelegd. Houd de route klein tot een concrete actie echt helpt." />
+                            </div>
+                          )}
+                        </div>
+                      ) : null}
+
                       <div className="rounded-[24px] border border-[#e4d9cb] bg-[#fcfaf7] px-6 py-6 shadow-[0_12px_36px_rgba(19,32,51,0.06)]">
                         <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Bespreekvoorbereiding</p>
                         <p className="mt-3 text-sm leading-8 text-[#4f6175]">
@@ -2747,8 +3455,12 @@ export function ActionCenterPreview({
                 </div>
               ) : (
                 <EmptySection
-                  title="Nog geen acties beschikbaar"
-                  body="Zodra er routes live staan, verschijnt hier automatisch de eerstvolgende managerstap, begrensde reactie of actiekaart."
+                  title={allowEmptyInitialSelection ? 'Kies eerst een route' : 'Nog geen acties beschikbaar'}
+                  body={
+                    allowEmptyInitialSelection
+                      ? 'Voor deze campagne zijn meerdere zichtbare routes gevonden. Kies eerst de juiste afdeling of route om de actiecontext te openen.'
+                      : 'Zodra er routes live staan, verschijnt hier automatisch de eerstvolgende managerstap, begrensde reactie of actiekaart.'
+                  }
                 />
               )
             ) : null}
@@ -2780,8 +3492,7 @@ export function ActionCenterPreview({
                       items={overdueReviews}
                       emptyText="In deze selectie staan nu geen achterstallige reviews meer open."
                       onOpen={(item) => {
-                        setSelectedItemId(item.id)
-                        setActiveView('actions')
+                        focusActionRoute(item.id)
                       }}
                     />
                     <ReviewLane
@@ -2789,8 +3500,7 @@ export function ActionCenterPreview({
                       items={thisWeekReviews}
                       emptyText="Voor deze week staat nu geen nieuw reviewgesprek meer open."
                       onOpen={(item) => {
-                        setSelectedItemId(item.id)
-                        setActiveView('actions')
+                        focusActionRoute(item.id)
                       }}
                     />
                     <ReviewLane
@@ -2798,8 +3508,7 @@ export function ActionCenterPreview({
                       items={nextWeekReviews}
                       emptyText="Voor volgende week is nog geen nieuw reviewgesprek ingepland."
                       onOpen={(item) => {
-                        setSelectedItemId(item.id)
-                        setActiveView('actions')
+                        focusActionRoute(item.id)
                       }}
                     />
                   </section>
@@ -2831,8 +3540,7 @@ export function ActionCenterPreview({
                         className="mt-6 inline-flex min-h-11 rounded-full bg-[#ff9b4a] px-4.5 py-2.5 text-sm font-semibold text-[#132033] transition hover:brightness-[0.98]"
                         onClick={() => {
                           if (upcomingReviews[0]) {
-                            setSelectedItemId(upcomingReviews[0].id)
-                            setActiveView('actions')
+                            focusActionRoute(upcomingReviews[0].id)
                           }
                         }}
                       >
@@ -2921,7 +3629,7 @@ export function ActionCenterPreview({
                               className="text-left"
                               onClick={() => {
                                 setSelectedTeamId(team.id)
-                                setActiveView('teams')
+                                setContextualView('teams')
                               }}
                             >
                               <p className="font-semibold">{team.label}</p>
@@ -3047,10 +3755,7 @@ export function ActionCenterPreview({
                               key={item.id}
                               type="button"
                               className="flex w-full items-start justify-between gap-4 rounded-[22px] border border-[#ebe1d5] bg-[#fcfaf7] px-5 py-5 text-left transition hover:border-[#d7cab9]"
-                              onClick={() => {
-                                setSelectedItemId(item.id)
-                                setActiveView('actions')
-                              }}
+                              onClick={() => focusActionRoute(item.id)}
                             >
                               <div className="min-w-0">
                                 <div className="flex flex-wrap items-center gap-2 text-sm text-[#6d6458]">
@@ -3110,10 +3815,7 @@ export function ActionCenterPreview({
                                 key={item.id}
                                 type="button"
                                 className="w-full rounded-[18px] border border-[#efe7dc] bg-[#fcfaf7] px-4 py-4 text-left transition hover:border-[#d7cab9]"
-                                onClick={() => {
-                                  setSelectedItemId(item.id)
-                                  setActiveView('actions')
-                                }}
+                                onClick={() => focusActionRoute(item.id)}
                               >
                                 <p className="font-semibold text-[#132033]">{item.title}</p>
                                 <p className="mt-1 text-sm text-[#5d6f84]">Volgende bespreking {item.reviewDateLabel}</p>
@@ -3318,32 +4020,14 @@ function SidebarGroup({
   )
 }
 
-function getActionCardThemeLabel(themeKey: ActionCenterManagerActionThemeKey) {
-  return (
-    ACTION_CENTER_MANAGER_RESPONSE_THEME_OPTIONS.find((option) => option.value === themeKey)?.label ?? themeKey
-  )
-}
-
-function getActionReviewOutcomeLabel(outcome: 'effect-zichtbaar' | 'bijsturen-nodig' | 'nog-te-vroeg' | 'stoppen') {
-  switch (outcome) {
-    case 'effect-zichtbaar':
-      return 'Effect zichtbaar'
-    case 'bijsturen-nodig':
-      return 'Bijsturen nodig'
-    case 'nog-te-vroeg':
-      return 'Nog te vroeg'
-    case 'stoppen':
-    default:
-      return 'Stoppen'
-  }
-}
-
 function ActionCenterBoundedOverview({
   visibleItems,
   blockedItems,
   upcomingReviews,
   overviewStatusCounts,
   selectedItem,
+  governanceQueue,
+  measurementReadback,
   onSelectItem,
   selectedItemHref,
   workbenchLabel,
@@ -3359,6 +4043,8 @@ function ActionCenterBoundedOverview({
     closed: number
   }
   selectedItem: ActionCenterPreviewItem | null
+  governanceQueue: ActionCenterGovernanceQueue | null
+  measurementReadback: ActionCenterMeasurementReadback | null
   onSelectItem: (itemId: string) => void
   selectedItemHref: string
   workbenchLabel: string
@@ -3375,7 +4061,7 @@ function ActionCenterBoundedOverview({
         <ActionCenterBoundedCounter
           label="Te bespreken / reviewbaar"
           value={`${overviewStatusCounts.reviewReady + overviewStatusCounts.blocked}`}
-          detail={`${overviewStatusCounts.reviewReady} reviewbaar / ${overviewStatusCounts.blocked} Geblokkeerd`}
+          detail={`${overviewStatusCounts.blocked} Geblokkeerd / ${overviewStatusCounts.reviewReady} reviewbaar`}
           tone="red"
         />
         <ActionCenterBoundedCounter
@@ -3387,10 +4073,18 @@ function ActionCenterBoundedOverview({
       </div>
 
       <div className="flex flex-wrap items-center gap-x-6 gap-y-2 border-b border-[#ebe1d5] pb-4 text-sm text-[#6d6458]">
-        <span>Afgerond: {overviewStatusCounts.closed}</span>
-        <span>Niet beschikbaar: {overviewStatusCounts.unavailable ?? 0}</span>
+        <span>Afgerond {overviewStatusCounts.closed}</span>
+        <span>
+          Niet beschikbaar{' '}
+          {typeof overviewStatusCounts.unavailable === 'number' ? overviewStatusCounts.unavailable : 'n.v.t.'}
+        </span>
         <span>{visibleItems.length} zichtbare route{visibleItems.length === 1 ? '' : 's'}</span>
       </div>
+
+      {governanceQueue ? <ActionCenterGovernanceQueueSection queue={governanceQueue} /> : null}
+      {measurementReadback ? (
+        <ActionCenterMeasurementReadbackSection readback={measurementReadback} />
+      ) : null}
 
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1.65fr),minmax(320px,0.95fr)]">
         <section className="rounded-[24px] border border-[#e4d9cb] bg-white">
@@ -3421,10 +4115,10 @@ function ActionCenterBoundedOverview({
         <div className="space-y-6">
           <aside className="rounded-[24px] border border-[#e4d9cb] bg-[#fcfaf7] px-6 py-6">
             <div>
-                      <div className="flex items-center justify-between gap-3">
-                        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Nu signalen</p>
-                        <span className="text-xs text-[#7d7368]">{blockedItems.length} geblokkeerd</span>
-                      </div>
+              <div className="flex items-center justify-between gap-3">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Wat vraagt nu aandacht?</p>
+                <span className="text-xs text-[#7d7368]">{blockedItems.length} Geblokkeerd</span>
+              </div>
               <div className="mt-4 space-y-3">
                 {blockedItems.length === 0 ? (
                   <EmptyBlock text="Er staan nu geen geblokkeerde routes in deze selectie." />
@@ -3475,7 +4169,6 @@ function ActionCenterBoundedOverview({
           <section className="rounded-[24px] border border-[#e4d9cb] bg-white px-6 py-6">
             {selectedItem ? (
               <>
-                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Wat vraagt nu aandacht?</p>
                 <div className="flex flex-wrap items-center gap-3">
                   <StatusPill status={selectedItem.status} />
                   <span className="text-sm font-semibold text-[#5a7088]">{selectedItem.code}</span>
@@ -3508,7 +4201,7 @@ function ActionCenterBoundedOverview({
               </>
             ) : (
               <>
-                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Wat vraagt nu aandacht?</p>
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#8d8377]">Gekozen route</p>
                 <h2 className="mt-3 text-[1.45rem] font-semibold tracking-[-0.04em] text-[#132033]">Kies eerst een route</h2>
                 <p className="mt-3 text-sm leading-7 text-[#42556b]">
                   Selecteer een item uit de lijst om status, scope, eigenaar en reviewdiscipline in detail te zien.
@@ -3844,40 +4537,21 @@ function buildDetailLineageEntries(
   item: ActionCenterPreviewItem,
   routeTitlesById: ReadonlyMap<string, string>,
 ): ActionCenterDetailLineageEntry[] {
-  const legacyLineage = (item.coreSemantics as ActionCenterPreviewItem['coreSemantics'] & {
-    lineageSemantics?: {
-      label?: string | null
-      followUpFromRouteId?: string | null
-      followUpTargetRouteId?: string | null
-    }
-  }).lineageSemantics
-  const backwardLabel =
-    item.coreSemantics.lineageSummary.backwardLabel ??
-    (legacyLineage?.label === 'Heropend traject' || legacyLineage?.label === 'Vervolg op eerdere route'
-      ? legacyLineage.label
-      : null) ??
-    (item.coreSemantics.route.lineageLabel === 'Heropend traject' ||
-    item.coreSemantics.route.lineageLabel === 'Vervolg op eerdere route'
-      ? item.coreSemantics.route.lineageLabel
+  const routeLineage = item.coreSemantics.route
+  const { backwardLabel, backwardRouteId, forwardLabel, forwardRouteId } = item.coreSemantics.lineageSummary
+  const fallbackBackwardLabel =
+    backwardLabel ??
+    (routeLineage.lineageLabel === 'Heropend traject' || routeLineage.followUpFromRouteId
+      ? routeLineage.lineageLabel
       : null)
-  const backwardRouteId =
-    item.coreSemantics.lineageSummary.backwardRouteId ??
-    legacyLineage?.followUpFromRouteId ??
-    item.coreSemantics.route.followUpFromRouteId
-  const forwardLabel =
-    item.coreSemantics.lineageSummary.forwardLabel ??
-    (legacyLineage?.label === 'Later opgevolgd' ? legacyLineage.label : null)
-  const forwardRouteId =
-    item.coreSemantics.lineageSummary.forwardRouteId ??
-    legacyLineage?.followUpTargetRouteId ??
-    item.coreSemantics.route.followUpTargetRouteId
+  const fallbackBackwardRouteId = backwardRouteId ?? routeLineage.followUpFromRouteId ?? null
   const entries: Array<ActionCenterDetailLineageEntry | null> = [
-    backwardLabel
+    fallbackBackwardLabel
       ? {
           key: 'backward',
-          label: backwardLabel,
-          routeId: backwardRouteId,
-          routeTitle: backwardRouteId ? (routeTitlesById.get(backwardRouteId) ?? null) : null,
+          label: fallbackBackwardLabel,
+          routeId: fallbackBackwardRouteId,
+          routeTitle: fallbackBackwardRouteId ? (routeTitlesById.get(fallbackBackwardRouteId) ?? null) : null,
         }
       : null,
     forwardLabel
@@ -3891,6 +4565,37 @@ function buildDetailLineageEntries(
   ]
 
   return entries.filter((entry): entry is ActionCenterDetailLineageEntry => entry !== null)
+}
+
+export function buildContextualEntryHref(
+  currentHref: string,
+  args: {
+    focus?: string | null
+    view: ActionCenterPreviewView
+  },
+) {
+  const url = new URL(currentHref)
+  const source = url.searchParams.get('source')
+  const nextSource: ActionCenterEntrySource | null = isActionCenterEntrySource(source) ? source : null
+  const canonicalEntryHref = buildActionCenterEntryHref({
+    focus: args.focus ?? null,
+    view: args.view,
+    source: nextSource,
+  })
+  const canonicalEntryUrl = new URL(canonicalEntryHref, url.origin)
+
+  for (const key of ['focus', 'view', 'source'] as const) {
+    const value = canonicalEntryUrl.searchParams.get(key)
+
+    if (value === null) {
+      url.searchParams.delete(key)
+      continue
+    }
+
+    url.searchParams.set(key, value)
+  }
+
+  return `${url.pathname}${url.search}${url.hash}`
 }
 
 function RouteFieldCard({ label, value }: { label: string; value: string }) {

--- a/frontend/lib/action-center-admin-governance.test.ts
+++ b/frontend/lib/action-center-admin-governance.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { resolveActionCenterAdminCapabilities } from './action-center-admin-governance'
+
+describe('action center admin governance capabilities', () => {
+  it('grants tenant admin only to verisight admin or explicit customer admin capability', () => {
+    expect(
+      resolveActionCenterAdminCapabilities({
+        persona: 'customer_owner',
+        isVerisightAdmin: false,
+        memberRole: 'owner',
+        workspaceRoles: [],
+      }).canManageTenantAdmin,
+    ).toBe(false)
+
+    expect(
+      resolveActionCenterAdminCapabilities({
+        persona: 'customer_owner',
+        isVerisightAdmin: false,
+        memberRole: 'owner',
+        workspaceRoles: ['hr_owner'],
+      }).canManageTenantAdmin,
+    ).toBe(true)
+
+    expect(
+      resolveActionCenterAdminCapabilities({
+        persona: 'verisight_admin',
+        isVerisightAdmin: true,
+        memberRole: null,
+        workspaceRoles: [],
+      }).canManageTenantAdmin,
+    ).toBe(true)
+  })
+
+  it('keeps executive viewer aggregated and read-only', () => {
+    const viewerCapabilities = resolveActionCenterAdminCapabilities({
+      persona: 'customer_viewer',
+      isVerisightAdmin: false,
+      memberRole: 'viewer',
+      workspaceRoles: [],
+    })
+
+    expect(viewerCapabilities.canViewExecutiveReadback).toBe(false)
+    expect(viewerCapabilities.canManageTenantAdmin).toBe(false)
+    expect(viewerCapabilities.canApproveRouteActivation).toBe(false)
+    expect(viewerCapabilities.canRequestAuditExport).toBe(false)
+    expect(viewerCapabilities.canLogSupportAccess).toBe(false)
+  })
+
+  it('grants bounded admin controls to explicit hr owners without broadening runtime access rules', () => {
+    expect(
+      resolveActionCenterAdminCapabilities({
+        persona: 'customer_owner',
+        isVerisightAdmin: false,
+        memberRole: 'owner',
+        workspaceRoles: ['hr_owner'],
+      }),
+    ).toEqual({
+      canManageTenantAdmin: true,
+      canApproveRouteActivation: true,
+      canRequestAuditExport: true,
+      canLogSupportAccess: true,
+      canViewExecutiveReadback: true,
+    })
+  })
+})

--- a/frontend/lib/action-center-admin-governance.ts
+++ b/frontend/lib/action-center-admin-governance.ts
@@ -1,0 +1,63 @@
+import type { MemberRole } from '@/lib/types'
+import type { ActionCenterWorkspaceRole, SuitePersona } from '@/lib/suite-access'
+
+export interface ActionCenterAdminCapabilities {
+  canManageTenantAdmin: boolean
+  canApproveRouteActivation: boolean
+  canRequestAuditExport: boolean
+  canLogSupportAccess: boolean
+  canViewExecutiveReadback: boolean
+}
+
+export const ACTION_CENTER_APPROVED_ROUTE_FAMILIES = ['exit', 'retention'] as const
+export type ActionCenterApprovedRouteFamily =
+  (typeof ACTION_CENTER_APPROVED_ROUTE_FAMILIES)[number]
+
+export const ACTION_CENTER_SUPPORT_ACCESS_KINDS = [
+  'support',
+  'privacy',
+  'governance',
+  'incident',
+] as const
+export type ActionCenterSupportAccessKind =
+  (typeof ACTION_CENTER_SUPPORT_ACCESS_KINDS)[number]
+
+export function resolveActionCenterAdminCapabilities(args: {
+  persona: SuitePersona
+  isVerisightAdmin: boolean
+  memberRole: MemberRole | null
+  workspaceRoles: ActionCenterWorkspaceRole[]
+}): ActionCenterAdminCapabilities {
+  const hasExplicitCustomerAdminCapability =
+    args.memberRole === 'owner' && args.workspaceRoles.includes('hr_owner')
+  const canManageTenantAdmin = args.isVerisightAdmin || hasExplicitCustomerAdminCapability
+  const canApproveRouteActivation = canManageTenantAdmin
+  const canRequestAuditExport = canManageTenantAdmin
+  const canLogSupportAccess = canManageTenantAdmin
+  const canViewExecutiveReadback =
+    args.isVerisightAdmin || args.memberRole === 'owner'
+
+  return {
+    canManageTenantAdmin,
+    canApproveRouteActivation,
+    canRequestAuditExport,
+    canLogSupportAccess,
+    canViewExecutiveReadback,
+  }
+}
+
+export function canAccessActionCenterAdminOrg(args: {
+  isVerisightAdmin: boolean
+  organizationIds: string[]
+  workspaceOrgIds: string[]
+  orgId: string
+}) {
+  if (args.isVerisightAdmin) {
+    return true
+  }
+
+  return (
+    args.organizationIds.includes(args.orgId) ||
+    args.workspaceOrgIds.includes(args.orgId)
+  )
+}

--- a/frontend/lib/action-center-enterprise-readback.test.ts
+++ b/frontend/lib/action-center-enterprise-readback.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildActionCenterExecutiveReadback,
+  buildActionCenterTenantAdminSummary,
+} from './action-center-enterprise-readback'
+
+describe('action center enterprise readback', () => {
+  it('builds a tenant admin summary with approval, support, and export counts', () => {
+    expect(
+      buildActionCenterTenantAdminSummary({
+        routeActivationApprovals: [
+          {
+            routeFamily: 'exit',
+            approvalStatus: 'approved',
+            scopeValue: 'org-1::department::ops',
+            createdAt: '2026-05-23T09:00:00.000Z',
+          },
+        ],
+        supportAccessEvents: [
+          {
+            accessKind: 'support',
+            accessReason: 'Check route',
+            createdAt: '2026-05-23T09:10:00.000Z',
+          },
+        ],
+        auditExportRequests: [
+          {
+            exportScope: 'bounded_summary',
+            requestStatus: 'generated',
+            createdAt: '2026-05-23T09:20:00.000Z',
+          },
+        ],
+      }).controlCounts,
+    ).toEqual({
+      routeActivationApprovals: 1,
+      supportAccessEvents: 1,
+      auditExportRequests: 1,
+    })
+  })
+
+  it('builds a read-only executive summary without manager/task framing', () => {
+    const executiveReadback = buildActionCenterExecutiveReadback({
+      routeActivationApprovals: [],
+      supportAccessEvents: [],
+      openRouteCount: 4,
+      staleRouteCount: 1,
+      closeoutReadyRouteCount: 2,
+    })
+
+    expect(executiveReadback.headline).toContain('Bestuurlijke follow-through readback')
+    expect(executiveReadback.operatingBoundaryNote).toContain('geen impactclaim')
+    expect(executiveReadback.summaryRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: 'Open routes', value: 4 }),
+        expect.objectContaining({ label: 'Closeout-ready routes', value: 2 }),
+      ]),
+    )
+  })
+})

--- a/frontend/lib/action-center-enterprise-readback.ts
+++ b/frontend/lib/action-center-enterprise-readback.ts
@@ -1,0 +1,74 @@
+export interface ActionCenterActivationApprovalReadbackRow {
+  routeFamily: string
+  approvalStatus: string
+  scopeValue: string
+  createdAt: string
+}
+
+export interface ActionCenterSupportAccessReadbackRow {
+  accessKind: string
+  accessReason: string
+  createdAt: string
+}
+
+export interface ActionCenterAuditExportReadbackRow {
+  exportScope: string
+  requestStatus: string
+  createdAt: string
+}
+
+export function buildActionCenterTenantAdminSummary(args: {
+  routeActivationApprovals: ActionCenterActivationApprovalReadbackRow[]
+  supportAccessEvents: ActionCenterSupportAccessReadbackRow[]
+  auditExportRequests: ActionCenterAuditExportReadbackRow[]
+}) {
+  return {
+    headline: 'Tenant-admin governance overzicht',
+    boundaryNote:
+      'Deze laag toont alleen approvals, support-access, export-signalen en rehearsal-links. Geen workflowboard en geen routeverbreding.',
+    controlCounts: {
+      routeActivationApprovals: args.routeActivationApprovals.length,
+      supportAccessEvents: args.supportAccessEvents.length,
+      auditExportRequests: args.auditExportRequests.length,
+    },
+    recentRouteActivation: args.routeActivationApprovals[0] ?? null,
+    recentSupportAccessEvent: args.supportAccessEvents[0] ?? null,
+    recentAuditExportRequest: args.auditExportRequests[0] ?? null,
+  }
+}
+
+export function buildActionCenterExecutiveReadback(args: {
+  routeActivationApprovals: ActionCenterActivationApprovalReadbackRow[]
+  supportAccessEvents: ActionCenterSupportAccessReadbackRow[]
+  openRouteCount: number
+  staleRouteCount: number
+  closeoutReadyRouteCount: number
+}) {
+  return {
+    headline: 'Bestuurlijke follow-through readback',
+    operatingBoundaryNote:
+      'Deze readback toont ritme, review, closeout en governance-signalen; geen manager-ranking, geen personeelsdossier en geen impactclaim.',
+    summaryRows: [
+      {
+        label: 'Open routes',
+        value: args.openRouteCount,
+      },
+      {
+        label: 'Stale routes',
+        value: args.staleRouteCount,
+      },
+      {
+        label: 'Closeout-ready routes',
+        value: args.closeoutReadyRouteCount,
+      },
+      {
+        label: 'Route activation approvals',
+        value: args.routeActivationApprovals.length,
+      },
+      {
+        label: 'Support access events',
+        value: args.supportAccessEvents.length,
+      },
+    ],
+  }
+}

--- a/frontend/lib/action-center-follow-through-mail-data.ts
+++ b/frontend/lib/action-center-follow-through-mail-data.ts
@@ -493,6 +493,11 @@ export async function getActionCenterFollowThroughMailDispatchData() {
     canManageActionCenterAssignments: true,
     canScheduleActionCenterReview: true,
     managerOnly: false,
+    canManageTenantAdmin: true,
+    canApproveRouteActivation: true,
+    canRequestAuditExport: true,
+    canLogSupportAccess: true,
+    canViewExecutiveReadback: true,
   }
 
   return getActionCenterFollowThroughMailData({

--- a/frontend/lib/action-center-ops-health.test.ts
+++ b/frontend/lib/action-center-ops-health.test.ts
@@ -50,10 +50,52 @@ describe('action center ops health', () => {
       ownerAssignedCount: 1,
       reviewScheduledCount: 1,
       closeoutRecordedCount: 0,
+      routeActivationApprovalCount: 0,
+      supportAccessEventCount: 0,
+      coveredControlTypes: [],
+      missingControlTypes: ['route_activation_approvals', 'support_access_logging'],
     })
   })
 
   it('returns stable Dutch labels for critical action center ops events', () => {
     expect(getActionCenterOpsEventLabel('action_center_closeout_recorded')).toBe('Closeout vastgelegd')
+  })
+
+  it('summarizes support access and route activation coverage in admin ops readback', () => {
+    const rows: SuiteTelemetryEventRow[] = [
+      {
+        id: 'evt-1',
+        eventType: 'action_center_route_opened',
+        orgId: 'org-1',
+        campaignId: 'cmp-1',
+        actorId: 'user-1',
+        payload: {},
+        createdAt: '2026-05-02T09:00:00.000Z',
+      },
+    ]
+
+    expect(
+      summarizeActionCenterOpsHealth(rows, {
+        routeActivationApprovals: [
+          {
+            routeFamily: 'exit',
+            approvalStatus: 'approved',
+            scopeValue: 'org-1::department::operations',
+            createdAt: '2026-05-02T09:05:00.000Z',
+          },
+        ],
+        supportAccessEvents: [
+          {
+            accessKind: 'support',
+            accessReason: 'Tenant admin verification',
+            createdAt: '2026-05-02T09:10:00.000Z',
+          },
+        ],
+      }),
+    ).toMatchObject({
+      routeActivationApprovalCount: 1,
+      supportAccessEventCount: 1,
+      missingControlTypes: [],
+    })
   })
 })

--- a/frontend/lib/action-center-ops-health.ts
+++ b/frontend/lib/action-center-ops-health.ts
@@ -9,6 +9,28 @@ const ACTION_CENTER_CRITICAL_EVENT_TYPES = [
 
 export type ActionCenterCriticalEventType = (typeof ACTION_CENTER_CRITICAL_EVENT_TYPES)[number]
 
+const ACTION_CENTER_ADMIN_CONTROL_TYPES = [
+  'route_activation_approvals',
+  'support_access_logging',
+] as const
+
+export type ActionCenterAdminControlType =
+  (typeof ACTION_CENTER_ADMIN_CONTROL_TYPES)[number]
+
+export interface ActionCenterAdminReadback {
+  routeActivationApprovals: Array<{
+    routeFamily: string
+    approvalStatus: string
+    scopeValue: string
+    createdAt: string
+  }>
+  supportAccessEvents: Array<{
+    accessKind: string
+    accessReason: string
+    createdAt: string
+  }>
+}
+
 export interface ActionCenterOpsHealthSnapshot {
   totalEventCount: number
   latestEventAt: string | null
@@ -18,6 +40,10 @@ export interface ActionCenterOpsHealthSnapshot {
   ownerAssignedCount: number
   reviewScheduledCount: number
   closeoutRecordedCount: number
+  routeActivationApprovalCount: number
+  supportAccessEventCount: number
+  coveredControlTypes: ActionCenterAdminControlType[]
+  missingControlTypes: ActionCenterAdminControlType[]
 }
 
 export function getActionCenterOpsEventLabel(eventType: ActionCenterCriticalEventType) {
@@ -33,7 +59,19 @@ export function getActionCenterOpsEventLabel(eventType: ActionCenterCriticalEven
   }
 }
 
-export function summarizeActionCenterOpsHealth(rows: SuiteTelemetryEventRow[]): ActionCenterOpsHealthSnapshot {
+export function getActionCenterAdminControlLabel(controlType: ActionCenterAdminControlType) {
+  switch (controlType) {
+    case 'route_activation_approvals':
+      return 'Route activation approvals'
+    case 'support_access_logging':
+      return 'Support access logging'
+  }
+}
+
+export function summarizeActionCenterOpsHealth(
+  rows: SuiteTelemetryEventRow[],
+  adminReadback?: ActionCenterAdminReadback,
+): ActionCenterOpsHealthSnapshot {
   const actionCenterRows = rows.filter((row) =>
     ACTION_CENTER_CRITICAL_EVENT_TYPES.includes(row.eventType as ActionCenterCriticalEventType),
   )
@@ -47,6 +85,18 @@ export function summarizeActionCenterOpsHealth(rows: SuiteTelemetryEventRow[]): 
     actionCenterRows
       .map((row) => row.createdAt)
       .sort((left, right) => right.localeCompare(left))[0] ?? null
+  const routeActivationApprovalCount = adminReadback?.routeActivationApprovals.length ?? 0
+  const supportAccessEventCount = adminReadback?.supportAccessEvents.length ?? 0
+  const coveredControlTypes = ACTION_CENTER_ADMIN_CONTROL_TYPES.filter((controlType) => {
+    if (controlType === 'route_activation_approvals') {
+      return routeActivationApprovalCount > 0
+    }
+
+    return supportAccessEventCount > 0
+  })
+  const missingControlTypes = ACTION_CENTER_ADMIN_CONTROL_TYPES.filter(
+    (controlType) => !coveredControlTypes.includes(controlType),
+  )
 
   return {
     totalEventCount: actionCenterRows.length,
@@ -57,5 +107,9 @@ export function summarizeActionCenterOpsHealth(rows: SuiteTelemetryEventRow[]): 
     ownerAssignedCount: actionCenterRows.filter((row) => row.eventType === 'action_center_owner_assigned').length,
     reviewScheduledCount: actionCenterRows.filter((row) => row.eventType === 'action_center_review_scheduled').length,
     closeoutRecordedCount: actionCenterRows.filter((row) => row.eventType === 'action_center_closeout_recorded').length,
+    routeActivationApprovalCount,
+    supportAccessEventCount,
+    coveredControlTypes,
+    missingControlTypes,
   }
 }

--- a/frontend/lib/action-center-page-data.test.ts
+++ b/frontend/lib/action-center-page-data.test.ts
@@ -185,6 +185,11 @@ describe('getActionCenterPageData invite eligibility', () => {
       canManageActionCenterAssignments: false,
       canScheduleActionCenterReview: true,
       managerOnly: false,
+      canManageTenantAdmin: false,
+      canApproveRouteActivation: false,
+      canRequestAuditExport: false,
+      canLogSupportAccess: false,
+      canViewExecutiveReadback: false,
     }
     const orgMemberships: SuiteOrgMembership[] = [{ org_id: 'org-1', role: 'member' }]
     const currentUserWorkspaceMemberships = [buildWorkspaceMember()]

--- a/frontend/lib/suite-access.test.ts
+++ b/frontend/lib/suite-access.test.ts
@@ -20,6 +20,11 @@ describe('suite access context', () => {
     expect(context.canViewReports).toBe(true)
     expect(context.canViewActionCenter).toBe(true)
     expect(context.canManageActionCenterAssignments).toBe(true)
+    expect(context.canManageTenantAdmin).toBe(false)
+    expect(context.canApproveRouteActivation).toBe(false)
+    expect(context.canRequestAuditExport).toBe(false)
+    expect(context.canLogSupportAccess).toBe(false)
+    expect(context.canViewExecutiveReadback).toBe(true)
     expect(context.managerOnly).toBe(false)
     expect(getDefaultSuiteLandingPath(context)).toBe('/dashboard')
   })
@@ -53,6 +58,11 @@ describe('suite access context', () => {
     expect(context.canViewActionCenter).toBe(true)
     expect(context.managerOnly).toBe(true)
     expect(context.managerScopeValues).toEqual(['sales'])
+    expect(context.canManageTenantAdmin).toBe(false)
+    expect(context.canApproveRouteActivation).toBe(false)
+    expect(context.canRequestAuditExport).toBe(false)
+    expect(context.canLogSupportAccess).toBe(false)
+    expect(context.canViewExecutiveReadback).toBe(false)
     expect(getDefaultSuiteLandingPath(context)).toBe('/action-center')
     expect(isScopeVisibleToActionCenterContext(context, 'sales')).toBe(true)
     expect(isScopeVisibleToActionCenterContext(context, 'hr')).toBe(false)
@@ -76,7 +86,42 @@ describe('suite access context', () => {
     expect(context.canViewReports).toBe(true)
     expect(context.canViewActionCenter).toBe(true)
     expect(context.canManageActionCenterAssignments).toBe(true)
+    expect(context.canManageTenantAdmin).toBe(true)
+    expect(context.canApproveRouteActivation).toBe(true)
+    expect(context.canRequestAuditExport).toBe(true)
+    expect(context.canLogSupportAccess).toBe(true)
+    expect(context.canViewExecutiveReadback).toBe(true)
     expect(isScopeVisibleToActionCenterContext(context, 'finance')).toBe(true)
+  })
+
+  it('requires explicit hr-owner workspace capability before customer owners gain admin-governance controls', () => {
+    const context = buildSuiteAccessContext({
+      isVerisightAdmin: false,
+      orgMemberships: [{ org_id: 'org-1', role: 'owner' }],
+      workspaceMemberships: [
+        {
+          org_id: 'org-1',
+          user_id: 'owner-1',
+          display_name: 'HR Owner',
+          login_email: 'owner@example.com',
+          access_role: 'hr_owner',
+          scope_type: 'org',
+          scope_value: 'org-1',
+          can_view: true,
+          can_update: true,
+          can_assign: true,
+          can_schedule_review: true,
+        },
+      ],
+    })
+
+    expect(context.canManageTenantAdmin).toBe(true)
+    expect(context.canApproveRouteActivation).toBe(true)
+    expect(context.canRequestAuditExport).toBe(true)
+    expect(context.canLogSupportAccess).toBe(true)
+    expect(context.canViewExecutiveReadback).toBe(true)
+    expect(context.canViewActionCenter).toBe(true)
+    expect(context.canManageActionCenterAssignments).toBe(true)
   })
 
   it('records owner access confirmation when an owner can enter the insight shell', () => {

--- a/frontend/lib/suite-access.ts
+++ b/frontend/lib/suite-access.ts
@@ -1,5 +1,9 @@
 import type { MemberRole } from '@/lib/types'
 import { buildSuiteTelemetryEvent, type SuiteTelemetryEvent } from '@/lib/telemetry/events'
+import {
+  resolveActionCenterAdminCapabilities,
+  type ActionCenterAdminCapabilities,
+} from '@/lib/action-center-admin-governance'
 
 export type ActionCenterWorkspaceRole = 'hr_owner' | 'hr_member' | 'manager_assignee'
 export type ActionCenterWorkspaceScopeType = 'org' | 'department' | 'item'
@@ -49,6 +53,11 @@ export interface SuiteAccessContext {
   canManageActionCenterAssignments: boolean
   canScheduleActionCenterReview: boolean
   managerOnly: boolean
+  canManageTenantAdmin: ActionCenterAdminCapabilities['canManageTenantAdmin']
+  canApproveRouteActivation: ActionCenterAdminCapabilities['canApproveRouteActivation']
+  canRequestAuditExport: ActionCenterAdminCapabilities['canRequestAuditExport']
+  canLogSupportAccess: ActionCenterAdminCapabilities['canLogSupportAccess']
+  canViewExecutiveReadback: ActionCenterAdminCapabilities['canViewExecutiveReadback']
 }
 
 function getRoleRank(role: MemberRole) {
@@ -111,6 +120,12 @@ export function buildSuiteAccessContext(args: {
     args.isVerisightAdmin ||
     memberRole === 'owner' ||
     workspaceMemberships.some((membership) => membership.can_schedule_review)
+  const adminCapabilities = resolveActionCenterAdminCapabilities({
+    persona,
+    isVerisightAdmin: args.isVerisightAdmin,
+    memberRole,
+    workspaceRoles: [...new Set(workspaceMemberships.map((membership) => membership.access_role))],
+  })
 
   return {
     persona,
@@ -127,6 +142,7 @@ export function buildSuiteAccessContext(args: {
     canManageActionCenterAssignments,
     canScheduleActionCenterReview,
     managerOnly,
+    ...adminCapabilities,
   }
 }
 

--- a/migrations/2026_05_23_add_action_center_enterprise_admin_controls.sql
+++ b/migrations/2026_05_23_add_action_center_enterprise_admin_controls.sql
@@ -1,0 +1,97 @@
+create table if not exists public.action_center_route_activation_approvals (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid not null references public.organizations(id) on delete cascade,
+  route_family text not null check (route_family in ('exit', 'retention')),
+  scope_value text not null,
+  requested_by uuid not null references auth.users(id) on delete set null,
+  approved_by uuid references auth.users(id) on delete set null,
+  approval_status text not null check (approval_status in ('requested', 'approved', 'rejected', 'revoked')),
+  rationale text,
+  updated_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (org_id, route_family, scope_value)
+);
+
+create table if not exists public.action_center_support_access_events (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid not null references public.organizations(id) on delete cascade,
+  route_id text,
+  scope_value text,
+  accessed_by uuid not null references auth.users(id) on delete set null,
+  access_reason text not null,
+  access_kind text not null check (access_kind in ('support', 'privacy', 'governance', 'incident')),
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.action_center_audit_export_requests (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid not null references public.organizations(id) on delete cascade,
+  requested_by uuid not null references auth.users(id) on delete set null,
+  export_scope text not null check (export_scope in ('bounded_summary')),
+  request_status text not null default 'generated' check (request_status in ('generated')),
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_action_center_route_activation_approvals_org
+  on public.action_center_route_activation_approvals(org_id, route_family, approval_status);
+create index if not exists idx_action_center_support_access_events_org
+  on public.action_center_support_access_events(org_id, access_kind, created_at desc);
+create index if not exists idx_action_center_audit_export_requests_org
+  on public.action_center_audit_export_requests(org_id, created_at desc);
+
+create or replace function public.set_action_center_enterprise_admin_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists action_center_route_activation_approvals_set_updated_at on public.action_center_route_activation_approvals;
+create trigger action_center_route_activation_approvals_set_updated_at
+before update on public.action_center_route_activation_approvals
+for each row execute function public.set_action_center_enterprise_admin_updated_at();
+
+alter table public.action_center_route_activation_approvals enable row level security;
+alter table public.action_center_support_access_events enable row level security;
+alter table public.action_center_audit_export_requests enable row level security;
+
+drop policy if exists "ac_route_activation_admins_select" on public.action_center_route_activation_approvals;
+drop policy if exists "ac_route_activation_admins_insert" on public.action_center_route_activation_approvals;
+drop policy if exists "ac_route_activation_admins_update" on public.action_center_route_activation_approvals;
+drop policy if exists "ac_support_access_admins_select" on public.action_center_support_access_events;
+drop policy if exists "ac_support_access_admins_insert" on public.action_center_support_access_events;
+drop policy if exists "ac_audit_export_admins_select" on public.action_center_audit_export_requests;
+drop policy if exists "ac_audit_export_admins_insert" on public.action_center_audit_export_requests;
+
+create policy "ac_route_activation_admins_select"
+  on public.action_center_route_activation_approvals for select
+  using (public.is_org_owner(org_id) or public.is_verisight_admin_user());
+
+create policy "ac_route_activation_admins_insert"
+  on public.action_center_route_activation_approvals for insert
+  with check (public.is_org_owner(org_id) or public.is_verisight_admin_user());
+
+create policy "ac_route_activation_admins_update"
+  on public.action_center_route_activation_approvals for update
+  using (public.is_org_owner(org_id) or public.is_verisight_admin_user())
+  with check (public.is_org_owner(org_id) or public.is_verisight_admin_user());
+
+create policy "ac_support_access_admins_select"
+  on public.action_center_support_access_events for select
+  using (public.is_org_owner(org_id) or public.is_verisight_admin_user());
+
+create policy "ac_support_access_admins_insert"
+  on public.action_center_support_access_events for insert
+  with check (public.is_org_owner(org_id) or public.is_verisight_admin_user());
+
+create policy "ac_audit_export_admins_select"
+  on public.action_center_audit_export_requests for select
+  using (public.is_org_owner(org_id) or public.is_verisight_admin_user());
+
+create policy "ac_audit_export_admins_insert"
+  on public.action_center_audit_export_requests for insert
+  with check (public.is_org_owner(org_id) or public.is_verisight_admin_user());

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -2096,6 +2096,106 @@ create policy "workspace_owners_and_admins_can_delete_rows"
   on public.action_center_workspace_members for delete
   using (public.is_org_owner(org_id) or public.is_verisight_admin_user());
 
+create table if not exists public.action_center_route_activation_approvals (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid not null references public.organizations(id) on delete cascade,
+  route_family text not null check (route_family in ('exit', 'retention')),
+  scope_value text not null,
+  requested_by uuid not null references auth.users(id) on delete set null,
+  approved_by uuid references auth.users(id) on delete set null,
+  approval_status text not null check (approval_status in ('requested', 'approved', 'rejected', 'revoked')),
+  rationale text,
+  updated_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (org_id, route_family, scope_value)
+);
+
+create table if not exists public.action_center_support_access_events (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid not null references public.organizations(id) on delete cascade,
+  route_id text,
+  scope_value text,
+  accessed_by uuid not null references auth.users(id) on delete set null,
+  access_reason text not null,
+  access_kind text not null check (access_kind in ('support', 'privacy', 'governance', 'incident')),
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.action_center_audit_export_requests (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid not null references public.organizations(id) on delete cascade,
+  requested_by uuid not null references auth.users(id) on delete set null,
+  export_scope text not null check (export_scope in ('bounded_summary')),
+  request_status text not null default 'generated' check (request_status in ('generated')),
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_action_center_route_activation_approvals_org
+  on public.action_center_route_activation_approvals(org_id, route_family, approval_status);
+
+create index if not exists idx_action_center_support_access_events_org
+  on public.action_center_support_access_events(org_id, access_kind, created_at desc);
+
+create index if not exists idx_action_center_audit_export_requests_org
+  on public.action_center_audit_export_requests(org_id, created_at desc);
+
+create or replace function public.set_action_center_enterprise_admin_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists action_center_route_activation_approvals_set_updated_at on public.action_center_route_activation_approvals;
+create trigger action_center_route_activation_approvals_set_updated_at
+before update on public.action_center_route_activation_approvals
+for each row execute function public.set_action_center_enterprise_admin_updated_at();
+
+alter table public.action_center_route_activation_approvals enable row level security;
+alter table public.action_center_support_access_events enable row level security;
+alter table public.action_center_audit_export_requests enable row level security;
+
+drop policy if exists "ac_route_activation_admins_select" on public.action_center_route_activation_approvals;
+drop policy if exists "ac_route_activation_admins_insert" on public.action_center_route_activation_approvals;
+drop policy if exists "ac_route_activation_admins_update" on public.action_center_route_activation_approvals;
+drop policy if exists "ac_support_access_admins_select" on public.action_center_support_access_events;
+drop policy if exists "ac_support_access_admins_insert" on public.action_center_support_access_events;
+drop policy if exists "ac_audit_export_admins_select" on public.action_center_audit_export_requests;
+drop policy if exists "ac_audit_export_admins_insert" on public.action_center_audit_export_requests;
+
+create policy "ac_route_activation_admins_select"
+  on public.action_center_route_activation_approvals for select
+  using (public.is_org_owner(org_id) or public.is_verisight_admin_user());
+
+create policy "ac_route_activation_admins_insert"
+  on public.action_center_route_activation_approvals for insert
+  with check (public.is_org_owner(org_id) or public.is_verisight_admin_user());
+
+create policy "ac_route_activation_admins_update"
+  on public.action_center_route_activation_approvals for update
+  using (public.is_org_owner(org_id) or public.is_verisight_admin_user())
+  with check (public.is_org_owner(org_id) or public.is_verisight_admin_user());
+
+create policy "ac_support_access_admins_select"
+  on public.action_center_support_access_events for select
+  using (public.is_org_owner(org_id) or public.is_verisight_admin_user());
+
+create policy "ac_support_access_admins_insert"
+  on public.action_center_support_access_events for insert
+  with check (public.is_org_owner(org_id) or public.is_verisight_admin_user());
+
+create policy "ac_audit_export_admins_select"
+  on public.action_center_audit_export_requests for select
+  using (public.is_org_owner(org_id) or public.is_verisight_admin_user());
+
+create policy "ac_audit_export_admins_insert"
+  on public.action_center_audit_export_requests for insert
+  with check (public.is_org_owner(org_id) or public.is_verisight_admin_user());
+
 drop trigger if exists on_user_created on auth.users;
 create trigger on_user_created
   after insert on auth.users


### PR DESCRIPTION
## Summary
- add enterprise-operating admin controls for Action Center, including approvals, support access logging, and audit export scaffolding
- add tenant-admin governance, executive readback, and bounded rehearsal surfaces
- update readiness and verification artifacts for the enterprise-operating wave

## Verification
- `npx vitest run "lib/action-center-enterprise-readback.test.ts" "app/(dashboard)/beheer/action-center-governance/page.test.ts" "app/(dashboard)/beheer/action-center-governance/rehearsal/page.test.ts" "app/(dashboard)/beheer/page.test.ts" "app/(dashboard)/action-center/executive/page.test.ts" "app/(dashboard)/action-center/page.route-shell.test.ts" "lib/action-center-admin-governance.test.ts" "lib/suite-access.test.ts" "lib/action-center-ops-health.test.ts" "app/api/action-center/admin/route-activation-approvals/route.test.ts" "app/api/action-center/admin/support-access-events/route.test.ts" "app/api/action-center/admin/audit-exports/route.test.ts"`
- `git diff --check origin/main...HEAD`
- placeholder scan on `docs/ops/ACTION_CENTER_FIRST_ROUTE_ONBOARDING_REHEARSAL.md` and `docs/ops/ACTION_CENTER_SUPPORT_REHEARSAL_SCORECARD.md` (no matches)
- `npm run build` compiles and typechecks through this wave; the remaining build stop is the known Supabase SSR/prerender baseline on `/login` when project URL/API key are absent
