### PR TITLE
[codex] Add standalone eNPS to ExitScan and RetentieScan

### DIFF
--- a/backend/products/exit/definition.py
+++ b/backend/products/exit/definition.py
@@ -36,6 +36,10 @@ SCAN_DEFINITION: dict[str, Any] = {
     "survey_privacy_note": "Je antwoorden worden vertrouwelijk verwerkt en alleen op gegroepeerd niveau gerapporteerd. De uitkomsten zijn bedoeld als groepsinzichten en gespreksinput, niet als individueel oordeel of harde voorspelling. Als je tussentijds stopt, bewaart deze browser tijdelijk een concept op dit apparaat totdat je verzendt of het concept wist.",
     "sdt_intro": "De volgende stellingen gaan over hoe jij je werk ervoer. Geef aan in welke mate elke stelling voor jou van toepassing was (1 = helemaal niet mee eens, 5 = helemaal mee eens).",
     "org_intro": "Geef aan in welke mate de volgende uitspraken van toepassing waren op jouw werksituatie.",
+    "enps_item": (
+        "enps_score",
+        "Hoe waarschijnlijk is het dat je deze organisatie zou aanbevelen als werkgever aan iemand die je kent?",
+    ),
     "open_text_label": "Wat had de organisatie volgens jou eerder moeten begrijpen, bespreken of zien rond je vertrek?",
     "open_text_placeholder": "Beschrijf wat voor management of HR eerder zichtbaar of bespreekbaar had mogen worden.",
     "open_text_help": "Je antwoord wordt geanonimiseerd opgeslagen. Noem bij voorkeur geen namen of direct herleidbare details.",

--- a/backend/products/exit/report_content.py
+++ b/backend/products/exit/report_content.py
@@ -58,6 +58,7 @@ def get_management_summary_payload(
     top_contributing_reason_label: str | None,
     strong_work_signal_pct: float | None,
     signal_visibility_average: float | None,
+    enps_summary: dict[str, int] | None = None,
     total_replacement_cost_eur: float | None = None,
 ) -> dict[str, Any]:
     top_factor_text = " en ".join(label.lower() for label in top_factor_labels[:2]) if top_factor_labels else "de scherpste werkfactoren"
@@ -220,6 +221,13 @@ def get_management_summary_payload(
             "value": visibility_value,
             "body": visibility_body,
         }
+    enps_card = None
+    if enps_summary is not None:
+        enps_card = {
+            "title": "eNPS",
+            "value": f"{enps_summary['score']:+d}",
+            "body": "Aandeel bevelers minus critici. Schaal -100 tot +100.",
+        }
 
     return {
         "section_title": "Managementsamenvatting",
@@ -238,7 +246,7 @@ def get_management_summary_payload(
         "boardroom_cards": boardroom_cards,
         "boardroom_watchout_title": "Wat je hier niet uit moet concluderen",
         "boardroom_watchout": boardroom_watchout,
-        "highlight_cards": [
+        "highlight_cards": ([
             {
                 "title": "Vertrekbeeld nu",
                 "value": (top_exit_reason_label or "Nog geen duidelijke hoofdreden"),
@@ -271,7 +279,7 @@ def get_management_summary_payload(
                 "value": visibility_value,
                 "body": visibility_body,
             },
-        ],
+        ] + ([enps_card] if enps_card else [])),
         "cards": [
             {
                 "title": "Vertrekbeeld nu",

--- a/backend/products/exit/scoring.py
+++ b/backend/products/exit/scoring.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from fastapi import HTTPException
 
+from backend.products.shared.enps import build_enps_summary
 from backend.products.shared.org_factors import compute_org_scores
 from backend.products.shared.sdt import compute_sdt_scores
 from backend.scoring import compute_preventability, compute_replacement_cost, get_recommendations
@@ -28,6 +29,8 @@ def validate_submission(payload: Any) -> None:
         raise HTTPException(status_code=422, detail="ExitScan vereist een antwoord op diensttijd.")
     if payload.exit_reason_category is None:
         raise HTTPException(status_code=422, detail="ExitScan vereist een hoofdreden voor vertrek.")
+    if payload.enps_score is None:
+        raise HTTPException(status_code=422, detail="ExitScan vereist een eNPS-antwoord.")
     if payload.stay_intent_score is None:
         raise HTTPException(status_code=422, detail="ExitScan vereist een antwoord op beïnvloedbaarheid.")
     if payload.signal_visibility_score is None:
@@ -158,7 +161,9 @@ def score_submission(
         exit_reason_code=exit_reason_code,
         contributing_reason_codes=contributing_reason_codes,
     )
+    enps_summary = build_enps_summary(payload.enps_score)
     full_result = {
+        "enps": enps_summary,
         "sdt_scores": sdt_scores,
         "org_scores": org_scores,
         "risk_result": risk_result,

--- a/backend/products/retention/definition.py
+++ b/backend/products/retention/definition.py
@@ -37,6 +37,10 @@ SCAN_DEFINITION: dict[str, Any] = {
     "org_intro": "Geef aan in welke mate de volgende uitspraken van toepassing zijn op jouw huidige werksituatie.",
     "stay_intro": "De volgende stelling gaat over jouw bereidheid om te blijven en de kans dat je hier op langere termijn wilt blijven werken.",
     "stay_item": ("stay_intent", "Als het aan mij ligt, werk ik over 12 maanden nog steeds bij deze organisatie."),
+    "enps_item": (
+        "enps_score",
+        "Hoe waarschijnlijk is het dat je deze organisatie als werkgever zou aanraden aan iemand die je kent?",
+    ),
     "open_text_label": "Welke verandering in je werk, leiding of samenwerking zou jouw bereidheid om te blijven het meest versterken?",
     "open_text_placeholder": "Welke verandering zou behoud voor jou het meest versterken?",
     "open_text_help": "Je antwoord wordt geanonimiseerd opgeslagen en alleen als groepssignaal voor verificatie en opvolging gebruikt.",

--- a/backend/products/retention/report_content.py
+++ b/backend/products/retention/report_content.py
@@ -59,6 +59,7 @@ def get_management_summary_payload(
     avg_turnover_intention: float | None,
     avg_stay_intent: float | None,
     retention_theme_title: str | None,
+    enps_summary: dict[str, int] | None = None,
 ) -> dict[str, Any]:
     top_factor_text = " en ".join(label.lower() for label in top_factor_labels[:2]) if top_factor_labels else "de laagst scorende werkfactoren"
     top_factor_value = " / ".join(top_factor_labels[:2]) if top_factor_labels else "Nog geen duidelijke topfactor"
@@ -186,6 +187,13 @@ def get_management_summary_payload(
             "value": "Continuiteitsdruk",
             "body": continuity_body,
         }
+    enps_card = None
+    if enps_summary is not None:
+        enps_card = {
+            "title": "eNPS",
+            "value": f"{enps_summary['score']:+d}",
+            "body": "Aandeel bevelers minus critici. Schaal -100 tot +100.",
+        }
 
     return {
         "section_title": "Bestuurlijke handoff",
@@ -230,7 +238,7 @@ def get_management_summary_payload(
         ],
         "boardroom_watchout_title": "Wat je hier niet uit moet concluderen",
         "boardroom_watchout": boardroom_watchout,
-        "highlight_cards": [
+        "highlight_cards": ([
             {
                 "title": "Groepsbeeld nu",
                 "value": signal_profile_value,
@@ -261,7 +269,7 @@ def get_management_summary_payload(
                 "value": signal_profile_value,
                 "body": signal_profile_copy.get(retention_signal_profile, signal_profile_copy["vroegsignaal"]),
             },
-        ],
+        ] + ([enps_card] if enps_card else [])),
         "cards": [
             {
                 "title": "Groepsbeeld nu",

--- a/backend/products/retention/scoring.py
+++ b/backend/products/retention/scoring.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from fastapi import HTTPException
 
+from backend.products.shared.enps import build_enps_summary
 from backend.products.shared.org_factors import compute_org_scores
 from backend.products.shared.sdt import compute_sdt_scores, scale_to_ten
 from backend.scoring import get_recommendations
@@ -109,6 +110,8 @@ def validate_submission(payload: Any) -> None:
         raise HTTPException(status_code=422, detail="RetentieScan vereist 3 bevlogenheidsitems.")
     if len(payload.turnover_intention_raw) != 2:
         raise HTTPException(status_code=422, detail="RetentieScan vereist 2 vertrekintentie-items.")
+    if payload.enps_score is None:
+        raise HTTPException(status_code=422, detail="RetentieScan vereist een eNPS-antwoord.")
     if payload.stay_intent_score is None:
         raise HTTPException(status_code=422, detail="RetentieScan vereist een stay-intent antwoord.")
 
@@ -134,6 +137,7 @@ def score_submission(
     stay_signal_score = supplemental_scores["stay_intent_score"]
 
     recommendations = get_recommendations(risk_result["factor_risks"])
+    enps_summary = build_enps_summary(payload.enps_score)
     retention_summary = {
         "retention_signal_score": risk_result["risk_score"],
         "retention_signal_band": risk_result["risk_band"],
@@ -149,6 +153,7 @@ def score_submission(
     }
 
     full_result = {
+        "enps": enps_summary,
         "sdt_scores": sdt_scores,
         "org_scores": org_scores,
         "risk_result": risk_result,

--- a/backend/products/shared/enps.py
+++ b/backend/products/shared/enps.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def build_enps_summary(raw_score: int) -> dict[str, Any]:
+    if raw_score >= 9:
+        band = "promoter"
+    elif raw_score >= 7:
+        band = "passive"
+    else:
+        band = "detractor"
+
+    return {
+        "raw_score": raw_score,
+        "band": band,
+    }

--- a/backend/report.py
+++ b/backend/report.py
@@ -2553,6 +2553,32 @@ def _compute_retention_signal_averages(responses: list[SurveyResponse]) -> dict[
     }
 
 
+def _compute_enps_summary(responses: list[SurveyResponse]) -> dict[str, int] | None:
+    scores: list[int] = []
+
+    for response in responses:
+        full_result = response.full_result if isinstance(response.full_result, dict) else {}
+        enps = full_result.get("enps") if isinstance(full_result, dict) else None
+        if not isinstance(enps, dict):
+            continue
+        raw_score = enps.get("raw_score")
+        if isinstance(raw_score, (int, float)):
+            score_int = int(raw_score)
+            if 0 <= score_int <= 10:
+                scores.append(score_int)
+
+    if len(scores) < 5:
+        return None
+
+    promoters = sum(1 for score in scores if score >= 9)
+    detractors = sum(1 for score in scores if score <= 6)
+    enps_score = round(((promoters - detractors) / len(scores)) * 100)
+    return {
+        "score": int(enps_score),
+        "sample_size": len(scores),
+    }
+
+
 def _build_retention_trend_rows(
     *,
     current: dict[str, float | None],
@@ -5992,6 +6018,7 @@ def generate_campaign_report(
     total_cost = sum(
         r.replacement_cost_eur for r in responses if r.replacement_cost_eur
     )
+    enps_summary = _compute_enps_summary(responses)
     if is_retention:
         management_summary_payload = product_module.get_management_summary_payload(
             top_factor_labels=top_factor_labels,
@@ -6001,6 +6028,7 @@ def generate_campaign_report(
             avg_turnover_intention=avg_turnover_intention,
             avg_stay_intent=avg_stay_intent,
             retention_theme_title=retention_themes[0]["title"] if retention_themes else None,
+            enps_summary=enps_summary,
         )
     elif camp.scan_type == "team":
         management_summary_payload = product_module.get_management_summary_payload(
@@ -6044,6 +6072,7 @@ def generate_campaign_report(
             top_contributing_reason_label=top_contributing_reason_label,
             strong_work_signal_pct=strong_work_signal_pct,
             signal_visibility_average=signal_visibility_average,
+            enps_summary=enps_summary,
             total_replacement_cost_eur=total_cost,
         )
     hypotheses_payload = product_module.get_hypotheses_payload()

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -291,7 +291,7 @@ class ContactRequestUpdate(BaseModel):
 class SurveySubmit(BaseModel):
     """
     Body POSTed when a respondent submits the survey.
-    All Likert values: integers 1-5.
+    Likert values: integers 1-5, plus eNPS 0-10.
     Open text is optional.
     """
     token: str
@@ -303,6 +303,7 @@ class SurveySubmit(BaseModel):
     # Shared request field for a product-specific direction/stay item.
     # Product interpretation must come from scan_type and product definition.
     stay_intent_score: Optional[int] = Field(None, ge=1, le=5)
+    enps_score: Optional[int] = Field(None, ge=0, le=10)
     signal_visibility_score: Optional[int] = Field(None, ge=1, le=5)
 
     # Module B — SDT (12 items, required)

--- a/frontend/app/(dashboard)/campaigns/[id]/page-helpers.test.ts
+++ b/frontend/app/(dashboard)/campaigns/[id]/page-helpers.test.ts
@@ -3,6 +3,7 @@ import {
   buildDecisionPanels,
   buildHeroDescription,
   buildNextStepBody,
+  computeENPS,
   computeAverageRiskScore,
   computeFactorAverages,
   computeRetentionSupplementalAverages,
@@ -77,6 +78,92 @@ describe('dashboard page helpers field semantics', () => {
     ]
 
     expect(computeRetentionSupplementalAverages(responses).stayIntent).toBe(5.5)
+  })
+
+  it('computes eNPS only when at least five responses expose a raw score', () => {
+    const tooSmall: SurveyResponse[] = Array.from({ length: 4 }, (_, index) => ({
+      id: `resp-small-${index}`,
+      respondent_id: `r-small-${index}`,
+      risk_score: 5.2,
+      risk_band: 'MIDDEN',
+      preventability: null,
+      exit_reason_code: null,
+      sdt_scores: {},
+      org_scores: {},
+      full_result: {
+        enps: {
+          raw_score: 10,
+          band: 'promoter',
+        },
+      },
+      submitted_at: '2026-04-18T10:00:00Z',
+    }))
+
+    const sufficient: SurveyResponse[] = [
+      {
+        id: 'resp-enps-1',
+        respondent_id: 'r-enps-1',
+        risk_score: 5.2,
+        risk_band: 'MIDDEN',
+        preventability: null,
+        exit_reason_code: null,
+        sdt_scores: {},
+        org_scores: {},
+        full_result: { enps: { raw_score: 10, band: 'promoter' } },
+        submitted_at: '2026-04-18T10:00:00Z',
+      },
+      {
+        id: 'resp-enps-2',
+        respondent_id: 'r-enps-2',
+        risk_score: 5.0,
+        risk_band: 'MIDDEN',
+        preventability: null,
+        exit_reason_code: null,
+        sdt_scores: {},
+        org_scores: {},
+        full_result: { enps: { raw_score: 9, band: 'promoter' } },
+        submitted_at: '2026-04-18T10:05:00Z',
+      },
+      {
+        id: 'resp-enps-3',
+        respondent_id: 'r-enps-3',
+        risk_score: 5.1,
+        risk_band: 'MIDDEN',
+        preventability: null,
+        exit_reason_code: null,
+        sdt_scores: {},
+        org_scores: {},
+        full_result: { enps: { raw_score: 8, band: 'passive' } },
+        submitted_at: '2026-04-18T10:10:00Z',
+      },
+      {
+        id: 'resp-enps-4',
+        respondent_id: 'r-enps-4',
+        risk_score: 5.4,
+        risk_band: 'MIDDEN',
+        preventability: null,
+        exit_reason_code: null,
+        sdt_scores: {},
+        org_scores: {},
+        full_result: { enps: { raw_score: 6, band: 'detractor' } },
+        submitted_at: '2026-04-18T10:15:00Z',
+      },
+      {
+        id: 'resp-enps-5',
+        respondent_id: 'r-enps-5',
+        risk_score: 5.3,
+        risk_band: 'MIDDEN',
+        preventability: null,
+        exit_reason_code: null,
+        sdt_scores: {},
+        org_scores: {},
+        full_result: { enps: { raw_score: 0, band: 'detractor' } },
+        submitted_at: '2026-04-18T10:20:00Z',
+      },
+    ]
+
+    expect(computeENPS(tooSmall)).toBeNull()
+    expect(computeENPS(sufficient)).toBe(0)
   })
 
   it('keeps retention helper summaries centered on retentiesignaal instead of stay-intent', () => {

--- a/frontend/app/(dashboard)/campaigns/[id]/page-helpers.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page-helpers.tsx
@@ -784,6 +784,15 @@ function getExitContextSummary(response: SurveyResponse) {
     : null
 }
 
+function getENPSScore(response: SurveyResponse) {
+  const fullResult = response.full_result as Record<string, unknown> | null | undefined
+  const enps = fullResult?.enps
+  if (!enps || typeof enps !== 'object') return null
+
+  const rawScore = (enps as Record<string, unknown>).raw_score
+  return typeof rawScore === 'number' ? rawScore : null
+}
+
 export function getTopExitReasonLabel(responses: SurveyResponse[]) {
   const counts = new Map<string, number>()
 
@@ -822,6 +831,18 @@ export function computeAverageSignalVisibility(responses: SurveyResponse[]) {
 
   if (!values.length) return null
   return values.reduce((sum, value) => sum + value, 0) / values.length
+}
+
+export function computeENPS(responses: SurveyResponse[]) {
+  const scores = responses
+    .map((response) => getENPSScore(response))
+    .filter((value): value is number => typeof value === 'number')
+
+  if (scores.length < 5) return null
+
+  const promoters = scores.filter((score) => score >= 9).length
+  const detractors = scores.filter((score) => score <= 6).length
+  return Math.round(((promoters - detractors) / scores.length) * 100)
 }
 
 export function computeRetentionSupplementalAverages(responses: SurveyResponse[]) {

--- a/frontend/app/(dashboard)/campaigns/[id]/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.tsx
@@ -76,6 +76,7 @@ import {
   clusterRetentionOpenSignals,
   computeAverageSignalScore,
   computePulseSignalAverages,
+  computeENPS,
   computeAverageSignalVisibility,
   computeFactorAverages,
   computeRetentionSignalAverages,
@@ -821,6 +822,10 @@ export default async function CampaignPage({ params }: Props) {
   const signalVisibilityAverage =
     stats.scan_type === "exit"
       ? computeAverageSignalVisibility(responses)
+      : null;
+  const enpsScore =
+    stats.scan_type === "exit" || stats.scan_type === "retention"
+      ? computeENPS(responses)
       : null;
   const retentionSupplemental = computeRetentionSupplementalAverages(responses);
   const currentRetentionSignals =
@@ -3130,6 +3135,22 @@ export default async function CampaignPage({ params }: Props) {
                     </p>
                   </div>
                 </div>
+                <div className="rounded-[24px] border border-[#E7D7C6] bg-white/82 px-5 py-5">
+                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                    eNPS
+                  </p>
+                  <p className="dash-number mt-3 text-[2rem] leading-none text-[color:var(--dashboard-ink)]">
+                    {enpsScore !== null ? `${enpsScore >= 0 ? "+" : ""}${enpsScore}` : "n.b."}
+                  </p>
+                  <p className="mt-3 text-sm leading-6 text-[color:var(--dashboard-text)]">
+                    Informatieve aanbevelingsmetric naast de frictiescore. eNPS telt niet mee in de vertrekduiding of factorweging.
+                  </p>
+                  <p className="mt-3 text-sm leading-6 text-[color:var(--dashboard-text)]">
+                    {enpsScore !== null
+                      ? "Aandeel bevelers minus critici. Schaal -100 tot +100."
+                      : "We tonen eNPS pas zodra minstens 5 responses een geldige aanbevelingsscore bevatten."}
+                  </p>
+                </div>
               </div>
             </div>
           </section>
@@ -3459,6 +3480,7 @@ export default async function CampaignPage({ params }: Props) {
                   { label: "Retentiesignaal", value: averageRiskScore !== null ? `${averageRiskScore.toFixed(1)}/10` : "Nog niet vrij" },
                   { label: "Vertrekintentie", value: retentionSupplemental.turnoverIntention !== null ? `${retentionSupplemental.turnoverIntention.toFixed(1)}/10` : "Nog niet vrij" },
                   { label: "Bevlogenheid", value: retentionSupplemental.engagement !== null ? `${retentionSupplemental.engagement.toFixed(1)}/10` : "Nog niet vrij" },
+                  { label: "eNPS", value: enpsScore !== null ? `${enpsScore >= 0 ? "+" : ""}${enpsScore}` : "n.b." },
                   { label: "Respons", value: `${stats.completion_rate_pct ?? 0}%` },
                 ]}
               />

--- a/templates/survey.html
+++ b/templates/survey.html
@@ -699,6 +699,7 @@ try { sessionStorage.removeItem(key); } catch (e) {}
       token:                    data.token,
       tenure_years:             data.tenure_years ? parseFloat(data.tenure_years) : null,
       exit_reason_category:     data.exit_reason_category || null,
+      enps_score:               data.enps_score ? parseInt(data.enps_score) : data.enps_score === "0" ? 0 : null,
       stay_intent_score:        data.stay_intent_score ? parseInt(data.stay_intent_score) : null,
       signal_visibility_score:  data.signal_visibility_score ? parseInt(data.signal_visibility_score) : null,
       sdt_raw,

--- a/templates/survey/exit-context.html
+++ b/templates/survey/exit-context.html
@@ -94,6 +94,27 @@
       <div class="field-error">Selecteer een antwoord.</div>
     </div>
 
+    <div class="question-block" id="qblock-exit-enps">
+      <div class="question-text">
+        {{ scan.enps_item[1] }}
+      </div>
+      <div class="likert-wrap">
+        <div class="likert-labels">
+          <span>Zeer onwaarschijnlijk</span>
+          <span>Zeer waarschijnlijk</span>
+        </div>
+        <div class="likert-options" style="display:grid;grid-template-columns:repeat(11,minmax(0,1fr));">
+          {% for i in range(0, 11) %}
+          <div class="likert-option">
+            <input type="radio" name="enps_score" id="exit_enps_{{ i }}" value="{{ i }}" required />
+            <label for="exit_enps_{{ i }}">{{ i }}</label>
+          </div>
+          {% endfor %}
+        </div>
+      </div>
+      <div class="field-error">Selecteer een antwoord.</div>
+    </div>
+
     <div class="question-block" id="qblock-contributing-reasons">
       <div class="question-text">
         Welke andere factoren speelden ook mee in je vertrek? <span style="color:var(--muted);font-weight:400;">(optioneel, maximaal 2)</span>

--- a/templates/survey/retention-signals.html
+++ b/templates/survey/retention-signals.html
@@ -55,4 +55,21 @@
   </div>
   <div class="field-error">Selecteer een antwoord.</div>
 </div>
+
+<p style="font-weight:600;font-size:14px;margin:24px 0 8px;color:var(--text);">eNPS</p>
+<div class="question-block" id="qblock-retention-enps">
+  <div class="question-text"><span class="question-number">â—†</span>{{ scan.enps_item[1] }}</div>
+  <div class="likert-wrap">
+    <div class="likert-labels"><span>Zeer onwaarschijnlijk</span><span>Zeer waarschijnlijk</span></div>
+    <div class="likert-options" style="display:grid;grid-template-columns:repeat(11,minmax(0,1fr));">
+      {% for i in range(0, 11) %}
+      <div class="likert-option">
+        <input type="radio" name="enps_score" id="retention_enps_{{ i }}" value="{{ i }}" required />
+        <label for="retention_enps_{{ i }}">{{ i }}</label>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+  <div class="field-error">Selecteer een antwoord.</div>
+</div>
 {% endif %}

--- a/tests/test_api_flows.py
+++ b/tests/test_api_flows.py
@@ -99,6 +99,7 @@ def _survey_payload(token: str):
         "token": token,
         "tenure_years": 2.0,
         "exit_reason_category": "groei",
+        "enps_score": 8,
         "stay_intent_score": 4,
         "signal_visibility_score": 2,
         "sdt_raw": {f"B{i}": 3 for i in range(1, 13)},
@@ -115,6 +116,7 @@ def _retention_payload(token: str):
         "token": token,
         "tenure_years": None,
         "exit_reason_category": None,
+        "enps_score": 9,
         "stay_intent_score": 4,
         "sdt_raw": {f"B{i}": 4 for i in range(1, 13)},
         "org_raw": {f"{factor}_{idx}": 4 for factor in ORG_FACTOR_KEYS for idx in range(1, 4)},
@@ -418,6 +420,8 @@ def test_survey_submit_persists_response_and_marks_respondent_complete(client, d
     assert respondent.completed is True
     assert stored.risk_score is not None
     assert stored.exit_reason_code == "P3"
+    assert stored.full_result["enps"]["raw_score"] == 8
+    assert stored.full_result["enps"]["band"] == "passive"
     assert stored.full_result["exit_context_summary"]["signal_visibility_score"] == 2
     assert stored.full_result["exit_context_summary"]["primary_reason_label"] == "Gebrek aan groei"
 
@@ -454,6 +458,19 @@ def test_exit_survey_submit_requires_signal_visibility_answer(client, db_session
     assert "eerdere signalering" in response.json()["detail"]
 
 
+def test_exit_survey_submit_requires_enps_answer(client, db_session: Session):
+    org = _create_org(db_session, api_key="missing-enps-key")
+    campaign = _create_campaign(db_session, org, name="Exit zonder eNPS")
+    respondent = _create_respondent(db_session, campaign)
+    payload = _survey_payload(respondent.token)
+    payload["enps_score"] = None
+
+    response = client.post("/survey/submit", json=payload)
+
+    assert response.status_code == 422
+    assert "eNPS" in response.json()["detail"]
+
+
 def test_retention_survey_submit_persists_normalized_scores_and_summary(client, db_session: Session):
     org = _create_org(db_session, api_key="retention-key")
     campaign = _create_campaign(db_session, org, name="Retentie Q2", scan_type="retention")
@@ -469,6 +486,8 @@ def test_retention_survey_submit_persists_normalized_scores_and_summary(client, 
     assert 1.0 <= stored.uwes_score <= 10.0
     assert 1.0 <= stored.turnover_intention_score <= 10.0
     assert stored.preventability is None
+    assert stored.full_result["enps"]["raw_score"] == 9
+    assert stored.full_result["enps"]["band"] == "promoter"
     assert stored.full_result["retention_summary"]["retention_signal_score"] == stored.risk_score
     assert stored.full_result["retention_summary"]["engagement_score"] == stored.uwes_score
     assert stored.full_result["retention_summary"]["turnover_intention_score"] == stored.turnover_intention_score
@@ -509,6 +528,19 @@ def test_retention_survey_submit_rejects_incomplete_signal_blocks(client, db_ses
 
     assert response.status_code == 422
     assert "RetentieScan vereist" in response.json()["detail"]
+
+
+def test_retention_survey_submit_requires_enps_answer(client, db_session: Session):
+    org = _create_org(db_session, api_key="retention-missing-enps-key")
+    campaign = _create_campaign(db_session, org, name="Retentie zonder eNPS", scan_type="retention")
+    respondent = _create_respondent(db_session, campaign, email="retention-missing-enps@example.com", department="People")
+    payload = _retention_payload(respondent.token)
+    payload["enps_score"] = None
+
+    response = client.post("/survey/submit", json=payload)
+
+    assert response.status_code == 422
+    assert "eNPS" in response.json()["detail"]
 
 
 def test_pulse_survey_submit_persists_snapshot_summary(client, db_session: Session):

--- a/tests/test_reporting_system_parity.py
+++ b/tests/test_reporting_system_parity.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 from backend.products.exit.report_content import (
     get_management_summary_payload as get_exit_management_summary_payload,
@@ -8,7 +9,11 @@ from backend.products.exit.report_content import (
 from backend.products.retention.report_content import (
     get_management_summary_payload as get_retention_management_summary_payload,
 )
-from backend.report import _build_exit_hypotheses, _build_retention_action_hypotheses
+from backend.report import (
+    _compute_enps_summary,
+    _build_exit_hypotheses,
+    _build_retention_action_hypotheses,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -26,6 +31,7 @@ def test_report_management_payloads_expose_executive_contract_fields():
         top_contributing_reason_label="Gebrek aan groei",
         strong_work_signal_pct=62,
         signal_visibility_average=2.6,
+        enps_summary={"score": 14, "sample_size": 8},
     )
     retention_payload = get_retention_management_summary_payload(
         top_factor_labels=["Werkbelasting", "Leiderschap"],
@@ -35,6 +41,7 @@ def test_report_management_payloads_expose_executive_contract_fields():
         avg_turnover_intention=6.1,
         avg_stay_intent=4.8,
         retention_theme_title="Werkdruk en planning",
+        enps_summary={"score": -11, "sample_size": 9},
     )
 
     for payload in (exit_payload, retention_payload):
@@ -47,8 +54,26 @@ def test_report_management_payloads_expose_executive_contract_fields():
         assert payload["boardroom_watchout"]
         assert len(payload["boardroom_cards"]) >= 5
         assert len(payload["highlight_cards"]) >= 3
+        assert any(card["title"] == "eNPS" for card in payload["highlight_cards"])
         assert any(card["title"] == "Eerste besluit" for card in payload["highlight_cards"])
         assert any(card["title"] == "Eerste eigenaar" for card in payload["highlight_cards"])
+
+
+def test_compute_enps_summary_respects_privacy_floor_and_signed_score():
+    insufficient = [
+        SimpleNamespace(full_result={"enps": {"raw_score": 10, "band": "promoter"}})
+        for _ in range(4)
+    ]
+    sufficient = [
+        SimpleNamespace(full_result={"enps": {"raw_score": 10, "band": "promoter"}}),
+        SimpleNamespace(full_result={"enps": {"raw_score": 9, "band": "promoter"}}),
+        SimpleNamespace(full_result={"enps": {"raw_score": 8, "band": "passive"}}),
+        SimpleNamespace(full_result={"enps": {"raw_score": 6, "band": "detractor"}}),
+        SimpleNamespace(full_result={"enps": {"raw_score": 0, "band": "detractor"}}),
+    ]
+
+    assert _compute_enps_summary(insufficient) is None
+    assert _compute_enps_summary(sufficient) == {"score": 0, "sample_size": 5}
 
 
 def test_report_hypotheses_include_owner_and_actionability():

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -24,7 +24,11 @@ from backend.scoring import (
     RISK_MEDIUM,
     ORG_FACTOR_KEYS,
 )
-from backend.products.exit.scoring import build_exit_context_summary, compute_exit_friction
+from backend.products.exit.scoring import (
+    build_enps_summary,
+    build_exit_context_summary,
+    compute_exit_friction,
+)
 from backend.products.exit.report_content import (
     get_hypotheses_payload as get_exit_hypotheses_payload,
     get_management_summary_payload as get_exit_management_summary_payload,
@@ -340,6 +344,13 @@ class TestExitContextSummary:
         assert summary["signal_visibility_summary"]["label"] == "Signalen bleven grotendeels onder de radar"
 
 
+class TestENPSSummary:
+    def test_enps_summary_maps_raw_scores_to_expected_bands(self):
+        assert build_enps_summary(10) == {"raw_score": 10, "band": "promoter"}
+        assert build_enps_summary(7) == {"raw_score": 7, "band": "passive"}
+        assert build_enps_summary(4) == {"raw_score": 4, "band": "detractor"}
+
+
 class TestExitReportContent:
     def test_exit_methodology_payload_stays_non_causal(self):
         payload = get_methodology_payload()
@@ -370,6 +381,7 @@ class TestExitReportContent:
             top_contributing_reason_label="Gebrek aan groei",
             strong_work_signal_pct=62.0,
             signal_visibility_average=2.4,
+            enps_summary={"score": 12, "sample_size": 6},
         )
 
         assert payload["section_title"] == "Managementsamenvatting"
@@ -383,6 +395,7 @@ class TestExitReportContent:
         assert "welke signalen" in payload["cards"][1]["body"].lower()
         assert payload["cards"][2]["title"] == "Eerste besluit"
         assert payload["cards"][3]["title"] == "Eerste eigenaar"
+        assert any(card["title"] == "eNPS" for card in payload["highlight_cards"])
 
     def test_exit_follow_up_payload_stays_improvement_oriented(self):
         payload = get_exit_next_steps_payload(
@@ -452,6 +465,7 @@ class TestRetentionReportContent:
             avg_turnover_intention=6.2,
             avg_stay_intent=4.8,
             retention_theme_title="Werkdruk en herstel",
+            enps_summary={"score": -8, "sample_size": 7},
         )
 
         assert payload["section_title"] == "Managementsamenvatting"
@@ -464,6 +478,7 @@ class TestRetentionReportContent:
         assert "werkdruk en herstel" in payload["cards"][1]["body"].lower()
         assert payload["cards"][2]["title"] == "Eerste besluit"
         assert payload["cards"][3]["title"] == "Eerste eigenaar"
+        assert any(card["title"] == "eNPS" for card in payload["highlight_cards"])
 
     def test_retention_follow_up_payload_keeps_verification_before_action(self):
         payload = get_retention_next_steps_payload(


### PR DESCRIPTION
## Summary
- add a standalone required `enps_score` to ExitScan and RetentieScan survey definitions, submit validation, scoring, and stored `full_result`
- compute and surface eNPS separately in the campaign dashboard and PDF management summaries without changing friction score, retention signal, SDT items, or organization factor logic
- add focused backend and dashboard helper coverage for raw eNPS persistence, banding, privacy-floor aggregation, and `n.b.` handling below `n < 5`

## Why
The product needed one additional recommendation metric that is visible across survey, storage, dashboard, and PDF, while preserving the existing product truth. eNPS is now informative only and does not feed any existing score model.

## Validation
- `python -m pytest tests/test_api_flows.py tests/test_scoring.py tests/test_reporting_system_parity.py -k enps -x`
- targeted TypeScript check confirmed no errors for `frontend/app/(dashboard)/campaigns/[id]/page.tsx`

## Known limits
- full `python -m pytest tests/ -x` was already blocked in the parent branch by unrelated existing failures outside this scope
- `npx tsc --noEmit` is also blocked in the parent branch by unrelated existing frontend typing failures outside this scope
- frontend Vitest in the clean publish worktree failed to resolve `vitest/config`, which appears to be a local dependency/worktree setup issue rather than an eNPS code regression
