### PR TITLE
[codex] Improve Action Center manager adoption flow

### DIFF
--- a/backend/email.py
+++ b/backend/email.py
@@ -310,3 +310,71 @@ def send_hr_notification(
         subject=f"Nieuwe response: {campaign_name} ({total_completed}/{total_invited})",
         html=html,
     )
+
+
+def send_manager_results_notification(
+    *,
+    to_email: str | None,
+    manager_name: str | None,
+    campaign_name: str,
+    scope_label: str,
+    action_center_url: str | None = None,
+    action_center_path: str | None = None,
+    response_count: int | None = None,
+) -> EmailSendResult:
+    """Notificeer een toegewezen manager dat een Action Center-route leesbaar is."""
+    resolved_url = action_center_url
+    if not resolved_url:
+        base_url = _require_runtime_url(_FRONTEND_URL, "FRONTEND_URL")
+        normalized_path = action_center_path or "/action-center"
+        if not normalized_path.startswith("/"):
+            normalized_path = f"/{normalized_path}"
+        resolved_url = f"{base_url}{normalized_path}"
+
+    safe_manager_name = (manager_name or "").strip() or "manager"
+    safe_scope_label = scope_label.strip() or "jouw scope"
+    response_html = (
+        f"""
+        <p style="margin:0 0 16px 0;font-size:15px;line-height:1.6;color:#42556b;">
+          Beschikbare responses in deze read: <strong>{int(response_count)}</strong>
+        </p>
+        """
+        if isinstance(response_count, int) and response_count >= 0
+        else ""
+    )
+    html = f"""
+    <div style="font-family:Arial,sans-serif;background:#f7f2ea;padding:32px;color:#132033;">
+      <div style="max-width:640px;margin:0 auto;background:#ffffff;border:1px solid #e6ddd2;border-radius:24px;padding:32px;">
+        <p style="margin:0 0 12px 0;font-size:13px;font-weight:700;letter-spacing:0.12em;text-transform:uppercase;color:#8b8174;">
+          Action Center
+        </p>
+        <h1 style="margin:0 0 18px 0;font-size:30px;line-height:1.15;color:#132033;">
+          Resultaten beschikbaar voor jouw team
+        </h1>
+        <p style="margin:0 0 16px 0;font-size:15px;line-height:1.6;color:#42556b;">
+          Hallo {escape(safe_manager_name)},
+        </p>
+        <p style="margin:0 0 16px 0;font-size:15px;line-height:1.6;color:#42556b;">
+          Voor <strong>{escape(campaign_name)}</strong> is er nu een leesbare en opvolgbare route beschikbaar
+          voor <strong>{escape(safe_scope_label)}</strong>.
+        </p>
+        {response_html}
+        <p style="margin:0 0 24px 0;font-size:15px;line-height:1.6;color:#42556b;">
+          Open direct de relevante route in Action Center om de eerste bounded vervolgstap en het reviewmoment
+          vast te leggen.
+        </p>
+        <a
+          href="{escape(resolved_url, quote=True)}"
+          style="display:inline-block;border-radius:999px;background:#132033;color:#ffffff;text-decoration:none;padding:14px 20px;font-weight:700;"
+        >
+          Open Action Center
+        </a>
+      </div>
+    </div>
+    """
+
+    return _send_result(
+        to=to_email or "",
+        subject=f"Resultaten beschikbaar voor jouw team - {campaign_name}",
+        html=html,
+    )

--- a/backend/main.py
+++ b/backend/main.py
@@ -55,6 +55,7 @@ from backend.database import DATABASE_URL, check_db_connection, get_db, init_db
 from backend.email import (
     send_contact_request_result,
     send_hr_notification,
+    send_manager_results_notification,
     send_survey_invite,
     send_survey_invite_result,
 )
@@ -187,6 +188,50 @@ def _send_hr_notification_safe(
             f"HR-notificatie mislukt na survey-submit: {exc}",
             level="warning",
         )
