### PR TITLE
Add per-item campaign score breakdowns

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -63,12 +63,14 @@ from backend.models import Campaign, ContactRequest, Organization, OrganizationS
 from backend.products.leadership.definition import DEFAULT_LEADERSHIP_MODULES
 from backend.products.onboarding.definition import DEFAULT_ONBOARDING_MODULES
 from backend.products.pulse.definition import DEFAULT_PULSE_MODULES
+from backend.products.shared.item_scores import build_campaign_item_scores_payload
 from backend.products.team.definition import DEFAULT_TEAM_MODULES
 from backend.products.shared.registry import get_product_module
 from backend.runtime import require_backend_admin_token, validate_runtime_config
 from backend.scan_definitions import get_scan_definition
 from backend.schemas import (
     CampaignCreate,
+    CampaignItemScoresResponse,
     CampaignRead,
     CampaignStats,
     ContactRequestCreate,
@@ -1803,6 +1805,64 @@ async def campaign_stats(
         "risk_band_distribution":   band_dist,
         "pattern_report":           pattern_report,
     }
+
+
+@app.get("/api/campaigns/{campaign_id}/item-scores", response_model=CampaignItemScoresResponse)
+async def campaign_item_scores(
+    campaign_id: str,
+    x_api_key: Annotated[str, Header()],
+    db: Session = Depends(get_db),
+) -> CampaignItemScoresResponse:
+    org = _get_org_by_api_key(x_api_key, db)
+    campaign = (
+        db.query(Campaign)
+        .options(selectinload(Campaign.respondents).selectinload(Respondent.response))
+        .filter(
+            Campaign.id == campaign_id,
+            Campaign.organization_id == org.id,
+        )
+        .first()
+    )
+    if not campaign:
+        raise HTTPException(status_code=404, detail="Campaign niet gevonden.")
+
+    responses = [
+        respondent.response
+        for respondent in campaign.respondents
+        if respondent.completed and respondent.response
+    ]
+    return build_campaign_item_scores_payload(
+        scan_type=campaign.scan_type,
+        responses=responses,
+    )
+
+
+@app.get("/api/internal/campaigns/{campaign_id}/item-scores", response_model=CampaignItemScoresResponse)
+async def campaign_item_scores_internal(
+    campaign_id: str,
+    x_admin_token: Annotated[str | None, Header()] = None,
+    db: Session = Depends(get_db),
+) -> CampaignItemScoresResponse:
+    require_backend_admin_token(x_admin_token, is_production=_IS_PRODUCTION)
+
+    campaign = (
+        db.query(Campaign)
+        .options(selectinload(Campaign.respondents).selectinload(Respondent.response))
+        .filter(Campaign.id == campaign_id)
+        .first()
+    )
+    if not campaign:
+        raise HTTPException(status_code=404, detail="Campaign niet gevonden.")
+
+    responses = [
+        respondent.response
+        for respondent in campaign.respondents
+        if respondent.completed and respondent.response
+    ]
+    return build_campaign_item_scores_payload(
+        scan_type=campaign.scan_type,
+        responses=responses,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/products/shared/item_scores.py
+++ b/backend/products/shared/item_scores.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from backend.models import SurveyResponse
+from backend.scoring_config import SDT_DIMENSION_ITEMS, SDT_REVERSE_ITEMS
+from backend.schemas import (
+    CampaignItemScoresResponse,
+    ItemScoreDetail,
+    ItemScoreGroup,
+    SdtDimensionItemScoreGroup,
+    SupplementalItemScoreGroup,
+)
+from backend.products.shared.registry import get_product_module
+from backend.products.shared.sdt import scale_to_ten
+
+ITEM_PRIVACY_FLOOR = 5
+
+SDT_DIMENSION_LABELS = {
+    "autonomy": "Autonomie",
+    "competence": "Competentie",
+    "relatedness": "Verbondenheid",
+}
+
+SUPPLEMENTAL_SECTION_LABELS = {
+    "uwes": "Bevlogenheid (UWES-3)",
+    "turnover_intention": "Vertrekintentie",
+}
+
+
+def _mean(values: list[float]) -> float | None:
+    if not values:
+        return None
+    return round(sum(values) / len(values), 2)
+
+
+def _normalize_item_score(item_key: str, raw_value: int | float, *, reverse: bool = False) -> float:
+    value = float(raw_value)
+    if reverse:
+        value = 6.0 - value
+    return round(scale_to_ten(value), 2)
+
+
+def _build_definition_maps(scan_type: str) -> dict[str, Any]:
+    definition = get_product_module(scan_type).get_definition()
+    sdt_items = dict(definition.get("sdt_items", []))
+    org_sections = definition.get("org_sections", [])
+    org_item_labels = {
+        item_key: item_label
+        for section in org_sections
+        for item_key, item_label in section.get("items", [])
+    }
+    org_factor_labels = {
+        section["key"]: section["title"]
+        for section in org_sections
+    }
+    uwes_items = dict(definition.get("uwes_items", []))
+    turnover_items = dict(definition.get("turnover_items", []))
+    return {
+        "definition": definition,
+        "sdt_items": sdt_items,
+        "org_item_labels": org_item_labels,
+        "org_factor_labels": org_factor_labels,
+        "org_sections": org_sections,
+        "uwes_items": uwes_items,
+        "turnover_items": turnover_items,
+    }
+
+
+def _aggregate_item_values(
+    responses: list[SurveyResponse],
+    *,
+    raw_attr: str,
+    item_order: list[str],
+    reverse_items: set[str] | None = None,
+) -> tuple[dict[str, list[float]], dict[str, int]]:
+    values_by_item: dict[str, list[float]] = defaultdict(list)
+    counts_by_item: dict[str, int] = {}
+    reverse_items = reverse_items or set()
+
+    for item_key in item_order:
+        item_values: list[float] = []
+        for response in responses:
+            raw_map = getattr(response, raw_attr) or {}
+            raw_value = raw_map.get(item_key)
+            if raw_value is None:
+                continue
+            item_values.append(
+                _normalize_item_score(
+                    item_key,
+                    raw_value,
+                    reverse=item_key in reverse_items,
+                )
+            )
+        values_by_item[item_key] = item_values
+        counts_by_item[item_key] = len(item_values)
+
+    return values_by_item, counts_by_item
+
+
+def _build_item_details(
+    *,
+    item_keys: list[str],
+    labels: dict[str, str],
+    values_by_item: dict[str, list[float]],
+    counts_by_item: dict[str, int],
+    privacy_suppressed_items: list[str],
+    suppressed_items: list[ItemScoreDetail],
+) -> list[ItemScoreDetail]:
+    visible_items: list[ItemScoreDetail] = []
+
+    for item_key in item_keys:
+        label = labels.get(item_key)
+        if not label:
+            continue
+
+        count = counts_by_item.get(item_key, 0)
+        if count < ITEM_PRIVACY_FLOOR:
+            privacy_suppressed_items.append(item_key)
+            suppressed_items.append(ItemScoreDetail(item_key=item_key, label=label, avg=None, n=count))
+            continue
+
+        visible_items.append(
+            ItemScoreDetail(
+                item_key=item_key,
+                label=label,
+                avg=_mean(values_by_item.get(item_key, [])),
+                n=count,
+            )
+        )
+
+    return visible_items
+
+
+def _build_factor_groups(
+    responses: list[SurveyResponse],
+    *,
+    org_sections: list[dict[str, Any]],
+    org_item_labels: dict[str, str],
+    org_factor_labels: dict[str, str],
+) -> tuple[list[ItemScoreGroup], list[str], list[ItemScoreDetail]]:
+    ordered_org_items = [
+        item_key
+        for section in org_sections
+        for item_key, _item_label in section.get("items", [])
+    ]
+    values_by_item, counts_by_item = _aggregate_item_values(
+        responses,
+        raw_attr="org_raw",
+        item_order=ordered_org_items,
+    )
+
+    privacy_suppressed_items: list[str] = []
+    suppressed_items: list[ItemScoreDetail] = []
+    groups: list[ItemScoreGroup] = []
+
+    for section in org_sections:
+        factor_key = section["key"]
+        factor_values = [
+            float(response.org_scores[factor_key])
+            for response in responses
+            if factor_key in (response.org_scores or {})
+        ]
+        if not factor_values:
+            continue
+
+        item_keys = [item_key for item_key, _label in section.get("items", [])]
+        items = _build_item_details(
+            item_keys=item_keys,
+            labels=org_item_labels,
+            values_by_item=values_by_item,
+            counts_by_item=counts_by_item,
+            privacy_suppressed_items=privacy_suppressed_items,
+            suppressed_items=suppressed_items,
+        )
+        groups.append(
+            ItemScoreGroup(
+                factor_key=factor_key,
+                factor_label=org_factor_labels.get(factor_key, factor_key),
+                avg_score=_mean(factor_values),
+                items=items,
+            )
+        )
+
+    return groups, privacy_suppressed_items, suppressed_items
+
+
+def _build_sdt_groups(
+    responses: list[SurveyResponse],
+    *,
+    sdt_item_labels: dict[str, str],
+) -> tuple[list[SdtDimensionItemScoreGroup], list[str], list[ItemScoreDetail]]:
+    ordered_sdt_items = [
+        item_key
+        for dimension in SDT_DIMENSION_ITEMS.values()
+        for item_key in dimension
+        if item_key in sdt_item_labels
+    ]
+    values_by_item, counts_by_item = _aggregate_item_values(
+        responses,
+        raw_attr="sdt_raw",
+        item_order=ordered_sdt_items,
+        reverse_items=SDT_REVERSE_ITEMS,
+    )
+
+    privacy_suppressed_items: list[str] = []
+    suppressed_items: list[ItemScoreDetail] = []
+    groups: list[SdtDimensionItemScoreGroup] = []
+
+    for dimension_key, item_keys in SDT_DIMENSION_ITEMS.items():
+        scoped_item_keys = [item_key for item_key in item_keys if item_key in sdt_item_labels]
+        if not scoped_item_keys:
+            continue
+
+        dimension_values = [
+            float(response.sdt_scores[dimension_key])
+            for response in responses
+            if dimension_key in (response.sdt_scores or {})
+        ]
+        if not dimension_values:
+            continue
+
+        items = _build_item_details(
+            item_keys=scoped_item_keys,
+            labels=sdt_item_labels,
+            values_by_item=values_by_item,
+            counts_by_item=counts_by_item,
+            privacy_suppressed_items=privacy_suppressed_items,
+            suppressed_items=suppressed_items,
+        )
+        groups.append(
+            SdtDimensionItemScoreGroup(
+                dimension_key=dimension_key,
+                dimension_label=SDT_DIMENSION_LABELS[dimension_key],
+                avg_score=_mean(dimension_values),
+                items=items,
+            )
+        )
+
+    return groups, privacy_suppressed_items, suppressed_items
+
+
+def _build_retention_supplemental_sections(
+    responses: list[SurveyResponse],
+    *,
+    uwes_item_labels: dict[str, str],
+    turnover_item_labels: dict[str, str],
+) -> tuple[list[SupplementalItemScoreGroup], list[str], list[ItemScoreDetail]]:
+    sections: list[SupplementalItemScoreGroup] = []
+    privacy_suppressed_items: list[str] = []
+    suppressed_items: list[ItemScoreDetail] = []
+
+    section_specs = [
+        ("uwes", "uwes_raw", uwes_item_labels, "uwes_score"),
+        ("turnover_intention", "turnover_intention_raw", turnover_item_labels, "turnover_intention_score"),
+    ]
+
+    for section_key, raw_attr, labels, aggregate_attr in section_specs:
+        if not labels:
+            continue
+
+        item_order = list(labels.keys())
+        values_by_item, counts_by_item = _aggregate_item_values(
+            responses,
+            raw_attr=raw_attr,
+            item_order=item_order,
+        )
+        aggregate_values = [
+            float(getattr(response, aggregate_attr))
+            for response in responses
+            if getattr(response, aggregate_attr) is not None
+        ]
+        if not aggregate_values:
+            continue
+
+        items = _build_item_details(
+            item_keys=item_order,
+            labels=labels,
+            values_by_item=values_by_item,
+            counts_by_item=counts_by_item,
+            privacy_suppressed_items=privacy_suppressed_items,
+            suppressed_items=suppressed_items,
+        )
+        sections.append(
+            SupplementalItemScoreGroup(
+                section_key=section_key,
+                section_label=SUPPLEMENTAL_SECTION_LABELS[section_key],
+                avg_score=_mean(aggregate_values),
+                items=items,
+            )
+        )
+
+    return sections, privacy_suppressed_items, suppressed_items
+
+
+def build_campaign_item_scores_payload(
+    *,
+    scan_type: str,
+    responses: list[SurveyResponse],
+) -> CampaignItemScoresResponse:
+    maps = _build_definition_maps(scan_type)
+
+    factor_groups, factor_suppressed_keys, factor_suppressed_items = _build_factor_groups(
+        responses,
+        org_sections=maps["org_sections"],
+        org_item_labels=maps["org_item_labels"],
+        org_factor_labels=maps["org_factor_labels"],
+    )
+    sdt_groups, sdt_suppressed_keys, sdt_suppressed_items = _build_sdt_groups(
+        responses,
+        sdt_item_labels=maps["sdt_items"],
+    )
+
+    supplemental_sections: list[SupplementalItemScoreGroup] = []
+    supplemental_suppressed_keys: list[str] = []
+    supplemental_suppressed_items: list[ItemScoreDetail] = []
+    if scan_type == "retention":
+        (
+            supplemental_sections,
+            supplemental_suppressed_keys,
+            supplemental_suppressed_items,
+        ) = _build_retention_supplemental_sections(
+            responses,
+            uwes_item_labels=maps["uwes_items"],
+            turnover_item_labels=maps["turnover_items"],
+        )
+
+    all_suppressed_items = (
+        factor_suppressed_items + sdt_suppressed_items + supplemental_suppressed_items
+    )
+    return CampaignItemScoresResponse(
+        factors=factor_groups,
+        sdt_dimensions=[
+            SdtDimensionItemScoreGroup(
+                dimension_key=group.dimension_key,
+                dimension_label=group.dimension_label,
+                avg_score=group.avg_score,
+                items=group.items,
+            )
+            for group in sdt_groups
+        ],
+        supplemental_sections=supplemental_sections,
+        privacy_suppressed_items=(
+            factor_suppressed_keys + sdt_suppressed_keys + supplemental_suppressed_keys
+        ),
+        suppressed_items=all_suppressed_items,
+    )

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -412,6 +412,42 @@ class CampaignStats(BaseModel):
         return self
 
 
+class ItemScoreDetail(BaseModel):
+    item_key: str
+    label: str
+    avg: float | None = None
+    n: int
+
+
+class ItemScoreGroup(BaseModel):
+    factor_key: str
+    factor_label: str
+    avg_score: float | None = None
+    items: list[ItemScoreDetail] = Field(default_factory=list)
+
+
+class SdtDimensionItemScoreGroup(BaseModel):
+    dimension_key: str
+    dimension_label: str
+    avg_score: float | None = None
+    items: list[ItemScoreDetail] = Field(default_factory=list)
+
+
+class SupplementalItemScoreGroup(BaseModel):
+    section_key: str
+    section_label: str
+    avg_score: float | None = None
+    items: list[ItemScoreDetail] = Field(default_factory=list)
+
+
+class CampaignItemScoresResponse(BaseModel):
+    factors: list[ItemScoreGroup] = Field(default_factory=list)
+    sdt_dimensions: list[SdtDimensionItemScoreGroup] = Field(default_factory=list)
+    supplemental_sections: list[SupplementalItemScoreGroup] = Field(default_factory=list)
+    privacy_suppressed_items: list[str] = Field(default_factory=list)
+    suppressed_items: list[ItemScoreDetail] = Field(default_factory=list)
+
+
 # ---------------------------------------------------------------------------
 # Operator API token
 # ---------------------------------------------------------------------------

--- a/frontend/app/(dashboard)/campaigns/[id]/page.tsx
+++ b/frontend/app/(dashboard)/campaigns/[id]/page.tsx
@@ -26,11 +26,22 @@ import {
 import { loadSuiteAccessContext } from '@/lib/suite-access-server'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { createClient } from '@/lib/supabase/server'
+import { getOrganizationApiKey } from '@/lib/organization-secrets'
+import { getBackendApiUrl } from '@/lib/server-env'
 import { FACTOR_LABELS, hasCampaignAddOn } from '@/lib/types'
-import type { Campaign, CampaignStats, MemberRole, Respondent, ScanType, SurveyResponse } from '@/lib/types'
+import type {
+  Campaign,
+  CampaignItemScoresResponse,
+  CampaignStats,
+  MemberRole,
+  Respondent,
+  ScanType,
+  SurveyResponse,
+} from '@/lib/types'
 import { buildExitDashboardViewModel } from '@/lib/products/exit/dashboard'
 import { buildRetentionDashboardViewModel } from '@/lib/products/retention/dashboard'
 import { ExitProductDashboard } from '@/components/dashboard/exit-product-dashboard'
+import { FactorTable } from '@/components/dashboard/factor-table'
 import { RetentionProductDashboard } from '@/components/dashboard/retention-product-dashboard'
 import {
   buildOpenAnswerItems,
@@ -879,6 +890,54 @@ function ResultsShellHeader({
   )
 }
 
+async function fetchCampaignItemScores(args: {
+  campaignId: string
+  organizationId: string
+  supabase: Awaited<ReturnType<typeof createClient>>
+}) {
+  try {
+    const backendBaseUrl = getBackendApiUrl()
+    const adminToken = process.env.BACKEND_ADMIN_TOKEN?.trim()
+
+    async function fetchWithAdminFallback() {
+      if (!adminToken) return null
+
+      return fetch(`${backendBaseUrl}/api/internal/campaigns/${args.campaignId}/item-scores`, {
+        headers: {
+          'x-admin-token': adminToken,
+        },
+        cache: 'no-store',
+      })
+    }
+
+    let backendResponse: globalThis.Response | null = null
+
+    try {
+      const apiKey = await getOrganizationApiKey(args.organizationId, { supabase: args.supabase })
+      backendResponse = await fetch(`${backendBaseUrl}/api/campaigns/${args.campaignId}/item-scores`, {
+        headers: {
+          'x-api-key': apiKey,
+        },
+        cache: 'no-store',
+      })
+
+      if ((backendResponse.status === 401 || backendResponse.status === 403) && adminToken) {
+        backendResponse = await fetchWithAdminFallback()
+      }
+    } catch {
+      backendResponse = await fetchWithAdminFallback()
+    }
+
+    if (!backendResponse?.ok) {
+      return null
+    }
+
+    return (await backendResponse.json()) as CampaignItemScoresResponse
+  } catch {
+    return null
+  }
+}
+
 export default async function CampaignPage({ params }: Props) {
   const { id } = await params
   const supabase = await createClient()
@@ -918,6 +977,7 @@ export default async function CampaignPage({ params }: Props) {
     { data: deliveryRecord },
     { data: profile },
     { data: membership },
+    itemScores,
   ] =
     await Promise.all([
       supabase.from('campaigns').select('enabled_modules').eq('id', id).maybeSingle(),
@@ -962,6 +1022,11 @@ export default async function CampaignPage({ params }: Props) {
         .eq('org_id', stats.organization_id)
         .eq('user_id', user.id)
         .maybeSingle(),
+      fetchCampaignItemScores({
+        campaignId: id,
+        organizationId: stats.organization_id,
+        supabase,
+      }),
     ])
 
   const responses = (responsesRaw ?? []) as unknown as (SurveyResponse & {
@@ -1343,7 +1408,9 @@ export default async function CampaignPage({ params }: Props) {
         compositionSegments={exitDistribution?.segments ?? []}
         compositionHighlights={compositionHighlights}
         factorRows={factorPriorityRows}
+        factorAverages={factorData.orgAverages}
         sdtRows={sdtRows}
+        itemScores={itemScores}
         surveyThemes={surveyThemes}
         verificationTrackLabel={topFactorLabel ?? 'Nog niet beschikbaar'}
         ownerRoleLabel={
@@ -1465,7 +1532,9 @@ export default async function CampaignPage({ params }: Props) {
           },
         ]}
         factorRows={factorPriorityRows}
+        factorAverages={factorData.orgAverages}
         sdtRows={sdtRows}
+        itemScores={itemScores}
         surveyThemes={retentionThemes.map((theme, index) => ({
           key: theme.key,
           title: theme.title,
@@ -2103,21 +2172,12 @@ export default async function CampaignPage({ params }: Props) {
                     Rangorde van de sterkst zichtbare factoren binnen deze route.
                   </p>
                 </div>
-                <div className="mt-4 space-y-4">
-                  {factorPriorityRows.slice(0, 5).map((row) => (
-                    <div key={row.factor} className="space-y-2">
-                      <div className="flex items-center justify-between gap-3 text-sm">
-                        <span className="font-medium text-[color:var(--dashboard-ink)]">{row.factor}</span>
-                        <span className="font-semibold text-[color:var(--dashboard-ink)]">{row.signal}</span>
-                      </div>
-                      <div className="h-2 overflow-hidden rounded-full bg-[color:var(--dashboard-soft)]">
-                        <div
-                          className="h-full rounded-full bg-[linear-gradient(90deg,#C36A29,#D9985D)]"
-                          style={{ width: `${Math.max(10, Math.min(100, row.signalValue * 10))}%` }}
-                        />
-                      </div>
-                    </div>
-                  ))}
+                <div className="mt-4">
+                  <FactorTable
+                    factorAverages={factorData.orgAverages}
+                    scanType={stats.scan_type}
+                    itemScores={itemScores}
+                  />
                 </div>
               </div>
             ) : null}

--- a/frontend/components/dashboard/exit-product-dashboard.tsx
+++ b/frontend/components/dashboard/exit-product-dashboard.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react'
+import { FactorTable } from '@/components/dashboard/factor-table'
 import {
   BoardroomEmptyState,
   BoardroomKeyValueList,
@@ -14,6 +15,7 @@ import {
   SdtTriangleMap,
   SignalCompositionRibbon,
 } from '@/components/dashboard/results-boardroom-visuals'
+import type { CampaignItemScoresResponse } from '@/lib/types'
 
 type ExitThemeCard = {
   key: string
@@ -52,53 +54,14 @@ interface ExitProductDashboardProps {
   compositionSegments: CompositionSegment[]
   compositionHighlights: Array<{ label: string; value: string; body: string }>
   factorRows: BoardroomFactorRow[]
+  factorAverages: Record<string, number>
   sdtRows: BoardroomSdtRow[]
+  itemScores?: CampaignItemScoresResponse | null
   surveyThemes: ExitThemeCard[]
   verificationTrackLabel: string
   ownerRoleLabel: string
   firstStepLabel: string
   reviewMomentLabel: string
-}
-
-function RankedFactorTable({ rows }: { rows: BoardroomFactorRow[] }) {
-  return (
-    <div className="overflow-hidden border border-[rgba(13,27,42,0.15)]">
-      <div className="hidden bg-[#F4F1EA] px-4 py-3 font-mono text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-[#44505C] lg:grid lg:grid-cols-[72px_minmax(0,1.2fr)_120px_160px_minmax(0,1.2fr)]">
-        <span>Rang</span>
-        <span>Factor</span>
-        <span>Score</span>
-        <span>Status</span>
-        <span>Leesnotitie</span>
-      </div>
-      {rows.map((row, index) => (
-        <div
-          key={`${row.factor}-${index}`}
-          className="grid gap-3 border-t border-[rgba(13,27,42,0.15)] bg-white px-4 py-4 first:border-t-0 lg:grid-cols-[72px_minmax(0,1.2fr)_120px_160px_minmax(0,1.2fr)] lg:items-start"
-        >
-          <span className="font-mono text-[0.72rem] font-semibold uppercase tracking-[0.2em] text-[#44505C]">
-            {(index + 1).toString().padStart(2, '0')}
-          </span>
-          <div className="space-y-2">
-            <p className="text-sm font-semibold text-[#132033]">{row.factor}</p>
-            {row.question ? (
-              <p className="text-xs leading-5 text-[#A06D11] lg:hidden">{row.question}</p>
-            ) : null}
-            <p className="text-xs leading-5 text-[#44505C] lg:hidden">{row.note}</p>
-          </div>
-          <p className="dash-number text-[1.2rem] leading-none text-[#132033]">{row.score}</p>
-          <p className="font-mono text-[0.72rem] font-semibold uppercase tracking-[0.2em] text-[#44505C]">
-            {row.band}
-          </p>
-          <div className="hidden space-y-2 lg:block">
-            <p className="text-sm leading-6 text-[#44505C]">{row.note}</p>
-            {row.question ? (
-              <p className="text-sm leading-6 text-[#A06D11]">Eerste toetsvraag: {row.question}</p>
-            ) : null}
-          </div>
-        </div>
-      ))}
-    </div>
-  )
 }
 
 function SectionMiniNav() {
@@ -156,7 +119,9 @@ export function ExitProductDashboard({
   compositionSegments,
   compositionHighlights,
   factorRows,
+  factorAverages,
   sdtRows,
+  itemScores,
   surveyThemes,
   verificationTrackLabel,
   ownerRoleLabel,
@@ -346,7 +311,12 @@ export function ExitProductDashboard({
                   />
                 ))}
               </div>
-              <RankedFactorTable rows={factorRows} />
+              <FactorTable
+                factorAverages={factorAverages}
+                scanType="exit"
+                itemScores={itemScores}
+                showIntro={false}
+              />
             </div>
           ) : (
             <BoardroomEmptyState

--- a/frontend/components/dashboard/factor-table.test.ts
+++ b/frontend/components/dashboard/factor-table.test.ts
@@ -1,0 +1,91 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import type { CampaignItemScoresResponse } from '@/lib/types'
+import { buildFactorItemLayerMap, truncateFactorItemLabel } from './factor-table'
+
+describe('factor table item layer helpers', () => {
+  it('merges visible and suppressed org items per factor without leaking non-factor items', () => {
+    const payload: CampaignItemScoresResponse = {
+      factors: [
+        {
+          factor_key: 'leadership',
+          factor_label: 'Leiderschap',
+          avg_score: 5.2,
+          items: [
+            {
+              item_key: 'leadership_1',
+              label: 'Mijn leidinggevende gaf richting die hielp om werk te prioriteren.',
+              avg: 4.8,
+              n: 12,
+            },
+            {
+              item_key: 'leadership_3',
+              label: 'Ik kreeg voldoende steun van mijn leidinggevende.',
+              avg: 5.4,
+              n: 12,
+            },
+          ],
+        },
+      ],
+      sdt_dimensions: [],
+      supplemental_sections: [],
+      privacy_suppressed_items: ['leadership_2', 'B1'],
+      suppressed_items: [
+        {
+          item_key: 'leadership_2',
+          label: 'Mijn leidinggevende gaf regelmatig bruikbare feedback.',
+          avg: null,
+          n: 4,
+        },
+        {
+          item_key: 'B1',
+          label: 'Ik kon zelf bepalen hoe ik mijn werk uitvoerde.',
+          avg: null,
+          n: 4,
+        },
+      ],
+    }
+
+    expect(buildFactorItemLayerMap(payload)).toEqual({
+      leadership: [
+        {
+          itemKey: 'leadership_1',
+          label: 'Mijn leidinggevende gaf richting die hielp om werk te prioriteren.',
+          avg: 4.8,
+          n: 12,
+          suppressed: false,
+        },
+        {
+          itemKey: 'leadership_2',
+          label: 'Mijn leidinggevende gaf regelmatig bruikbare feedback.',
+          avg: null,
+          n: 4,
+          suppressed: true,
+        },
+        {
+          itemKey: 'leadership_3',
+          label: 'Ik kreeg voldoende steun van mijn leidinggevende.',
+          avg: 5.4,
+          n: 12,
+          suppressed: false,
+        },
+      ],
+    })
+  })
+
+  it('truncates long item labels to keep the subrows compact', () => {
+    expect(
+      truncateFactorItemLabel(
+        'Dit is een extra lange vraagtekst die bewust langer is dan zestig tekens zodat we de truncatielogica raken.',
+      ),
+    ).toBe('Dit is een extra lange vraagtekst die bewust langer is da...')
+  })
+
+  it('keeps the privacy-suppressed messaging and toggle semantics in the component source', () => {
+    const source = readFileSync(new URL('./factor-table.tsx', import.meta.url), 'utf8')
+
+    expect(source).toContain('Niet zichtbaar (te weinig respondenten)')
+    expect(source).toContain('aria-expanded')
+    expect(source).toContain('Klap een factor open om de losse itemlaag te bekijken.')
+  })
+})

--- a/frontend/components/dashboard/factor-table.tsx
+++ b/frontend/components/dashboard/factor-table.tsx
@@ -1,17 +1,92 @@
 'use client'
 
+import { useState } from 'react'
 import { buildFactorPresentation, getRiskBandFromScore, RISK_BG_COLORS, RISK_COLORS } from '@/lib/management-language'
 import { FACTOR_LABELS } from '@/lib/types'
-import type { ScanType } from '@/lib/types'
+import type { CampaignItemScoresResponse, ItemScoreDetail, ScanType } from '@/lib/types'
 
-const ORG_FACTORS = ['leadership', 'culture', 'growth', 'compensation', 'workload', 'role_clarity']
+const ORG_FACTORS = ['leadership', 'culture', 'growth', 'compensation', 'workload', 'role_clarity'] as const
+type OrgFactorKey = typeof ORG_FACTORS[number]
+
+export type FactorItemRow = {
+  itemKey: string
+  label: string
+  avg: number | null
+  n: number
+  suppressed: boolean
+}
 
 interface Props {
   factorAverages: Record<string, number>
   scanType: ScanType
+  itemScores?: CampaignItemScoresResponse | null
+  showIntro?: boolean
 }
 
-export function FactorTable({ factorAverages, scanType }: Props) {
+function isOrgFactorKey(value: string): value is OrgFactorKey {
+  return ORG_FACTORS.includes(value as OrgFactorKey)
+}
+
+function getOrgFactorKeyFromItemKey(itemKey: string): OrgFactorKey | null {
+  const match = itemKey.match(/^(.*)_(\d+)$/)
+  if (!match) return null
+
+  const factorKey = match[1]
+  return isOrgFactorKey(factorKey) ? factorKey : null
+}
+
+function getItemSortOrder(itemKey: string) {
+  const match = itemKey.match(/_(\d+)$/)
+  if (!match) return Number.MAX_SAFE_INTEGER
+  return Number(match[1])
+}
+
+export function truncateFactorItemLabel(value: string, limit = 60) {
+  return value.length > limit ? `${value.slice(0, limit - 3).trimEnd()}...` : value
+}
+
+export function buildFactorItemLayerMap(itemScores?: CampaignItemScoresResponse | null) {
+  if (!itemScores) {
+    return {} as Record<string, FactorItemRow[]>
+  }
+
+  const rowsByFactor: Record<string, FactorItemRow[]> = {}
+
+  for (const group of itemScores.factors) {
+    const visibleRows = group.items.map((item) => ({
+      itemKey: item.item_key,
+      label: item.label,
+      avg: item.avg,
+      n: item.n,
+      suppressed: false,
+    }))
+    const visibleKeys = new Set(visibleRows.map((item) => item.itemKey))
+    const suppressedRows = itemScores.suppressed_items
+      .filter((item) => getOrgFactorKeyFromItemKey(item.item_key) === group.factor_key)
+      .filter((item) => !visibleKeys.has(item.item_key))
+      .map((item) => ({
+        itemKey: item.item_key,
+        label: item.label,
+        avg: item.avg,
+        n: item.n,
+        suppressed: true,
+      }))
+
+    rowsByFactor[group.factor_key] = [...visibleRows, ...suppressedRows].sort((left, right) => {
+      return getItemSortOrder(left.itemKey) - getItemSortOrder(right.itemKey)
+    })
+  }
+
+  return rowsByFactor
+}
+
+function buildSuppressedMessage(item: ItemScoreDetail | FactorItemRow) {
+  return item.n > 0
+    ? `Niet zichtbaar (te weinig respondenten, n=${item.n})`
+    : 'Niet zichtbaar (te weinig respondenten)'
+}
+
+export function FactorTable({ factorAverages, scanType, itemScores, showIntro = true }: Props) {
   const rows = ORG_FACTORS
     .filter((factor) => factor in factorAverages)
     .map((factor) => {
@@ -33,47 +108,151 @@ export function FactorTable({ factorAverages, scanType }: Props) {
           : 'De belevingsscore laat zien hoe medewerkers een thema gemiddeld ervaren. Het managementlabel vertaalt dat naar wat dit bestuurlijk vraagt voor behoud.'
 
   const bandLabels = { HOOG: 'Direct prioriteren', MIDDEN: 'Eerst toetsen', LAAG: 'Volgen' }
+  const itemLayerMap = buildFactorItemLayerMap(itemScores)
+  const [expandedFactors, setExpandedFactors] = useState<Record<string, boolean>>({})
 
   return (
     <div className="space-y-1">
-      <p className="mb-4 text-[0.85rem] leading-6 text-[color:var(--dashboard-muted)]">{introText}</p>
-      {rows.map((row, index) => (
-        <div
-          key={row.factor}
-          className="flex items-center gap-4 py-3"
-          style={{
-            borderBottom: index < rows.length - 1 ? '1px solid rgba(19,32,51,0.06)' : undefined,
-          }}
-        >
-          <span className="w-40 shrink-0 text-[0.875rem] text-[color:var(--dashboard-ink)]">
-            {FACTOR_LABELS[row.factor]}
-          </span>
+      {showIntro ? (
+        <p className="mb-4 text-[0.85rem] leading-6 text-[color:var(--dashboard-muted)]">
+          {introText} Klap een factor open om de losse itemlaag te bekijken.
+        </p>
+      ) : null}
+      {rows.map((row, index) => {
+        const factorItems = itemLayerMap[row.factor] ?? []
+        const canExpand = factorItems.length > 0
 
-          <div className="h-[6px] flex-1 overflow-hidden rounded-[3px] bg-[rgba(19,32,51,0.08)]">
-            <div
-              className="h-full rounded-[3px]"
-              style={{
-                width: `${((row.score - 1) / 9) * 100}%`,
-                backgroundColor: RISK_COLORS[row.band],
-              }}
-            />
-          </div>
-
-          <span className="w-16 shrink-0 text-right text-[0.875rem] font-medium text-[color:var(--dashboard-ink)]">
-            {row.presentation.scoreDisplay}
-          </span>
-
-          <span
-            className="min-w-[7rem] shrink-0 rounded-full px-2.5 py-0.5 text-center text-[0.65rem] font-medium uppercase tracking-[0.04em]"
+        return (
+          <div
+            key={row.factor}
+            className="py-3"
             style={{
-              background: RISK_BG_COLORS[row.band],
-              color: RISK_COLORS[row.band],
+              borderBottom: index < rows.length - 1 ? '1px solid rgba(19,32,51,0.06)' : undefined,
             }}
           >
-            {bandLabels[row.band]}
-          </span>
-        </div>
-      ))}
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+              <div className="flex min-w-0 items-center gap-3 sm:w-56 sm:shrink-0">
+                {canExpand ? (
+                  <button
+                    type="button"
+                    className="inline-flex size-8 shrink-0 items-center justify-center rounded-full border border-[rgba(19,32,51,0.12)] text-[0.9rem] font-medium text-[color:var(--dashboard-ink)] transition-colors hover:bg-[color:var(--dashboard-soft)]"
+                    aria-expanded={expandedFactors[row.factor] ?? false}
+                    aria-controls={`factor-items-${row.factor}`}
+                    aria-label={`${expandedFactors[row.factor] ? 'Verberg' : 'Toon'} items voor ${FACTOR_LABELS[row.factor]}`}
+                    onClick={() =>
+                      setExpandedFactors((current) => ({
+                        ...current,
+                        [row.factor]: !current[row.factor],
+                      }))
+                    }
+                  >
+                    {expandedFactors[row.factor] ? '-' : '+'}
+                  </button>
+                ) : (
+                  <span className="inline-flex size-8 shrink-0" aria-hidden="true" />
+                )}
+                <span className="min-w-0 text-[0.875rem] text-[color:var(--dashboard-ink)]">
+                  {FACTOR_LABELS[row.factor]}
+                </span>
+              </div>
+
+              <div className="h-[6px] flex-1 overflow-hidden rounded-[3px] bg-[rgba(19,32,51,0.08)]">
+                <div
+                  className="h-full rounded-[3px]"
+                  style={{
+                    width: `${((row.score - 1) / 9) * 100}%`,
+                    backgroundColor: RISK_COLORS[row.band],
+                  }}
+                />
+              </div>
+
+              <span className="w-16 shrink-0 text-right text-[0.875rem] font-medium text-[color:var(--dashboard-ink)]">
+                {row.presentation.scoreDisplay}
+              </span>
+
+              <span
+                className="min-w-[7rem] shrink-0 rounded-full px-2.5 py-0.5 text-center text-[0.65rem] font-medium uppercase tracking-[0.04em]"
+                style={{
+                  background: RISK_BG_COLORS[row.band],
+                  color: RISK_COLORS[row.band],
+                }}
+              >
+                {bandLabels[row.band]}
+              </span>
+            </div>
+
+            {(expandedFactors[row.factor] ?? false) ? (
+              <div
+                id={`factor-items-${row.factor}`}
+                className="space-y-3 pl-11 pt-3"
+              >
+                {factorItems.length > 0 ? (
+                  factorItems.map((item) => {
+                    if (item.suppressed) {
+                      return (
+                        <div
+                          key={item.itemKey}
+                          className="rounded-[16px] border border-[rgba(19,32,51,0.08)] bg-[rgba(19,32,51,0.02)] px-4 py-3"
+                        >
+                          <div className="flex flex-col gap-1.5 sm:flex-row sm:items-center sm:justify-between">
+                            <span
+                              className="text-[0.82rem] leading-6 text-[color:var(--dashboard-text)]"
+                              title={item.label}
+                            >
+                              {truncateFactorItemLabel(item.label)}
+                            </span>
+                            <span className="text-[0.78rem] font-medium text-[color:var(--dashboard-muted)]">
+                              {buildSuppressedMessage(item)}
+                            </span>
+                          </div>
+                        </div>
+                      )
+                    }
+
+                    if (item.avg === null) {
+                      return null
+                    }
+
+                    const itemBand = getRiskBandFromScore(11 - item.avg)
+
+                    return (
+                      <div
+                        key={item.itemKey}
+                        className="rounded-[16px] border border-[rgba(19,32,51,0.08)] bg-white/90 px-4 py-3"
+                      >
+                        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
+                          <span
+                            className="min-w-0 flex-1 text-[0.82rem] leading-6 text-[color:var(--dashboard-text)]"
+                            title={item.label}
+                          >
+                            {truncateFactorItemLabel(item.label)}
+                          </span>
+                          <div className="h-[4px] flex-1 overflow-hidden rounded-[3px] bg-[rgba(19,32,51,0.08)]">
+                            <div
+                              className="h-full rounded-[3px]"
+                              style={{
+                                width: `${((item.avg - 1) / 9) * 100}%`,
+                                backgroundColor: RISK_COLORS[itemBand],
+                              }}
+                            />
+                          </div>
+                          <span className="w-12 shrink-0 text-right text-[0.82rem] font-semibold text-[color:var(--dashboard-ink)]">
+                            {item.avg.toFixed(1)}
+                          </span>
+                        </div>
+                      </div>
+                    )
+                  })
+                ) : (
+                  <div className="rounded-[16px] border border-[rgba(19,32,51,0.08)] bg-[rgba(19,32,51,0.02)] px-4 py-3 text-[0.82rem] text-[color:var(--dashboard-muted)]">
+                    Nog geen itemlaag zichtbaar voor deze factor.
+                  </div>
+                )}
+              </div>
+            ) : null}
+          </div>
+        )
+      })}
     </div>
   )
 }

--- a/frontend/components/dashboard/retention-product-dashboard.tsx
+++ b/frontend/components/dashboard/retention-product-dashboard.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react'
+import { FactorTable } from '@/components/dashboard/factor-table'
 import {
   BoardroomEmptyState,
   BoardroomKeyValueList,
@@ -14,6 +15,7 @@ import {
   SdtTriangleMap,
   SignalCompositionRibbon,
 } from '@/components/dashboard/results-boardroom-visuals'
+import type { CampaignItemScoresResponse } from '@/lib/types'
 
 type RetentionThemeCard = {
   key: string
@@ -52,45 +54,14 @@ interface RetentionProductDashboardProps {
   compositionSegments: CompositionSegment[]
   compositionHighlights: Array<{ label: string; value: string; body: string }>
   factorRows: BoardroomFactorRow[]
+  factorAverages: Record<string, number>
   sdtRows: BoardroomSdtRow[]
+  itemScores?: CampaignItemScoresResponse | null
   surveyThemes: RetentionThemeCard[]
   verificationTrackLabel: string
   ownerRoleLabel: string
   firstStepLabel: string
   reviewMomentLabel: string
-}
-
-function RankedFactorTable({ rows }: { rows: BoardroomFactorRow[] }) {
-  return (
-    <div className="overflow-hidden border border-[rgba(13,27,42,0.15)]">
-      <div className="hidden bg-[#F4F1EA] px-4 py-3 font-mono text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-[#44505C] lg:grid lg:grid-cols-[72px_minmax(0,1.3fr)_120px_160px_minmax(0,1.4fr)]">
-        <span>Rang</span>
-        <span>Factor</span>
-        <span>Score</span>
-        <span>Band</span>
-        <span>Leesnotitie</span>
-      </div>
-      {rows.map((row, index) => (
-        <div
-          key={`${row.factor}-${index}`}
-          className="grid gap-3 border-t border-[rgba(13,27,42,0.15)] bg-white px-4 py-4 first:border-t-0 lg:grid-cols-[72px_minmax(0,1.3fr)_120px_160px_minmax(0,1.4fr)] lg:items-start"
-        >
-          <span className="font-mono text-[0.72rem] font-semibold uppercase tracking-[0.2em] text-[#44505C]">
-            {(index + 1).toString().padStart(2, '0')}
-          </span>
-          <div>
-            <p className="text-sm font-semibold text-[#132033]">{row.factor}</p>
-            <p className="mt-1 text-xs leading-5 text-[#44505C] lg:hidden">{row.note}</p>
-          </div>
-          <p className="dash-number text-[1.2rem] leading-none text-[#132033]">{row.score}</p>
-          <p className="font-mono text-[0.72rem] font-semibold uppercase tracking-[0.2em] text-[#44505C]">
-            {row.band}
-          </p>
-          <p className="hidden text-sm leading-6 text-[#44505C] lg:block">{row.note}</p>
-        </div>
-      ))}
-    </div>
-  )
 }
 
 export function RetentionProductDashboard({
@@ -120,7 +91,9 @@ export function RetentionProductDashboard({
   compositionSegments,
   compositionHighlights,
   factorRows,
+  factorAverages,
   sdtRows,
+  itemScores,
   surveyThemes,
   verificationTrackLabel,
   ownerRoleLabel,
@@ -286,7 +259,12 @@ export function RetentionProductDashboard({
                 />
               ))}
             </div>
-            <RankedFactorTable rows={factorRows} />
+            <FactorTable
+              factorAverages={factorAverages}
+              scanType="retention"
+              itemScores={itemScores}
+              showIntro={false}
+            />
           </div>
         ) : (
           <BoardroomEmptyState

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -104,6 +104,42 @@ export interface SurveyResponse {
   submitted_at: string
 }
 
+export interface ItemScoreDetail {
+  item_key: string
+  label: string
+  avg: number | null
+  n: number
+}
+
+export interface FactorItemScoreGroup {
+  factor_key: string
+  factor_label: string
+  avg_score: number | null
+  items: ItemScoreDetail[]
+}
+
+export interface SdtDimensionItemScoreGroup {
+  dimension_key: string
+  dimension_label: string
+  avg_score: number | null
+  items: ItemScoreDetail[]
+}
+
+export interface SupplementalItemScoreGroup {
+  section_key: string
+  section_label: string
+  avg_score: number | null
+  items: ItemScoreDetail[]
+}
+
+export interface CampaignItemScoresResponse {
+  factors: FactorItemScoreGroup[]
+  sdt_dimensions: SdtDimensionItemScoreGroup[]
+  supplemental_sections: SupplementalItemScoreGroup[]
+  privacy_suppressed_items: string[]
+  suppressed_items: ItemScoreDetail[]
+}
+
 export interface OrgMember {
   id: string
   org_id: string

--- a/tests/test_api_flows.py
+++ b/tests/test_api_flows.py
@@ -67,23 +67,49 @@ def _create_response(
     *,
     risk_score: float = 5.8,
     risk_band: str = "MIDDEN",
+    stay_intent_score: int = 4,
+    sdt_raw: dict[str, int] | None = None,
+    sdt_scores: dict[str, float] | None = None,
+    org_raw: dict[str, int] | None = None,
+    org_scores: dict[str, float] | None = None,
+    uwes_raw: dict[str, int] | None = None,
+    uwes_score: float | None = None,
+    turnover_intention_raw: dict[str, int] | None = None,
+    turnover_intention_score: float | None = None,
+    full_result: dict[str, object] | None = None,
 ):
+    resolved_sdt_raw = sdt_raw or {f"B{i}": 3 for i in range(1, 13)}
+    resolved_sdt_scores = sdt_scores or {
+        "autonomy": 5.5,
+        "competence": 5.5,
+        "relatedness": 5.5,
+        "sdt_total": 5.5,
+        "sdt_risk": 5.5,
+    }
+    resolved_org_raw = org_raw or {
+        f"{factor}_{idx}": 3 for factor in ORG_FACTOR_KEYS for idx in range(1, 4)
+    }
+    resolved_org_scores = org_scores or {factor: 5.5 for factor in ORG_FACTOR_KEYS}
     response = SurveyResponse(
         respondent_id=respondent.id,
         tenure_years=2.4,
         exit_reason_category="groei",
         exit_reason_code="P3",
-        stay_intent_score=4,
-        sdt_raw={f"B{i}": 3 for i in range(1, 13)},
-        sdt_scores={"autonomy": 5.5, "competence": 5.5, "relatedness": 5.5, "sdt_total": 5.5, "sdt_risk": 5.5},
-        org_raw={f"{factor}_{idx}": 3 for factor in ORG_FACTOR_KEYS for idx in range(1, 4)},
-        org_scores={factor: 5.5 for factor in ORG_FACTOR_KEYS},
+        stay_intent_score=stay_intent_score,
+        sdt_raw=resolved_sdt_raw,
+        sdt_scores=resolved_sdt_scores,
+        org_raw=resolved_org_raw,
+        org_scores=resolved_org_scores,
         pull_factors_raw={"P1": 1},
         open_text_raw="Meer groeiperspectief gewenst.",
+        uwes_raw=uwes_raw or {},
+        uwes_score=uwes_score,
+        turnover_intention_raw=turnover_intention_raw or {},
+        turnover_intention_score=turnover_intention_score,
         risk_score=risk_score,
         risk_band=risk_band,
         preventability="GEMENGD_WERKSIGNAAL",
-        full_result={"risk_result": {"risk_score": risk_score, "risk_band": risk_band}},
+        full_result=full_result or {"risk_result": {"risk_score": risk_score, "risk_band": risk_band}},
     )
     respondent.completed = True
     respondent.completed_at = datetime.now(timezone.utc)
@@ -868,6 +894,209 @@ def test_campaign_stats_returns_zero_values_for_empty_campaign(client, db_sessio
     assert body["avg_signal_score"] is None
     assert body["completion_rate_pct"] == 0.0
     assert body["risk_band_distribution"] == {"HOOG": 0, "MIDDEN": 0, "LAAG": 0}
+
+
+def test_campaign_item_scores_returns_exit_factor_and_sdt_item_averages(client, db_session: Session):
+    org = _create_org(db_session, api_key="item-scores-exit-key")
+    campaign = _create_campaign(db_session, org, name="Exit itemlaag", scan_type="exit")
+
+    for index in range(5):
+        respondent = _create_respondent(
+            db_session,
+            campaign,
+            email=f"exit-item-{index}@example.com",
+            department="Operations",
+            completed=True,
+        )
+        _create_response(
+            db_session,
+            respondent,
+            sdt_raw={
+                "B1": 5,
+                "B2": 3,
+                "B3": 3,
+                "B4": 1,
+                "B5": 3,
+                "B6": 3,
+                "B7": 3,
+                "B8": 3,
+                "B9": 3,
+                "B10": 3,
+                "B11": 3,
+                "B12": 3,
+            },
+            sdt_scores={
+                "autonomy": 7.19,
+                "competence": 5.5,
+                "relatedness": 5.5,
+                "sdt_total": 6.06,
+                "sdt_risk": 4.94,
+            },
+            org_raw={
+                **{f"{factor}_{item}": 3 for factor in ORG_FACTOR_KEYS for item in range(1, 4)},
+                "leadership_1": 5,
+            },
+            org_scores={
+                **{factor: 5.5 for factor in ORG_FACTOR_KEYS},
+                "leadership": 7.0,
+            },
+            full_result={"risk_result": {"risk_score": 5.8, "risk_band": "MIDDEN"}},
+        )
+
+    response = client.get(
+        f"/api/campaigns/{campaign.id}/item-scores",
+        headers={"x-api-key": "item-scores-exit-key"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+
+    leadership = next(item for item in body["factors"] if item["factor_key"] == "leadership")
+    assert leadership["factor_label"] == "Leiderschap"
+    assert leadership["avg_score"] == pytest.approx(7.0, abs=0.01)
+    assert leadership["items"][0]["item_key"] == "leadership_1"
+    assert leadership["items"][0]["label"] == "Mijn leidinggevende gaf mij nuttige feedback over mijn functioneren."
+    assert leadership["items"][0]["avg"] == pytest.approx(10.0, abs=0.01)
+    assert leadership["items"][0]["n"] == 5
+
+    autonomy = next(item for item in body["sdt_dimensions"] if item["dimension_key"] == "autonomy")
+    assert autonomy["dimension_label"] == "Autonomie"
+    assert autonomy["items"][0]["item_key"] == "B1"
+    assert autonomy["items"][0]["label"].startswith("In mijn werk had ik het gevoel")
+    reverse_item = next(item for item in autonomy["items"] if item["item_key"] == "B4")
+    assert reverse_item["avg"] == pytest.approx(10.0, abs=0.01)
+    assert body["privacy_suppressed_items"] == []
+
+
+def test_campaign_item_scores_suppresses_items_below_privacy_floor(client, db_session: Session):
+    org = _create_org(db_session, api_key="item-scores-suppressed-key")
+    campaign = _create_campaign(db_session, org, name="Exit suppressie", scan_type="exit")
+
+    for index in range(4):
+        respondent = _create_respondent(
+            db_session,
+            campaign,
+            email=f"exit-suppress-{index}@example.com",
+            department="Operations",
+            completed=True,
+        )
+        _create_response(db_session, respondent)
+
+    response = client.get(
+        f"/api/campaigns/{campaign.id}/item-scores",
+        headers={"x-api-key": "item-scores-suppressed-key"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert "leadership_1" in body["privacy_suppressed_items"]
+    assert "B1" in body["privacy_suppressed_items"]
+
+    leadership = next(item for item in body["factors"] if item["factor_key"] == "leadership")
+    autonomy = next(item for item in body["sdt_dimensions"] if item["dimension_key"] == "autonomy")
+    assert leadership["items"] == []
+    assert autonomy["items"] == []
+
+
+def test_campaign_item_scores_returns_retention_supplemental_sections(client, db_session: Session):
+    org = _create_org(db_session, api_key="item-scores-retention-key")
+    campaign = _create_campaign(db_session, org, name="Retentie itemlaag", scan_type="retention")
+
+    for index in range(5):
+        respondent = _create_respondent(
+            db_session,
+            campaign,
+            email=f"retention-item-{index}@example.com",
+            department="People",
+            completed=True,
+        )
+        _create_response(
+            db_session,
+            respondent,
+            uwes_raw={"uwes_1": 4, "uwes_2": 5, "uwes_3": 4},
+            uwes_score=8.5,
+            turnover_intention_raw={"ti_1": 2, "ti_2": 3},
+            turnover_intention_score=3.25,
+            full_result={"risk_result": {"risk_score": 4.4, "risk_band": "LAAG"}},
+        )
+
+    response = client.get(
+        f"/api/campaigns/{campaign.id}/item-scores",
+        headers={"x-api-key": "item-scores-retention-key"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    sections = {section["section_key"]: section for section in body["supplemental_sections"]}
+
+    assert sections["uwes"]["section_label"] == "Bevlogenheid (UWES-3)"
+    assert sections["uwes"]["avg_score"] == pytest.approx(8.5, abs=0.01)
+    assert sections["uwes"]["items"][0]["item_key"] == "uwes_1"
+    assert sections["uwes"]["items"][0]["label"] == "Op mijn werk bruis ik van energie."
+
+    assert sections["turnover_intention"]["section_label"] == "Vertrekintentie"
+    assert sections["turnover_intention"]["avg_score"] == pytest.approx(3.25, abs=0.01)
+    assert sections["turnover_intention"]["items"][0]["item_key"] == "ti_1"
+    assert sections["turnover_intention"]["items"][0]["label"] == "Ik denk er serieus over na om deze organisatie te verlaten."
+
+
+def test_campaign_item_scores_limits_onboarding_to_active_modules(client, db_session: Session):
+    org = _create_org(db_session, api_key="item-scores-onboarding-key")
+    campaign = _create_campaign(db_session, org, name="Onboarding itemlaag", scan_type="onboarding")
+
+    for index in range(5):
+        respondent = _create_respondent(
+            db_session,
+            campaign,
+            email=f"onboarding-item-{index}@example.com",
+            department="People",
+            exit_month=None,
+            completed=True,
+        )
+        _create_response(
+            db_session,
+            respondent,
+            sdt_raw={"B1": 4, "B5": 4, "B9": 5},
+            sdt_scores={
+                "autonomy": 7.75,
+                "competence": 7.75,
+                "relatedness": 10.0,
+                "sdt_total": 8.5,
+                "sdt_risk": 2.5,
+            },
+            org_raw={
+                "leadership_1": 4,
+                "role_clarity_1": 3,
+            },
+            org_scores={
+                "leadership": 7.75,
+                "role_clarity": 5.5,
+            },
+            full_result={"risk_result": {"risk_score": 4.2, "risk_band": "LAAG"}},
+        )
+
+    response = client.get(
+        f"/api/campaigns/{campaign.id}/item-scores",
+        headers={"x-api-key": "item-scores-onboarding-key"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+
+    factor_keys = [factor["factor_key"] for factor in body["factors"]]
+    assert factor_keys == ["leadership", "role_clarity"]
+
+    sdt_keys = [dimension["dimension_key"] for dimension in body["sdt_dimensions"]]
+    assert sdt_keys == ["autonomy", "competence", "relatedness"]
+
+    labels_by_key = {
+        item["item_key"]: item["label"]
+        for dimension in body["sdt_dimensions"]
+        for item in dimension["items"]
+    }
+    assert labels_by_key["B1"].startswith("Ik voel me in deze eerste periode")
+    assert labels_by_key["B5"].startswith("Ik voel me in deze eerste periode voldoende toegerust")
+    assert labels_by_key["B9"].startswith("Ik voel me in deze eerste periode voldoende verbonden")
 
 
 def test_report_route_returns_pdf(client, db_session: Session):


### PR DESCRIPTION
## Summary
- add `/api/campaigns/{campaign_id}/item-scores` plus internal admin fallback for exit, retention, and onboarding campaigns
- aggregate item-level means with a hard `n >= 5` privacy floor and return grouped factor/SDT/supplemental sections from product definitions
- surface expandable per-item factor rows in the dashboard for ExitScan, RetentieScan, and the generic Onboarding/generic campaign detail path

## Verification
- `python -m pytest tests/test_api_flows.py -k item_scores -x`
- `npm exec -- vitest run "components/dashboard/factor-table.test.ts" "app/(dashboard)/campaigns/[id]/page-helpers.test.ts"`

## Notes
- `npm exec -- tsc --noEmit` still reports pre-existing, unrelated TypeScript failures elsewhere in the repo (mainly Action Center and marketing test files); no hits came back on the files touched in this PR.