### PR TITLE
Fix campaign detail result visuals

### DIFF
--- a/frontend/app/(dashboard)/campaigns/[id]/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.tsx
@@ -437,10 +437,43 @@ function buildSdtRows(sdtAverages: {
   competence?: number
   relatedness?: number
 }) {
+  function getSdtDescription(
+    key: "autonomy" | "competence" | "relatedness",
+    value: number,
+  ) {
+    if (key === "autonomy") {
+      if (value < 5.0) {
+        return "Medewerkers ervaren beperkte ruimte om eigen keuzes te maken in hun werk. Dit raakt het gevoel van eigenaarschap."
+      }
+      if (value <= 6.5) {
+        return "Autonomie is aanwezig maar niet sterk. Bespreek of medewerkers voldoende zeggenschap ervaren over hun werkinhoud."
+      }
+      return "Autonomiebeleving is relatief stabiel. Minder urgent dan de topfactoren."
+    }
+
+    if (key === "competence") {
+      if (value < 5.0) {
+        return "Groeimogelijkheden en competentieontwikkeling worden als onvoldoende ervaren. Sluit aan op het dominante groei-thema."
+      }
+      if (value <= 6.5) {
+        return "Competentie- en groeibeleving vraagt verificatie. Toets of perspectief structureel ontbreekt of situationeel is."
+      }
+      return "Competentiebeleving is relatief goed. Gebruik als aanvullende context, niet als eerste prioriteit."
+    }
+
+    if (value < 5.0) {
+      return "Verbondenheid met team of organisatie staat onder druk. Dit versterkt vaak het vertrek- of behoudsrisico."
+    }
+    if (value <= 6.5) {
+      return "Verbondenheid is gemiddeld aanwezig. Bespreek of teamdynamiek of cultuurfit een rol speelt in het hoofdsignaal."
+    }
+    return "Verbondenheid is relatief stabiel. Monitoring volstaat op dit moment."
+  }
+
   return [
-    { key: "autonomy", label: "Autonomie", value: sdtAverages.autonomy },
-    { key: "competence", label: "Competentie & groei", value: sdtAverages.competence },
-    { key: "relatedness", label: "Verbondenheid", value: sdtAverages.relatedness },
+    { key: "autonomy" as const, label: "Autonomie", value: sdtAverages.autonomy },
+    { key: "competence" as const, label: "Competentie & groei", value: sdtAverages.competence },
+    { key: "relatedness" as const, label: "Verbondenheid", value: sdtAverages.relatedness },
   ]
     .filter((item) => typeof item.value === "number")
     .map((item) => {
@@ -451,12 +484,7 @@ function buildSdtRows(sdtAverages: {
         scoreValue: Number(item.value),
         signal: `${signalScore.toFixed(1)}/10`,
         band: getManagementBandLabel(signalScore),
-        note:
-          signalScore >= 7
-            ? "Draagt duidelijk mee aan het vertrekbeeld."
-            : signalScore >= 4.5
-              ? "Relevant als verdiepingslaag naast de organisatiefactoren."
-              : "Ondersteunend, maar niet de eerste driver van dit beeld.",
+        note: getSdtDescription(item.key, Number(item.value)),
       }
     })
 }
@@ -1709,13 +1737,39 @@ export default async function CampaignPage({ params }: Props) {
                 </p>
                 <div className="mt-4 grid gap-4 sm:grid-cols-3">
                   {(["autonomy", "competence", "relatedness"] as const).map(
-                    (dimension) => (
-                      <SdtGauge
-                        key={dimension}
-                        label={FACTOR_LABELS[dimension]}
-                        score={factorData.sdtAverages[dimension] ?? 5.5}
-                      />
-                    ),
+                    (dimension) => {
+                      const score = factorData.sdtAverages[dimension] ?? 5.5
+                      const description =
+                        dimension === "autonomy"
+                          ? score < 5.0
+                            ? "Medewerkers ervaren beperkte ruimte om eigen keuzes te maken in hun werk. Dit raakt het gevoel van eigenaarschap."
+                            : score <= 6.5
+                              ? "Autonomie is aanwezig maar niet sterk. Bespreek of medewerkers voldoende zeggenschap ervaren over hun werkinhoud."
+                              : "Autonomiebeleving is relatief stabiel. Minder urgent dan de topfactoren."
+                          : dimension === "competence"
+                            ? score < 5.0
+                              ? "Groeimogelijkheden en competentieontwikkeling worden als onvoldoende ervaren. Sluit aan op het dominante groei-thema."
+                              : score <= 6.5
+                                ? "Competentie- en groeibeleving vraagt verificatie. Toets of perspectief structureel ontbreekt of situationeel is."
+                                : "Competentiebeleving is relatief goed. Gebruik als aanvullende context, niet als eerste prioriteit."
+                            : score < 5.0
+                              ? "Verbondenheid met team of organisatie staat onder druk. Dit versterkt vaak het vertrek- of behoudsrisico."
+                              : score <= 6.5
+                                ? "Verbondenheid is gemiddeld aanwezig. Bespreek of teamdynamiek of cultuurfit een rol speelt in het hoofdsignaal."
+                                : "Verbondenheid is relatief stabiel. Monitoring volstaat op dit moment."
+
+                      return (
+                        <div key={dimension} className="space-y-2">
+                          <SdtGauge
+                            label={FACTOR_LABELS[dimension]}
+                            score={score}
+                          />
+                          <p className="px-1 text-sm leading-6 text-slate-600">
+                            {description}
+                          </p>
+                        </div>
+                      )
+                    },
                   )}
                 </div>
               </div>
@@ -2190,7 +2244,8 @@ export default async function CampaignPage({ params }: Props) {
               body: `${secondFactor} kleurt het vertrekbeeld mee naast de sterkste factor en hoort daarom in dezelfde analytische lezing thuis.`,
             }
           : null,
-        topContributingReasonLabel
+        topContributingReasonLabel &&
+        topContributingReasonLabel !== "Nog niet zichtbaar"
           ? {
               label: "Meelezende context",
               value: topContributingReasonLabel,

--- a/frontend/components/dashboard/dashboard-primitives.tsx
+++ b/frontend/components/dashboard/dashboard-primitives.tsx
@@ -91,7 +91,7 @@ function DashboardSectionHeader({
           className={joinClasses(
             surface === "ops"
               ? "mt-1 text-lg text-[color:var(--ink)]"
-              : "mt-2 max-w-4xl text-[1.65rem] text-[color:var(--dashboard-ink)] sm:text-[1.85rem]",
+              : "mt-2 max-w-4xl text-[1.35rem] text-[color:var(--dashboard-ink)] sm:text-[1.5rem]",
             "font-semibold tracking-[-0.04em]",
           )}
         >

--- a/frontend/components/dashboard/exit-dashboard-visuals.tsx
+++ b/frontend/components/dashboard/exit-dashboard-visuals.tsx
@@ -6,11 +6,8 @@ import {
   CartesianGrid,
   Cell,
   LabelList,
-  ReferenceArea,
   ReferenceLine,
   ResponsiveContainer,
-  Scatter,
-  ScatterChart,
   Tooltip,
   XAxis,
   YAxis,
@@ -41,74 +38,67 @@ function getBandColor(signalValue: number) {
 }
 
 export function ExitDriversPriorityChart({ rows }: { rows: FactorRow[] }) {
-  const data = rows.map((row) => ({
-    ...row,
-    x: Number(row.scoreValue.toFixed(1)),
-    y: Number(row.signalValue.toFixed(1)),
-    fill: getBandColor(row.signalValue),
-  }))
+  const data = [...rows]
+    .sort((left, right) => left.scoreValue - right.scoreValue)
+    .map((row) => ({
+      ...row,
+      value: Number(row.scoreValue.toFixed(1)),
+      fill: getBandColor(row.signalValue),
+    }))
 
   return (
     <div className="rounded-[24px] border border-[color:var(--dashboard-frame-border)] bg-white/82 p-5">
       <p className="text-sm font-medium text-slate-400">Prioriteitenbeeld</p>
-      <div className="mt-4 h-[360px] w-full">
+      <div className="mt-4 h-[300px] w-full">
         <ResponsiveContainer width="100%" height="100%">
-          <ScatterChart margin={{ top: 18, right: 28, bottom: 18, left: 12 }}>
-            <CartesianGrid stroke="#E9E5DE" strokeDasharray="2 2" />
-            <ReferenceArea y1={7} y2={10} fill="rgba(60,141,138,0.10)" />
-            <ReferenceArea x1={1} x2={4.5} fill="rgba(20,27,45,0.03)" />
+          <BarChart
+            data={data}
+            layout="vertical"
+            margin={{ top: 12, right: 28, bottom: 12, left: 12 }}
+          >
+            <CartesianGrid stroke="#E9E5DE" horizontal={false} />
             <ReferenceLine x={5.5} stroke="#D5CEC4" strokeDasharray="4 4" />
-            <ReferenceLine y={5.5} stroke="#D5CEC4" strokeDasharray="4 4" />
             <XAxis
               type="number"
-              dataKey="x"
+              dataKey="value"
               domain={[1, 10]}
-              tickCount={10}
               tick={{ fontSize: 11, fill: '#7C8A95' }}
               axisLine={false}
               tickLine={false}
-              label={{
-                value: 'Beleving / score',
-                position: 'insideBottom',
-                offset: -8,
-                fill: '#64748B',
-                fontSize: 12,
-              }}
             />
             <YAxis
-              type="number"
-              dataKey="y"
-              domain={[1, 10]}
-              tickCount={10}
-              tick={{ fontSize: 11, fill: '#7C8A95' }}
+              type="category"
+              dataKey="factor"
+              width={140}
+              tick={{ fontSize: 12, fill: '#4B5563' }}
               axisLine={false}
               tickLine={false}
-              label={{
-                value: 'Signaal / aandacht',
-                angle: -90,
-                position: 'insideLeft',
-                fill: '#64748B',
-                fontSize: 12,
-              }}
             />
             <Tooltip
-              cursor={{ strokeDasharray: '3 3' }}
+              cursor={{ fill: 'rgba(36,50,71,0.04)' }}
               formatter={(value, _name, item) => {
-                const row = item.payload as typeof data[number]
+                const row = item.payload as (typeof data)[number]
                 return [`${Number(value).toFixed(1)}`, row.factor]
               }}
               labelFormatter={(_label, payload) => {
-                const row = payload?.[0]?.payload as typeof data[number] | undefined
+                const row = payload?.[0]?.payload as ((typeof data)[number] | undefined)
                 return row ? `${row.factor} · ${row.note}` : ''
               }}
             />
-            <Scatter data={data}>
+            <Bar dataKey="value" radius={[0, 0, 0, 0]} barSize={34}>
               {data.map((entry) => (
-                <Cell key={entry.factor} fill={entry.fill} stroke="#243247" strokeWidth={1.5} />
+                <Cell key={entry.factor} fill={entry.fill} />
               ))}
-              <LabelList dataKey="factor" position="right" offset={8} fontSize={11} fill="#243247" />
-            </Scatter>
-          </ScatterChart>
+              <LabelList
+                dataKey="value"
+                position="right"
+                offset={8}
+                formatter={(value) => Number(value).toFixed(1)}
+                fill="#243247"
+                fontSize={11}
+              />
+            </Bar>
+          </BarChart>
         </ResponsiveContainer>
       </div>
     </div>
@@ -139,7 +129,7 @@ export function ExitSdtNeedsChart({ rows }: { rows: SdtRow[] }) {
               axisLine={false}
               tickLine={false}
               label={{
-                value: 'Score (1–10)',
+                value: 'Score (1-10)',
                 position: 'insideBottom',
                 offset: -6,
                 fill: '#64748B',
@@ -158,7 +148,13 @@ export function ExitSdtNeedsChart({ rows }: { rows: SdtRow[] }) {
             <ReferenceLine x={7} stroke="#F1998F" strokeDasharray="2 3" />
             <Tooltip formatter={(value) => `${Number(value).toFixed(1)}/10`} />
             <Bar dataKey="value" fill="#D19422" radius={[0, 0, 0, 0]} barSize={42}>
-              <LabelList dataKey="value" position="right" formatter={(value) => Number(value).toFixed(1)} fill="#4B5563" fontSize={11} />
+              <LabelList
+                dataKey="value"
+                position="right"
+                formatter={(value) => Number(value).toFixed(1)}
+                fill="#4B5563"
+                fontSize={11}
+              />
             </Bar>
           </BarChart>
         </ResponsiveContainer>
@@ -168,23 +164,20 @@ export function ExitSdtNeedsChart({ rows }: { rows: SdtRow[] }) {
 }
 
 export function ExitOrgFactorsChart({ rows }: { rows: FactorRow[] }) {
-  const data = [...rows]
-    .sort((a, b) => b.scoreValue - a.scoreValue)
-    .map((row) => ({
-      ...row,
-      value: Number(row.scoreValue.toFixed(1)),
-      fill: getBandColor(row.signalValue),
-    }))
+  const data = [...rows].map((row) => ({
+    ...row,
+    value: Number(row.scoreValue.toFixed(1)),
+  }))
 
   return (
     <div className="rounded-[24px] border border-[color:var(--dashboard-frame-border)] bg-white/82 p-5">
       <p className="text-sm font-medium text-slate-400">Organisatiefactoren</p>
-      <div className="mt-4 h-[380px] w-full">
+      <div className="mt-4 h-[320px] w-full">
         <ResponsiveContainer width="100%" height="100%">
           <BarChart
             data={data}
             layout="vertical"
-            margin={{ top: 8, right: 26, bottom: 24, left: 108 }}
+            margin={{ top: 10, right: 24, bottom: 10, left: 24 }}
           >
             <CartesianGrid stroke="#EFE8DE" horizontal={false} />
             <XAxis
@@ -193,35 +186,27 @@ export function ExitOrgFactorsChart({ rows }: { rows: FactorRow[] }) {
               tick={{ fontSize: 11, fill: '#7C8A95' }}
               axisLine={false}
               tickLine={false}
-              label={{
-                value: 'Score (1 = laag, 10 = hoog)',
-                position: 'insideBottom',
-                offset: -8,
-                fill: '#64748B',
-                fontSize: 12,
-              }}
             />
             <YAxis
               type="category"
               dataKey="factor"
-              width={180}
+              width={136}
               tick={{ fontSize: 12, fill: '#4B5563' }}
               axisLine={false}
               tickLine={false}
             />
-            <ReferenceLine x={5.5} stroke="#E4D7C4" strokeDasharray="4 4" />
             <Tooltip
               formatter={(value) => `${Number(value).toFixed(1)}/10`}
-              labelFormatter={(_label, payload) => {
-                const row = payload?.[0]?.payload as typeof data[number] | undefined
-                return row ? row.factor : ''
-              }}
+              labelFormatter={(label) => String(label)}
             />
-            <Bar dataKey="value" radius={[0, 0, 0, 0]} barSize={38}>
-              {data.map((entry) => (
-                <Cell key={entry.factor} fill={entry.fill} />
-              ))}
-              <LabelList dataKey="value" position="right" formatter={(value) => Number(value).toFixed(1)} fill="#4B5563" fontSize={11} />
+            <Bar dataKey="value" fill="#243247" radius={[0, 0, 0, 0]} barSize={34}>
+              <LabelList
+                dataKey="value"
+                position="right"
+                formatter={(value) => Number(value).toFixed(1)}
+                fill="#4B5563"
+                fontSize={11}
+              />
             </Bar>
           </BarChart>
         </ResponsiveContainer>


### PR DESCRIPTION
## Summary
- replace the Exit priority scatter plot with a readable horizontal bar chart
- add unique SDT descriptions per dimension and score band
- hide empty aanvullende context output and reduce section-header weight

## Verification
- `npx tsc --noEmit` still fails due to pre-existing unrelated frontend errors elsewhere in the repo
- the touched results-slice no longer introduces its own TypeScript errors
- `ExitDriversPriorityChart` remains a named export
- `factor-table.tsx` and the dark management handoff were not changed