+
+
+def _send_manager_results_notification_safe(
+    *,
+    to_email: str | None,
+    manager_name: str | None,
+    campaign_name: str,
+    scope_label: str,
+    action_center_url: str | None = None,
+    action_center_path: str | None = None,
+    response_count: int | None = None,
+) -> dict[str, Any]:
+    try:
+        result = send_manager_results_notification(
+            to_email=to_email,
+            manager_name=manager_name,
+            campaign_name=campaign_name,
+            scope_label=scope_label,
+            action_center_url=action_center_url,
+            action_center_path=action_center_path,
+            response_count=response_count,
+        )
+    except Exception as exc:
+        logger.warning("Manager-resultaatnotificatie crashte: %s", exc)
+        sentry_sdk.capture_exception(exc)
+        return {"ok": False, "reason": "unexpected_error"}
+
+    if result.ok:
+        return {"ok": True, "reason": None}
+
+    log_level = logging.INFO if result.reason == "missing_recipient" else logging.WARNING
+    logger.log(
+        log_level,
+        "Manager-resultaatnotificatie niet verzonden voor %s / %s: %s",
+        campaign_name,
+        scope_label,
+        result.reason,
+    )
+    if result.reason != "missing_recipient":
+        sentry_sdk.capture_message(
+            f"Manager-resultaatnotificatie niet verzonden voor {campaign_name} / {scope_label}: {result.reason}",
+            level="warning",
+        )
+    return {"ok": False, "reason": result.reason}
 
 
 @asynccontextmanager
@@ -965,6 +1010,42 @@ async def update_contact_request(
     db.commit()
     db.refresh(lead)
     return lead
+
+
+@app.post("/api/internal/action-center/manager-results-notification")
+async def send_manager_results_notification_internal(
+    request: Request,
+    x_admin_token: Annotated[str | None, Header()] = None,
+) -> JSONResponse:
+    require_backend_admin_token(x_admin_token, is_production=_IS_PRODUCTION)
+
+    payload = await request.json()
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=400, detail="Ongeldige notificatiepayload.")
+
+    campaign_name = _normalize_optional_text(payload.get("campaign_name"))
+    scope_label = _normalize_optional_text(payload.get("scope_label"))
+    action_center_url = _normalize_optional_text(payload.get("action_center_url"))
+    action_center_path = _normalize_optional_text(payload.get("action_center_path"))
+    response_count_raw = payload.get("response_count")
+    response_count = response_count_raw if isinstance(response_count_raw, int) else None
+
+    if not campaign_name or not scope_label or (not action_center_url and not action_center_path):
+        raise HTTPException(
+            status_code=400,
+            detail="campagnenaam, scopelabel en Action Center-link zijn verplicht.",
+        )
+
+    result = _send_manager_results_notification_safe(
+        to_email=_normalize_optional_text(payload.get("to_email")),
+        manager_name=_normalize_optional_text(payload.get("manager_name")),
+        campaign_name=campaign_name,
+        scope_label=scope_label,
+        action_center_url=action_center_url,
+        action_center_path=action_center_path,
+        response_count=response_count,
+    )
+    return JSONResponse(result)
 
 
 @app.get("/survey/complete", response_class=HTMLResponse)

