### PR TITLE
[codex] allow Railway free-plan serverless deploys

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -8,4 +8,3 @@ healthcheckTimeout = 30
 restartPolicyType = "on_failure"
 # Railway pingt elke 30s de healthcheck — dit houdt de container warm
 # en voorkomt cold starts (10-30s vertraging bij survey-openen).
-sleepApplication = false


### PR DESCRIPTION
## What changed
- removed `sleepApplication = false` from `railway.toml`

## Why
- Railway config defined in code overrides dashboard deploy settings for the current deployment
- the backend service is now on Railway free/serverless mode, and the explicit `sleepApplication = false` conflicted with that requirement
- build logs reported: `Free plan deployments must be serverless`

## Validation
- verified the repo diff is limited to removing the explicit always-on setting from `railway.toml`
- current `railway.toml` now keeps the existing start command, health check, and restart policy intact while no longer forcing always-on behavior