### PR TITLE
[codex] strengthen report layer surface

### DIFF
--- a/backend/report.py
+++ b/backend/report.py
@@ -64,6 +64,10 @@ from reportlab.lib.utils import ImageReader
 from sqlalchemy.orm import Session, joinedload, selectinload
 
 from backend.models import Campaign, Organization, Respondent, SurveyResponse
+from backend.products.exit.report_content import (
+    EXIT_DECISION_BY_FACTOR,
+    EXIT_OWNER_BY_FACTOR,
+)
 from backend.products.shared.management_language import (
     build_factor_presentation,
     management_band_label,
@@ -1671,6 +1675,293 @@ def _append_data_table(
 
 def _factor_signal_score(factor: str, factor_avgs: dict[str, float]) -> float:
     return round(11.0 - factor_avgs.get(factor, 5.5), 1)
+
+
+def _build_department_overview_row(
+    *,
+    department: str,
+    items: list[SurveyResponse],
+) -> dict[str, Any] | None:
+    scored_items = [
+        item for item in items
+        if isinstance(item.risk_score, (int, float))
+    ]
+    if len(scored_items) < MIN_SEGMENT_N:
+        return None
+
+    avg_score = round(
+        sum(float(item.risk_score) for item in scored_items) / len(scored_items),
+        2,
+    )
+    factor_signal_scores: list[tuple[str, float]] = []
+    for factor in ORG_FACTOR_KEYS:
+        factor_values = [
+            float(item.org_scores[factor])
+            for item in scored_items
+            if item.org_scores and item.org_scores.get(factor) is not None
+        ]
+        if not factor_values:
+            continue
+        factor_signal_scores.append((factor, round(11.0 - (sum(factor_values) / len(factor_values)), 2)))
+
+    top_factor = (
+        FACTOR_LABELS_NL.get(
+            max(factor_signal_scores, key=lambda item: item[1])[0],
+            "Nog geen duidelijke topfactor",
+        )
+        if factor_signal_scores
+        else "Nog geen duidelijke topfactor"
+    )
+
+    return {
+        "department": department,
+        "n": len(scored_items),
+        "avg_score": avg_score,
+        "band": management_band_label(score=avg_score),
+        "top_factor": top_factor,
+    }
+
+
+def _build_department_overview_payload(
+    *,
+    responses: list[SurveyResponse],
+    score_label: str,
+) -> dict[str, Any] | None:
+    grouped: dict[str, list[SurveyResponse]] = {}
+    for response in responses:
+        department = getattr(getattr(response, "respondent", None), "department", None)
+        if not department:
+            continue
+        grouped.setdefault(str(department), []).append(response)
+
+    eligible_groups = {
+        department: items
+        for department, items in grouped.items()
+        if len([item for item in items if isinstance(item.risk_score, (int, float))]) >= MIN_SEGMENT_N
+    }
+    if len(eligible_groups) < 2:
+        return None
+
+    individual_rows = [
+        row
+        for row in (
+            _build_department_overview_row(department=department, items=items)
+            for department, items in eligible_groups.items()
+        )
+        if row is not None
+    ]
+    individual_rows.sort(
+        key=lambda row: (row["avg_score"], row["n"], row["department"]),
+        reverse=True,
+    )
+
+    overflow_departments = {row["department"] for row in individual_rows[7:]} if len(individual_rows) > 8 else set()
+    other_items: list[SurveyResponse] = []
+    for department, items in grouped.items():
+        if department not in eligible_groups or department in overflow_departments:
+            other_items.extend(items)
+
+    other_row = _build_department_overview_row(
+        department="Overige afdelingen",
+        items=other_items,
+    ) if other_items else None
+
+    if other_row is not None:
+        visible_rows = individual_rows[:7]
+        visible_rows.append(other_row)
+    else:
+        visible_rows = individual_rows[:8]
+
+    visible_rows.sort(
+        key=lambda row: (
+            row["department"] == "Overige afdelingen",
+            -row["avg_score"],
+            -row["n"],
+            row["department"],
+        ),
+    )
+    if len([row for row in visible_rows if row["department"] != "Overige afdelingen"]) < 2:
+        return None
+
+    return {
+        "section_title": "Afdelingsoverzicht",
+        "intro": (
+            f"Lees dit overzicht als rustige verdiepingslaag op het organisatieniveau. "
+            f"We tonen alleen afdelingen met minimaal {MIN_SEGMENT_N} responses individueel; kleinere groepen vallen onder "
+            "\"Overige afdelingen\" om privacy en uitlegbaarheid te bewaken. "
+            f"Sorteer de afdelingen op hoogste {score_label} eerst en gebruik dit niet als causale ranking."
+        ),
+        "sections": visible_rows,
+    }
+
+
+def _exit_playbook_copy(factor: str, band: str) -> dict[str, Any] | None:
+    label = FACTOR_LABELS_NL.get(factor, factor)
+    playbooks: dict[str, dict[str, dict[str, Any]]] = {
+        "leadership": {
+            "HOOG": {
+                "title": "Leiderschap vraagt correctieve opvolging",
+                "validate": "Onderzoek in 60-90 dagen of dit vertrekpatroon structureel terugkomt in dezelfde teams, managersituaties of escalatiemomenten.",
+                "actions": [
+                    "Onderzoek of feedback, bereikbaarheid of besluitvorming onder dezelfde leiding vaker terugkomen in exitgesprekken, HR-cases of teamreviews.",
+                    "Bepaal welke 1-2 managementcorrecties nodig zijn om te voorkomen dat dit bij de volgende persoon opnieuw meespeelt.",
+                ],
+                "caution": "Lees dit niet als sluitende toewijzing aan één manager; toets steeds teamcontext en bredere frictie mee.",
+            },
+            "MIDDEN": {
+                "title": "Leiderschap vraagt gerichte terugblik",
+                "validate": "Onderzoek in 60-90 dagen of dit signaal incidenteel was of vaker samenvalt met hetzelfde team, dezelfde leiding of hetzelfde type gesprek.",
+                "actions": [
+                    "Onderzoek of beperkte correcties in feedbackritme, bereikbaarheid of besluitvorming herhaling bij de volgende persoon kunnen verkleinen.",
+                    "Leg vast welk leiderschapsmoment bij een volgende exit eerder getoetst moet worden.",
+                ],
+                "caution": "Maak hier geen generiek leiderschapsprobleem van als het patroon vooral lokaal of situationeel blijkt.",
+            },
+        },
+        "culture": {
+            "HOOG": {
+                "title": "Cultuur- en veiligheidssignalen vragen correctieve duiding",
+                "validate": "Onderzoek in 60-90 dagen of onveiligheid, teamdynamiek of cultuurfrictie vaker terugkomen in dezelfde afdeling of overgangsmomenten.",
+                "actions": [
+                    "Onderzoek welke teamgedragingen of samenwerkingspatronen bij de volgende persoon opnieuw tot frictie kunnen leiden.",
+                    "Bepaal welke gerichte cultuur- of veiligheidsafspraken nodig zijn om herhaling in dezelfde context te voorkomen.",
+                ],
+                "caution": "Gebruik dit niet als bewijs voor een organisatiebreed cultuurprobleem zonder toets op teamniveau.",
+            },
+            "MIDDEN": {
+                "title": "Cultuursignalen vragen gerichte verificatie",
+                "validate": "Onderzoek in 60-90 dagen of dit signaal vooral over psychologische veiligheid, samenwerking of mismatch met de manier van werken ging.",
+                "actions": [
+                    "Onderzoek welke terugkerende teamsituaties of werkafspraken bij een volgende persoon opnieuw kunnen schuren.",
+                    "Leg vast welk deel van de samenwerking eerst gecorrigeerd moet worden voordat het patroon breder wordt.",
+                ],
+                "caution": "Laat losse exits niet te snel uitgroeien tot een brede cultuurclaim.",
+            },
+        },
+        "growth": {
+            "HOOG": {
+                "title": "Groeiperspectief vraagt correctieve herijking",
+                "validate": "Onderzoek in 60-90 dagen of vertrek vaker samenvalt met gebrekkig perspectief, beperkte ontwikkelruimte of een te laat gesprek daarover.",
+                "actions": [
+                    "Onderzoek waar perspectief voor vergelijkbare rollen te laat, te vaag of te weinig geloofwaardig werd gemaakt.",
+                    "Bepaal hoe je voorkomt dat hetzelfde gebrek aan perspectief bij de volgende persoon opnieuw meespeelt.",
+                ],
+                "caution": "Lees dit niet als bewijs dat meer doorgroei op zichzelf elk vertrek had voorkomen.",
+            },
+            "MIDDEN": {
+                "title": "Groeisignalen vragen gerichte terugblik",
+                "validate": "Onderzoek in 60-90 dagen of dit vooral ging om zicht op groei, feitelijke ruimte of het managementgesprek daarover.",
+                "actions": [
+                    "Onderzoek welke ontwikkelverwachting in vergelijkbare rollen eerder expliciet gemaakt moet worden.",
+                    "Leg vast welke kleine correctie nodig is om dit signaal bij de volgende persoon minder snel te laten terugkomen.",
+                ],
+                "caution": "Verwar teleurstelling over groei niet automatisch met één eenduidige vertrekverklaring.",
+            },
+        },
+        "compensation": {
+            "HOOG": {
+                "title": "Beloning vraagt correctieve duiding",
+                "validate": "Onderzoek in 60-90 dagen of dit patroon vooral zit in hoogte, fairness of uitlegbaarheid van voorwaarden voor vergelijkbare groepen.",
+                "actions": [
+                    "Onderzoek of dezelfde belonings- of voorwaardenfrictie vaker terugkomt in vergelijkbare rollen of afdelingen.",
+                    "Bepaal welke correctie nodig is om te voorkomen dat dit bij de volgende persoon opnieuw een vertrekversneller wordt.",
+                ],
+                "caution": "Ga niet uit van een puur salarisverhaal als ervaren eerlijkheid en uitlegbaarheid ook meespelen.",
+            },
+            "MIDDEN": {
+                "title": "Beloningssignalen vragen gecontroleerde terugblik",
+                "validate": "Onderzoek in 60-90 dagen of dit vooral een communicatievraag was of dat de feitelijke voorwaarden structureel frictie geven.",
+                "actions": [
+                    "Onderzoek waar uitleg of verwachtingsmanagement voor vergelijkbare rollen tekortschiet.",
+                    "Leg vast welke beperkte correctie helpt om dit bij de volgende persoon minder snel te laten terugkomen.",
+                ],
+                "caution": "Behandel dit niet te snel als opgelost wanneer alleen de communicatie wordt aangescherpt.",
+            },
+        },
+        "workload": {
+            "HOOG": {
+                "title": "Werkdruk vraagt correctieve opvolging",
+                "validate": "Onderzoek in 60-90 dagen of structurele druk, bezetting of prioritering in dezelfde teams vaker samenvalt met vertrek.",
+                "actions": [
+                    "Onderzoek welke werk- of planningsfrictie in dezelfde context bij de volgende persoon opnieuw kan spelen.",
+                    "Bepaal welke correctie in werkverdeling, bezetting of prioritering nodig is om herhaling te verkleinen.",
+                ],
+                "caution": "Noem dit niet alleen een belevingskwestie als de onderliggende werkdruk feitelijk structureel blijkt.",
+            },
+            "MIDDEN": {
+                "title": "Werkdruksignalen vragen gerichte terugblik",
+                "validate": "Onderzoek in 60-90 dagen of dit vooral piekdruk, structurele overbelasting of beperkte regelruimte in dezelfde context was.",
+                "actions": [
+                    "Onderzoek welk type druk in vergelijkbare teams het vaakst terugkomt vóór vertrek.",
+                    "Leg vast welke beperkte correctie nodig is om dit bij de volgende persoon minder snel te laten escaleren.",
+                ],
+                "caution": "Laat dit signaal niet verdwijnen in algemene drukte als er aanwijzingen zijn voor een terugkerend patroon.",
+            },
+        },
+        "role_clarity": {
+            "HOOG": {
+                "title": "Rolhelderheid vraagt correctieve herordening",
+                "validate": "Onderzoek in 60-90 dagen of onduidelijke prioriteiten, rolgrenzen of besluitvorming vaker samenkomen in dezelfde rol of afdeling.",
+                "actions": [
+                    "Onderzoek waar vergelijkbare rollen opnieuw vastlopen op verwachtingen, tegenstrijdige opdrachten of beslisruimte.",
+                    "Bepaal welke correctie nodig is om te voorkomen dat dezelfde onduidelijkheid bij de volgende persoon opnieuw meespeelt.",
+                ],
+                "caution": "Lees dit niet als bewijs dat een functiebeschrijving alleen het patroon oplost.",
+            },
+            "MIDDEN": {
+                "title": "Rolhelderheid vraagt gerichte terugblik",
+                "validate": "Onderzoek in 60-90 dagen of het vooral ging om prioriteiten, eigenaarschap of dagelijkse besluitvorming.",
+                "actions": [
+                    "Onderzoek welk deel van de rolafbakening voor vergelijkbare functies eerder expliciet gemaakt moet worden.",
+                    "Leg vast welke beperkte correctie nodig is om dit bij de volgende persoon minder snel te laten terugkomen.",
+                ],
+                "caution": "Verwar losse onduidelijkheid niet direct met een volledig organisatiebreed rolontwerpvraagstuk.",
+            },
+        },
+    }
+    base = playbooks.get(factor, {}).get(band)
+    if base is None:
+        return None
+    return {
+        "title": base["title"],
+        "validate": base["validate"],
+        "owner": "HR en betrokken manager samen",
+        "actions": base["actions"],
+        "caution": base["caution"],
+        "label": label,
+    }
+
+
+def _build_exit_playbook_rows(
+    *,
+    top_risks: list[tuple[str, float]],
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for factor, signal_value in top_risks:
+        band = "HOOG" if signal_value >= 7 else "MIDDEN" if signal_value >= 4.5 else "LAAG"
+        if band == "LAAG":
+            continue
+        playbook = _exit_playbook_copy(factor, band)
+        if playbook is None:
+            continue
+        rows.append({
+            "factor": factor,
+            "label": playbook["label"],
+            "signal_value": round(float(signal_value), 1),
+            "band": management_band_label(band=band),
+            "title": playbook["title"],
+            "decision": EXIT_DECISION_BY_FACTOR.get(
+                factor,
+                f"Beslis eerst welk deel van {playbook['label'].lower()} in 60-90 dagen het eerst correctieve opvolging vraagt.",
+            ),
+            "validate": playbook["validate"],
+            "owner": playbook["owner"],
+            "actions": playbook["actions"],
+            "caution": playbook["caution"],
+            "review": "Weeg binnen 60-90 dagen opnieuw of dit patroon terugkomt in exitgesprekken, HR-signalen of teamdynamiek.",
+            "owner_basis": EXIT_OWNER_BY_FACTOR.get(factor),
+        })
+    return rows[:2]
 
 
 def _factor_explanation_lookup() -> dict[str, str]:
@@ -3917,6 +4208,90 @@ def _append_rebrand_actions(
     story.append(PageBreak())
 
 
+def _append_department_overview_section(
+    story: list,
+    *,
+    department_overview_payload: dict[str, Any] | None,
+    content_width: float,
+    report_theme: dict[str, colors.Color],
+) -> None:
+    if not department_overview_payload:
+        return
+
+    _append_section_heading(
+        story,
+        eyebrow="Verdieping",
+        title=department_overview_payload["section_title"],
+        intro=department_overview_payload["intro"],
+        content_width=content_width,
+    )
+    table_rows = [["Afdeling", "n", "Score", "Band", "Topfactor"]]
+    for row in department_overview_payload["sections"]:
+        table_rows.append([
+            row["department"],
+            str(row["n"]),
+            f"{row['avg_score']:.1f}/10",
+            row["band"],
+            row["top_factor"],
+        ])
+    story.append(_build_data_table_flowable(
+        rows=table_rows,
+        col_widths=[content_width * 0.30, content_width * 0.08, content_width * 0.14, content_width * 0.18, content_width * 0.30],
+        theme=report_theme,
+        align_columns=[1, 2],
+        bold_columns=[1, 2],
+    ))
+    story.append(PageBreak())
+
+
+def _append_exit_playbooks(
+    story: list,
+    *,
+    exit_playbooks: list[dict[str, Any]],
+    content_width: float,
+    report_theme: dict[str, colors.Color],
+) -> None:
+    if not exit_playbooks:
+        return
+
+    _append_section_heading(
+        story,
+        eyebrow="Wat nu",
+        title="Correctieve exit-playbooks",
+        intro=(
+            "Deze playbooks lezen vertrek retrospectief: de persoon is al weg. "
+            "Gebruik ze om in 60-90 dagen te onderzoeken welk patroon structureel terugkomt en wat gecorrigeerd moet worden "
+            "om herhaling bij de volgende persoon te verkleinen, zonder achteraf één oorzaak te claimen."
+        ),
+        content_width=content_width,
+    )
+    playbook_cards = []
+    for playbook in exit_playbooks[:2]:
+        actions_text = " ".join([f"• {action}" for action in playbook["actions"][:2]])
+        playbook_cards.append({
+            "title": playbook["label"],
+            "badge": _risk_badge(playbook["signal_value"]),
+            "value": f"{playbook['signal_value']:.1f}/10",
+            "body": (
+                f"<b>{playbook['title']}</b><br/>"
+                f"<b>Eerste besluit:</b> {playbook['decision']}<br/>"
+                f"<b>Te onderzoeken in 60-90 dagen:</b> {playbook['validate']}<br/>"
+                f"<b>Gezamenlijke eigenaar:</b> {playbook['owner']}<br/>"
+                f"{actions_text}<br/>"
+                f"<b>Leesgrens:</b> {playbook['caution']}"
+            ),
+            "background": TOKENS["cream"],
+        })
+    _append_highlight_cards(
+        story,
+        playbook_cards,
+        content_width=content_width,
+        theme=report_theme,
+        columns=min(2, len(playbook_cards)),
+    )
+    story.append(PageBreak())
+
+
 def _append_rebrand_retention_playbooks(
     story: list,
     *,
@@ -4899,6 +5274,8 @@ def _build_exit_embedded_story(
     hypotheses_payload: dict[str, str],
     hypotheses: list[dict[str, str]],
     next_steps_payload: dict[str, Any],
+    exit_playbooks: list[dict[str, Any]],
+    department_overview_payload: dict[str, Any] | None,
     signal_visibility_average: float | None,
     top_exit_reason_label: str | None,
     top_contributing_reason_label: str | None,
@@ -4997,6 +5374,12 @@ def _build_exit_embedded_story(
         content_width=content_width,
         report_theme=report_theme,
     )
+    _append_department_overview_section(
+        story,
+        department_overview_payload=department_overview_payload,
+        content_width=content_width,
+        report_theme=report_theme,
+    )
     _append_rebrand_actions(
         story,
         hypotheses_payload=hypotheses_payload,
@@ -5014,6 +5397,12 @@ def _build_exit_embedded_story(
         report_theme=report_theme,
         title="Eerste route & actie",
         intro="Hier komt de vertaalslag van interpretatie naar opvolging samen: eerste route, eerste eigenaar, eerste stap en reviewmoment.",
+    )
+    _append_exit_playbooks(
+        story,
+        exit_playbooks=exit_playbooks,
+        content_width=content_width,
+        report_theme=report_theme,
     )
     _append_exit_methodology_page(
         story,
@@ -5111,6 +5500,7 @@ def _build_shared_non_exit_runtime_story(
     retention_playbook_calibration_note: str | None,
     retention_segment_playbooks: list[dict[str, Any]],
     segment_deep_dive: dict[str, Any],
+    department_overview_payload: dict[str, Any] | None,
     scan_meta: dict[str, Any],
     has_segment_deep_dive: bool,
     cover_distribution_note: str,
@@ -5152,6 +5542,12 @@ def _build_shared_non_exit_runtime_story(
         management_summary_payload=management_summary_payload,
         next_steps_payload=next_steps_payload,
         top_factor_labels=top_factor_labels,
+        content_width=content_width,
+        report_theme=report_theme,
+    )
+    _append_department_overview_section(
+        story,
+        department_overview_payload=department_overview_payload,
         content_width=content_width,
         report_theme=report_theme,
     )
@@ -5916,6 +6312,11 @@ def generate_campaign_report(
         top_risks=top_risks,
         playbooks=product_module.get_action_playbooks_payload(),
     ) if is_retention and has_pattern and hasattr(product_module, "get_action_playbooks_payload") else []
+    exit_playbooks = (
+        _build_exit_playbook_rows(top_risks=top_risks)
+        if camp.scan_type == "exit" and has_pattern
+        else []
+    )
     retention_playbook_calibration_note = (
         product_module.get_action_playbook_calibration_note()
         if is_retention and hasattr(product_module, "get_action_playbook_calibration_note")
@@ -5980,6 +6381,10 @@ def generate_campaign_report(
         responses=responses,
         org_avg_risk=pattern.get("avg_risk_score") if has_pattern else avg_risk,
     ) if has_segment_deep_dive else {"coverage": {}, "rows": []}
+    department_overview_payload = _build_department_overview_payload(
+        responses=responses,
+        score_label=scan_meta["signal_short_label"],
+    )
     retention_segment_playbooks = (
         _build_retention_segment_playbook_rows(
             responses=responses,
@@ -6212,6 +6617,8 @@ def generate_campaign_report(
             hypotheses_payload=hypotheses_payload,
             hypotheses=action_hypotheses,
             next_steps_payload=next_steps_payload,
+            exit_playbooks=exit_playbooks,
+            department_overview_payload=department_overview_payload,
             signal_visibility_average=signal_visibility_average,
             top_exit_reason_label=top_exit_reason_label,
             top_contributing_reason_label=top_contributing_reason_label,
@@ -6267,6 +6674,7 @@ def generate_campaign_report(
             retention_playbook_calibration_note=retention_playbook_calibration_note,
             retention_segment_playbooks=retention_segment_playbooks,
             segment_deep_dive=segment_deep_dive,
+            department_overview_payload=department_overview_payload,
             scan_meta=scan_meta,
             has_segment_deep_dive=has_segment_deep_dive,
             cover_distribution_note=cover_distribution_note,

--- a/tests/test_report_department_overview_and_exit_playbooks.py
+++ b/tests/test_report_department_overview_and_exit_playbooks.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from backend.report import (
+    _build_department_overview_payload,
+    _build_exit_playbook_rows,
+)
+
+
+def _fake_response(
+    *,
+    department: str | None,
+    risk_score: float,
+    org_scores: dict[str, float],
+):
+    respondent = SimpleNamespace(department=department, role_level=None)
+    return SimpleNamespace(
+        risk_score=risk_score,
+        org_scores=org_scores,
+        respondent=respondent,
+    )
+
+
+def test_department_overview_payload_groups_small_departments_and_sorts_by_highest_score():
+    responses = []
+    responses.extend([
+        _fake_response(
+            department="Operations",
+            risk_score=7.8,
+            org_scores={
+                "leadership": 3.2,
+                "culture": 4.1,
+                "growth": 4.4,
+                "compensation": 5.0,
+                "workload": 4.2,
+                "role_clarity": 4.7,
+            },
+        )
+        for _ in range(6)
+    ])
+    responses.extend([
+        _fake_response(
+            department="Sales",
+            risk_score=6.4,
+            org_scores={
+                "leadership": 4.8,
+                "culture": 4.9,
+                "growth": 4.2,
+                "compensation": 5.1,
+                "workload": 5.0,
+                "role_clarity": 4.6,
+            },
+        )
+        for _ in range(5)
+    ])
+    responses.extend([
+        _fake_response(
+            department="HR",
+            risk_score=5.1,
+            org_scores={
+                "leadership": 5.3,
+                "culture": 4.8,
+                "growth": 5.2,
+                "compensation": 4.1,
+                "workload": 5.0,
+                "role_clarity": 5.4,
+            },
+        )
+        for _ in range(5)
+    ])
+    responses.extend([
+        _fake_response(
+            department="Legal",
+            risk_score=6.8,
+            org_scores={
+                "leadership": 4.7,
+                "culture": 4.6,
+                "growth": 4.9,
+                "compensation": 4.8,
+                "workload": 3.5,
+                "role_clarity": 4.5,
+            },
+        )
+        for _ in range(3)
+    ])
+    responses.extend([
+        _fake_response(
+            department="Finance",
+            risk_score=5.9,
+            org_scores={
+                "leadership": 4.9,
+                "culture": 4.7,
+                "growth": 4.8,
+                "compensation": 5.1,
+                "workload": 4.4,
+                "role_clarity": 4.9,
+            },
+        )
+        for _ in range(2)
+    ])
+
+    payload = _build_department_overview_payload(
+        responses=responses,
+        score_label="frictiescore",
+    )
+
+    assert payload is not None
+    assert payload["sections"][0]["department"] == "Operations"
+    assert payload["sections"][0]["n"] == 6
+    assert payload["sections"][0]["band"] == "Direct prioriteren"
+    assert payload["sections"][0]["top_factor"] == "Leiderschap"
+    assert payload["sections"][1]["department"] == "Sales"
+    assert payload["sections"][2]["department"] == "HR"
+    assert payload["sections"][3]["department"] == "Overige afdelingen"
+    assert payload["sections"][3]["n"] == 5
+    assert payload["sections"][3]["top_factor"] == "Werkbelasting"
+    assert all(section["n"] >= 5 for section in payload["sections"])
+    assert "Legal" not in [section["department"] for section in payload["sections"]]
+    assert "Finance" not in [section["department"] for section in payload["sections"]]
+
+
+def test_department_overview_payload_returns_none_when_too_few_departments_clear_privacy_floor():
+    responses = []
+    responses.extend([
+        _fake_response(
+            department="Operations",
+            risk_score=7.2,
+            org_scores={
+                "leadership": 3.5,
+                "culture": 4.2,
+                "growth": 4.6,
+                "compensation": 5.0,
+                "workload": 4.3,
+                "role_clarity": 4.9,
+            },
+        )
+        for _ in range(6)
+    ])
+    responses.extend([
+        _fake_response(
+            department="HR",
+            risk_score=5.6,
+            org_scores={
+                "leadership": 4.8,
+                "culture": 4.7,
+                "growth": 5.0,
+                "compensation": 4.5,
+                "workload": 4.9,
+                "role_clarity": 5.1,
+            },
+        )
+        for _ in range(4)
+    ])
+
+    payload = _build_department_overview_payload(
+        responses=responses,
+        score_label="retentiesignaal",
+    )
+
+    assert payload is None
+
+
+def test_exit_playbooks_use_retrospective_tone_and_hr_manager_joint_owner():
+    rows = _build_exit_playbook_rows(
+        top_risks=[("leadership", 7.6), ("workload", 6.3)],
+    )
+
+    assert len(rows) == 2
+    assert rows[0]["factor"] == "leadership"
+    assert rows[0]["label"] == "Leiderschap"
+    assert rows[0]["signal_value"] == 7.6
+    assert rows[0]["decision"]
+    assert rows[0]["decision"].startswith("Beslis eerst")
+    assert rows[0]["owner"] == "HR en betrokken manager samen"
+    assert "onderzoek" in rows[0]["validate"].lower()
+    assert "60-90 dagen" in rows[0]["validate"]
+    assert any("volgende persoon" in action.lower() for action in rows[0]["actions"])
+    assert any("onderzoek" in action.lower() for action in rows[0]["actions"])
+    assert "oorzaak" not in rows[0]["caution"].lower()


### PR DESCRIPTION
## What changed
- added a privacy-safe department overview section to the shared report pipeline for both ExitScan and RetentieScan
- added retrospective ExitScan playbooks directly in the report pipeline, using existing exit decision/owner mappings without changing product report content payloads
- added focused regression tests for department overview privacy behavior and exit playbook tone

## Why
- the report needed a stronger bestuurslaag without weakening the management summary
- department detail needed to appear only when respondent.department data is strong enough and privacy thresholds are met
- ExitScan needed deeper corrective follow-up guidance without introducing diagnostic or causal language

## Validation
- `python -m pytest tests/test_report_department_overview_and_exit_playbooks.py -q`
- `python -m py_compile backend/report.py`
- `python -m pytest tests/ -x` still fails on an existing unrelated baseline copy test in `tests/test_account_billing_model_readiness.py::test_legal_terms_keep_manual_billing_and_no_self_serve_claims_explicit`

## Notes
- management summary content in `backend/products/*/report_content.py` was left intact
- small departments remain hidden individually and are only shown as `Overige afdelingen` when the grouped total reaches the privacy floor