--- a/frontend/app/(dashboard)/action-center/page.tsx
+++ b/frontend/app/(dashboard)/action-center/page.tsx
@@ -17,6 +17,7 @@ import {
 import { createAdminClient } from '@/lib/supabase/admin'
 import {
   isScopeVisibleToActionCenterContext,
+  shouldUseBoundedActionCenterOverview,
   type ActionCenterWorkspaceMember,
 } from '@/lib/suite-access'
 import { loadSuiteAccessContext } from '@/lib/suite-access-server'
@@ -609,7 +610,7 @@ export default async function ActionCenterPage({
         readOnly
         itemHrefs={itemHrefs}
         hideSidebar
-        boundedOverviewOnly={entry.view === 'overview'}
+        boundedOverviewOnly={entry.view === 'overview' && shouldUseBoundedActionCenterOverview(context)}
         allowEmptyInitialSelection={hasAmbiguousCampaignFocus}
         governanceQueue={governanceReadback.governanceQueue}
         measurementReadback={governanceReadback.measurementReadback}

--- a/frontend/app/(dashboard)/campaigns/[id]/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.tsx
@@ -15,6 +15,7 @@ import {
   getActionCenterRouteOpenableStages,
   hasOpenedActionCenterRoute,
 } from '@/lib/dashboard/open-action-center-route'
+import { notifyManagersForCampaignAvailability } from '@/lib/action-center-manager-results-notifications'
 import { getManagementBandLabel } from '@/lib/management-language'
 import { getScanDefinition } from '@/lib/scan-definitions'
 import {
@@ -1191,6 +1192,14 @@ export default async function CampaignPage({ params }: Props) {
         notFound()
       }
     }
+
+    redirect(actionCenterHref)
+
+    await notifyManagersForCampaignAvailability({
+      campaignId: id,
+      previousLifecycleStage: currentDeliveryRecord.lifecycle_stage,
+      nextLifecycleStage: 'first_management_use',
+    })
 
     redirect(actionCenterHref)
   }

--- a/frontend/app/api/action-center/workspace-members/route.ts
+++ b/frontend/app/api/action-center/workspace-members/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import { notifyManagerForAssignmentIfReady } from '@/lib/action-center-manager-results-notifications'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { createClient } from '@/lib/supabase/server'
 
@@ -42,6 +43,13 @@ export async function POST(request: Request) {
   }
 
   const adminClient = createAdminClient()
+  const { data: existingAssignments } = await adminClient
+    .from('action_center_workspace_members')
+    .select('user_id')
+    .eq('org_id', body.orgId)
+    .eq('access_role', 'manager_assignee')
+    .eq('scope_type', body.scopeType)
+    .eq('scope_value', body.scopeValue)
 
   if (!body.managerUserId) {
     const { error } = await adminClient
@@ -92,13 +100,25 @@ export async function POST(request: Request) {
       },
     )
 
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 })
-  }
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 })
+    }
 
-  return NextResponse.json({
-    ok: true,
-    manager: {
+    const previousManagerUserId = existingAssignments?.[0]?.user_id ?? null
+    const managerChanged = previousManagerUserId !== body.managerUserId
+    if (managerChanged) {
+      await notifyManagerForAssignmentIfReady({
+        orgId: body.orgId,
+        scopeType: body.scopeType,
+        scopeValue: body.scopeValue,
+        managerEmail: managerUser.email ?? null,
+        managerName: managerDisplayName,
+      })
+    }
+
+    return NextResponse.json({
+      ok: true,
+      manager: {
       userId: body.managerUserId,
       label: managerDisplayName,
       email: managerUser.email ?? null,

--- a/frontend/app/api/campaign-delivery/[id]/route.ts
+++ b/frontend/app/api/campaign-delivery/[id]/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import { notifyManagersForCampaignAvailability } from '@/lib/action-center-manager-results-notifications'
 import { insertCampaignAuditEvent } from '@/lib/campaign-audit'
 import { createClient } from '@/lib/supabase/server'
 import {
@@ -222,6 +223,12 @@ export async function PATCH(request: Request, context: Context) {
   }
 
   if ('lifecycle_stage' in body && body.lifecycle_stage && body.lifecycle_stage !== record.lifecycle_stage) {
+    await notifyManagersForCampaignAvailability({
+      campaignId: id,
+      previousLifecycleStage: record.lifecycle_stage as DeliveryLifecycleStage | null,
+      nextLifecycleStage: body.lifecycle_stage,
+    })
+
     await insertCampaignAuditEvent({
       supabase: admin.supabase,
       organizationId: record.organization_id,

--- a/frontend/lib/action-center-landing.test.ts
+++ b/frontend/lib/action-center-landing.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildSuiteAccessContext,
+  shouldUseBoundedActionCenterOverview,
+  type ActionCenterWorkspaceMember,
+} from './suite-access'
+
+describe('action center landing mode', () => {
+  it('keeps manager assignees with live route interaction in the richer landing', () => {
+    const workspaceMemberships: ActionCenterWorkspaceMember[] = [
+      {
+        org_id: 'org-1',
+        user_id: 'manager-1',
+        display_name: 'Manager Noord',
+        login_email: 'manager.noord@example.com',
+        access_role: 'manager_assignee',
+        scope_type: 'department',
+        scope_value: 'sales',
+        can_view: true,
+        can_update: true,
+        can_assign: false,
+        can_schedule_review: true,
+      },
+    ]
+
+    const context = buildSuiteAccessContext({
+      isVerisightAdmin: false,
+      orgMemberships: [],
+      workspaceMemberships,
+    })
+
+    expect(shouldUseBoundedActionCenterOverview(context)).toBe(false)
+  })
+
+  it('keeps read-only action center viewers in bounded overview mode', () => {
+    const workspaceMemberships: ActionCenterWorkspaceMember[] = [
+      {
+        org_id: 'org-1',
+        user_id: 'viewer-1',
+        display_name: 'Viewer',
+        login_email: 'viewer@example.com',
+        access_role: 'hr_member',
+        scope_type: 'org',
+        scope_value: 'org-1',
+        can_view: true,
+        can_update: false,
+        can_assign: false,
+        can_schedule_review: false,
+      },
+    ]
+
+    const context = buildSuiteAccessContext({
+      isVerisightAdmin: false,
+      orgMemberships: [{ org_id: 'org-1', role: 'viewer' }],
+      workspaceMemberships,
+    })
+
+    expect(shouldUseBoundedActionCenterOverview(context)).toBe(true)
+  })
+
+  it('keeps owner and admin readbacks in the existing bounded landing when no manager scopes exist', () => {
+    const ownerContext = buildSuiteAccessContext({
+      isVerisightAdmin: false,
+      orgMemberships: [{ org_id: 'org-1', role: 'owner' }],
+      workspaceMemberships: [],
+    })
+    const adminContext = buildSuiteAccessContext({
+      isVerisightAdmin: true,
+      orgMemberships: [],
+      workspaceMemberships: [],
+    })
+
+    expect(shouldUseBoundedActionCenterOverview(ownerContext)).toBe(true)
+    expect(shouldUseBoundedActionCenterOverview(adminContext)).toBe(true)
+  })
+})

--- a/frontend/lib/action-center-manager-results-notifications.ts
+++ b/frontend/lib/action-center-manager-results-notifications.ts
@@ -1,0 +1,309 @@
+import 'server-only'
+
+import { buildActionCenterRouteId } from '@/lib/action-center-route-contract'
+import type { DeliveryLifecycleStage } from '@/lib/ops-delivery'
+import { isDashboardReleaseReady } from '@/lib/response-activation'
+import { getBackendApiUrl } from '@/lib/server-env'
+import { createAdminClient } from '@/lib/supabase/admin'
+import type { ScanType } from '@/lib/types'
+
+type CampaignRow = {
+  id: string
+  organization_id: string
+  name: string
+  scan_type: ScanType
+  is_active: boolean
+}
+
+type CampaignStatsRow = {
+  campaign_id: string
+  total_completed: number
+}
+
+type DeliveryRecordRow = {
+  campaign_id: string
+  lifecycle_stage: DeliveryLifecycleStage | null
+}
+
+type RespondentDepartmentRow = {
+  campaign_id: string
+  department: string | null
+}
+
+type WorkspaceManagerRow = {
+  org_id: string
+  user_id: string
+  display_name: string | null
+  login_email: string | null
+  access_role: 'manager_assignee'
+  scope_type: 'org' | 'department' | 'item'
+  scope_value: string
+  can_view: boolean
+}
+
+type ActionCenterScopeCandidate = {
+  scopeType: 'department' | 'item'
+  scopeValue: string
+  scopeLabel: string
+}
+
+const NOTIFIABLE_LIFECYCLE_STAGES = new Set<DeliveryLifecycleStage>([
+  'first_management_use',
+  'follow_up_decided',
+  'learning_closed',
+])
+
+function normalizeDepartmentLabel(value: string | null | undefined) {
+  return value?.trim() || null
+}
+
+function buildDepartmentScopeValue(orgId: string, departmentLabel: string) {
+  return `${orgId}::department::${departmentLabel.toLowerCase()}`
+}
+
+function buildCampaignFallbackScopeValue(orgId: string, campaignId: string) {
+  return `${orgId}::campaign::${campaignId}`
+}
+
+function buildScopeCandidates(campaign: CampaignRow, departmentLabels: string[]) {
+  const uniqueDepartments = [
+    ...new Set(
+      departmentLabels
+        .map((label) => normalizeDepartmentLabel(label))
+        .filter((label): label is string => Boolean(label)),
+    ),
+  ]
+
+  if (uniqueDepartments.length > 0) {
+    return uniqueDepartments.map<ActionCenterScopeCandidate>((departmentLabel) => ({
+      scopeType: 'department',
+      scopeValue: buildDepartmentScopeValue(campaign.organization_id, departmentLabel),
+      scopeLabel: departmentLabel,
+    }))
+  }
+
+  return [
+    {
+      scopeType: 'item' as const,
+      scopeValue: buildCampaignFallbackScopeValue(campaign.organization_id, campaign.id),
+      scopeLabel: campaign.name,
+    },
+  ]
+}
+
+function isLifecycleFollowThroughReady(stage: DeliveryLifecycleStage | null | undefined) {
+  return Boolean(stage && NOTIFIABLE_LIFECYCLE_STAGES.has(stage))
+}
+
+function isCampaignReadableForManagers(args: {
+  totalCompleted: number
+  scanType: ScanType
+  isActive: boolean
+  lifecycleStage: DeliveryLifecycleStage | null | undefined
+}) {
+  return (
+    isDashboardReleaseReady(args.totalCompleted, {
+      scanType: args.scanType,
+      isActive: args.isActive,
+    }) && isLifecycleFollowThroughReady(args.lifecycleStage)
+  )
+}
+
+async function postManagerResultsNotification(args: {
+  managerEmail: string | null
+  managerName: string | null
+  campaignName: string
+  scopeLabel: string
+  routeId: string
+  responseCount: number | null
+}) {
+  const adminToken = process.env.BACKEND_ADMIN_TOKEN?.trim()
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  }
+  if (adminToken) {
+    headers['x-admin-token'] = adminToken
+  }
+
+  try {
+    const response = await fetch(`${getBackendApiUrl()}/api/internal/action-center/manager-results-notification`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        to_email: args.managerEmail,
+        manager_name: args.managerName,
+        campaign_name: args.campaignName,
+        scope_label: args.scopeLabel,
+        action_center_path: `/action-center?focus=${encodeURIComponent(args.routeId)}`,
+        response_count: args.responseCount,
+      }),
+      cache: 'no-store',
+    })
+    if (!response.ok) {
+      console.error('Manager-resultaatnotificatie backend gaf geen succesvolle respons terug.', response.status)
+    }
+  } catch (error) {
+    console.error('Manager-resultaatnotificatie kon niet worden verstuurd.', error)
+  }
+}
+
+export async function notifyManagersForCampaignAvailability(args: {
+  campaignId: string
+  previousLifecycleStage: DeliveryLifecycleStage | null
+  nextLifecycleStage: DeliveryLifecycleStage | null
+}) {
+  if (
+    isLifecycleFollowThroughReady(args.previousLifecycleStage) ||
+    !isLifecycleFollowThroughReady(args.nextLifecycleStage)
+  ) {
+    return
+  }
+
+  const admin = createAdminClient()
+  const [{ data: campaign }, { data: stats }, { data: respondents }, { data: managerAssignments }] = await Promise.all([
+    admin
+      .from('campaigns')
+      .select('id, organization_id, name, scan_type, is_active')
+      .eq('id', args.campaignId)
+      .maybeSingle(),
+    admin
+      .from('campaign_stats')
+      .select('campaign_id, total_completed')
+      .eq('campaign_id', args.campaignId)
+      .maybeSingle(),
+    admin.from('respondents').select('campaign_id, department').eq('campaign_id', args.campaignId),
+    admin
+      .from('action_center_workspace_members')
+      .select('org_id, user_id, display_name, login_email, access_role, scope_type, scope_value, can_view')
+      .eq('access_role', 'manager_assignee')
+      .eq('can_view', true)
+      .in('scope_type', ['department', 'item']),
+  ])
+
+  if (!campaign) {
+    return
+  }
+
+  const totalCompleted = stats?.total_completed ?? 0
+  if (
+    !isCampaignReadableForManagers({
+      totalCompleted,
+      scanType: campaign.scan_type,
+      isActive: campaign.is_active,
+      lifecycleStage: args.nextLifecycleStage,
+    })
+  ) {
+    return
+  }
+
+  const scopeCandidates = buildScopeCandidates(
+    campaign as CampaignRow,
+    ((respondents ?? []) as RespondentDepartmentRow[])
+      .map((row) => row.department)
+      .filter((value): value is string => Boolean(value)),
+  )
+  const assignments = ((managerAssignments ?? []) as WorkspaceManagerRow[]).filter(
+    (assignment) => assignment.org_id === campaign.organization_id,
+  )
+
+  for (const scope of scopeCandidates) {
+    const assignment = assignments.find(
+      (candidate) => candidate.scope_type === scope.scopeType && candidate.scope_value === scope.scopeValue,
+    )
+    if (!assignment) {
+      continue
+    }
+
+    await postManagerResultsNotification({
+      managerEmail: assignment.login_email,
+      managerName: assignment.display_name,
+      campaignName: campaign.name,
+      scopeLabel: scope.scopeLabel,
+      routeId: buildActionCenterRouteId(campaign.id, scope.scopeValue),
+      responseCount: totalCompleted,
+    })
+  }
+}
+
+export async function notifyManagerForAssignmentIfReady(args: {
+  orgId: string
+  scopeType: 'org' | 'department' | 'item'
+  scopeValue: string
+  managerEmail: string | null
+  managerName: string | null
+}) {
+  if (args.scopeType === 'org') {
+    return
+  }
+
+  const admin = createAdminClient()
+  const { data: campaigns } = await admin
+    .from('campaigns')
+    .select('id, organization_id, name, scan_type, is_active')
+    .eq('organization_id', args.orgId)
+
+  const eligibleCampaigns = ((campaigns ?? []) as CampaignRow[])
+  if (eligibleCampaigns.length === 0) {
+    return
+  }
+
+  const campaignIds = eligibleCampaigns.map((campaign) => campaign.id)
+  const [{ data: statsRows }, { data: deliveryRows }, { data: respondentRows }] = await Promise.all([
+    admin.from('campaign_stats').select('campaign_id, total_completed').in('campaign_id', campaignIds),
+    admin.from('campaign_delivery_records').select('campaign_id, lifecycle_stage').in('campaign_id', campaignIds),
+    admin.from('respondents').select('campaign_id, department').in('campaign_id', campaignIds),
+  ])
+
+  const statsByCampaignId = new Map(
+    ((statsRows ?? []) as CampaignStatsRow[]).map((row) => [row.campaign_id, row.total_completed]),
+  )
+  const lifecycleByCampaignId = new Map(
+    ((deliveryRows ?? []) as DeliveryRecordRow[]).map((row) => [row.campaign_id, row.lifecycle_stage]),
+  )
+  const departmentLabelsByCampaignId = ((respondentRows ?? []) as RespondentDepartmentRow[]).reduce<Record<string, string[]>>(
+    (acc, row) => {
+      const departmentLabel = normalizeDepartmentLabel(row.department)
+      if (!departmentLabel) {
+        return acc
+      }
+
+      acc[row.campaign_id] ??= []
+      acc[row.campaign_id].push(departmentLabel)
+      return acc
+    },
+    {},
+  )
+
+  for (const campaign of eligibleCampaigns) {
+    const totalCompleted = statsByCampaignId.get(campaign.id) ?? 0
+    const lifecycleStage = lifecycleByCampaignId.get(campaign.id) ?? null
+
+    if (
+      !isCampaignReadableForManagers({
+        totalCompleted,
+        scanType: campaign.scan_type,
+        isActive: campaign.is_active,
+        lifecycleStage,
+      })
+    ) {
+      continue
+    }
+
+    const matchingScope = buildScopeCandidates(campaign, departmentLabelsByCampaignId[campaign.id] ?? []).find(
+      (scope) => scope.scopeType === args.scopeType && scope.scopeValue === args.scopeValue,
+    )
+
+    if (!matchingScope) {
+      continue
+    }
+
+    await postManagerResultsNotification({
+      managerEmail: args.managerEmail,
+      managerName: args.managerName,
+      campaignName: campaign.name,
+      scopeLabel: matchingScope.scopeLabel,
+      routeId: buildActionCenterRouteId(campaign.id, matchingScope.scopeValue),
+      responseCount: totalCompleted,
+    })
+  }
+}

--- a/frontend/lib/suite-access.ts
+++ b/frontend/lib/suite-access.ts
@@ -154,6 +154,26 @@ export function getDefaultSuiteLandingPath(context: Pick<SuiteAccessContext, 'ca
   return '/dashboard'
 }
 
+export function shouldUseBoundedActionCenterOverview(
+  context: Pick<
+    SuiteAccessContext,
+    | 'canViewActionCenter'
+    | 'canUpdateActionCenter'
+    | 'canScheduleActionCenterReview'
+    | 'managerScopeValues'
+  >,
+) {
+  if (!context.canViewActionCenter) {
+    return true
+  }
+
+  if (context.managerScopeValues.length === 0) {
+    return true
+  }
+
+  return !(context.canUpdateActionCenter || context.canScheduleActionCenterReview)
+}
+
 export function isScopeVisibleToActionCenterContext(
   context: Pick<SuiteAccessContext, 'isVerisightAdmin' | 'memberRole' | 'managerScopeValues'>,
   scopeValue: string,

--- a/tests/test_action_center_manager_notifications.py
+++ b/tests/test_action_center_manager_notifications.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import pytest
+
+from backend.email import EmailSendResult, send_manager_results_notification
+
+
+def test_send_manager_results_notification_skips_when_manager_email_missing() -> None:
+    result = send_manager_results_notification(
+        to_email=None,
+        manager_name="Sanne",
+        campaign_name="Retentie voorjaar",
+        scope_label="Operations",
+        action_center_url="https://app.verisight.nl/action-center?focus=route-1",
+        response_count=12,
+    )
+
+    assert result.ok is False
+    assert result.reason == "missing_recipient"
+
+
+def test_send_manager_results_notification_uses_expected_subject_and_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, str] = {}
+
+    def _fake_send_result(*, to: str, subject: str, html: str, reply_to: str | None = None) -> EmailSendResult:
+        captured["to"] = to
+        captured["subject"] = subject
+        captured["html"] = html
+        return EmailSendResult(ok=True)
+
+    monkeypatch.setattr("backend.email._send_result", _fake_send_result)
+
+    result = send_manager_results_notification(
+        to_email="manager@example.com",
+        manager_name="Sanne",
+        campaign_name="Retentie voorjaar",
+        scope_label="Operations",
+        action_center_url="https://app.verisight.nl/action-center?focus=route-1",
+        response_count=12,
+    )
+
+    assert result.ok is True
+    assert captured["to"] == "manager@example.com"
+    assert captured["subject"] == "Resultaten beschikbaar voor jouw team - Retentie voorjaar"
+    assert "Sanne" in captured["html"]
+    assert "Retentie voorjaar" in captured["html"]
+    assert "Operations" in captured["html"]
+    assert "12" in captured["html"]
+    assert "https://app.verisight.nl/action-center?focus=route-1" in captured["html"]


### PR DESCRIPTION
## Summary
- add a fail-soft manager results notification flow when an assigned manager scope becomes readable and follow-uppable
- relax Action Center landing boundedness only for manager-scoped users when existing visibility and action/review capabilities already allow the richer view
- keep tenant, role, and scope visibility boundaries intact by reusing existing readiness, visibility, and capability layers

## Why
Managers were missing a clean notification when their assigned scope first became actionable, and they could still land in bounded summary mode even when the current context layer already permitted a richer Action Center view.

## Validation
- `C:\Users\larsh\Desktop\Business\Verisight\.venv\Scripts\python.exe -m pytest tests/test_action_center_manager_notifications.py -q`
- `npx vitest run lib/action-center-landing.test.ts lib/suite-access.test.ts "app/(dashboard)/route-access.test.ts"` in the original working tree where frontend dependencies were available
- `C:\Users\larsh\Desktop\Business\Verisight\.venv\Scripts\python.exe -m py_compile backend\email.py backend\main.py`
- `npx tsc --noEmit` still fails because of pre-existing TypeScript issues in unrelated Action Center and test files outside this patch

## Notes
- no notification is sent without a valid manager/scope match
- missing manager email stays non-fatal and logs quietly
- HR notification behavior remains unchanged
- deploy path appears to remain Vercel for `frontend/` and Railway for the Python backend